### PR TITLE
Add QA gate: post-Skeptic browser verification for UI changes

### DIFF
--- a/.claude/skills/agentic-engineering/references/agent-team.md
+++ b/.claude/skills/agentic-engineering/references/agent-team.md
@@ -10,9 +10,10 @@
 | `architect` | Pre-implementation design. Reads the codebase, produces a structured technical plan. | No |
 | `orchestration-planner` | Team composition and sequencing. Given a goal, produces a structured execution plan: which agents to spawn, in what order, with what handoffs, and where Skeptic review is needed. | No |
 | `engineer` | Implements the change. Reads conventions, writes code, runs quality gates, reports clearly. | Yes |
+| `qa-engineer` | Post-Skeptic browser verification. Spawns after Skeptic sign-off when the diff matches QA trigger patterns in `.claude/qa.md`. Verifies changes in a real browser, returns structured pass/fail report. Appends learned quirks to `.claude/qa.md` Knowledge section. | No (appends to qa.md only) |
 | `skeptic` | Adversarial reviewer. Reviews Worker output for Critical/Major/Minor findings. | No |
 
-The `skeptic` is the review layer - it is not a specialist. All others are specialists that produce output feeding into the main flow.
+The `skeptic` is the review layer - it is not a specialist. The `qa-engineer` is a conditional gate that fires only when UI-visible changes are detected. All others are specialists that produce output feeding into the main flow.
 
 ---
 
@@ -29,6 +30,8 @@ engineer (implement)  ←── re-routes findings
     ↓
 skeptic (review)
     ↓ sign-off
+qa-engineer (verify)  ←── conditional: only if .claude/qa.md trigger patterns match the diff
+    ↓ pass
 done
 ```
 
@@ -45,6 +48,8 @@ skeptic (review)
     ↓ sign-off
 security-auditor (audit)
     ↓
+qa-engineer (verify)  ←── conditional: only if .claude/qa.md trigger patterns match the diff
+    ↓ pass
 done (or route findings back to engineer if Critical/High)
 ```
 
@@ -113,6 +118,11 @@ Use `orchestration-planner` when the right agent combination is not obvious, whe
 - A stack trace or production error needs diagnosis before a fix is attempted
 - Skip it when the bug is already understood - go straight to `engineer`
 
+**Use `qa-engineer` when:**
+- Skeptic has signed off AND the project has `.claude/qa.md` with trigger patterns matching the diff
+- User explicitly asks to verify, test, or QA a change ("run QA", "check the feature works", "verify in the browser", "does it work")
+- Do NOT use when: no `.claude/qa.md` exists, the change is backend-only (no matching patterns), or the change is Low risk
+
 **When the architect returns a plan, spawn a Skeptic to review it before proceeding.** This is mandatory - do not spawn engineers, run the orchestration-planner, or take any action on the plan until the Skeptic grants sign-off. Use the "Document synthesis, architecture, and planning" adversarial brief. A flawed plan propagates errors through every downstream Worker; the plan review Skeptic is the gate that prevents this.
 
 **Skeptic is always spawned for Elevated risk.** It reviews whatever the engineer produced. The security-auditor is an additional pass, not a replacement for the Skeptic.
@@ -142,3 +152,11 @@ When spawning `skeptic` for engineer output review, include:
 When spawning `security-auditor`, include:
 - The files changed or the scope of the feature
 - The domain (e.g., "authentication flow", "payment processing")
+
+When spawning `qa-engineer`, include:
+- The unit's acceptance criteria as the test plan
+- The `.claude/qa.md` config (dev server command, port, URLs)
+- Which pages/features to verify based on the files changed
+- The qa-engineer uses `agent-browser` for all browser interaction
+- QA returns a structured pass/fail report with bugs and evidence
+- On failure, the conductor spawns fix engineers, then re-runs QA

--- a/.claude/skills/agentic-engineering/references/skeptic-protocol.md
+++ b/.claude/skills/agentic-engineering/references/skeptic-protocol.md
@@ -131,10 +131,13 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 9. **Repeat steps 4–8** until the Skeptic grants sign-off:
    > "No unresolved Critical or Major findings. Sign-off granted."
 
-10. **Primary agent reports back** with:
+10. **QA gate check (conditional).** After sign-off is granted and any minor fixes are applied, the conductor checks the QA gate condition (see agent-methodology.md QA Gate section). If the project has `.claude/qa.md` with trigger patterns matching the diff, spawn `qa-engineer` before reporting back. QA failure routes back to an engineer for fixes, then re-runs QA. If no QA gate applies, proceed directly to step 11.
+
+11. **Primary agent reports back** with:
     - The final implementation
     - The full exchange log (round-by-round: findings, fixes, deferrals with reasoning)
     - The verbatim sign-off statement from the final Skeptic round
+    - QA result (pass/fail) if the QA gate was triggered
 
 ---
 

--- a/.claude/skills/agentic-engineering/references/subagent-protocol.md
+++ b/.claude/skills/agentic-engineering/references/subagent-protocol.md
@@ -108,6 +108,7 @@ Format: `[phase: label]` — one line, no surrounding prose required. Add parent
 | `applying-minors` | Minor findings being applied post-sign-off |
 | `cleanup` | /simplify pass running (Elevated + Cleanup path only) |
 | `cleanup-review` | Narrow Skeptic reviewing /simplify diff |
+| `qa-review` | QA engineer is verifying the change in a browser |
 | `complete` | All work done, synthesizing results |
 
 Example status update: "Skeptic spawned for round 1 review. [phase: skeptic-review (round 1)]"

--- a/.claude/skills/agentic-engineering/rules/agent-methodology.md
+++ b/.claude/skills/agentic-engineering/rules/agent-methodology.md
@@ -46,7 +46,7 @@
 | Configuration changes | No | **Yes** |
 | Anything where a mistake costs time or data | No | **Yes** |
 
-**Named agents:** Prefer named agents over generic Workers. Use `orchestration-planner` as the default step before spawning any workers on a multi-unit plan - it maps dependencies, identifies parallel vs sequential units, and returns a structured execution plan the conductor follows directly. Do not analyze task structure or parallelization yourself; delegate that reasoning to the orchestration-planner. Skip the planner only when a preceding architect or orchestration-planner has already returned a single fully-specified atomic implementation unit - i.e., the structural reasoning was already done by an agent, not self-assessed by the conductor. Use `engineer` for implementation, `architect` for pre-implementation design, `investigator` for codebase exploration and blast radius mapping, `debugger` for root cause analysis, `security-auditor` for security review. Fall back to `general-purpose` only when none of these fit. Use `bash` agents only for pure shell operations. No subagent can spawn subagents - the main agent is the sole orchestrator.
+**Named agents:** Prefer named agents over generic Workers. Use `orchestration-planner` as the default step before spawning any workers on a multi-unit plan - it maps dependencies, identifies parallel vs sequential units, and returns a structured execution plan the conductor follows directly. Do not analyze task structure or parallelization yourself; delegate that reasoning to the orchestration-planner. Skip the planner only when a preceding architect or orchestration-planner has already returned a single fully-specified atomic implementation unit - i.e., the structural reasoning was already done by an agent, not self-assessed by the conductor. Use `engineer` for implementation, `architect` for pre-implementation design, `investigator` for codebase exploration and blast radius mapping, `debugger` for root cause analysis, `security-auditor` for security review, `qa-engineer` for post-Skeptic browser verification of UI-visible changes. Fall back to `general-purpose` only when none of these fit. Use `bash` agents only for pure shell operations. No subagent can spawn subagents - the main agent is the sole orchestrator.
 
 **Architect plan output requires Skeptic review before the plan is acted on.** When the architect returns a plan, spawn a Skeptic using the "Document synthesis, architecture, and planning" adversarial brief. Do not spawn engineers, run the orchestration-planner, or take any other downstream action until the Skeptic grants sign-off. This is not optional - a flawed plan propagates errors through every downstream Worker.
 
@@ -83,6 +83,26 @@ Applying adversarial review.
 Risk: Elevated + Cleanup - [specific signal]
 Applying adversarial review with /simplify cleanup pass.
 ```
+
+## QA Gate
+
+**Post-Skeptic QA for UI-visible changes.** After Skeptic sign-off on any Elevated unit, check whether the project has a `.claude/qa.md` with a `## QA triggers` section containing file patterns. If the reviewed diff includes files matching any trigger pattern, spawn `qa-engineer` before declaring the unit complete. QA failure blocks completion - the conductor spawns a fix engineer, then re-runs QA.
+
+**When QA is skipped:**
+- No `.claude/qa.md` exists in the project
+- `.claude/qa.md` has no `## QA triggers` section
+- No files in the reviewed diff match any trigger pattern
+- The change is Low risk (direct action)
+
+**QA gate flow:**
+1. Skeptic grants sign-off (minor fixes applied if any)
+2. Conductor checks `.claude/qa.md` trigger patterns against the diff
+3. If matched: spawn `qa-engineer` with the unit's acceptance criteria and the qa.md config
+4. QA engineer opens the dev server in a browser, verifies functionality, returns pass/fail report
+5. On PASS: unit is complete
+6. On FAIL: spawn fix engineer for each bug, then re-run QA
+
+**Phase breadcrumb:** `[phase: qa-review]`
 
 ## Task Decomposition
 
@@ -161,3 +181,6 @@ Read `~/agentic-engineering/.claude/skills/agentic-engineering/references/subage
 
 **Agent team composition** - which agent to use and how they compose:
 Read `~/agentic-engineering/.claude/skills/agentic-engineering/references/agent-team.md` for flows (feature, bug, security), decision rules, and spawn prompts.
+
+**QA gate** - when Skeptic sign-off is granted on a UI-visible change:
+Check `.claude/qa.md` for trigger patterns. If the diff matches, spawn `qa-engineer`. The qa-engineer reads `.claude/qa.md` for dev server config, trigger patterns, and accumulated knowledge. See the QA Gate section above for the full flow.


### PR DESCRIPTION
## Summary

- Adds `qa-engineer` as a new named agent in the team playbook
- Introduces a QA gate after Skeptic sign-off for UI-visible changes
- Opt-in per project via `.claude/qa.md` trigger patterns - no qa.md means no automatic QA

## Changes

| File | What |
|---|---|
| `rules/agent-methodology.md` | QA Gate section with trigger condition, flow, skip rules. `qa-engineer` added to named agents. QA gate trigger pointer in Protocol Details. |
| `references/agent-team.md` | `qa-engineer` row in team table. QA step added to Standard and Security-sensitive flows. Decision rules and spawn guidance. |
| `references/subagent-protocol.md` | `qa-review` phase label in vocabulary table. |
| `references/skeptic-protocol.md` | Step 10 (QA gate check) inserted before final report-back. |

## How it works

1. After Skeptic sign-off, conductor checks `.claude/qa.md` for `## QA triggers` patterns
2. If the diff matches any pattern, `qa-engineer` is spawned
3. QA engineer opens the dev server in a browser, verifies functionality, returns pass/fail
4. On FAIL: fix engineer spawned, then re-QA. On PASS: unit complete
5. If no `.claude/qa.md` or no matching patterns: QA is skipped (zero overhead)

## Test plan

- [ ] Verify QA gate triggers when a project has `.claude/qa.md` with matching patterns
- [ ] Verify QA is skipped when no qa.md exists
- [ ] Verify QA is skipped for backend-only changes (no pattern match)
- [ ] Verify phase breadcrumb `[phase: qa-review]` emits correctly