### PR TITLE
fix: claude install script error

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -497,6 +497,20 @@ echo ""
 python3 - <<'PYEOF'
 import json, os
 
+def tty_input(prompt: str) -> str:
+    """Read a line from the controlling terminal.
+
+    Required when this script is fed via stdin (heredoc): Python stdin is the
+    program text, so builtin input() raises EOFError.
+    """
+    try:
+        with open("/dev/tty", "r+") as tty:
+            tty.write(prompt)
+            tty.flush()
+            return tty.readline() or ""
+    except OSError:
+        return ""
+
 settings_path = os.path.expanduser("~/.claude/settings.json")
 
 if os.path.exists(settings_path):
@@ -559,7 +573,7 @@ else:
     print("  Recommended: bypassPermissions mode with deny rules for destructive commands.")
     print("  Agents work best with uninterrupted tool access. The deny list blocks dangerous")
     print("  operations (force push, rm -rf, hard reset) as a safety net.")
-    resp = input("  Configure recommended permission settings? [y/N] ").strip().lower()
+    resp = tty_input("  Configure recommended permission settings? [y/N] ").strip().lower()
     if resp == "y":
         existing_allow = set(perms.get("allow", []))
         existing_deny = set(perms.get("deny", []))


### PR DESCRIPTION
When `install.sh` is fed via stdin (heredoc/pipe), builtin input() reads the program text and raises EOFError before the user can answer. Route the prompt through /dev/tty so the heredoc install flow works.

```
➜  agentic-engineering git:(main) ./update.sh
Will run:
  git fetch origin
  git pull --ff-only origin main
  bash .claude/install.sh
  bash .kimi/install.sh

Adapters to refresh: Claude Kimi

Proceed? [Y/n]

>>> git fetch origin

>>> git pull --ff-only origin main
From github.com:Solara6/agentic-engineering
 * branch            main       -> FETCH_HEAD
Already up to date.

>>> bash /Users/solara6/agentic-engineering/.claude/install.sh

Activation mode...
  = agentic-engineering mode already set to 'opt-out' (keeping /Users/solara6/.claude/agentic-engineering.json)
Linking agents...
  = adr-drift-detector.md (already linked)
  = adr-generator.md (already linked)
  = architect.md (already linked)
  = debugger.md (already linked)
  = dependency-auditor.md (already linked)
  = engineer.md (already linked)
  = investigator.md (already linked)
  = orchestration-planner.md (already linked)
  = perf-analyst.md (already linked)
  = qa-engineer.md (already linked)
  = release-orchestrator.md (already linked)
  = security-auditor.md (already linked)
  = skeptic.md (already linked)
Linking commands...
  = cleanup-worktrees.md (already linked)
  = implement-ticket.md (already linked)
  = init-project.md (already linked)
  = memory-update.md (already linked)
  = prune-harness.md (already linked)
  = representation-audit.md (already linked)
  = skeptic.md (already linked)
  = update-agentic-engineering.md (already linked)
  = wrap.md (already linked)
Linking skill: agentic-engineering...
  = engineering (already linked)
Updating ~/.claude/settings.json...
  = UserPromptSubmit risk-classification hook already present
  = Stop hook already points to correct stop-context.js
  settings.json written.
Updating ~/.claude/CLAUDE.md...
  = Updated managed-by-agentic-engineering section in ~/.claude/CLAUDE.md
Running initial build...
Claude adapter build complete.
Cursor adapter build complete.
Installing pre-commit hook...
  = pre-commit hook already linked

Recommended tools (optional):

  = gh already installed
  = agent-browser already installed
  = lc already installed
  = jira already installed
  = rclone already installed

  = chrome-devtools MCP already configured

  = mcp-atlassian MCP already configured

  Note: Enable the 'context7' plugin in Claude Code settings — agents use it to look up current library and framework documentation instead of relying on training data.

  Recommended: bypassPermissions mode with deny rules for destructive commands.
  Agents work best with uninterrupted tool access. The deny list blocks dangerous
  operations (force push, rm -rf, hard reset) as a safety net.
  Configure recommended permission settings? [y/N] Traceback (most recent call last):
  File "<stdin>", line 65, in <module>
EOFError: EOF when reading a line

error: install script failed: /Users/solara6/agentic-engineering/.claude/install.sh (exit 1).
       partial progress: pulled 0 commit(s); failed on the first adapter (Claude).
       re-run ./update.sh after resolving the failure.
```