### PR TITLE
fix(evals): preserve Claude CLI auth in Tier 2 HOME redirect

### DIFF
--- a/evals/auto/tests/test_isolator_auth.py
+++ b/evals/auto/tests/test_isolator_auth.py
@@ -1,0 +1,83 @@
+"""Tier 2 isolator auth-preservation tests.
+
+Verifies:
+- Auth artifacts (keychain dir on macOS, .credentials.json on all platforms)
+  are exposed to the fake HOME via symlink.
+- home_config seeded files take precedence over symlinks.
+- __exit__ cleanup removes symlinks without following them: real auth
+  artifacts remain intact.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from evals.runner.isolator import Tier2HomeRedirect
+
+
+@pytest.fixture
+def fake_real_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fabricate a 'real' home dir with credentials + keychain so we can
+    safely test the symlink path without touching the developer's actual home.
+    """
+    real = tmp_path / "real-home"
+    (real / ".claude").mkdir(parents=True)
+    (real / ".claude" / ".credentials.json").write_text('{"token":"REAL"}')
+    (real / ".claude" / ".credentials.json.bak").write_text('{"token":"BAK"}')
+    if sys.platform == "darwin":
+        (real / "Library" / "Keychains").mkdir(parents=True)
+        (real / "Library" / "Keychains" / "login.keychain-db").write_bytes(b"REALKC")
+
+    # Patch expanduser so isolator resolves to our fake real home.
+    real_str = str(real)
+
+    def fake_expand(p: str) -> str:
+        if p == "~" or p.startswith("~/"):
+            return real_str + p[1:]
+        return p
+
+    monkeypatch.setattr(os.path, "expanduser", fake_expand)
+    return real
+
+
+def test_credentials_symlinked_into_fake_home(fake_real_home: Path) -> None:
+    iso = Tier2HomeRedirect(home_config={})
+    with iso as (_wt, fake_home):
+        cred = fake_home / ".claude" / ".credentials.json"
+        assert cred.is_symlink(), "expected credentials.json to be a symlink"
+        assert cred.read_text() == '{"token":"REAL"}'
+        bak = fake_home / ".claude" / ".credentials.json.bak"
+        assert bak.is_symlink()
+
+
+def test_home_config_takes_precedence_over_symlink(fake_real_home: Path) -> None:
+    iso = Tier2HomeRedirect(home_config={".credentials.json": '{"token":"SEEDED"}'})
+    with iso as (_wt, fake_home):
+        cred = fake_home / ".claude" / ".credentials.json"
+        assert not cred.is_symlink(), "home_config should win over symlink"
+        assert cred.read_text() == '{"token":"SEEDED"}'
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS keychain only")
+def test_keychain_dir_symlinked_on_macos(fake_real_home: Path) -> None:
+    iso = Tier2HomeRedirect(home_config={})
+    with iso as (_wt, fake_home):
+        kc = fake_home / "Library" / "Keychains"
+        assert kc.is_symlink()
+        assert (kc / "login.keychain-db").read_bytes() == b"REALKC"
+
+
+def test_cleanup_does_not_follow_symlinks(fake_real_home: Path) -> None:
+    iso = Tier2HomeRedirect(home_config={})
+    with iso as (_wt, _fake_home):
+        pass
+    # Real auth artifacts must still exist.
+    assert (fake_real_home / ".claude" / ".credentials.json").read_text() == '{"token":"REAL"}'
+    assert (fake_real_home / ".claude" / ".credentials.json.bak").read_text() == '{"token":"BAK"}'
+    if sys.platform == "darwin":
+        assert (fake_real_home / "Library" / "Keychains" / "login.keychain-db").read_bytes() == b"REALKC"

--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -4,27 +4,47 @@ Purpose: Provide component-tier isolation for eval runs. Tier 1 = git worktree
          redirect for commands that write to the fixture (/init-project, /wrap).
          Tier 3 is a stub for Docker-sandboxed code execution.
 
+         NOTE on Tier 2 auth preservation: Tier 2 redirects $HOME to a fresh
+         tmpdir to keep the developer's real ~/.claude/ uncontaminated. The
+         Claude CLI, however, resolves auth relative to $HOME (macOS keychain
+         at ~/Library/Keychains/login.keychain-db, Linux at
+         ~/.claude/.credentials.json). A bare HOME redirect produces "Not
+         logged in" failures. To resolve this without giving the eval write
+         access to the real ~/.claude/, Tier 2 creates narrow read-through
+         symlinks for ONLY the auth artifacts:
+           - macOS: fake_home/Library/Keychains -> real ~/Library/Keychains
+           - all:   fake_home/.claude/.credentials.json -> real one (if any)
+                    fake_home/.claude/.credentials.json.bak -> real one (if any)
+         home_config seeded files take precedence over the symlinks (existence
+         check before symlinking). __exit__ uses shutil.rmtree which removes
+         symlinks without following them, so the real keychain and real
+         credentials file are never touched on cleanup.
+
 Public API: make_isolator(tier: int, **kwargs) -> Isolator,
             Tier1Worktree (context manager yielding a worktree Path),
             Tier2HomeRedirect (context manager yielding (worktree, fake_home)),
             IsolatorBase abstract contract.
 
-Upstream deps: stdlib subprocess, pathlib, tempfile, shutil, uuid, os, json.
+Upstream deps: stdlib subprocess, pathlib, tempfile, shutil, uuid, os, sys, json.
 
 Downstream consumers: evals.runner.cli, evals.runner.invoker.
 
 Failure modes: raises RuntimeError if git worktree creation fails. Cleanup
                best-effort; stale dirs under evals/.worktrees/ and the
                per-run fake-HOME temp dir are logged with a warning if
-               removal fails.
+               removal fails. Auth-symlink creation failures are logged but
+               do not raise - the eval still runs, may fall back to
+               ANTHROPIC_API_KEY env if propagated.
 
 Performance: worktree add/remove is O(repo size); fake-HOME creation is
-             O(1) plus a handful of small file writes.
+             O(1) plus a handful of small file writes plus 1-3 symlinks.
 """
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import uuid
 from abc import ABC, abstractmethod
@@ -155,6 +175,42 @@ class Tier2HomeRedirect(IsolatorBase):
         claude_dir.mkdir(parents=True, exist_ok=True)
         for name, content in self.home_config.items():
             (claude_dir / name).write_text(content, encoding="utf-8")
+
+        # Auth preservation: narrow symlinks so Claude CLI can resolve auth
+        # via $HOME without exposing the rest of the developer's real config.
+        # See module docstring for rationale.
+        real_home = Path(os.path.expanduser("~"))
+
+        # macOS keychain: symlink the entire Keychains directory so sub-keychain
+        # files remain accessible to the Security framework.
+        if sys.platform == "darwin":
+            real_keychains = real_home / "Library" / "Keychains"
+            if real_keychains.exists():
+                fake_library = fake_home / "Library"
+                fake_library.mkdir(parents=True, exist_ok=True)
+                fake_keychains = fake_library / "Keychains"
+                if not fake_keychains.exists():
+                    try:
+                        fake_keychains.symlink_to(real_keychains, target_is_directory=True)
+                    except OSError as e:
+                        _log.warning(
+                            "Tier 2: failed to symlink keychain dir %s -> %s: %s",
+                            fake_keychains, real_keychains, e,
+                        )
+
+        # Linux/cross-platform credentials.json (and .bak). home_config wins.
+        for cred_name in (".credentials.json", ".credentials.json.bak"):
+            real_cred = real_home / ".claude" / cred_name
+            fake_cred = claude_dir / cred_name
+            if real_cred.exists() and not fake_cred.exists():
+                try:
+                    fake_cred.symlink_to(real_cred)
+                except OSError as e:
+                    _log.warning(
+                        "Tier 2: failed to symlink credential %s -> %s: %s",
+                        fake_cred, real_cred, e,
+                    )
+
         self._fake_home = fake_home
 
         # Worktree: copy the fixture's seeded repo into a fresh tmpdir. If no


### PR DESCRIPTION
## Summary

- Tier 2 isolator's HOME redirect was breaking Claude CLI auth on every command-mode eval. The CLI resolves credentials relative to \$HOME (macOS keychain at \`~/Library/Keychains\`, Linux at \`~/.claude/.credentials.json\`); with HOME pointed at a fresh tempdir the CLI returned "Not logged in" after ~500ms with 0 turns. Every Tier 2 component (implement-ticket, wrap, init-project, prune-harness, memory-update, cleanup-worktrees, update-agentic-engineering, representation-audit) has been silently scoring the 0.2 floor (forbidden_credit only - agent never executed) since the isolator landed.
- Fix adds narrow auth-preservation symlinks in \`Tier2HomeRedirect.__enter__\`: \`fake_home/Library/Keychains -> real ~/Library/Keychains\` (macOS), \`fake_home/.claude/.credentials.json -> real ~/.claude/.credentials.json\` (cross-platform). Existence check preserves \`home_config\` precedence. Symlinks are not followed by \`shutil.rmtree\` on cleanup, so the real keychain is untouched.
- 4 new tests in \`evals/auto/tests/test_isolator_auth.py\` cover symlink creation, home_config precedence, macOS keychain dir, and rmtree round-trip safety.

## Verification

- \`implement-ticket --fixture it-001 --n 1\` before: \`cli_status=cli_exit_1\`, \`turns_used=0\`, score 0.2. After: \`cli_status=ok\`, \`turns_used=18\`, \`latency_ms=72370\`, score 1.0.
- Tier 1 (debugger fixture db-001) unaffected: status=ok, score 0.78.
- Real keychain at \`~/Library/Keychains/login.keychain-db\` intact post-cleanup.
- Full test suite: 41 passed.

## Test plan

- [x] Unit tests for new symlink behavior pass
- [x] Existing test suite passes (41 passed)
- [x] Live smoke run on implement-ticket fixture confirms agent now executes
- [x] Tier 1 (agent-mode) eval unaffected
- [x] Real keychain survives a full Tier 2 isolator round-trip