### PR TITLE
feat(architect): tighten Open Questions definition (auto-harness +0.085)

### DIFF
--- a/content/agents/architect.md
+++ b/content/agents/architect.md
@@ -66,7 +66,7 @@ Use this exact structure. Do not rename or reorder sections.
 [What was decided against and why; known limitations; things to watch out for]
 
 ### Open questions
-[Genuine ambiguities that need human input before implementation — or "None" if the plan is complete. A non-empty Open Questions section is a protocol-level blocker: the conductor must resolve every item before spawning any downstream worker.]
+[Genuine ambiguities that need human input before implementation — or "None" if the plan is complete. Design-taste choices among reasonable approaches are NOT open questions: commit to one in Approach and record the alternative in Trade-offs. Questions answerable by reading the codebase are NOT open questions: do the reading. A non-empty Open Questions section is a protocol-level blocker: the conductor must resolve every item before spawning any downstream worker.]
 ```
 
 ## Rules


### PR DESCRIPTION
## Summary

Auto-harness editor agent identified that the architect was leaving Open Questions populated with items it should resolve itself. The proposed edit excludes two non-questions from the Open Questions section:

- Design-taste choices among reasonable approaches (commit to one + record alternative in Trade-offs)
- Questions answerable by reading the codebase (do the reading)

The edit is consistent with existing methodology: Exploration Process step 5 already requires committing to an approach; the Worker autonomy contract already requires resolving design-taste ambiguity.

## Empirical signal

- Component: architect, 5 fixtures, n=3 each
- Baseline: 0.8712, pooled_stdev 0.0515
- After edit: 0.9563 (+0.085, exceeded keep_delta_threshold)
- 1 keep, 2 subsequent revert iterations confirmed the edit was a true improvement (didn't regress)
- Cost: ~$1.89 across 4 iterations

## Skeptic review

APPROVED_WITH_MINOR (2 minors, none blocking):
1. The 'do the reading' instruction is unqualified - if codebase access is blocked the architect should still surface as an open question. Mitigated by surrounding rules.
2. agent-methodology.md's Open Questions resolution path (b) names 'spawn an Investigator' as a valid resolver - new architect.md guidance implies architect should preempt those. Direction is correct, documentation gap is minor.

OVERFITTING-RULE compliant: both sentences are independently defensible as correct architect guidance, motivated by methodology principles not by fixture-specific scoring patterns.