### PR TITLE
chore: demote module-manifest enforcement to Suggestion

### DIFF
--- a/content/agents/architect.md
+++ b/content/agents/architect.md
@@ -54,7 +54,7 @@ Use this exact structure. Do not rename or reorder sections.
 2. [...]
 (ordered by dependency — each step should be atomic enough for a Worker to execute)
 
-**Note any new modules requiring a manifest.** For each new file that will export a public symbol, exceed ~50 LOC, or implement a side-effecting operation, include a step or inline note: `[filename] — new non-trivial module, requires manifest header (see content/rules/module-manifest.md).` This signals the Worker up front so the manifest is not an afterthought caught by Skeptic.
+**Note any new modules where a manifest is recommended.** For each new file that will export a public symbol, exceed ~50 LOC, or implement a side-effecting operation, consider including a step or inline note: `[filename] — new non-trivial module, manifest header recommended (see content/rules/module-manifest.md).` Manifests are encouraged practice for comprehension hygiene; Skeptic surfaces missing manifests as Suggestions rather than blocking findings.
 
 ### Trade-offs and constraints
 **Alternatives considered (before committing to the chosen approach above):**

--- a/content/agents/architect.md
+++ b/content/agents/architect.md
@@ -54,7 +54,7 @@ Use this exact structure. Do not rename or reorder sections.
 2. [...]
 (ordered by dependency — each step should be atomic enough for a Worker to execute)
 
-**Note any new modules where a manifest is recommended.** For each new file that will export a public symbol, exceed ~50 LOC, or implement a side-effecting operation, consider including a step or inline note: `[filename] — new non-trivial module, manifest header recommended (see content/rules/module-manifest.md).` Manifests are encouraged practice for comprehension hygiene; Skeptic surfaces missing manifests as Suggestions rather than blocking findings.
+**Note any new modules where a manifest is recommended.** For each new file that will export a public symbol, exceed ~50 LOC, or implement a side-effecting operation, consider including a step or inline note: `[filename] — new non-trivial module, manifest header recommended (see content/rules/module-manifest.md).` Manifests are encouraged practice for comprehension hygiene; Skeptic surfaces missing manifests as Minor findings rather than blocking findings.
 
 ### Trade-offs and constraints
 **Alternatives considered (before committing to the chosen approach above):**

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -33,7 +33,7 @@ Your spawn prompt will contain three things:
 4. Apply the brief actively - for each concern it raises, look specifically for that failure mode in the code. Do not skim.
 5. Search broadly for other Critical or Major issues beyond what the brief explicitly names.
 6. **Brief coverage check** - re-read the adversarial brief one more time, concern by concern. For each specific failure mode the brief names, confirm you have either raised a finding for it or can explicitly state you checked and found no issue. Do not let a named concern go unaddressed.
-7. **Module manifest check** - for any new or modified non-trivial module in the diff (exports a public symbol consumed elsewhere, over ~50 LOC, or implements a side-effecting operation), verify a manifest header is present and reflects the current file. A missing or stale manifest is a **Suggestion** (informational), not a blocking finding. Note it in the findings list so the author can address it, but do not withhold sign-off on this basis alone.
+7. **Module manifest check** - for any new or modified non-trivial module in the diff (exports a public symbol consumed elsewhere, over ~50 LOC, or implements a side-effecting operation), verify a manifest header is present and reflects the current file. A missing or stale manifest is a **Minor finding** (does not block sign-off). Note it in the findings list so the author can address it, but do not withhold sign-off on this basis alone.
 8. **Regression test check** - if this is a fix round (the spawn prompt identifies Critical or Major findings that were addressed), verify each fixed finding has a corresponding regression test, or a documented reason why one is not possible. A missing test without explanation is a **Major** finding: `Missing regression test for [finding title] — a test that would have caught this failure mode is required before sign-off.`
 9. Check the resolved issues preflight - do not re-raise resolved findings unless the resolution is genuinely insufficient.
 10. Write your findings using the sign-off format below.
@@ -67,7 +67,7 @@ An over-blocking Skeptic produces unnecessary rework and erodes trust in the pro
 - Style preferences, non-critical naming choices, and minor documentation gaps belong in Minor.
 - The goal is to catch genuine problems, not to find something to flag. "Looks fine but could be improved" is a Minor, not a Major.
 - Do not block on hypothetical future scenarios that are not present in the actual requirements.
-- **Module manifests:** Missing or stale module manifests are Suggestions (informational), not Major findings. They do not block sign-off. List them so the author can address them as comprehension hygiene, but treat them as recommendations rather than blockers.
+- **Module manifests:** Missing or stale module manifests are **Minor findings** (does not block sign-off), not Major findings. List them so the author can address them as comprehension hygiene, but treat them as recommendations rather than blockers.
 
 ## Rules
 

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -33,7 +33,7 @@ Your spawn prompt will contain three things:
 4. Apply the brief actively - for each concern it raises, look specifically for that failure mode in the code. Do not skim.
 5. Search broadly for other Critical or Major issues beyond what the brief explicitly names.
 6. **Brief coverage check** - re-read the adversarial brief one more time, concern by concern. For each specific failure mode the brief names, confirm you have either raised a finding for it or can explicitly state you checked and found no issue. Do not let a named concern go unaddressed.
-7. **Module manifest check** - for any new or modified non-trivial module in the diff (exports a public symbol consumed elsewhere, over ~50 LOC, or implements a side-effecting operation), verify a manifest header is present and reflects the current file. A missing or stale manifest is a **Major** finding.
+7. **Module manifest check** - for any new or modified non-trivial module in the diff (exports a public symbol consumed elsewhere, over ~50 LOC, or implements a side-effecting operation), verify a manifest header is present and reflects the current file. A missing or stale manifest is a **Suggestion** (informational), not a blocking finding. Note it in the findings list so the author can address it, but do not withhold sign-off on this basis alone.
 8. **Regression test check** - if this is a fix round (the spawn prompt identifies Critical or Major findings that were addressed), verify each fixed finding has a corresponding regression test, or a documented reason why one is not possible. A missing test without explanation is a **Major** finding: `Missing regression test for [finding title] — a test that would have caught this failure mode is required before sign-off.`
 9. Check the resolved issues preflight - do not re-raise resolved findings unless the resolution is genuinely insufficient.
 10. Write your findings using the sign-off format below.
@@ -67,7 +67,7 @@ An over-blocking Skeptic produces unnecessary rework and erodes trust in the pro
 - Style preferences, non-critical naming choices, and minor documentation gaps belong in Minor.
 - The goal is to catch genuine problems, not to find something to flag. "Looks fine but could be improved" is a Minor, not a Major.
 - Do not block on hypothetical future scenarios that are not present in the actual requirements.
-- **Exception - module manifests:** Missing or stale module manifests are Major, not Minor, despite appearing to be a documentation gap. Manifests are a spec-mandated structural requirement defined in `module-manifest.md`, not a style preference, and their absence blocks sign-off per that rule. The "documentation gaps belong in Minor" default does not apply.
+- **Module manifests:** Missing or stale module manifests are Suggestions (informational), not Major findings. They do not block sign-off. List them so the author can address them as comprehension hygiene, but treat them as recommendations rather than blockers.
 
 ## Rules
 

--- a/content/rules/code-standards.md
+++ b/content/rules/code-standards.md
@@ -41,7 +41,7 @@ Key tools and their uses:
 
 ## Module Manifests
 
-**Non-trivial modules should carry a manifest header.** Any source file that exports a public symbol consumed by another module, is over ~50 lines of non-trivial logic, or implements a side-effecting operation (network, disk, database, external service) is encouraged to include a manifest comment or docstring at the top of the file. See `content/rules/module-manifest.md` for required fields, examples, and exemptions. Skeptic flags missing or stale manifests as a Suggestion (informational), not a blocking finding.
+**Non-trivial modules should carry a manifest header.** Any source file that exports a public symbol consumed by another module, is over ~50 lines of non-trivial logic, or implements a side-effecting operation (network, disk, database, external service) is encouraged to include a manifest comment or docstring at the top of the file. See `content/rules/module-manifest.md` for required fields, examples, and exemptions. Skeptic flags missing or stale manifests as a **Minor finding** (does not block sign-off).
 
 ## Code Quality Gates
 

--- a/content/rules/code-standards.md
+++ b/content/rules/code-standards.md
@@ -41,7 +41,7 @@ Key tools and their uses:
 
 ## Module Manifests
 
-**Non-trivial modules must carry a manifest header.** Any source file that exports a public symbol consumed by another module, is over ~50 lines of non-trivial logic, or implements a side-effecting operation (network, disk, database, external service) requires a manifest comment or docstring at the top of the file. See `content/rules/module-manifest.md` for required fields, examples, and exemptions. Skeptic flags missing or stale manifests as a Major finding.
+**Non-trivial modules should carry a manifest header.** Any source file that exports a public symbol consumed by another module, is over ~50 lines of non-trivial logic, or implements a side-effecting operation (network, disk, database, external service) is encouraged to include a manifest comment or docstring at the top of the file. See `content/rules/module-manifest.md` for required fields, examples, and exemptions. Skeptic flags missing or stale manifests as a Suggestion (informational), not a blocking finding.
 
 ## Code Quality Gates
 

--- a/content/rules/module-manifest.md
+++ b/content/rules/module-manifest.md
@@ -87,6 +87,6 @@ Comprehension should live in the code. An Architect plan describes what was deci
 
 ## Enforcement
 
-Skeptic flags missing or stale manifests on non-trivial modules as a **Major** finding. This is not a Critical finding — it is not a correctness bug — but it blocks sign-off. A non-trivial module without a manifest (or with a manifest that no longer matches the file) ships without the comprehension layer that makes future work safe.
+Skeptic flags missing or stale manifests on non-trivial modules as a **Suggestion** (informational), not a Major finding. Suggestions do not block sign-off. Manifests remain a recommended practice for comprehension hygiene.
 
 See `content/references/skeptic-protocol.md` for findings classification definitions.

--- a/content/rules/module-manifest.md
+++ b/content/rules/module-manifest.md
@@ -87,6 +87,6 @@ Comprehension should live in the code. An Architect plan describes what was deci
 
 ## Enforcement
 
-Skeptic flags missing or stale manifests on non-trivial modules as a **Suggestion** (informational), not a Major finding. Suggestions do not block sign-off. Manifests remain a recommended practice for comprehension hygiene.
+Skeptic flags missing or stale manifests on non-trivial modules as a **Minor finding** (does not block sign-off). Manifests remain recommended practice for comprehension hygiene; missing manifests are flagged for awareness, not as a blocker.
 
 See `content/references/skeptic-protocol.md` for findings classification definitions.


### PR DESCRIPTION
## Summary
- Demotes Skeptic's module-manifest check from Major (blocking) to Suggestion (informational) across rules and agent specs.
- Manifests remain recommended practice for comprehension hygiene; absence no longer blocks sign-off.
- Part of AE editorial sweep (Q6).

## Files
- content/rules/module-manifest.md - rewrote Enforcement section.
- content/rules/code-standards.md - softened "must" -> "should"; Major -> Suggestion.
- content/agents/skeptic.md - step 7 manifest check + Calibration exception updated to Suggestion.
- content/agents/architect.md - softened manifest planning note to "recommended".

## Out of scope
- content/agents/engineer.md is handled in a separate unit.

## Test plan
- [ ] Skeptic review confirms language consistent across the four files.