### PR TITLE
feat!: remove tight-fix-path Skeptic skip

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -365,8 +365,6 @@ For full worktree cleanup rules (isolation worktrees, feature worktrees, stale b
 
 ## Phase 6: Skeptic review
 
-**Phase 6 guard (tight-fix path).** If Phase 5 spawned the engineer under the Elevated (tight-fix path) sub-path (see `agent-methodology.md`) AND the Worker returned Status: DONE with the verbatim pre-commit test output in its summary, skip the rest of Phase 6. The tight-fix path's pre-commit test verification replaces the post-impl Skeptic for this case. If the Worker returned Status: BLOCKED or DONE_WITH_CONCERNS, fall through to the standard Phase 6 Skeptic spawn on the uncommitted diff (see `skeptic-protocol.md` line 376 for the amended "no irreversible changes" rule that permits this sub-path).
-
 **Phase 6 guard (fan-out integration Skeptic).** When fan-out was active in Phase 5 and `SKEPTIC_STRATEGY: integration`, the integration Skeptic that reviewed the combined diff in Phase 5 IS the Phase 6 gate. Do not spawn a second Skeptic - Phase 6 is complete when the integration Skeptic signs off. When `SKEPTIC_STRATEGY: per-unit`, Phase 6 fires as normal - a Skeptic reviews the combined diff from `BASE_BRANCH` after all merges (`git -C $REPO diff origin/$BASE_BRANCH..HEAD`). This is a full-picture review that catches cross-unit interactions the per-unit Skeptics could not see (emergent behaviors, combined diff scope). Phase 6 is NOT skipped for the `per-unit` strategy.
 
 Spawn a `skeptic` agent with:
@@ -598,8 +596,6 @@ This phase runs after Phase 6 and 6b loops have already exited cleanly. A qualit
 7. If it still fails: set `status=stalled`. Escalate to the human. Include the quality gate output from both the first run and the post-fix re-run. Do not spawn another Engineer pass.
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase.
-
-**Tight-fix path interaction:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed successfully, then Phase 7 fails - this triggers the one-Engineer-pass rule above. It does NOT re-enter the Phase 6 Skeptic loop. The Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
 
 ---
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -115,7 +115,6 @@ Then wait. Do NOT keep spawning Workers against an under-specified plan - that c
 - "The Skeptic will catch any mistakes" - the Skeptic reviews Worker output; it does not excuse skipping risk classification or spawning a Worker
 - "This change is too minor to bother with a Worker" - delegate on risk signals, not on size; the Worker overhead is small, the cost of an unreviewed error is not
 - "I can figure out the task structure / parallelization myself" or "this is obviously a single-unit task" - conductor does not self-assess task structure, unit count, or parallelization; delegate that reasoning to the orchestration-planner; the only valid skip is when a preceding agent has already returned a single atomic unit
-- "This qualifies as the tight-fix path, so I can skip Skeptic" - Valid only when every checklist item is explicitly satisfied AND declared. An incomplete declaration, a stale debugger brief, Low debugger confidence, or any disqualifier reverts to standard Elevated. The default when uncertain is standard Elevated.
 
 **Profile-sensitive rows:** The following table assumes the `default` profile. In `strict`, several Low overrides are removed (see Risk profiles). In `relaxed`, additional Elevated signals are downgraded to Low.
 
@@ -238,41 +237,7 @@ All signals not mentioned above keep their default level regardless of profile.
 
 **Conductor rule for Trivial:** If no subagents are currently running, the conductor edits directly (no Worker, no Skeptic, no brief file). If any subagent is currently running, spawn a single `engineer` Worker in foreground (no Skeptic, no brief file) - the conductor must stay available to manage in-flight work. A commit message is still required. If a Worker discovers mid-task that the change is not actually Trivial (e.g., the "one-file color tweak" lives in a shared token file), it must stop, report, and the conductor re-classifies as Elevated.
 
-**Elevated (tight-fix path) - Skeptic skip.** A narrow sub-path within Elevated that lets the conductor spawn a single engineer Worker with pre-commit test verification and skip the post-implementation Skeptic on tight debugger-brief-backed bug fixes. Motivated by the finding that verifiers hurt on tight, well-specified tasks. The path applies only when ALL 6 checklist items hold simultaneously; any single disqualifier reverts to standard Elevated.
-
-**Checklist (every item must be explicitly declared):**
-1. Task is a bug fix, not a new feature or refactor.
-2. A debugger agent produced a fix brief for this bug in the current session. Stale briefs from prior sessions disqualify.
-3. Debugger confidence is High or Medium. Low confidence disqualifies.
-4. Fix touches at most one file, or one file plus its colocated test file (colocated = same directory, test file for the same symbol).
-5. At least one existing test already exercises the fix path. Direct unit test or integration test both acceptable. The test must exist before the fix - new test file creation disqualifies; test additions to the pre-existing colocated test file are allowed.
-6. No security, auth, crypto, payments, secrets, or data-loss surface involved.
-
-**Declaration format:**
-
-```
-Risk: Elevated (tight-fix path)
-Debugger brief: [session reference]
-Checklist:
-  [x] Bug fix, not a new feature
-  [x] Debugger brief from current session
-  [x] Debugger confidence: High | Medium
-  [x] Single file (+ colocated test file if applicable)
-  [x] Existing test exercises the fix path
-  [x] No security/auth/crypto/payments/secrets/data-loss surface
-Skipping post-implementation Skeptic. Engineer Worker performs pre-commit test verification.
-If pre-commit tests fail, standard Elevated loop applies.
-```
-
-**Pre-commit test verification protocol.** The engineer Worker on this path runs the sequence: BASELINE (run affected tests before touching anything; ANY failure is an absolute stop, no "unrelated failure" escape - return BLOCKED with output) -> APPLY (implement the fix per debugger brief, no scope expansion) -> VERIFY (run affected tests + project quality gate) -> COMMIT (only if VERIFY passes) -> RETURN (include verbatim test output in summary).
-
-**Scope-expansion stop.** If the Worker discovers the fix requires more than 50 changed lines in the production file (excluding the colocated test file), OR requires touching a second production file, OR exposes cross-component interactions not flagged in the debugger brief, the Worker stops immediately with Status: BLOCKED. The 50-line threshold is measured against the production file's diff, not including test file changes. The Worker counts by estimating scope from the debugger brief BEFORE starting implementation; if the brief's scope is unclear, the Worker stops and the conductor reclassifies as standard Elevated.
-
-**Failure path.** If VERIFY fails, the Worker does NOT commit. Worker returns Status: DONE_WITH_CONCERNS with the failed test output and the uncommitted diff. Conductor spawns a standard Skeptic with the uncommitted diff. Skeptic reviews, conductor routes any further fix through a normal Elevated loop.
-
-**Rollback for latent bugs.** If tests pass but a defect is later discovered (the tests did not cover the actual failure scenario), standard `git revert [commit-sha]` applies. No special rollback.
-
-**Fallback is automatic.** Any BLOCKED status, failed baseline, failed verify, or disqualifier reverts the task to standard Elevated with a Skeptic. This is not an escape hatch - it is the safe default that fires on any deviation.
+**Post-debugger Low classification.** Post-debugger-brief bug fixes that are single-file and exercised by an existing test may be classified Low if they meet all Trivial signals; otherwise standard Elevated applies.
 
 **Low signals:** clearly reversible reads (reads with no writes); exploration / research / draft work - only when the output is understanding, not a decision-driving artifact; **diagnostic-only changes** (pure logging additions - console.log, .catch() for error visibility, test interceptors) across any number of files, where every change has zero behavioral effect — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **documentation-only file creation** (new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the "new file creation" Elevated signal for this case only) — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **targeted wording fixes to already-reviewed content** (phrasing adjustments where the substance was already Skeptic-approved in the current or a recent session - e.g., syncing parallel descriptions, adding a clarifying phrase to an existing enumeration; does not apply to new decisions, new recommendations, or new content not previously reviewed; does not override the "modifies protocol or infrastructure files" Elevated signal; overrides the single-file edit and new file Elevated signals for this case only) — **in `strict` profile, this override is removed; treat as Elevated**; **file renaming** (renaming or moving files via `git mv` or equivalent, with no content changes to any file - neither the renamed file nor any other file; overrides the "new file creation", "multi-file changes", and "Bash with side effects" Elevated signals for this case only; does not override the "modifies protocol or infrastructure files" Elevated signal - renaming protocol or infrastructure files remains Elevated regardless; if any other files reference the renamed path - imports, cross-references, config entries - the operation is Elevated because those reference updates constitute content changes in other files; if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the operation is Elevated because the rename changes behavior without changing file contents) — **in `strict` profile, this override is removed; treat as Elevated**; **UI-only copy changes** (rewording display strings, labels, tooltips, or placeholder text where the change has no logic, structural, or behavioral effect - e.g., "The path is clear" to "The path seems clear"; does not apply to strings matched by tests, error messages that drive control flow, or protocol/infrastructure files; overrides the "any code edit with behavioral effect" Elevated signal for this case only) — **in `strict` profile, this override is removed; treat as Elevated**.
 

--- a/.codex/agents/architect.toml
+++ b/.codex/agents/architect.toml
@@ -66,7 +66,7 @@ Use this exact structure. Do not rename or reorder sections.
 [What was decided against and why; known limitations; things to watch out for]
 
 ### Open questions
-[Genuine ambiguities that need human input before implementation — or "None" if the plan is complete. A non-empty Open Questions section is a protocol-level blocker: the conductor must resolve every item before spawning any downstream worker.]
+[Genuine ambiguities that need human input before implementation — or "None" if the plan is complete. Design-taste choices among reasonable approaches are NOT open questions: commit to one in Approach and record the alternative in Trade-offs. Questions answerable by reading the codebase are NOT open questions: do the reading. A non-empty Open Questions section is a protocol-level blocker: the conductor must resolve every item before spawning any downstream worker.]
 ```
 
 ## Rules

--- a/.codex/agents/debugger.toml
+++ b/.codex/agents/debugger.toml
@@ -78,8 +78,6 @@ Use this exact structure:
 
 ## Rules
 
-**Tight-fix path consumption.** A fix brief produced in the current session may be consumed directly by an engineer Worker under the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`, without a separate Architect plan. The existing fix brief format (file, symbol, rationale, confidence) is sufficient for this use. No new fields are required. If your diagnosis confidence is Low, the tight-fix path does not apply - the conductor will route through standard Elevated with a Skeptic regardless.
-
 - Diagnose only. Do not implement the fix. Do not write code to disk.
 - Do not speculate without evidence. If you have not found the root cause, say "Confidence: Low" and describe what you found and what is still unclear.
 - If the error is ambiguous or codebase context is insufficient, set Confidence to Medium (not High), state why under Confidence, and list exactly what additional information would let you close the diagnosis.

--- a/.codex/agents/engineer.toml
+++ b/.codex/agents/engineer.toml
@@ -33,19 +33,7 @@ When spawned via `/implement-ticket` Phase 5 with a `task_id` in the execution c
 
 **HUD file writes (Phase 2 fan-out only).** When spawned as a parallel fan-out Worker with a `worker_id` field in the execution contract, the engineer writes phase transition updates to `.agentic/hud/<worker-id>.json` before each major action (before spawning sub-agents, at loop phase transitions, at completion). The HUD file write accompanies `[loop: ...]` breadcrumb emissions - both happen at the same event. Engineers spawned without a `worker_id` (single-unit, non-fan-out contexts) do not write HUD files. The `worker_id` is provided in the spawn prompt alongside `task_id`.
 
-**Tight-fix path execution contract.** When the conductor declares the Elevated (tight-fix path) sub-path (see `agent-methodology.md`), your `completion_conditions` will specify a pre-commit test verification sequence. You must execute this sequence exactly:
-
-1. BASELINE: Before modifying any file, run the affected test(s) (and full project quality gate if defined). Capture the output verbatim. If ANY test fails in baseline, stop immediately. Return Status: BLOCKED with the baseline failure output. Do NOT attempt to classify the failure as "unrelated" and proceed - any baseline failure is an absolute stop.
-
-2. APPLY: Implement the fix per the debugger brief. No scope expansion. If you discover the fix requires more than 50 changed lines in the production file (excluding the colocated test file), touching a second production file, or reveals cross-component interactions not flagged in the brief, stop immediately. Return Status: BLOCKED with a description of what you discovered.
-
-3. VERIFY: Run the affected test(s) again, plus the full project quality gate if defined. If any test or gate fails, do NOT commit. Return Status: DONE_WITH_CONCERNS with the failed output and the uncommitted diff.
-
-4. COMMIT: Only if VERIFY passes. Stage only the files touched (do not use `git add -A` or `git add .`). Commit with a message referencing the debugger brief.
-
-5. RETURN: Status: DONE, with verbatim BASELINE and VERIFY test output included in the summary so the conductor can inspect the raw output.
-
-The tight-fix path is the only circumstance under which an engineer Worker commits without prior Skeptic sign-off, and it is conditional on the pre-commit test verification sequence passing. The amendment to the "no irreversible changes before sign-off" rule is in `skeptic-protocol.md`.
+(Tight-fix path removed; see post-debugger Low classification rule in `content/rules/agent-methodology.md`.)
 
 ## Implementation process
 

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -363,8 +363,6 @@ For full worktree cleanup rules (isolation worktrees, feature worktrees, stale b
 
 ## Phase 6: Skeptic review
 
-**Phase 6 guard (tight-fix path).** If Phase 5 spawned the engineer under the Elevated (tight-fix path) sub-path (see `agent-methodology.md`) AND the Worker returned Status: DONE with the verbatim pre-commit test output in its summary, skip the rest of Phase 6. The tight-fix path's pre-commit test verification replaces the post-impl Skeptic for this case. If the Worker returned Status: BLOCKED or DONE_WITH_CONCERNS, fall through to the standard Phase 6 Skeptic spawn on the uncommitted diff (see `skeptic-protocol.md` line 376 for the amended "no irreversible changes" rule that permits this sub-path).
-
 **Phase 6 guard (fan-out integration Skeptic).** When fan-out was active in Phase 5 and `SKEPTIC_STRATEGY: integration`, the integration Skeptic that reviewed the combined diff in Phase 5 IS the Phase 6 gate. Do not spawn a second Skeptic - Phase 6 is complete when the integration Skeptic signs off. When `SKEPTIC_STRATEGY: per-unit`, Phase 6 fires as normal - a Skeptic reviews the combined diff from `BASE_BRANCH` after all merges (`git -C $REPO diff origin/$BASE_BRANCH..HEAD`). This is a full-picture review that catches cross-unit interactions the per-unit Skeptics could not see (emergent behaviors, combined diff scope). Phase 6 is NOT skipped for the `per-unit` strategy.
 
 Spawn a `skeptic` agent with:
@@ -596,8 +594,6 @@ This phase runs after Phase 6 and 6b loops have already exited cleanly. A qualit
 7. If it still fails: set `status=stalled`. Escalate to the human. Include the quality gate output from both the first run and the post-fix re-run. Do not spawn another Engineer pass.
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase.
-
-**Tight-fix path interaction:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed successfully, then Phase 7 fails - this triggers the one-Engineer-pass rule above. It does NOT re-enter the Phase 6 Skeptic loop. The Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
 
 ---
 

--- a/.codex/references/skeptic-protocol.md
+++ b/.codex/references/skeptic-protocol.md
@@ -52,7 +52,6 @@ None of the above:
 | "The Skeptic will catch any mistakes." | The Skeptic reviews Worker output. It does not excuse skipping risk classification or spawning a Worker. |
 | "We're moving fast, we can skip review this time." | The protocol exists precisely for times when moving fast creates pressure to skip it. Speed is not a Low signal. |
 | "This change is too minor to bother with a Worker." | Delegate on risk signals, not on size. The Worker overhead is small; the cost of an unreviewed error is not. |
-| "I ran the tests myself, I don't need a Skeptic" | Valid only when the tight-fix path declaration was made with all 6 checklist items ticked AND the Worker's pre-commit test verification sequence passed. Outside that declared sub-path, tests passing is not a substitute for Skeptic review. The tight-fix path is a narrow declared opt-in, not a general permission to self-verify. |
 
 ### Approach by risk level
 
@@ -378,7 +377,7 @@ The primary agent treats a Skeptic response as a valid sign-off only when it con
 
 **Format re-invocation limit:** Format re-invocations are limited to 3 attempts. If the Skeptic's response remains format-noncompliant after 3 re-invocations, the primary agent escalates to the human with the last Skeptic response verbatim.
 
-**Irreversible changes:** Workers must not apply irreversible changes before the primary agent has confirmed Skeptic sign-off. The sole exception is the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`: when a tight-fix path declaration is made with all 6 checklist items ticked AND the engineer Worker's pre-commit test verification (BASELINE -> APPLY -> VERIFY) passes, the Worker may commit without prior Skeptic sign-off. Any failure in the verification sequence reverts to the standard rule - the Worker does NOT commit, returns the uncommitted diff, and the conductor spawns a Skeptic on the uncommitted diff. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
+**Irreversible changes:** Workers must not apply irreversible changes before Skeptic sign-off. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
 
 ---
 

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -363,8 +363,6 @@ For full worktree cleanup rules (isolation worktrees, feature worktrees, stale b
 
 ## Phase 6: Skeptic review
 
-**Phase 6 guard (tight-fix path).** If Phase 5 spawned the engineer under the Elevated (tight-fix path) sub-path (see `agent-methodology.md`) AND the Worker returned Status: DONE with the verbatim pre-commit test output in its summary, skip the rest of Phase 6. The tight-fix path's pre-commit test verification replaces the post-impl Skeptic for this case. If the Worker returned Status: BLOCKED or DONE_WITH_CONCERNS, fall through to the standard Phase 6 Skeptic spawn on the uncommitted diff (see `skeptic-protocol.md` line 376 for the amended "no irreversible changes" rule that permits this sub-path).
-
 **Phase 6 guard (fan-out integration Skeptic).** When fan-out was active in Phase 5 and `SKEPTIC_STRATEGY: integration`, the integration Skeptic that reviewed the combined diff in Phase 5 IS the Phase 6 gate. Do not spawn a second Skeptic - Phase 6 is complete when the integration Skeptic signs off. When `SKEPTIC_STRATEGY: per-unit`, Phase 6 fires as normal - a Skeptic reviews the combined diff from `BASE_BRANCH` after all merges (`git -C $REPO diff origin/$BASE_BRANCH..HEAD`). This is a full-picture review that catches cross-unit interactions the per-unit Skeptics could not see (emergent behaviors, combined diff scope). Phase 6 is NOT skipped for the `per-unit` strategy.
 
 Spawn a `skeptic` agent with:
@@ -596,8 +594,6 @@ This phase runs after Phase 6 and 6b loops have already exited cleanly. A qualit
 7. If it still fails: set `status=stalled`. Escalate to the human. Include the quality gate output from both the first run and the post-fix re-run. Do not spawn another Engineer pass.
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase.
-
-**Tight-fix path interaction:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed successfully, then Phase 7 fails - this triggers the one-Engineer-pass rule above. It does NOT re-enter the Phase 6 Skeptic loop. The Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
 
 ---
 

--- a/.cursor/rules/agent-methodology.mdc
+++ b/.cursor/rules/agent-methodology.mdc
@@ -110,7 +110,6 @@ Then wait. Do NOT keep spawning Workers against an under-specified plan - that c
 - "The Skeptic will catch any mistakes" - the Skeptic reviews Worker output; it does not excuse skipping risk classification or spawning a Worker
 - "This change is too minor to bother with a Worker" - delegate on risk signals, not on size; the Worker overhead is small, the cost of an unreviewed error is not
 - "I can figure out the task structure / parallelization myself" or "this is obviously a single-unit task" - conductor does not self-assess task structure, unit count, or parallelization; delegate that reasoning to the orchestration-planner; the only valid skip is when a preceding agent has already returned a single atomic unit
-- "This qualifies as the tight-fix path, so I can skip Skeptic" - Valid only when every checklist item is explicitly satisfied AND declared. An incomplete declaration, a stale debugger brief, Low debugger confidence, or any disqualifier reverts to standard Elevated. The default when uncertain is standard Elevated.
 
 **Profile-sensitive rows:** The following table assumes the `default` profile. In `strict`, several Low overrides are removed (see Risk profiles). In `relaxed`, additional Elevated signals are downgraded to Low.
 
@@ -233,41 +232,7 @@ All signals not mentioned above keep their default level regardless of profile.
 
 **Conductor rule for Trivial:** If no subagents are currently running, the conductor edits directly (no Worker, no Skeptic, no brief file). If any subagent is currently running, spawn a single `engineer` Worker in foreground (no Skeptic, no brief file) - the conductor must stay available to manage in-flight work. A commit message is still required. If a Worker discovers mid-task that the change is not actually Trivial (e.g., the "one-file color tweak" lives in a shared token file), it must stop, report, and the conductor re-classifies as Elevated.
 
-**Elevated (tight-fix path) - Skeptic skip.** A narrow sub-path within Elevated that lets the conductor spawn a single engineer Worker with pre-commit test verification and skip the post-implementation Skeptic on tight debugger-brief-backed bug fixes. Motivated by the finding that verifiers hurt on tight, well-specified tasks. The path applies only when ALL 6 checklist items hold simultaneously; any single disqualifier reverts to standard Elevated.
-
-**Checklist (every item must be explicitly declared):**
-1. Task is a bug fix, not a new feature or refactor.
-2. A debugger agent produced a fix brief for this bug in the current session. Stale briefs from prior sessions disqualify.
-3. Debugger confidence is High or Medium. Low confidence disqualifies.
-4. Fix touches at most one file, or one file plus its colocated test file (colocated = same directory, test file for the same symbol).
-5. At least one existing test already exercises the fix path. Direct unit test or integration test both acceptable. The test must exist before the fix - new test file creation disqualifies; test additions to the pre-existing colocated test file are allowed.
-6. No security, auth, crypto, payments, secrets, or data-loss surface involved.
-
-**Declaration format:**
-
-```
-Risk: Elevated (tight-fix path)
-Debugger brief: [session reference]
-Checklist:
-  [x] Bug fix, not a new feature
-  [x] Debugger brief from current session
-  [x] Debugger confidence: High | Medium
-  [x] Single file (+ colocated test file if applicable)
-  [x] Existing test exercises the fix path
-  [x] No security/auth/crypto/payments/secrets/data-loss surface
-Skipping post-implementation Skeptic. Engineer Worker performs pre-commit test verification.
-If pre-commit tests fail, standard Elevated loop applies.
-```
-
-**Pre-commit test verification protocol.** The engineer Worker on this path runs the sequence: BASELINE (run affected tests before touching anything; ANY failure is an absolute stop, no "unrelated failure" escape - return BLOCKED with output) -> APPLY (implement the fix per debugger brief, no scope expansion) -> VERIFY (run affected tests + project quality gate) -> COMMIT (only if VERIFY passes) -> RETURN (include verbatim test output in summary).
-
-**Scope-expansion stop.** If the Worker discovers the fix requires more than 50 changed lines in the production file (excluding the colocated test file), OR requires touching a second production file, OR exposes cross-component interactions not flagged in the debugger brief, the Worker stops immediately with Status: BLOCKED. The 50-line threshold is measured against the production file's diff, not including test file changes. The Worker counts by estimating scope from the debugger brief BEFORE starting implementation; if the brief's scope is unclear, the Worker stops and the conductor reclassifies as standard Elevated.
-
-**Failure path.** If VERIFY fails, the Worker does NOT commit. Worker returns Status: DONE_WITH_CONCERNS with the failed test output and the uncommitted diff. Conductor spawns a standard Skeptic with the uncommitted diff. Skeptic reviews, conductor routes any further fix through a normal Elevated loop.
-
-**Rollback for latent bugs.** If tests pass but a defect is later discovered (the tests did not cover the actual failure scenario), standard `git revert [commit-sha]` applies. No special rollback.
-
-**Fallback is automatic.** Any BLOCKED status, failed baseline, failed verify, or disqualifier reverts the task to standard Elevated with a Skeptic. This is not an escape hatch - it is the safe default that fires on any deviation.
+**Post-debugger Low classification.** Post-debugger-brief bug fixes that are single-file and exercised by an existing test may be classified Low if they meet all Trivial signals; otherwise standard Elevated applies.
 
 **Low signals:** clearly reversible reads (reads with no writes); exploration / research / draft work - only when the output is understanding, not a decision-driving artifact; **diagnostic-only changes** (pure logging additions - console.log, .catch() for error visibility, test interceptors) across any number of files, where every change has zero behavioral effect — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **documentation-only file creation** (new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the "new file creation" Elevated signal for this case only) — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **targeted wording fixes to already-reviewed content** (phrasing adjustments where the substance was already Skeptic-approved in the current or a recent session - e.g., syncing parallel descriptions, adding a clarifying phrase to an existing enumeration; does not apply to new decisions, new recommendations, or new content not previously reviewed; does not override the "modifies protocol or infrastructure files" Elevated signal; overrides the single-file edit and new file Elevated signals for this case only) — **in `strict` profile, this override is removed; treat as Elevated**; **file renaming** (renaming or moving files via `git mv` or equivalent, with no content changes to any file - neither the renamed file nor any other file; overrides the "new file creation", "multi-file changes", and "Bash with side effects" Elevated signals for this case only; does not override the "modifies protocol or infrastructure files" Elevated signal - renaming protocol or infrastructure files remains Elevated regardless; if any other files reference the renamed path - imports, cross-references, config entries - the operation is Elevated because those reference updates constitute content changes in other files; if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the operation is Elevated because the rename changes behavior without changing file contents) — **in `strict` profile, this override is removed; treat as Elevated**; **UI-only copy changes** (rewording display strings, labels, tooltips, or placeholder text where the change has no logic, structural, or behavioral effect - e.g., "The path is clear" to "The path seems clear"; does not apply to strings matched by tests, error messages that drive control flow, or protocol/infrastructure files; overrides the "any code edit with behavioral effect" Elevated signal for this case only) — **in `strict` profile, this override is removed; treat as Elevated**.
 

--- a/.cursor/rules/references/skeptic-protocol.md
+++ b/.cursor/rules/references/skeptic-protocol.md
@@ -52,7 +52,6 @@ None of the above:
 | "The Skeptic will catch any mistakes." | The Skeptic reviews Worker output. It does not excuse skipping risk classification or spawning a Worker. |
 | "We're moving fast, we can skip review this time." | The protocol exists precisely for times when moving fast creates pressure to skip it. Speed is not a Low signal. |
 | "This change is too minor to bother with a Worker." | Delegate on risk signals, not on size. The Worker overhead is small; the cost of an unreviewed error is not. |
-| "I ran the tests myself, I don't need a Skeptic" | Valid only when the tight-fix path declaration was made with all 6 checklist items ticked AND the Worker's pre-commit test verification sequence passed. Outside that declared sub-path, tests passing is not a substitute for Skeptic review. The tight-fix path is a narrow declared opt-in, not a general permission to self-verify. |
 
 ### Approach by risk level
 
@@ -378,7 +377,7 @@ The primary agent treats a Skeptic response as a valid sign-off only when it con
 
 **Format re-invocation limit:** Format re-invocations are limited to 3 attempts. If the Skeptic's response remains format-noncompliant after 3 re-invocations, the primary agent escalates to the human with the last Skeptic response verbatim.
 
-**Irreversible changes:** Workers must not apply irreversible changes before the primary agent has confirmed Skeptic sign-off. The sole exception is the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`: when a tight-fix path declaration is made with all 6 checklist items ticked AND the engineer Worker's pre-commit test verification (BASELINE -> APPLY -> VERIFY) passes, the Worker may commit without prior Skeptic sign-off. Any failure in the verification sequence reverts to the standard rule - the Worker does NOT commit, returns the uncommitted diff, and the conductor spawns a Skeptic on the uncommitted diff. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
+**Irreversible changes:** Workers must not apply irreversible changes before Skeptic sign-off. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
 
 ---
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -115,7 +115,6 @@ Then wait. Do NOT keep spawning Workers against an under-specified plan - that c
 - "The Skeptic will catch any mistakes" - the Skeptic reviews Worker output; it does not excuse skipping risk classification or spawning a Worker
 - "This change is too minor to bother with a Worker" - delegate on risk signals, not on size; the Worker overhead is small, the cost of an unreviewed error is not
 - "I can figure out the task structure / parallelization myself" or "this is obviously a single-unit task" - conductor does not self-assess task structure, unit count, or parallelization; delegate that reasoning to the orchestration-planner; the only valid skip is when a preceding agent has already returned a single atomic unit
-- "This qualifies as the tight-fix path, so I can skip Skeptic" - Valid only when every checklist item is explicitly satisfied AND declared. An incomplete declaration, a stale debugger brief, Low debugger confidence, or any disqualifier reverts to standard Elevated. The default when uncertain is standard Elevated.
 
 **Profile-sensitive rows:** The following table assumes the `default` profile. In `strict`, several Low overrides are removed (see Risk profiles). In `relaxed`, additional Elevated signals are downgraded to Low.
 
@@ -238,41 +237,7 @@ All signals not mentioned above keep their default level regardless of profile.
 
 **Conductor rule for Trivial:** If no subagents are currently running, the conductor edits directly (no Worker, no Skeptic, no brief file). If any subagent is currently running, spawn a single `engineer` Worker in foreground (no Skeptic, no brief file) - the conductor must stay available to manage in-flight work. A commit message is still required. If a Worker discovers mid-task that the change is not actually Trivial (e.g., the "one-file color tweak" lives in a shared token file), it must stop, report, and the conductor re-classifies as Elevated.
 
-**Elevated (tight-fix path) - Skeptic skip.** A narrow sub-path within Elevated that lets the conductor spawn a single engineer Worker with pre-commit test verification and skip the post-implementation Skeptic on tight debugger-brief-backed bug fixes. Motivated by the finding that verifiers hurt on tight, well-specified tasks. The path applies only when ALL 6 checklist items hold simultaneously; any single disqualifier reverts to standard Elevated.
-
-**Checklist (every item must be explicitly declared):**
-1. Task is a bug fix, not a new feature or refactor.
-2. A debugger agent produced a fix brief for this bug in the current session. Stale briefs from prior sessions disqualify.
-3. Debugger confidence is High or Medium. Low confidence disqualifies.
-4. Fix touches at most one file, or one file plus its colocated test file (colocated = same directory, test file for the same symbol).
-5. At least one existing test already exercises the fix path. Direct unit test or integration test both acceptable. The test must exist before the fix - new test file creation disqualifies; test additions to the pre-existing colocated test file are allowed.
-6. No security, auth, crypto, payments, secrets, or data-loss surface involved.
-
-**Declaration format:**
-
-```
-Risk: Elevated (tight-fix path)
-Debugger brief: [session reference]
-Checklist:
-  [x] Bug fix, not a new feature
-  [x] Debugger brief from current session
-  [x] Debugger confidence: High | Medium
-  [x] Single file (+ colocated test file if applicable)
-  [x] Existing test exercises the fix path
-  [x] No security/auth/crypto/payments/secrets/data-loss surface
-Skipping post-implementation Skeptic. Engineer Worker performs pre-commit test verification.
-If pre-commit tests fail, standard Elevated loop applies.
-```
-
-**Pre-commit test verification protocol.** The engineer Worker on this path runs the sequence: BASELINE (run affected tests before touching anything; ANY failure is an absolute stop, no "unrelated failure" escape - return BLOCKED with output) -> APPLY (implement the fix per debugger brief, no scope expansion) -> VERIFY (run affected tests + project quality gate) -> COMMIT (only if VERIFY passes) -> RETURN (include verbatim test output in summary).
-
-**Scope-expansion stop.** If the Worker discovers the fix requires more than 50 changed lines in the production file (excluding the colocated test file), OR requires touching a second production file, OR exposes cross-component interactions not flagged in the debugger brief, the Worker stops immediately with Status: BLOCKED. The 50-line threshold is measured against the production file's diff, not including test file changes. The Worker counts by estimating scope from the debugger brief BEFORE starting implementation; if the brief's scope is unclear, the Worker stops and the conductor reclassifies as standard Elevated.
-
-**Failure path.** If VERIFY fails, the Worker does NOT commit. Worker returns Status: DONE_WITH_CONCERNS with the failed test output and the uncommitted diff. Conductor spawns a standard Skeptic with the uncommitted diff. Skeptic reviews, conductor routes any further fix through a normal Elevated loop.
-
-**Rollback for latent bugs.** If tests pass but a defect is later discovered (the tests did not cover the actual failure scenario), standard `git revert [commit-sha]` applies. No special rollback.
-
-**Fallback is automatic.** Any BLOCKED status, failed baseline, failed verify, or disqualifier reverts the task to standard Elevated with a Skeptic. This is not an escape hatch - it is the safe default that fires on any deviation.
+**Post-debugger Low classification.** Post-debugger-brief bug fixes that are single-file and exercised by an existing test may be classified Low if they meet all Trivial signals; otherwise standard Elevated applies.
 
 **Low signals:** clearly reversible reads (reads with no writes); exploration / research / draft work - only when the output is understanding, not a decision-driving artifact; **diagnostic-only changes** (pure logging additions - console.log, .catch() for error visibility, test interceptors) across any number of files, where every change has zero behavioral effect — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **documentation-only file creation** (new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the "new file creation" Elevated signal for this case only) — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **targeted wording fixes to already-reviewed content** (phrasing adjustments where the substance was already Skeptic-approved in the current or a recent session - e.g., syncing parallel descriptions, adding a clarifying phrase to an existing enumeration; does not apply to new decisions, new recommendations, or new content not previously reviewed; does not override the "modifies protocol or infrastructure files" Elevated signal; overrides the single-file edit and new file Elevated signals for this case only) — **in `strict` profile, this override is removed; treat as Elevated**; **file renaming** (renaming or moving files via `git mv` or equivalent, with no content changes to any file - neither the renamed file nor any other file; overrides the "new file creation", "multi-file changes", and "Bash with side effects" Elevated signals for this case only; does not override the "modifies protocol or infrastructure files" Elevated signal - renaming protocol or infrastructure files remains Elevated regardless; if any other files reference the renamed path - imports, cross-references, config entries - the operation is Elevated because those reference updates constitute content changes in other files; if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the operation is Elevated because the rename changes behavior without changing file contents) — **in `strict` profile, this override is removed; treat as Elevated**; **UI-only copy changes** (rewording display strings, labels, tooltips, or placeholder text where the change has no logic, structural, or behavioral effect - e.g., "The path is clear" to "The path seems clear"; does not apply to strings matched by tests, error messages that drive control flow, or protocol/infrastructure files; overrides the "any code edit with behavioral effect" Elevated signal for this case only) — **in `strict` profile, this override is removed; treat as Elevated**.
 

--- a/.gemini/agents/debugger.md
+++ b/.gemini/agents/debugger.md
@@ -79,8 +79,6 @@ Use this exact structure:
 
 ## Rules
 
-**Tight-fix path consumption.** A fix brief produced in the current session may be consumed directly by an engineer Worker under the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`, without a separate Architect plan. The existing fix brief format (file, symbol, rationale, confidence) is sufficient for this use. No new fields are required. If your diagnosis confidence is Low, the tight-fix path does not apply - the conductor will route through standard Elevated with a Skeptic regardless.
-
 - Diagnose only. Do not implement the fix. Do not write code to disk.
 - Do not speculate without evidence. If you have not found the root cause, say "Confidence: Low" and describe what you found and what is still unclear.
 - If the error is ambiguous or codebase context is insufficient, set Confidence to Medium (not High), state why under Confidence, and list exactly what additional information would let you close the diagnosis.

--- a/.gemini/agents/engineer.md
+++ b/.gemini/agents/engineer.md
@@ -34,19 +34,7 @@ When spawned via `/implement-ticket` Phase 5 with a `task_id` in the execution c
 
 **HUD file writes (Phase 2 fan-out only).** When spawned as a parallel fan-out Worker with a `worker_id` field in the execution contract, the engineer writes phase transition updates to `.agentic/hud/<worker-id>.json` before each major action (before spawning sub-agents, at loop phase transitions, at completion). The HUD file write accompanies `[loop: ...]` breadcrumb emissions - both happen at the same event. Engineers spawned without a `worker_id` (single-unit, non-fan-out contexts) do not write HUD files. The `worker_id` is provided in the spawn prompt alongside `task_id`.
 
-**Tight-fix path execution contract.** When the conductor declares the Elevated (tight-fix path) sub-path (see `agent-methodology.md`), your `completion_conditions` will specify a pre-commit test verification sequence. You must execute this sequence exactly:
-
-1. BASELINE: Before modifying any file, run the affected test(s) (and full project quality gate if defined). Capture the output verbatim. If ANY test fails in baseline, stop immediately. Return Status: BLOCKED with the baseline failure output. Do NOT attempt to classify the failure as "unrelated" and proceed - any baseline failure is an absolute stop.
-
-2. APPLY: Implement the fix per the debugger brief. No scope expansion. If you discover the fix requires more than 50 changed lines in the production file (excluding the colocated test file), touching a second production file, or reveals cross-component interactions not flagged in the brief, stop immediately. Return Status: BLOCKED with a description of what you discovered.
-
-3. VERIFY: Run the affected test(s) again, plus the full project quality gate if defined. If any test or gate fails, do NOT commit. Return Status: DONE_WITH_CONCERNS with the failed output and the uncommitted diff.
-
-4. COMMIT: Only if VERIFY passes. Stage only the files touched (do not use `git add -A` or `git add .`). Commit with a message referencing the debugger brief.
-
-5. RETURN: Status: DONE, with verbatim BASELINE and VERIFY test output included in the summary so the conductor can inspect the raw output.
-
-The tight-fix path is the only circumstance under which an engineer Worker commits without prior Skeptic sign-off, and it is conditional on the pre-commit test verification sequence passing. The amendment to the "no irreversible changes before sign-off" rule is in `skeptic-protocol.md`.
+(Tight-fix path removed; see post-debugger Low classification rule in `content/rules/agent-methodology.md`.)
 
 ## Implementation process
 

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -369,8 +369,6 @@ For full worktree cleanup rules (isolation worktrees, feature worktrees, stale b
 
 ## Phase 6: Skeptic review
 
-**Phase 6 guard (tight-fix path).** If Phase 5 spawned the engineer under the Elevated (tight-fix path) sub-path (see `agent-methodology.md`) AND the Worker returned Status: DONE with the verbatim pre-commit test output in its summary, skip the rest of Phase 6. The tight-fix path's pre-commit test verification replaces the post-impl Skeptic for this case. If the Worker returned Status: BLOCKED or DONE_WITH_CONCERNS, fall through to the standard Phase 6 Skeptic spawn on the uncommitted diff (see `skeptic-protocol.md` line 376 for the amended "no irreversible changes" rule that permits this sub-path).
-
 **Phase 6 guard (fan-out integration Skeptic).** When fan-out was active in Phase 5 and `SKEPTIC_STRATEGY: integration`, the integration Skeptic that reviewed the combined diff in Phase 5 IS the Phase 6 gate. Do not spawn a second Skeptic - Phase 6 is complete when the integration Skeptic signs off. When `SKEPTIC_STRATEGY: per-unit`, Phase 6 fires as normal - a Skeptic reviews the combined diff from `BASE_BRANCH` after all merges (`git -C $REPO diff origin/$BASE_BRANCH..HEAD`). This is a full-picture review that catches cross-unit interactions the per-unit Skeptics could not see (emergent behaviors, combined diff scope). Phase 6 is NOT skipped for the `per-unit` strategy.
 
 Spawn a `skeptic` agent with:
@@ -602,8 +600,6 @@ This phase runs after Phase 6 and 6b loops have already exited cleanly. A qualit
 7. If it still fails: set `status=stalled`. Escalate to the human. Include the quality gate output from both the first run and the post-fix re-run. Do not spawn another Engineer pass.
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase.
-
-**Tight-fix path interaction:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed successfully, then Phase 7 fails - this triggers the one-Engineer-pass rule above. It does NOT re-enter the Phase 6 Skeptic loop. The Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
 
 ---
 

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -52,7 +52,6 @@ None of the above:
 | "The Skeptic will catch any mistakes." | The Skeptic reviews Worker output. It does not excuse skipping risk classification or spawning a Worker. |
 | "We're moving fast, we can skip review this time." | The protocol exists precisely for times when moving fast creates pressure to skip it. Speed is not a Low signal. |
 | "This change is too minor to bother with a Worker." | Delegate on risk signals, not on size. The Worker overhead is small; the cost of an unreviewed error is not. |
-| "I ran the tests myself, I don't need a Skeptic" | Valid only when the tight-fix path declaration was made with all 6 checklist items ticked AND the Worker's pre-commit test verification sequence passed. Outside that declared sub-path, tests passing is not a substitute for Skeptic review. The tight-fix path is a narrow declared opt-in, not a general permission to self-verify. |
 
 ### Approach by risk level
 
@@ -378,7 +377,7 @@ The primary agent treats a Skeptic response as a valid sign-off only when it con
 
 **Format re-invocation limit:** Format re-invocations are limited to 3 attempts. If the Skeptic's response remains format-noncompliant after 3 re-invocations, the primary agent escalates to the human with the last Skeptic response verbatim.
 
-**Irreversible changes:** Workers must not apply irreversible changes before the primary agent has confirmed Skeptic sign-off. The sole exception is the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`: when a tight-fix path declaration is made with all 6 checklist items ticked AND the engineer Worker's pre-commit test verification (BASELINE -> APPLY -> VERIFY) passes, the Worker may commit without prior Skeptic sign-off. Any failure in the verification sequence reverts to the standard rule - the Worker does NOT commit, returns the uncommitted diff, and the conductor spawns a Skeptic on the uncommitted diff. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
+**Irreversible changes:** Workers must not apply irreversible changes before Skeptic sign-off. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
 
 ---
 

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -115,7 +115,6 @@ Then wait. Do NOT keep spawning Workers against an under-specified plan - that c
 - "The Skeptic will catch any mistakes" - the Skeptic reviews Worker output; it does not excuse skipping risk classification or spawning a Worker
 - "This change is too minor to bother with a Worker" - delegate on risk signals, not on size; the Worker overhead is small, the cost of an unreviewed error is not
 - "I can figure out the task structure / parallelization myself" or "this is obviously a single-unit task" - conductor does not self-assess task structure, unit count, or parallelization; delegate that reasoning to the orchestration-planner; the only valid skip is when a preceding agent has already returned a single atomic unit
-- "This qualifies as the tight-fix path, so I can skip Skeptic" - Valid only when every checklist item is explicitly satisfied AND declared. An incomplete declaration, a stale debugger brief, Low debugger confidence, or any disqualifier reverts to standard Elevated. The default when uncertain is standard Elevated.
 
 **Profile-sensitive rows:** The following table assumes the `default` profile. In `strict`, several Low overrides are removed (see Risk profiles). In `relaxed`, additional Elevated signals are downgraded to Low.
 
@@ -238,41 +237,7 @@ All signals not mentioned above keep their default level regardless of profile.
 
 **Conductor rule for Trivial:** If no subagents are currently running, the conductor edits directly (no Worker, no Skeptic, no brief file). If any subagent is currently running, spawn a single `engineer` Worker in foreground (no Skeptic, no brief file) - the conductor must stay available to manage in-flight work. A commit message is still required. If a Worker discovers mid-task that the change is not actually Trivial (e.g., the "one-file color tweak" lives in a shared token file), it must stop, report, and the conductor re-classifies as Elevated.
 
-**Elevated (tight-fix path) - Skeptic skip.** A narrow sub-path within Elevated that lets the conductor spawn a single engineer Worker with pre-commit test verification and skip the post-implementation Skeptic on tight debugger-brief-backed bug fixes. Motivated by the finding that verifiers hurt on tight, well-specified tasks. The path applies only when ALL 6 checklist items hold simultaneously; any single disqualifier reverts to standard Elevated.
-
-**Checklist (every item must be explicitly declared):**
-1. Task is a bug fix, not a new feature or refactor.
-2. A debugger agent produced a fix brief for this bug in the current session. Stale briefs from prior sessions disqualify.
-3. Debugger confidence is High or Medium. Low confidence disqualifies.
-4. Fix touches at most one file, or one file plus its colocated test file (colocated = same directory, test file for the same symbol).
-5. At least one existing test already exercises the fix path. Direct unit test or integration test both acceptable. The test must exist before the fix - new test file creation disqualifies; test additions to the pre-existing colocated test file are allowed.
-6. No security, auth, crypto, payments, secrets, or data-loss surface involved.
-
-**Declaration format:**
-
-```
-Risk: Elevated (tight-fix path)
-Debugger brief: [session reference]
-Checklist:
-  [x] Bug fix, not a new feature
-  [x] Debugger brief from current session
-  [x] Debugger confidence: High | Medium
-  [x] Single file (+ colocated test file if applicable)
-  [x] Existing test exercises the fix path
-  [x] No security/auth/crypto/payments/secrets/data-loss surface
-Skipping post-implementation Skeptic. Engineer Worker performs pre-commit test verification.
-If pre-commit tests fail, standard Elevated loop applies.
-```
-
-**Pre-commit test verification protocol.** The engineer Worker on this path runs the sequence: BASELINE (run affected tests before touching anything; ANY failure is an absolute stop, no "unrelated failure" escape - return BLOCKED with output) -> APPLY (implement the fix per debugger brief, no scope expansion) -> VERIFY (run affected tests + project quality gate) -> COMMIT (only if VERIFY passes) -> RETURN (include verbatim test output in summary).
-
-**Scope-expansion stop.** If the Worker discovers the fix requires more than 50 changed lines in the production file (excluding the colocated test file), OR requires touching a second production file, OR exposes cross-component interactions not flagged in the debugger brief, the Worker stops immediately with Status: BLOCKED. The 50-line threshold is measured against the production file's diff, not including test file changes. The Worker counts by estimating scope from the debugger brief BEFORE starting implementation; if the brief's scope is unclear, the Worker stops and the conductor reclassifies as standard Elevated.
-
-**Failure path.** If VERIFY fails, the Worker does NOT commit. Worker returns Status: DONE_WITH_CONCERNS with the failed test output and the uncommitted diff. Conductor spawns a standard Skeptic with the uncommitted diff. Skeptic reviews, conductor routes any further fix through a normal Elevated loop.
-
-**Rollback for latent bugs.** If tests pass but a defect is later discovered (the tests did not cover the actual failure scenario), standard `git revert [commit-sha]` applies. No special rollback.
-
-**Fallback is automatic.** Any BLOCKED status, failed baseline, failed verify, or disqualifier reverts the task to standard Elevated with a Skeptic. This is not an escape hatch - it is the safe default that fires on any deviation.
+**Post-debugger Low classification.** Post-debugger-brief bug fixes that are single-file and exercised by an existing test may be classified Low if they meet all Trivial signals; otherwise standard Elevated applies.
 
 **Low signals:** clearly reversible reads (reads with no writes); exploration / research / draft work - only when the output is understanding, not a decision-driving artifact; **diagnostic-only changes** (pure logging additions - console.log, .catch() for error visibility, test interceptors) across any number of files, where every change has zero behavioral effect — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **documentation-only file creation** (new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the "new file creation" Elevated signal for this case only) — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **targeted wording fixes to already-reviewed content** (phrasing adjustments where the substance was already Skeptic-approved in the current or a recent session - e.g., syncing parallel descriptions, adding a clarifying phrase to an existing enumeration; does not apply to new decisions, new recommendations, or new content not previously reviewed; does not override the "modifies protocol or infrastructure files" Elevated signal; overrides the single-file edit and new file Elevated signals for this case only) — **in `strict` profile, this override is removed; treat as Elevated**; **file renaming** (renaming or moving files via `git mv` or equivalent, with no content changes to any file - neither the renamed file nor any other file; overrides the "new file creation", "multi-file changes", and "Bash with side effects" Elevated signals for this case only; does not override the "modifies protocol or infrastructure files" Elevated signal - renaming protocol or infrastructure files remains Elevated regardless; if any other files reference the renamed path - imports, cross-references, config entries - the operation is Elevated because those reference updates constitute content changes in other files; if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the operation is Elevated because the rename changes behavior without changing file contents) — **in `strict` profile, this override is removed; treat as Elevated**; **UI-only copy changes** (rewording display strings, labels, tooltips, or placeholder text where the change has no logic, structural, or behavioral effect - e.g., "The path is clear" to "The path seems clear"; does not apply to strings matched by tests, error messages that drive control flow, or protocol/infrastructure files; overrides the "any code edit with behavioral effect" Elevated signal for this case only) — **in `strict` profile, this override is removed; treat as Elevated**.
 

--- a/content/agents/debugger.md
+++ b/content/agents/debugger.md
@@ -78,8 +78,6 @@ Use this exact structure:
 
 ## Rules
 
-**Tight-fix path consumption.** A fix brief produced in the current session may be consumed directly by an engineer Worker under the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`, without a separate Architect plan. The existing fix brief format (file, symbol, rationale, confidence) is sufficient for this use. No new fields are required. If your diagnosis confidence is Low, the tight-fix path does not apply - the conductor will route through standard Elevated with a Skeptic regardless.
-
 - Diagnose only. Do not implement the fix. Do not write code to disk.
 - Do not speculate without evidence. If you have not found the root cause, say "Confidence: Low" and describe what you found and what is still unclear.
 - If the error is ambiguous or codebase context is insufficient, set Confidence to Medium (not High), state why under Confidence, and list exactly what additional information would let you close the diagnosis.

--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -33,19 +33,7 @@ When spawned via `/implement-ticket` Phase 5 with a `task_id` in the execution c
 
 **HUD file writes (Phase 2 fan-out only).** When spawned as a parallel fan-out Worker with a `worker_id` field in the execution contract, the engineer writes phase transition updates to `.agentic/hud/<worker-id>.json` before each major action (before spawning sub-agents, at loop phase transitions, at completion). The HUD file write accompanies `[loop: ...]` breadcrumb emissions - both happen at the same event. Engineers spawned without a `worker_id` (single-unit, non-fan-out contexts) do not write HUD files. The `worker_id` is provided in the spawn prompt alongside `task_id`.
 
-**Tight-fix path execution contract.** When the conductor declares the Elevated (tight-fix path) sub-path (see `agent-methodology.md`), your `completion_conditions` will specify a pre-commit test verification sequence. You must execute this sequence exactly:
-
-1. BASELINE: Before modifying any file, run the affected test(s) (and full project quality gate if defined). Capture the output verbatim. If ANY test fails in baseline, stop immediately. Return Status: BLOCKED with the baseline failure output. Do NOT attempt to classify the failure as "unrelated" and proceed - any baseline failure is an absolute stop.
-
-2. APPLY: Implement the fix per the debugger brief. No scope expansion. If you discover the fix requires more than 50 changed lines in the production file (excluding the colocated test file), touching a second production file, or reveals cross-component interactions not flagged in the brief, stop immediately. Return Status: BLOCKED with a description of what you discovered.
-
-3. VERIFY: Run the affected test(s) again, plus the full project quality gate if defined. If any test or gate fails, do NOT commit. Return Status: DONE_WITH_CONCERNS with the failed output and the uncommitted diff.
-
-4. COMMIT: Only if VERIFY passes. Stage only the files touched (do not use `git add -A` or `git add .`). Commit with a message referencing the debugger brief.
-
-5. RETURN: Status: DONE, with verbatim BASELINE and VERIFY test output included in the summary so the conductor can inspect the raw output.
-
-The tight-fix path is the only circumstance under which an engineer Worker commits without prior Skeptic sign-off, and it is conditional on the pre-commit test verification sequence passing. The amendment to the "no irreversible changes before sign-off" rule is in `skeptic-protocol.md`.
+(Tight-fix path removed; see post-debugger Low classification rule in `content/rules/agent-methodology.md`.)
 
 ## Implementation process
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -363,8 +363,6 @@ For full worktree cleanup rules (isolation worktrees, feature worktrees, stale b
 
 ## Phase 6: Skeptic review
 
-**Phase 6 guard (tight-fix path).** If Phase 5 spawned the engineer under the Elevated (tight-fix path) sub-path (see `agent-methodology.md`) AND the Worker returned Status: DONE with the verbatim pre-commit test output in its summary, skip the rest of Phase 6. The tight-fix path's pre-commit test verification replaces the post-impl Skeptic for this case. If the Worker returned Status: BLOCKED or DONE_WITH_CONCERNS, fall through to the standard Phase 6 Skeptic spawn on the uncommitted diff (see `skeptic-protocol.md` line 376 for the amended "no irreversible changes" rule that permits this sub-path).
-
 **Phase 6 guard (fan-out integration Skeptic).** When fan-out was active in Phase 5 and `SKEPTIC_STRATEGY: integration`, the integration Skeptic that reviewed the combined diff in Phase 5 IS the Phase 6 gate. Do not spawn a second Skeptic - Phase 6 is complete when the integration Skeptic signs off. When `SKEPTIC_STRATEGY: per-unit`, Phase 6 fires as normal - a Skeptic reviews the combined diff from `BASE_BRANCH` after all merges (`git -C $REPO diff origin/$BASE_BRANCH..HEAD`). This is a full-picture review that catches cross-unit interactions the per-unit Skeptics could not see (emergent behaviors, combined diff scope). Phase 6 is NOT skipped for the `per-unit` strategy.
 
 Spawn a `skeptic` agent with:
@@ -596,8 +594,6 @@ This phase runs after Phase 6 and 6b loops have already exited cleanly. A qualit
 7. If it still fails: set `status=stalled`. Escalate to the human. Include the quality gate output from both the first run and the post-fix re-run. Do not spawn another Engineer pass.
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase.
-
-**Tight-fix path interaction:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed successfully, then Phase 7 fails - this triggers the one-Engineer-pass rule above. It does NOT re-enter the Phase 6 Skeptic loop. The Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
 
 ---
 

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -52,7 +52,6 @@ None of the above:
 | "The Skeptic will catch any mistakes." | The Skeptic reviews Worker output. It does not excuse skipping risk classification or spawning a Worker. |
 | "We're moving fast, we can skip review this time." | The protocol exists precisely for times when moving fast creates pressure to skip it. Speed is not a Low signal. |
 | "This change is too minor to bother with a Worker." | Delegate on risk signals, not on size. The Worker overhead is small; the cost of an unreviewed error is not. |
-| "I ran the tests myself, I don't need a Skeptic" | Valid only when the tight-fix path declaration was made with all 6 checklist items ticked AND the Worker's pre-commit test verification sequence passed. Outside that declared sub-path, tests passing is not a substitute for Skeptic review. The tight-fix path is a narrow declared opt-in, not a general permission to self-verify. |
 
 ### Approach by risk level
 
@@ -378,7 +377,7 @@ The primary agent treats a Skeptic response as a valid sign-off only when it con
 
 **Format re-invocation limit:** Format re-invocations are limited to 3 attempts. If the Skeptic's response remains format-noncompliant after 3 re-invocations, the primary agent escalates to the human with the last Skeptic response verbatim.
 
-**Irreversible changes:** Workers must not apply irreversible changes before the primary agent has confirmed Skeptic sign-off. The sole exception is the Elevated (tight-fix path) sub-path defined in `agent-methodology.md`: when a tight-fix path declaration is made with all 6 checklist items ticked AND the engineer Worker's pre-commit test verification (BASELINE -> APPLY -> VERIFY) passes, the Worker may commit without prior Skeptic sign-off. Any failure in the verification sequence reverts to the standard rule - the Worker does NOT commit, returns the uncommitted diff, and the conductor spawns a Skeptic on the uncommitted diff. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
+**Irreversible changes:** Workers must not apply irreversible changes before Skeptic sign-off. Workers that must stage irreversible changes as part of implementation must write a revert procedure in their return output before applying those changes. If the Skeptic subsequently flags Critical issues, the primary agent instructs the Worker to execute the revert procedure before further changes.
 
 ---
 

--- a/content/rules/agent-methodology.md
+++ b/content/rules/agent-methodology.md
@@ -105,7 +105,6 @@ Then wait. Do NOT keep spawning Workers against an under-specified plan - that c
 - "The Skeptic will catch any mistakes" - the Skeptic reviews Worker output; it does not excuse skipping risk classification or spawning a Worker
 - "This change is too minor to bother with a Worker" - delegate on risk signals, not on size; the Worker overhead is small, the cost of an unreviewed error is not
 - "I can figure out the task structure / parallelization myself" or "this is obviously a single-unit task" - conductor does not self-assess task structure, unit count, or parallelization; delegate that reasoning to the orchestration-planner; the only valid skip is when a preceding agent has already returned a single atomic unit
-- "This qualifies as the tight-fix path, so I can skip Skeptic" - Valid only when every checklist item is explicitly satisfied AND declared. An incomplete declaration, a stale debugger brief, Low debugger confidence, or any disqualifier reverts to standard Elevated. The default when uncertain is standard Elevated.
 
 **Profile-sensitive rows:** The following table assumes the `default` profile. In `strict`, several Low overrides are removed (see Risk profiles). In `relaxed`, additional Elevated signals are downgraded to Low.
 
@@ -228,41 +227,7 @@ All signals not mentioned above keep their default level regardless of profile.
 
 **Conductor rule for Trivial:** If no subagents are currently running, the conductor edits directly (no Worker, no Skeptic, no brief file). If any subagent is currently running, spawn a single `engineer` Worker in foreground (no Skeptic, no brief file) - the conductor must stay available to manage in-flight work. A commit message is still required. If a Worker discovers mid-task that the change is not actually Trivial (e.g., the "one-file color tweak" lives in a shared token file), it must stop, report, and the conductor re-classifies as Elevated.
 
-**Elevated (tight-fix path) - Skeptic skip.** A narrow sub-path within Elevated that lets the conductor spawn a single engineer Worker with pre-commit test verification and skip the post-implementation Skeptic on tight debugger-brief-backed bug fixes. Motivated by the finding that verifiers hurt on tight, well-specified tasks. The path applies only when ALL 6 checklist items hold simultaneously; any single disqualifier reverts to standard Elevated.
-
-**Checklist (every item must be explicitly declared):**
-1. Task is a bug fix, not a new feature or refactor.
-2. A debugger agent produced a fix brief for this bug in the current session. Stale briefs from prior sessions disqualify.
-3. Debugger confidence is High or Medium. Low confidence disqualifies.
-4. Fix touches at most one file, or one file plus its colocated test file (colocated = same directory, test file for the same symbol).
-5. At least one existing test already exercises the fix path. Direct unit test or integration test both acceptable. The test must exist before the fix - new test file creation disqualifies; test additions to the pre-existing colocated test file are allowed.
-6. No security, auth, crypto, payments, secrets, or data-loss surface involved.
-
-**Declaration format:**
-
-```
-Risk: Elevated (tight-fix path)
-Debugger brief: [session reference]
-Checklist:
-  [x] Bug fix, not a new feature
-  [x] Debugger brief from current session
-  [x] Debugger confidence: High | Medium
-  [x] Single file (+ colocated test file if applicable)
-  [x] Existing test exercises the fix path
-  [x] No security/auth/crypto/payments/secrets/data-loss surface
-Skipping post-implementation Skeptic. Engineer Worker performs pre-commit test verification.
-If pre-commit tests fail, standard Elevated loop applies.
-```
-
-**Pre-commit test verification protocol.** The engineer Worker on this path runs the sequence: BASELINE (run affected tests before touching anything; ANY failure is an absolute stop, no "unrelated failure" escape - return BLOCKED with output) -> APPLY (implement the fix per debugger brief, no scope expansion) -> VERIFY (run affected tests + project quality gate) -> COMMIT (only if VERIFY passes) -> RETURN (include verbatim test output in summary).
-
-**Scope-expansion stop.** If the Worker discovers the fix requires more than 50 changed lines in the production file (excluding the colocated test file), OR requires touching a second production file, OR exposes cross-component interactions not flagged in the debugger brief, the Worker stops immediately with Status: BLOCKED. The 50-line threshold is measured against the production file's diff, not including test file changes. The Worker counts by estimating scope from the debugger brief BEFORE starting implementation; if the brief's scope is unclear, the Worker stops and the conductor reclassifies as standard Elevated.
-
-**Failure path.** If VERIFY fails, the Worker does NOT commit. Worker returns Status: DONE_WITH_CONCERNS with the failed test output and the uncommitted diff. Conductor spawns a standard Skeptic with the uncommitted diff. Skeptic reviews, conductor routes any further fix through a normal Elevated loop.
-
-**Rollback for latent bugs.** If tests pass but a defect is later discovered (the tests did not cover the actual failure scenario), standard `git revert [commit-sha]` applies. No special rollback.
-
-**Fallback is automatic.** Any BLOCKED status, failed baseline, failed verify, or disqualifier reverts the task to standard Elevated with a Skeptic. This is not an escape hatch - it is the safe default that fires on any deviation.
+**Post-debugger Low classification.** Post-debugger-brief bug fixes that are single-file and exercised by an existing test may be classified Low if they meet all Trivial signals; otherwise standard Elevated applies.
 
 **Low signals:** clearly reversible reads (reads with no writes); exploration / research / draft work - only when the output is understanding, not a decision-driving artifact; **diagnostic-only changes** (pure logging additions - console.log, .catch() for error visibility, test interceptors) across any number of files, where every change has zero behavioral effect — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **documentation-only file creation** (new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the "new file creation" Elevated signal for this case only) — **in `strict` profile, treat as Low (self-check required) rather than unconditionally direct**; **targeted wording fixes to already-reviewed content** (phrasing adjustments where the substance was already Skeptic-approved in the current or a recent session - e.g., syncing parallel descriptions, adding a clarifying phrase to an existing enumeration; does not apply to new decisions, new recommendations, or new content not previously reviewed; does not override the "modifies protocol or infrastructure files" Elevated signal; overrides the single-file edit and new file Elevated signals for this case only) — **in `strict` profile, this override is removed; treat as Elevated**; **file renaming** (renaming or moving files via `git mv` or equivalent, with no content changes to any file - neither the renamed file nor any other file; overrides the "new file creation", "multi-file changes", and "Bash with side effects" Elevated signals for this case only; does not override the "modifies protocol or infrastructure files" Elevated signal - renaming protocol or infrastructure files remains Elevated regardless; if any other files reference the renamed path - imports, cross-references, config entries - the operation is Elevated because those reference updates constitute content changes in other files; if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the operation is Elevated because the rename changes behavior without changing file contents) — **in `strict` profile, this override is removed; treat as Elevated**; **UI-only copy changes** (rewording display strings, labels, tooltips, or placeholder text where the change has no logic, structural, or behavioral effect - e.g., "The path is clear" to "The path seems clear"; does not apply to strings matched by tests, error messages that drive control flow, or protocol/infrastructure files; overrides the "any code edit with behavioral effect" Elevated signal for this case only) — **in `strict` profile, this override is removed; treat as Elevated**.
 

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -995,7 +995,7 @@
       </div>
       <figcaption class="infographic-title">The risk router decides the whole shape of execution</figcaption>
       <p class="infographic-copy">The methodology does not ask, "How many lines is this?" It asks what kind of mistake is possible. One Elevated signal is enough to move the task into Worker plus Skeptic territory, and the default under uncertainty is to classify upward, not downward.</p>
-      <svg class="infographic-svg" viewBox="0 0 1180 560" role="img" aria-label="A risk classification flowchart showing an initial risk check leading to Trivial, Low, and Elevated paths, with a narrow debugger-backed tight-fix path under Elevated.">
+      <svg class="infographic-svg" viewBox="0 0 1180 560" role="img" aria-label="A risk classification flowchart showing an initial risk check leading to Trivial, Low, and Elevated paths.">
         <defs>
           <marker id="ae-arrow-rose-2" markerWidth="11" markerHeight="11" refX="8" refY="5.5" orient="auto">
             <path d="M0,0 L10,5.5 L0,11 Z" fill="#a83a2a"></path>
@@ -1031,12 +1031,6 @@
         <text x="774" y="402" class="svg-copy">independent Skeptic until sign-off or escalation.</text>
 
         <path d="M590 296 V338 H746" class="stroke-violet" fill="none" marker-end="url(#ae-arrow-violet-2)"></path>
-
-        <rect x="760" y="445" width="306" height="64" rx="18" class="bg-gold stroke-gold"></rect>
-        <text x="913" y="470" class="svg-mono svg-center">NARROW EXCEPTION</text>
-        <text x="913" y="491" class="svg-copy svg-center">tight-fix path: debugger brief, bug fix only, existing test coverage,</text>
-        <text x="913" y="507" class="svg-copy svg-center">single-file scope, no security or data-loss surface</text>
-        <path d="M914 424 V445" class="stroke-gold" fill="none" marker-end="url(#ae-arrow-violet-2)"></path>
 
         <path d="M466 204 H360" class="stroke-cyan" fill="none" marker-end="url(#ae-arrow-cyan-2)"></path>
         <text x="418" y="190" class="svg-pill svg-center">NO</text>

--- a/docs/planning/p0-persistence-loop.md
+++ b/docs/planning/p0-persistence-loop.md
@@ -304,7 +304,7 @@ If `$QUALITY_CMD` fails after Phase 6 and 6b loops exit cleanly, this does NOT c
 
 **No unbounded loop:** Phase 7 failure only ever triggers one Engineer fix pass followed by one re-run. There is no retry loop at this phase. If the second run fails, escalate immediately.
 
-**Tight-fix path interaction with Phase 7:** If the tight-fix path fired (Phase 6 guard bypassed the Skeptic entirely) and the Worker committed, then Phase 7 fails - this triggers the Phase 7 fix pass described above (one Engineer pass, one re-run, then escalate if still failing). It does NOT re-enter the Phase 6 Skeptic loop; the Skeptic already signed off on the implementation via the tight-fix path's pre-commit verification. The Phase 7 fix pass is scoped to quality gate failures only.
+**[archived: tight-fix removed 2026-04-29]** Tight-fix path interaction with Phase 7: previously, if the tight-fix path fired and the Worker committed, a Phase 7 failure triggered the one-pass fix rule above without re-entering the Phase 6 Skeptic loop. The tight-fix path has since been removed; standard Elevated review applies.
 
 ### Phase 6c (Promote findings) - no change
 
@@ -383,7 +383,7 @@ Per MEMORY.md, adding a new protocol primitive requires auditing 7 surfaces. Aud
 
 **6. Cap reached on the final iteration before a bug is fixed.** When the cap is reached, the conductor must NOT commit the partial fix. The branch should be left in the state of the last Engineer output (which may be partially fixed). The human receives the escalation and decides whether to direct another fix pass manually, defer, or abandon the ticket.
 
-**7. Phase 6 guard interaction (tight-fix path).** The tight-fix path (Phase 6 guard) bypasses the Skeptic entirely when all 6 checklist items pass. The persistence loop does not change this - the guard fires before the loop is initialized. If the tight-fix path fires, no loop is started. If the Worker returns `DONE_WITH_CONCERNS`, the loop is initialized at iteration 1 with the uncommitted diff as input to the Skeptic. If the tight-fix path fires and the Worker commits successfully but Phase 7 (quality gate) subsequently fails, the Phase 7 fix pass rule applies (one Engineer pass, one re-run, then escalate if still failing) - not the Phase 6 loop, since the Skeptic already signed off via the pre-commit verification.
+**7. Phase 6 guard interaction (tight-fix path).** **[archived: tight-fix removed 2026-04-29]** Previously, the tight-fix path bypassed the Skeptic when all 6 checklist items passed and interacted with the persistence loop as described in this entry. The tight-fix path has since been removed; standard Elevated review applies and the persistence loop is initialized normally.
 
 **8. Zero-finding Skeptic with open findings_log items.** If the Skeptic raises zero new findings but findings_log has status=open items, the plan might imply a clean exit with inconsistent log state. Resolution: when the Skeptic raises zero new findings (grants sign-off), the conductor auto-closes ALL findings_log entries with status=open or status=addressed. The absence of re-raise is an implicit confirmation that the fixes were accepted. This auto-close fires before proceeding to Phase 6b.
 

--- a/docs/planning/p2-rate-limit-resumer.md
+++ b/docs/planning/p2-rate-limit-resumer.md
@@ -410,4 +410,4 @@ Implement Part 1 first. Part 2 is additive on top of Part 1's infrastructure.
 
 **Q5: ON-DEMAND FOR PHASE 2.** Decision: HUD rendered on-demand only (conductor reads HUD files and prints when asked or at phase transitions). No background `watch` process. A `watch`-compatible `.agentic/hud/status.txt` file is a Phase 3 optional enhancement. Rationale: matches existing breadcrumb pattern, requires no background process, still provides observability.
 
-**Q6: NO SPECIAL HANDLING FOR TIGHT-FIX PATH.** Decision: the existing dirty-branch resume path (check `git status --porcelain`, ask human if dirty) covers the tight-fix interruption case. No tight-fix-specific resume logic needed. Rationale: the tight-fix failure path in P0 (VERIFY fails -> uncommitted diff -> standard Skeptic) is already consistent with the dirty-branch resume path. Flag as a test case during implementation verification.
+**Q6: NO SPECIAL HANDLING FOR TIGHT-FIX PATH.** **[archived]** Tight-fix path has been removed; this question no longer applies.

--- a/docs/planning/p2-self-improving-harness.md
+++ b/docs/planning/p2-self-improving-harness.md
@@ -59,9 +59,9 @@ Two viable orderings exist: (a) build shared infra first, then component evals (
 
 #### Conductor / orchestration-planner (highest leverage)
 
-The conductor is the primary decision-making surface in this repo: when to fan out vs. go sequential, when to tight-fix vs. re-enter the full loop, when a cap is reached, when to escalate. A prompt edit to `content/rules/agent-methodology.md` or `content/agents/orchestration-planner.md` can silently regress routing quality and no Worker / Skeptic eval would catch it.
+The conductor is the primary decision-making surface in this repo: when to fan out vs. go sequential, when to loop iterate vs. escalate, when a cap is reached, when to escalate. A prompt edit to `content/rules/agent-methodology.md` or `content/agents/orchestration-planner.md` can silently regress routing quality and no Worker / Skeptic eval would catch it.
 
-- **Fixture set:** seeded task descriptions + observed state (e.g. "Skeptic returned 2 Major findings, Engineer previously attempted fix X, QA reports test failure Y") with ground-truth labels for the correct next routing decision (tight-fix, full-loop re-enter, escalate, proceed to next phase). 20-30 fixtures covering the canonical decision points in `agent-methodology.md` and the persistence-loop contract in `p0-persistence-loop.md`.
+- **Fixture set:** seeded task descriptions + observed state (e.g. "Skeptic returned 2 Major findings, Engineer previously attempted fix X, QA reports test failure Y") with ground-truth labels for the correct next routing decision (loop iterate, escalate, proceed to next phase). 20-30 fixtures covering the canonical decision points in `agent-methodology.md` and the persistence-loop contract in `p0-persistence-loop.md`.
 - **Primary scalar:** weighted accuracy with asymmetric cost - incorrectly-bypassing-Skeptic counts heavily against; incorrectly-escalating-early counts moderately; minor routing suboptimalities count lightly.
 - **Diagnostic fields:** per-decision-class accuracy, cap-enforcement correctness, escalation-trigger precision/recall.
 - **Why first (or tied-first):** highest leverage per edit. This eval should land alongside or immediately after Skeptic.


### PR DESCRIPTION
## Summary

Removes the 6-checklist Elevated (tight-fix path) Skeptic skip in favor of a single-sentence post-debugger Low classification rule. Part of AE editorial sweep (Q8).

## Changes

- `content/rules/agent-methodology.md`: removed entire tight-fix section (231-265) and the rationalization bullet (108). Replaced with one sentence covering legitimate post-debugger Low classification.
- `content/agents/engineer.md`: removed Tight-fix path execution contract (BASELINE/APPLY/VERIFY/COMMIT) block. Replaced with pointer to the new rule.
- `content/agents/debugger.md`: removed Tight-fix path consumption paragraph.
- `content/references/skeptic-protocol.md`: removed anti-pattern row; rewrote irreversible-changes paragraph to drop the tight-fix carve-out.
- `content/commands/implement-ticket.md`: removed Phase 6 guard and Phase 7 interaction paragraphs.
- `docs/agentic-engineering.html`: dropped tight-fix arm from the risk-router SVG flowchart and aria-label.
- `docs/planning/p0-persistence-loop.md`, `docs/planning/p2-rate-limit-resumer.md`, `docs/planning/p2-self-improving-harness.md`: archived/rewrote tight-fix references.
- All adapter trees (.claude, .codex, .cursor, .gemini, .kimi) regenerated via build scripts.

## Breaking change

Projects relying on the `Risk: Elevated (tight-fix path)` declaration format will fail validation. Reclassify those tasks as Low (per the new post-debugger rule) or standard Elevated.

## Test plan

- [ ] Skeptic review of methodology change
- [ ] grep -rn "tight-fix" content/ docs/ shows only intentionally-archived entries
- [ ] adapter builds succeed for all harnesses