### PR TITLE
chore: rename agent-methodology -> METHODOLOGY across adapters and content (Wave 1.5)

### DIFF
--- a/.claude/commands/cleanup-worktrees.md
+++ b/.claude/commands/cleanup-worktrees.md
@@ -2,7 +2,7 @@
 
 # /cleanup-worktrees
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Clean up stale git worktrees and local branches in the current repository.
 

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -2,7 +2,7 @@
 
 # Implement Ticket
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
@@ -170,9 +170,9 @@ Ask the architect for:
 3. Any risks, gotchas, or ambiguities that need resolution before coding
 4. The appropriate adversarial brief type for Skeptic review (security, logic, performance, data integrity, etc.)
 
-**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `agent-methodology.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
+**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `METHODOLOGY.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 ---
 
@@ -249,13 +249,13 @@ Read the orchestration-planner's output to make the routing determination below 
 ### If work is a single logical unit (or units must be sequential):
 
 Spawn one `engineer` agent per unit in sequence. Each agent prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), filling in fields from the architect's plan / orchestration-planner output for this unit
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, filling in fields from the architect's plan / orchestration-planner output for this unit
 - The plan for this unit: if Phase 3b ran, use the orchestration-planner's output for this unit; if Phase 3b was skipped, use the architect's plan for this unit
 - The branch name to work on
 - The repo path: `$REPO`
 - Instruction to run `$QUALITY_CMD` from the repo root before finishing and fix any errors
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
@@ -288,7 +288,7 @@ git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
 **Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, verify all `depends_on` task_ids are `done` in the file and update each task entry from `pending` -> `in_progress`. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), with fields filled in from the per-unit scope in the planner's JSONL block
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
 - The unit's `task_id`, acceptance criteria, `files_in_scope`, `quality_cmd`, and worktree path
 - The per-unit scope: extracted from the orchestration-planner's JSONL block for that unit
 
@@ -357,7 +357,7 @@ git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```
 
-For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `agent-methodology.md §Worktree Lifecycle`.
+For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `METHODOLOGY.md §Worktree Lifecycle`.
 
 **Merge-conflict re-route and loop iteration:** If a merge conflict re-route occurred above and the re-routed Engineer's output then goes through Skeptic review in Phase 6, the conflict re-route counts as iteration 1 of the Phase 6 loop. Do not double-count: the conflict-resolution Engineer pass is the first fix pass; Phase 6 initializes its `iteration` counter at 1 to reflect this.
 
@@ -375,7 +375,7 @@ Spawn a `skeptic` agent with:
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Findings handling - loop contract:**
 
@@ -444,7 +444,7 @@ agentic-emit spawn_start skeptic - '{"tier":<tier>,"tool_use_id":"<toolu_id_if_k
 USAGE="$(agentic-parse-subagent-usage <session_uuid> <agent_id>)"
 agentic-emit spawn_complete skeptic - "$(printf '{"tier":<tier>,"agent_id":"<agent_id>","status":"ok",%s}' "${USAGE#\{}")"
 ```
-See `agent-methodology.md` Events log section for the full event schema.
+See `METHODOLOGY.md §Events log` for the full event schema.
 
 ```
 ## Prior iteration findings
@@ -519,7 +519,7 @@ Note: the escalation format surfaces findings and history only. The conductor do
 - **If not triggered:** skip directly to Phase 7.
 - **If triggered:** proceed with the QA loop contract below.
 
-For full QA gate rules, see `agent-methodology.md §QA Gate`.
+For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
 **QA loop contract:**
 

--- a/.claude/commands/init-project.md
+++ b/.claude/commands/init-project.md
@@ -2,7 +2,7 @@
 
 # /init-project
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 >
 > Additional activation behavior for this command: see Step 0 "Global activation mode" below.
 
@@ -17,7 +17,7 @@ Scaffold a new project with the standard AGENTS.md hierarchy, CLI tool config, a
 
 **0a. Global activation mode** — read this before any other discovery work.
 
-Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `agent-methodology.md`.
+Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `METHODOLOGY.md`.
 
 - **If `mode=opt-in`**: prompt the user before doing any scaffolding:
 
@@ -581,7 +581,7 @@ Because `.agentic/` is gitignored, `.agentic/preferences.json` is per-developer 
 
 If `~/.agentic/presets.yml` does not already exist, copy `content/references/spawn-presets-example.yml` from the `agentic-engineering` install to `~/.agentic/presets.yml`. **Never overwrite** an existing file - if `~/.agentic/presets.yml` is already present, leave it untouched (the user may have edited it).
 
-Resolution order at spawn time (per `agent-methodology.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
+Resolution order at spawn time (per `METHODOLOGY.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
 
 This step is global (writes outside the project tree). It is idempotent - the file is created on the first `/init-project` invocation on a machine, and subsequent invocations are no-ops. The example library defines `engineer:default`, `engineer:tight-bug`, `skeptic:standard`, `skeptic:plan-review`, `skeptic:security`, and `architect:default`.
 

--- a/.claude/commands/memory-update.md
+++ b/.claude/commands/memory-update.md
@@ -2,7 +2,7 @@
 
 # /memory-update - Memory Protocol: Capture a Decision
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 When a project-affecting decision has been confirmed in conversation, the main agent invokes this command with the decision context passed as `$ARGUMENTS`.
 

--- a/.claude/commands/prune-harness.md
+++ b/.claude/commands/prune-harness.md
@@ -2,7 +2,7 @@
 
 # /prune-harness
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic analysis pass over methodology files to surface deletion candidates - rules whose motivating assumptions have expired as Claude has become more capable.
 
@@ -12,7 +12,7 @@ Performs a periodic analysis pass over methodology files to surface deletion can
 
 ## Safety model
 
-The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
+The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `METHODOLOGY.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -20,7 +20,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the prune analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a pruning proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -40,7 +40,7 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
-**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `agent-methodology.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `agent-methodology.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
+**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
 **Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 

--- a/.claude/commands/representation-audit.md
+++ b/.claude/commands/representation-audit.md
@@ -2,7 +2,7 @@
 
 # /representation-audit
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic prose quality pass over methodology files to surface Python-shaped writing and propose cleaner natural-language rewrites.
 
@@ -14,7 +14,7 @@ Performs a periodic prose quality pass over methodology files to surface Python-
 
 ## Safety model
 
-The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
+The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per `METHODOLOGY.md §Delegation > Worker preamble`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -22,7 +22,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the audit analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a representation audit proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -42,13 +42,13 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 Candidate if a rule is stated with 4+ qualifier clauses chained in a single sentence or paragraph ("unless A, unless B, unless C, does not apply when D..."). The structure signals a Python-shaped approach: rules are expressed by adding exception branches rather than by restating the positive principle more precisely.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, the Low signals block - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
 
 **Signal R2 - nested conditional prose.**
 
 Candidate if more than two conditional branches are expressed in a single prose block without a structural separator (table, sub-heading, or bullet). The reader must hold all branches in working memory to understand any single path.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, same Low signals block - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in the table at lines 19-49 is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in `METHODOLOGY.md §Delegation > spawn-threshold table` is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
 
 **Signal R3 - imperative pseudocode in prose.**
 
@@ -56,13 +56,13 @@ Candidate if prose reads like a switch statement or procedural step sequence whe
 
 Real instance to calibrate against: `skeptic-protocol.md` Section 2 Step-by-step (lines ~93-140) - the numbered 1-through-11 loop reads procedurally, but because execution order genuinely matters here, the format is appropriate and the section is borderline. Use it to calibrate the signal's upper boundary. Flag blocks where the imperative structure obscures rather than clarifies. Confidence: MEDIUM.
 
-**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block, lines ~79-83) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
+**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
 
 **Signal R4 - reference by code-name rather than meaning.**
 
 Candidate if an explanatory prose sentence uses a code-name or file path where the role description or plain-language label would communicate faster to a reader who does not know the repo.
 
-Real instance to calibrate against: `design-goals.md` line 22 - "The Subagent Protocol (`agent-methodology/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `design-goals.md` - "The Subagent Protocol (`content/references/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
 
 **Signal R5 - definition by exclusion.**
 
@@ -74,13 +74,13 @@ Real instance to calibrate against: `skeptic-protocol.md` lines 27-35, the Low r
 
 Candidate if the same qualifier phrase appears 2+ times in the same document where a single anchored reference would suffice. Repetition that serves a genuine cross-reference purpose is excluded (see Non-Signals).
 
-Real instance to calibrate against: `agent-methodology.md` lines 27-29 and 106 - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table` and `METHODOLOGY.md §Risk Classification > Low signals` - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
 
 **Signal R7 - rationale buried after mechanism.**
 
 Candidate if a rule states the imperative first and the rationale last, and the rationale is non-obvious enough that a reader encountering the rule cold would reasonably ask "why?" before complying.
 
-Real instance to calibrate against: `agent-methodology.md` line 29, the file renaming direct-action row note: "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table > file-renaming row` - the note "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
 
 ## Non-signals (explicit carve-outs)
 
@@ -92,7 +92,7 @@ The analyst must NOT flag the following as rewrite candidates under any signal:
 
 **Fenced code blocks.** Exact-syntax examples, CLI commands, and format templates inside code fences are appropriate as-is.
 
-**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block around lines 79-83) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
+**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble (Execution Contract template)` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
 
 **Intentional cross-reference duplication.** Per the `/prune-harness` Signal 3 exception - a rule appearing verbatim in both a rule file and a command that instructs agents to follow it is load-bearing structural redundancy. The same qualifier appearing in two different rules within one document because each rule needs to be independently self-contained is also not R6 if removing the repetition would make either rule ambiguous when read in isolation.
 

--- a/.claude/commands/skeptic.md
+++ b/.claude/commands/skeptic.md
@@ -2,7 +2,7 @@
 
 # /skeptic - The Skeptic Protocol Invocation
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Orchestrate adversarial review for `$ARGUMENTS`. The main agent drives the loop: spawn Worker, spawn Skeptic, route findings, repeat until sign-off.
 

--- a/.claude/commands/test-suite-comprehension.md
+++ b/.claude/commands/test-suite-comprehension.md
@@ -2,7 +2,7 @@
 
 # /test-suite-comprehension
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Map a project's test suite against its source files and surface where verification gaps live. Returns a coverage summary, a gap report ranked by risk, and the specific test files that are highest-leverage places to add coverage.
 
@@ -39,7 +39,7 @@ The report is written to `docs/planning/test-suite-comprehension-YYYY-MM-DD.md`.
 
 ### Step 0 - Activation preflight
 
-Run the Activation preflight from `agent-methodology.md`. If inactive, no-op and exit.
+Run the Activation preflight from `METHODOLOGY.md`. If inactive, no-op and exit.
 
 ### Step 1 - Detect language and test framework
 

--- a/.claude/commands/update-agentic-engineering.md
+++ b/.claude/commands/update-agentic-engineering.md
@@ -2,7 +2,7 @@
 
 # /update-agentic-engineering
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
 

--- a/.claude/commands/wrap.md
+++ b/.claude/commands/wrap.md
@@ -2,7 +2,7 @@
 
 # /wrap — On-Demand Session Context Enrichment
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Use when you want a richer context file than the auto-hook provides — e.g. before handing off complex in-progress work to a future session.
 

--- a/.codex/commands/cleanup-worktrees.md
+++ b/.codex/commands/cleanup-worktrees.md
@@ -1,6 +1,6 @@
 # /cleanup-worktrees
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Clean up stale git worktrees and local branches in the current repository.
 

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1,6 +1,6 @@
 # Implement Ticket
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
@@ -168,9 +168,9 @@ Ask the architect for:
 3. Any risks, gotchas, or ambiguities that need resolution before coding
 4. The appropriate adversarial brief type for Skeptic review (security, logic, performance, data integrity, etc.)
 
-**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `agent-methodology.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
+**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `METHODOLOGY.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 ---
 
@@ -247,13 +247,13 @@ Read the orchestration-planner's output to make the routing determination below 
 ### If work is a single logical unit (or units must be sequential):
 
 Spawn one `engineer` agent per unit in sequence. Each agent prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), filling in fields from the architect's plan / orchestration-planner output for this unit
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, filling in fields from the architect's plan / orchestration-planner output for this unit
 - The plan for this unit: if Phase 3b ran, use the orchestration-planner's output for this unit; if Phase 3b was skipped, use the architect's plan for this unit
 - The branch name to work on
 - The repo path: `$REPO`
 - Instruction to run `$QUALITY_CMD` from the repo root before finishing and fix any errors
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
@@ -286,7 +286,7 @@ git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
 **Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, verify all `depends_on` task_ids are `done` in the file and update each task entry from `pending` -> `in_progress`. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), with fields filled in from the per-unit scope in the planner's JSONL block
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
 - The unit's `task_id`, acceptance criteria, `files_in_scope`, `quality_cmd`, and worktree path
 - The per-unit scope: extracted from the orchestration-planner's JSONL block for that unit
 
@@ -355,7 +355,7 @@ git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```
 
-For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `agent-methodology.md §Worktree Lifecycle`.
+For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `METHODOLOGY.md §Worktree Lifecycle`.
 
 **Merge-conflict re-route and loop iteration:** If a merge conflict re-route occurred above and the re-routed Engineer's output then goes through Skeptic review in Phase 6, the conflict re-route counts as iteration 1 of the Phase 6 loop. Do not double-count: the conflict-resolution Engineer pass is the first fix pass; Phase 6 initializes its `iteration` counter at 1 to reflect this.
 
@@ -373,7 +373,7 @@ Spawn a `skeptic` agent with:
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Findings handling - loop contract:**
 
@@ -442,7 +442,7 @@ agentic-emit spawn_start skeptic - '{"tier":<tier>,"tool_use_id":"<toolu_id_if_k
 USAGE="$(agentic-parse-subagent-usage <session_uuid> <agent_id>)"
 agentic-emit spawn_complete skeptic - "$(printf '{"tier":<tier>,"agent_id":"<agent_id>","status":"ok",%s}' "${USAGE#\{}")"
 ```
-See `agent-methodology.md` Events log section for the full event schema.
+See `METHODOLOGY.md §Events log` for the full event schema.
 
 ```
 ## Prior iteration findings
@@ -517,7 +517,7 @@ Note: the escalation format surfaces findings and history only. The conductor do
 - **If not triggered:** skip directly to Phase 7.
 - **If triggered:** proceed with the QA loop contract below.
 
-For full QA gate rules, see `agent-methodology.md §QA Gate`.
+For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
 **QA loop contract:**
 

--- a/.codex/commands/init-project.md
+++ b/.codex/commands/init-project.md
@@ -1,6 +1,6 @@
 # /init-project
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 >
 > Additional activation behavior for this command: see Step 0 "Global activation mode" below.
 
@@ -15,7 +15,7 @@ Scaffold a new project with the standard AGENTS.md hierarchy, CLI tool config, a
 
 **0a. Global activation mode** — read this before any other discovery work.
 
-Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `agent-methodology.md`.
+Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `METHODOLOGY.md`.
 
 - **If `mode=opt-in`**: prompt the user before doing any scaffolding:
 
@@ -579,7 +579,7 @@ Because `.agentic/` is gitignored, `.agentic/preferences.json` is per-developer 
 
 If `~/.agentic/presets.yml` does not already exist, copy `content/references/spawn-presets-example.yml` from the `agentic-engineering` install to `~/.agentic/presets.yml`. **Never overwrite** an existing file - if `~/.agentic/presets.yml` is already present, leave it untouched (the user may have edited it).
 
-Resolution order at spawn time (per `agent-methodology.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
+Resolution order at spawn time (per `METHODOLOGY.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
 
 This step is global (writes outside the project tree). It is idempotent - the file is created on the first `/init-project` invocation on a machine, and subsequent invocations are no-ops. The example library defines `engineer:default`, `engineer:tight-bug`, `skeptic:standard`, `skeptic:plan-review`, `skeptic:security`, and `architect:default`.
 

--- a/.codex/commands/memory-update.md
+++ b/.codex/commands/memory-update.md
@@ -1,6 +1,6 @@
 # /memory-update - Memory Protocol: Capture a Decision
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 When a project-affecting decision has been confirmed in conversation, the main agent invokes this command with the decision context passed as `$ARGUMENTS`.
 

--- a/.codex/commands/prune-harness.md
+++ b/.codex/commands/prune-harness.md
@@ -1,6 +1,6 @@
 # /prune-harness
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic analysis pass over methodology files to surface deletion candidates - rules whose motivating assumptions have expired as Claude has become more capable.
 
@@ -10,7 +10,7 @@ Performs a periodic analysis pass over methodology files to surface deletion can
 
 ## Safety model
 
-The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
+The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `METHODOLOGY.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -18,7 +18,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the prune analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a pruning proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -38,7 +38,7 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
-**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `agent-methodology.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `agent-methodology.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
+**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
 **Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 

--- a/.codex/commands/representation-audit.md
+++ b/.codex/commands/representation-audit.md
@@ -1,6 +1,6 @@
 # /representation-audit
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic prose quality pass over methodology files to surface Python-shaped writing and propose cleaner natural-language rewrites.
 
@@ -12,7 +12,7 @@ Performs a periodic prose quality pass over methodology files to surface Python-
 
 ## Safety model
 
-The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
+The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per `METHODOLOGY.md §Delegation > Worker preamble`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -20,7 +20,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the audit analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a representation audit proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -40,13 +40,13 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 Candidate if a rule is stated with 4+ qualifier clauses chained in a single sentence or paragraph ("unless A, unless B, unless C, does not apply when D..."). The structure signals a Python-shaped approach: rules are expressed by adding exception branches rather than by restating the positive principle more precisely.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, the Low signals block - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
 
 **Signal R2 - nested conditional prose.**
 
 Candidate if more than two conditional branches are expressed in a single prose block without a structural separator (table, sub-heading, or bullet). The reader must hold all branches in working memory to understand any single path.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, same Low signals block - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in the table at lines 19-49 is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in `METHODOLOGY.md §Delegation > spawn-threshold table` is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
 
 **Signal R3 - imperative pseudocode in prose.**
 
@@ -54,13 +54,13 @@ Candidate if prose reads like a switch statement or procedural step sequence whe
 
 Real instance to calibrate against: `skeptic-protocol.md` Section 2 Step-by-step (lines ~93-140) - the numbered 1-through-11 loop reads procedurally, but because execution order genuinely matters here, the format is appropriate and the section is borderline. Use it to calibrate the signal's upper boundary. Flag blocks where the imperative structure obscures rather than clarifies. Confidence: MEDIUM.
 
-**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block, lines ~79-83) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
+**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
 
 **Signal R4 - reference by code-name rather than meaning.**
 
 Candidate if an explanatory prose sentence uses a code-name or file path where the role description or plain-language label would communicate faster to a reader who does not know the repo.
 
-Real instance to calibrate against: `design-goals.md` line 22 - "The Subagent Protocol (`agent-methodology/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `design-goals.md` - "The Subagent Protocol (`content/references/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
 
 **Signal R5 - definition by exclusion.**
 
@@ -72,13 +72,13 @@ Real instance to calibrate against: `skeptic-protocol.md` lines 27-35, the Low r
 
 Candidate if the same qualifier phrase appears 2+ times in the same document where a single anchored reference would suffice. Repetition that serves a genuine cross-reference purpose is excluded (see Non-Signals).
 
-Real instance to calibrate against: `agent-methodology.md` lines 27-29 and 106 - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table` and `METHODOLOGY.md §Risk Classification > Low signals` - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
 
 **Signal R7 - rationale buried after mechanism.**
 
 Candidate if a rule states the imperative first and the rationale last, and the rationale is non-obvious enough that a reader encountering the rule cold would reasonably ask "why?" before complying.
 
-Real instance to calibrate against: `agent-methodology.md` line 29, the file renaming direct-action row note: "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table > file-renaming row` - the note "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
 
 ## Non-signals (explicit carve-outs)
 
@@ -90,7 +90,7 @@ The analyst must NOT flag the following as rewrite candidates under any signal:
 
 **Fenced code blocks.** Exact-syntax examples, CLI commands, and format templates inside code fences are appropriate as-is.
 
-**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block around lines 79-83) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
+**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble (Execution Contract template)` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
 
 **Intentional cross-reference duplication.** Per the `/prune-harness` Signal 3 exception - a rule appearing verbatim in both a rule file and a command that instructs agents to follow it is load-bearing structural redundancy. The same qualifier appearing in two different rules within one document because each rule needs to be independently self-contained is also not R6 if removing the repetition would make either rule ambiguous when read in isolation.
 

--- a/.codex/commands/skeptic.md
+++ b/.codex/commands/skeptic.md
@@ -1,6 +1,6 @@
 # /skeptic - The Skeptic Protocol Invocation
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Orchestrate adversarial review for `$ARGUMENTS`. The main agent drives the loop: spawn Worker, spawn Skeptic, route findings, repeat until sign-off.
 

--- a/.codex/commands/test-suite-comprehension.md
+++ b/.codex/commands/test-suite-comprehension.md
@@ -1,6 +1,6 @@
 # /test-suite-comprehension
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Map a project's test suite against its source files and surface where verification gaps live. Returns a coverage summary, a gap report ranked by risk, and the specific test files that are highest-leverage places to add coverage.
 
@@ -37,7 +37,7 @@ The report is written to `docs/planning/test-suite-comprehension-YYYY-MM-DD.md`.
 
 ### Step 0 - Activation preflight
 
-Run the Activation preflight from `agent-methodology.md`. If inactive, no-op and exit.
+Run the Activation preflight from `METHODOLOGY.md`. If inactive, no-op and exit.
 
 ### Step 1 - Detect language and test framework
 

--- a/.codex/commands/update-agentic-engineering.md
+++ b/.codex/commands/update-agentic-engineering.md
@@ -1,6 +1,6 @@
 # /update-agentic-engineering
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
 

--- a/.codex/commands/wrap.md
+++ b/.codex/commands/wrap.md
@@ -1,6 +1,6 @@
 # /wrap — On-Demand Session Context Enrichment
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Use when you want a richer context file than the auto-hook provides — e.g. before handing off complex in-progress work to a future session.
 

--- a/.cursor/commands/cleanup-worktrees.md
+++ b/.cursor/commands/cleanup-worktrees.md
@@ -1,6 +1,6 @@
 # /cleanup-worktrees
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Clean up stale git worktrees and local branches in the current repository.
 

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1,6 +1,6 @@
 # Implement Ticket
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
@@ -168,9 +168,9 @@ Ask the architect for:
 3. Any risks, gotchas, or ambiguities that need resolution before coding
 4. The appropriate adversarial brief type for Skeptic review (security, logic, performance, data integrity, etc.)
 
-**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `agent-methodology.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
+**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `METHODOLOGY.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 ---
 
@@ -247,13 +247,13 @@ Read the orchestration-planner's output to make the routing determination below 
 ### If work is a single logical unit (or units must be sequential):
 
 Spawn one `engineer` agent per unit in sequence. Each agent prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), filling in fields from the architect's plan / orchestration-planner output for this unit
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, filling in fields from the architect's plan / orchestration-planner output for this unit
 - The plan for this unit: if Phase 3b ran, use the orchestration-planner's output for this unit; if Phase 3b was skipped, use the architect's plan for this unit
 - The branch name to work on
 - The repo path: `$REPO`
 - Instruction to run `$QUALITY_CMD` from the repo root before finishing and fix any errors
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
@@ -286,7 +286,7 @@ git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
 **Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, verify all `depends_on` task_ids are `done` in the file and update each task entry from `pending` -> `in_progress`. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), with fields filled in from the per-unit scope in the planner's JSONL block
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
 - The unit's `task_id`, acceptance criteria, `files_in_scope`, `quality_cmd`, and worktree path
 - The per-unit scope: extracted from the orchestration-planner's JSONL block for that unit
 
@@ -355,7 +355,7 @@ git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```
 
-For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `agent-methodology.md §Worktree Lifecycle`.
+For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `METHODOLOGY.md §Worktree Lifecycle`.
 
 **Merge-conflict re-route and loop iteration:** If a merge conflict re-route occurred above and the re-routed Engineer's output then goes through Skeptic review in Phase 6, the conflict re-route counts as iteration 1 of the Phase 6 loop. Do not double-count: the conflict-resolution Engineer pass is the first fix pass; Phase 6 initializes its `iteration` counter at 1 to reflect this.
 
@@ -373,7 +373,7 @@ Spawn a `skeptic` agent with:
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Findings handling - loop contract:**
 
@@ -442,7 +442,7 @@ agentic-emit spawn_start skeptic - '{"tier":<tier>,"tool_use_id":"<toolu_id_if_k
 USAGE="$(agentic-parse-subagent-usage <session_uuid> <agent_id>)"
 agentic-emit spawn_complete skeptic - "$(printf '{"tier":<tier>,"agent_id":"<agent_id>","status":"ok",%s}' "${USAGE#\{}")"
 ```
-See `agent-methodology.md` Events log section for the full event schema.
+See `METHODOLOGY.md §Events log` for the full event schema.
 
 ```
 ## Prior iteration findings
@@ -517,7 +517,7 @@ Note: the escalation format surfaces findings and history only. The conductor do
 - **If not triggered:** skip directly to Phase 7.
 - **If triggered:** proceed with the QA loop contract below.
 
-For full QA gate rules, see `agent-methodology.md §QA Gate`.
+For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
 **QA loop contract:**
 

--- a/.cursor/commands/init-project.md
+++ b/.cursor/commands/init-project.md
@@ -1,6 +1,6 @@
 # /init-project
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 >
 > Additional activation behavior for this command: see Step 0 "Global activation mode" below.
 
@@ -15,7 +15,7 @@ Scaffold a new project with the standard AGENTS.md hierarchy, CLI tool config, a
 
 **0a. Global activation mode** — read this before any other discovery work.
 
-Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `agent-methodology.md`.
+Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `METHODOLOGY.md`.
 
 - **If `mode=opt-in`**: prompt the user before doing any scaffolding:
 
@@ -579,7 +579,7 @@ Because `.agentic/` is gitignored, `.agentic/preferences.json` is per-developer 
 
 If `~/.agentic/presets.yml` does not already exist, copy `content/references/spawn-presets-example.yml` from the `agentic-engineering` install to `~/.agentic/presets.yml`. **Never overwrite** an existing file - if `~/.agentic/presets.yml` is already present, leave it untouched (the user may have edited it).
 
-Resolution order at spawn time (per `agent-methodology.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
+Resolution order at spawn time (per `METHODOLOGY.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
 
 This step is global (writes outside the project tree). It is idempotent - the file is created on the first `/init-project` invocation on a machine, and subsequent invocations are no-ops. The example library defines `engineer:default`, `engineer:tight-bug`, `skeptic:standard`, `skeptic:plan-review`, `skeptic:security`, and `architect:default`.
 

--- a/.cursor/commands/memory-update.md
+++ b/.cursor/commands/memory-update.md
@@ -1,6 +1,6 @@
 # /memory-update - Memory Protocol: Capture a Decision
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 When a project-affecting decision has been confirmed in conversation, the main agent invokes this command with the decision context passed as `$ARGUMENTS`.
 

--- a/.cursor/commands/prune-harness.md
+++ b/.cursor/commands/prune-harness.md
@@ -1,6 +1,6 @@
 # /prune-harness
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic analysis pass over methodology files to surface deletion candidates - rules whose motivating assumptions have expired as Claude has become more capable.
 
@@ -10,7 +10,7 @@ Performs a periodic analysis pass over methodology files to surface deletion can
 
 ## Safety model
 
-The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
+The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `METHODOLOGY.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -18,7 +18,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the prune analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a pruning proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -38,7 +38,7 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
-**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `agent-methodology.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `agent-methodology.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
+**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
 **Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 

--- a/.cursor/commands/representation-audit.md
+++ b/.cursor/commands/representation-audit.md
@@ -1,6 +1,6 @@
 # /representation-audit
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic prose quality pass over methodology files to surface Python-shaped writing and propose cleaner natural-language rewrites.
 
@@ -12,7 +12,7 @@ Performs a periodic prose quality pass over methodology files to surface Python-
 
 ## Safety model
 
-The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
+The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per `METHODOLOGY.md §Delegation > Worker preamble`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -20,7 +20,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the audit analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a representation audit proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -40,13 +40,13 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 Candidate if a rule is stated with 4+ qualifier clauses chained in a single sentence or paragraph ("unless A, unless B, unless C, does not apply when D..."). The structure signals a Python-shaped approach: rules are expressed by adding exception branches rather than by restating the positive principle more precisely.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, the Low signals block - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
 
 **Signal R2 - nested conditional prose.**
 
 Candidate if more than two conditional branches are expressed in a single prose block without a structural separator (table, sub-heading, or bullet). The reader must hold all branches in working memory to understand any single path.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, same Low signals block - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in the table at lines 19-49 is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in `METHODOLOGY.md §Delegation > spawn-threshold table` is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
 
 **Signal R3 - imperative pseudocode in prose.**
 
@@ -54,13 +54,13 @@ Candidate if prose reads like a switch statement or procedural step sequence whe
 
 Real instance to calibrate against: `skeptic-protocol.md` Section 2 Step-by-step (lines ~93-140) - the numbered 1-through-11 loop reads procedurally, but because execution order genuinely matters here, the format is appropriate and the section is borderline. Use it to calibrate the signal's upper boundary. Flag blocks where the imperative structure obscures rather than clarifies. Confidence: MEDIUM.
 
-**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block, lines ~79-83) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
+**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
 
 **Signal R4 - reference by code-name rather than meaning.**
 
 Candidate if an explanatory prose sentence uses a code-name or file path where the role description or plain-language label would communicate faster to a reader who does not know the repo.
 
-Real instance to calibrate against: `design-goals.md` line 22 - "The Subagent Protocol (`agent-methodology/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `design-goals.md` - "The Subagent Protocol (`content/references/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
 
 **Signal R5 - definition by exclusion.**
 
@@ -72,13 +72,13 @@ Real instance to calibrate against: `skeptic-protocol.md` lines 27-35, the Low r
 
 Candidate if the same qualifier phrase appears 2+ times in the same document where a single anchored reference would suffice. Repetition that serves a genuine cross-reference purpose is excluded (see Non-Signals).
 
-Real instance to calibrate against: `agent-methodology.md` lines 27-29 and 106 - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table` and `METHODOLOGY.md §Risk Classification > Low signals` - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
 
 **Signal R7 - rationale buried after mechanism.**
 
 Candidate if a rule states the imperative first and the rationale last, and the rationale is non-obvious enough that a reader encountering the rule cold would reasonably ask "why?" before complying.
 
-Real instance to calibrate against: `agent-methodology.md` line 29, the file renaming direct-action row note: "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table > file-renaming row` - the note "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
 
 ## Non-signals (explicit carve-outs)
 
@@ -90,7 +90,7 @@ The analyst must NOT flag the following as rewrite candidates under any signal:
 
 **Fenced code blocks.** Exact-syntax examples, CLI commands, and format templates inside code fences are appropriate as-is.
 
-**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block around lines 79-83) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
+**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble (Execution Contract template)` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
 
 **Intentional cross-reference duplication.** Per the `/prune-harness` Signal 3 exception - a rule appearing verbatim in both a rule file and a command that instructs agents to follow it is load-bearing structural redundancy. The same qualifier appearing in two different rules within one document because each rule needs to be independently self-contained is also not R6 if removing the repetition would make either rule ambiguous when read in isolation.
 

--- a/.cursor/commands/skeptic.md
+++ b/.cursor/commands/skeptic.md
@@ -1,6 +1,6 @@
 # /skeptic - The Skeptic Protocol Invocation
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Orchestrate adversarial review for `$ARGUMENTS`. The main agent drives the loop: spawn Worker, spawn Skeptic, route findings, repeat until sign-off.
 

--- a/.cursor/commands/test-suite-comprehension.md
+++ b/.cursor/commands/test-suite-comprehension.md
@@ -1,6 +1,6 @@
 # /test-suite-comprehension
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Map a project's test suite against its source files and surface where verification gaps live. Returns a coverage summary, a gap report ranked by risk, and the specific test files that are highest-leverage places to add coverage.
 
@@ -37,7 +37,7 @@ The report is written to `docs/planning/test-suite-comprehension-YYYY-MM-DD.md`.
 
 ### Step 0 - Activation preflight
 
-Run the Activation preflight from `agent-methodology.md`. If inactive, no-op and exit.
+Run the Activation preflight from `METHODOLOGY.md`. If inactive, no-op and exit.
 
 ### Step 1 - Detect language and test framework
 

--- a/.cursor/commands/update-agentic-engineering.md
+++ b/.cursor/commands/update-agentic-engineering.md
@@ -1,6 +1,6 @@
 # /update-agentic-engineering
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
 

--- a/.cursor/commands/wrap.md
+++ b/.cursor/commands/wrap.md
@@ -1,6 +1,6 @@
 # /wrap — On-Demand Session Context Enrichment
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Use when you want a richer context file than the auto-hook provides — e.g. before handing off complex in-progress work to a future session.
 

--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -33,7 +33,7 @@ When spawned via `/implement-ticket` Phase 5 with a `task_id` in the execution c
 
 **HUD file writes (Phase 2 fan-out only).** When spawned as a parallel fan-out Worker with a `worker_id` field in the execution contract, the engineer writes phase transition updates to `.agentic/hud/<worker-id>.json` before each major action (before spawning sub-agents, at loop phase transitions, at completion). The HUD file write accompanies `[loop: ...]` breadcrumb emissions - both happen at the same event. Engineers spawned without a `worker_id` (single-unit, non-fan-out contexts) do not write HUD files. The `worker_id` is provided in the spawn prompt alongside `task_id`.
 
-(Tight-fix path removed; see post-debugger Low classification rule in `content/rules/agent-methodology.md`.)
+(Tight-fix path removed; see post-debugger Low classification rule in `METHODOLOGY.md`.)
 
 ## Implementation process
 

--- a/content/commands/cleanup-worktrees.md
+++ b/content/commands/cleanup-worktrees.md
@@ -1,6 +1,6 @@
 # /cleanup-worktrees
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Clean up stale git worktrees and local branches in the current repository.
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1,6 +1,6 @@
 # Implement Ticket
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
@@ -168,9 +168,9 @@ Ask the architect for:
 3. Any risks, gotchas, or ambiguities that need resolution before coding
 4. The appropriate adversarial brief type for Skeptic review (security, logic, performance, data integrity, etc.)
 
-**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `agent-methodology.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
+**Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every open question before proceeding - see `METHODOLOGY.md` for resolution paths. For the full adversarial brief menu, see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 ---
 
@@ -247,13 +247,13 @@ Read the orchestration-planner's output to make the routing determination below 
 ### If work is a single logical unit (or units must be sequential):
 
 Spawn one `engineer` agent per unit in sequence. Each agent prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), filling in fields from the architect's plan / orchestration-planner output for this unit
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, filling in fields from the architect's plan / orchestration-planner output for this unit
 - The plan for this unit: if Phase 3b ran, use the orchestration-planner's output for this unit; if Phase 3b was skipped, use the architect's plan for this unit
 - The branch name to work on
 - The repo path: `$REPO`
 - Instruction to run `$QUALITY_CMD` from the repo root before finishing and fix any errors
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
@@ -286,7 +286,7 @@ git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
 **Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, verify all `depends_on` task_ids are `done` in the file and update each task entry from `pending` -> `in_progress`. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
-- The execution contract block from `agent-methodology.md` (Worker preamble section), with fields filled in from the per-unit scope in the planner's JSONL block
+- The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
 - The unit's `task_id`, acceptance criteria, `files_in_scope`, `quality_cmd`, and worktree path
 - The per-unit scope: extracted from the orchestration-planner's JSONL block for that unit
 
@@ -355,7 +355,7 @@ git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```
 
-For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `agent-methodology.md §Worktree Lifecycle`.
+For full worktree cleanup rules (isolation worktrees, feature worktrees, stale branch pruning), see `METHODOLOGY.md §Worktree Lifecycle`.
 
 **Merge-conflict re-route and loop iteration:** If a merge conflict re-route occurred above and the re-routed Engineer's output then goes through Skeptic review in Phase 6, the conflict re-route counts as iteration 1 of the Phase 6 loop. Do not double-count: the conflict-resolution Engineer pass is the first fix pass; Phase 6 initializes its `iteration` counter at 1 to reflect this.
 
@@ -373,7 +373,7 @@ Spawn a `skeptic` agent with:
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
-**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in agent-methodology.md). Default is Tier 2 (omit the model param).
+**Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
 
 **Findings handling - loop contract:**
 
@@ -442,7 +442,7 @@ agentic-emit spawn_start skeptic - '{"tier":<tier>,"tool_use_id":"<toolu_id_if_k
 USAGE="$(agentic-parse-subagent-usage <session_uuid> <agent_id>)"
 agentic-emit spawn_complete skeptic - "$(printf '{"tier":<tier>,"agent_id":"<agent_id>","status":"ok",%s}' "${USAGE#\{}")"
 ```
-See `agent-methodology.md` Events log section for the full event schema.
+See `METHODOLOGY.md §Events log` for the full event schema.
 
 ```
 ## Prior iteration findings
@@ -559,7 +559,7 @@ Note: the escalation format surfaces findings and history only. The conductor do
 - **If not triggered:** skip directly to Phase 7.
 - **If triggered:** proceed with the QA loop contract below.
 
-For full QA gate rules, see `agent-methodology.md §QA Gate`.
+For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
 **QA loop contract:**
 

--- a/content/commands/init-project.md
+++ b/content/commands/init-project.md
@@ -1,6 +1,6 @@
 # /init-project
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 >
 > Additional activation behavior for this command: see Step 0 "Global activation mode" below.
 
@@ -15,7 +15,7 @@ Scaffold a new project with the standard AGENTS.md hierarchy, CLI tool config, a
 
 **0a. Global activation mode** — read this before any other discovery work.
 
-Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `agent-methodology.md`.
+Read `~/.claude/agentic-engineering.json`. Expected shape: `{ "mode": "opt-out" | "opt-in", "profile": "relaxed" | "default" | "strict", "preset": "lean" | "standard" | "strict" | null, "set_at": "<ISO8601>" }`. If missing or unreadable, assume `mode=opt-out`, `profile=default`, and `preset=null`. The `preset` field is optional and back-compat - when null/missing, the direct `profile` field is used. When writing this file during init (if creating it for the first time), include `"preset": "standard"` as a sensible default that maps to `profile=default` via the preset table in `METHODOLOGY.md`.
 
 - **If `mode=opt-in`**: prompt the user before doing any scaffolding:
 
@@ -579,7 +579,7 @@ Because `.agentic/` is gitignored, `.agentic/preferences.json` is per-developer 
 
 If `~/.agentic/presets.yml` does not already exist, copy `content/references/spawn-presets-example.yml` from the `agentic-engineering` install to `~/.agentic/presets.yml`. **Never overwrite** an existing file - if `~/.agentic/presets.yml` is already present, leave it untouched (the user may have edited it).
 
-Resolution order at spawn time (per `agent-methodology.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
+Resolution order at spawn time (per `METHODOLOGY.md` Spawn presets section): the conductor reads `.agentic/presets.yml` (project-local) first, merged shallowly over `~/.agentic/presets.yml` (user-global). Project keys win on collision.
 
 This step is global (writes outside the project tree). It is idempotent - the file is created on the first `/init-project` invocation on a machine, and subsequent invocations are no-ops. The example library defines `engineer:default`, `engineer:tight-bug`, `skeptic:standard`, `skeptic:plan-review`, `skeptic:security`, and `architect:default`.
 

--- a/content/commands/memory-update.md
+++ b/content/commands/memory-update.md
@@ -1,6 +1,6 @@
 # /memory-update - Memory Protocol: Capture a Decision
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 When a project-affecting decision has been confirmed in conversation, the main agent invokes this command with the decision context passed as `$ARGUMENTS`.
 

--- a/content/commands/prune-harness.md
+++ b/content/commands/prune-harness.md
@@ -1,6 +1,6 @@
 # /prune-harness
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic analysis pass over methodology files to surface deletion candidates - rules whose motivating assumptions have expired as Claude has become more capable.
 
@@ -10,7 +10,7 @@ Performs a periodic analysis pass over methodology files to surface deletion can
 
 ## Safety model
 
-The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
+The prune analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `METHODOLOGY.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the Skeptic review on each subsequent deletion via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot delete" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -18,7 +18,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the prune analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a pruning proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -38,7 +38,7 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
-**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `agent-methodology.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `agent-methodology.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
+**Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
 **Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 

--- a/content/commands/representation-audit.md
+++ b/content/commands/representation-audit.md
@@ -1,6 +1,6 @@
 # /representation-audit
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Performs a periodic prose quality pass over methodology files to surface Python-shaped writing and propose cleaner natural-language rewrites.
 
@@ -12,7 +12,7 @@ Performs a periodic prose quality pass over methodology files to surface Python-
 
 ## Safety model
 
-The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per the Worker preamble section of `agent-methodology.md`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
+The audit analyst Worker is instructed not to write to `content/` and to restrict writes to the single output path in `docs/planning/`. This is enforced by Worker brief compliance, NOT by a harness-level technical barrier. The `tool_scope` field in the execution contract is documentation only - per `METHODOLOGY.md §Delegation > Worker preamble`, it does not physically prevent writes. The analyst is instructed not to write to `content/`, and any violation would surface as a diff the conductor rejects before moving to Step 4. The authoritative gate is the meaning-preservation Skeptic review on each subsequent rewrite via `/update-agentic-engineering`. Do not describe this mechanism as "physically cannot edit" - it cannot and does not make that guarantee.
 
 ## Step 0 - Preflight git sync
 
@@ -20,7 +20,7 @@ Run the Step 0 preflight from `/update-agentic-engineering` verbatim (fetch orig
 
 ## Step 1 - Spawn the audit analyst
 
-Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `agent-methodology.md`):
+Spawn a single `general-purpose` Worker in background with the following execution contract (NLH format per `METHODOLOGY.md`):
 
 *"You are a Worker agent. Produce a representation audit proposal for the agentic-engineering methodology corpus and return your complete output. The main agent will present the proposal to the user for approval."*
 
@@ -40,45 +40,45 @@ The analyst applies each signal to every file in scope and flags candidates as t
 
 Candidate if a rule is stated with 4+ qualifier clauses chained in a single sentence or paragraph ("unless A, unless B, unless C, does not apply when D..."). The structure signals a Python-shaped approach: rules are expressed by adding exception branches rather than by restating the positive principle more precisely.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, the Low signals block - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - the "documentation-only file creation" bullet chains six qualifiers in a single parenthetical: "new .md or .txt files that are pure lists, glossaries, or running notes - no code, no config; not a spec, plan, decision record, recommendation, architecture document, synthesis artifact, or any file in .claude/ or ~/agentic-engineering/; overrides the 'new file creation' Elevated signal for this case only." That sentence is the calibration specimen for R1 intensity. Flag at or above that density. Confidence: MEDIUM-HIGH depending on intensity.
 
 **Signal R2 - nested conditional prose.**
 
 Candidate if more than two conditional branches are expressed in a single prose block without a structural separator (table, sub-heading, or bullet). The reader must hold all branches in working memory to understand any single path.
 
-Real instance to calibrate against: `agent-methodology.md` line 106, same Low signals block - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in the table at lines 19-49 is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Risk Classification > Low signals` - it packs four distinct direct-action overrides (documentation creation, wording fixes, file renaming, UI copy changes) into a single paragraph, each with their own conditions and carve-outs. That is the calibration specimen for R2 density. The clean spawn-threshold enumeration in `METHODOLOGY.md §Delegation > spawn-threshold table` is NOT an R2 candidate - it uses structural separation (table) correctly. Confidence: MEDIUM.
 
 **Signal R3 - imperative pseudocode in prose.**
 
 Candidate if prose reads like a switch statement or procedural step sequence where a structural description of the outcome would communicate the same intent more directly.
 
-Real instance to calibrate against: `skeptic-protocol.md` Section 2 Step-by-step (lines ~93-140) - the numbered 1-through-11 loop reads procedurally, but because execution order genuinely matters here, the format is appropriate and the section is borderline. Use it to calibrate the signal's upper boundary. Flag blocks where the imperative structure obscures rather than clarifies. Confidence: MEDIUM.
+Real instance to calibrate against: `skeptic-protocol.md §Section 2 (Step-by-step)` - the numbered 1-through-11 loop reads procedurally, but because execution order genuinely matters here, the format is appropriate and the section is borderline. Use it to calibrate the signal's upper boundary. Flag blocks where the imperative structure obscures rather than clarifies. Confidence: MEDIUM.
 
-**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block, lines ~79-83) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
+**IMPORTANT non-signal - see Non-Signals section below.** The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) is a Markdown bullet list that could superficially match R3. It must NOT be flagged. Template blocks are load-bearing structured formats, not prose.
 
 **Signal R4 - reference by code-name rather than meaning.**
 
 Candidate if an explanatory prose sentence uses a code-name or file path where the role description or plain-language label would communicate faster to a reader who does not know the repo.
 
-Real instance to calibrate against: `design-goals.md` line 22 - "The Subagent Protocol (`agent-methodology/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `design-goals.md` - "The Subagent Protocol (`content/references/subagent-protocol.md`) operationalizes this goal" - the parenthetical path reference is functional, but in a pure explanatory sentence, "the orchestration rules file" or the section heading would land faster for a first-time reader. Use this as a low-end calibration (LOW confidence). Note: proper agent names (`engineer`, `skeptic`, `orchestration-planner`) used as proper nouns in normative rules are NOT R4 candidates - see Non-Signals below. Confidence: LOW-MEDIUM.
 
 **Signal R5 - definition by exclusion.**
 
 Candidate if a concept is defined entirely as "when not X and not Y and not Z" without a positive anchor that states what the concept IS.
 
-Real instance to calibrate against: `skeptic-protocol.md` lines 27-35, the Low risk definition - it opens with "None of the above:" and lists examples, but the positive definition ("direct action with a brief inline self-check") appears as a secondary label rather than the lead. Compare to the Elevated definition above it, which leads with the positive mechanism ("Full Adversarial Review: Worker + fresh independent Skeptic"). The contrast makes the R5 pattern visible. Confidence: MEDIUM.
+Real instance to calibrate against: `skeptic-protocol.md §Risk Classification (Skeptic) > Low risk` - it opens with "None of the above:" and lists examples, but the positive definition ("direct action with a brief inline self-check") appears as a secondary label rather than the lead. Compare to the Elevated definition above it, which leads with the positive mechanism ("Full Adversarial Review: Worker + fresh independent Skeptic"). The contrast makes the R5 pattern visible. Confidence: MEDIUM.
 
 **Signal R6 - duplicated conditional clauses.**
 
 Candidate if the same qualifier phrase appears 2+ times in the same document where a single anchored reference would suffice. Repetition that serves a genuine cross-reference purpose is excluded (see Non-Signals).
 
-Real instance to calibrate against: `agent-methodology.md` lines 27-29 and 106 - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table` and `METHODOLOGY.md §Risk Classification > Low signals` - the phrase "does not override the 'modifies protocol or infrastructure files' Elevated signal" appears in the Documentation-only creation bullet, the targeted wording fix bullet, the file renaming bullet, and again in the Low signals paragraph. Four occurrences of the same qualifier in the same document. This is the calibration specimen for R6. Confidence: MEDIUM.
 
 **Signal R7 - rationale buried after mechanism.**
 
 Candidate if a rule states the imperative first and the rationale last, and the rationale is non-obvious enough that a reader encountering the rule cold would reasonably ask "why?" before complying.
 
-Real instance to calibrate against: `agent-methodology.md` line 29, the file renaming direct-action row note: "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
+Real instance to calibrate against: `METHODOLOGY.md §Delegation > spawn-threshold table > file-renaming row` - the note "does not apply if the file's name or path has behavioral significance by convention - framework routing, auto-discovery, config naming - the rename changes behavior without changing file contents." The mechanism (exclusion condition) comes first; the explanatory principle ("the rename changes behavior without changing file contents") comes last. For a reader unfamiliar with the pattern, leading with the principle would reduce parsing friction. Confidence: LOW-MEDIUM.
 
 ## Non-signals (explicit carve-outs)
 
@@ -90,7 +90,7 @@ The analyst must NOT flag the following as rewrite candidates under any signal:
 
 **Fenced code blocks.** Exact-syntax examples, CLI commands, and format templates inside code fences are appropriate as-is.
 
-**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `agent-methodology.md` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block around lines 79-83) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
+**Markdown bullet lists that function as templates.** This is the key exclusion. The Execution Contract template in `METHODOLOGY.md §Delegation > Worker preamble (Execution Contract template)` (the 5-field outputs/budget/tool_scope/completion_conditions/output_paths block) and any other template block whose bullet structure is copied verbatim into agent spawn prompts or proposal documents is load-bearing structured format, NOT prose. Do not propose rewriting templates into flowing prose. The signal is "this reads like Python"; templates are not prose and cannot read like Python. This exclusion applies to any block that functions as a fill-in-the-blank form.
 
 **Intentional cross-reference duplication.** Per the `/prune-harness` Signal 3 exception - a rule appearing verbatim in both a rule file and a command that instructs agents to follow it is load-bearing structural redundancy. The same qualifier appearing in two different rules within one document because each rule needs to be independently self-contained is also not R6 if removing the repetition would make either rule ambiguous when read in isolation.
 

--- a/content/commands/skeptic.md
+++ b/content/commands/skeptic.md
@@ -1,6 +1,6 @@
 # /skeptic - The Skeptic Protocol Invocation
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Orchestrate adversarial review for `$ARGUMENTS`. The main agent drives the loop: spawn Worker, spawn Skeptic, route findings, repeat until sign-off.
 

--- a/content/commands/test-suite-comprehension.md
+++ b/content/commands/test-suite-comprehension.md
@@ -1,6 +1,6 @@
 # /test-suite-comprehension
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Map a project's test suite against its source files and surface where verification gaps live. Returns a coverage summary, a gap report ranked by risk, and the specific test files that are highest-leverage places to add coverage.
 
@@ -37,7 +37,7 @@ The report is written to `docs/planning/test-suite-comprehension-YYYY-MM-DD.md`.
 
 ### Step 0 - Activation preflight
 
-Run the Activation preflight from `agent-methodology.md`. If inactive, no-op and exit.
+Run the Activation preflight from `METHODOLOGY.md`. If inactive, no-op and exit.
 
 ### Step 1 - Detect language and test framework
 

--- a/content/commands/update-agentic-engineering.md
+++ b/content/commands/update-agentic-engineering.md
@@ -1,6 +1,6 @@
 # /update-agentic-engineering
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
 

--- a/content/commands/wrap.md
+++ b/content/commands/wrap.md
@@ -1,6 +1,6 @@
 # /wrap — On-Demand Session Context Enrichment
 
-> Run the Activation preflight from `agent-methodology.md` before proceeding. If inactive, no-op and exit.
+> Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
 Use when you want a richer context file than the auto-hook provides — e.g. before handing off complex in-progress work to a future session.
 

--- a/content/references/agent-team.md
+++ b/content/references/agent-team.md
@@ -174,7 +174,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`~/.claude/projects/[hash]/context.md`)
-- For Elevated-path spawns: the execution contract block from `agent-methodology.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
+- For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.
 

--- a/content/references/design-goals.md
+++ b/content/references/design-goals.md
@@ -18,7 +18,7 @@ This document captures the design intent of the claude-protocols system. It is w
 
 **An evaluator should ask:** Does the main agent ever block, wait, or do substantial work inline? Is the spawn threshold being respected? Are independent tasks actually running in parallel?
 
-The Subagent Protocol (`agent-methodology/subagent-protocol.md`) operationalizes this goal with specific rules, a decision table, and an anti-patterns section.
+The Subagent Protocol (`content/references/subagent-protocol.md`) operationalizes this goal with specific rules, a decision table, and an anti-patterns section.
 
 ---
 
@@ -39,7 +39,7 @@ The Skeptic pattern counters this by introducing a genuinely independent reviewe
 
 **An evaluator should ask:** Is the Skeptic actually fresh each round? Is the adversarial brief being passed verbatim? Is the brief specific enough to catch real problems? Are Critical and Major findings being genuinely resolved or just rationalized away?
 
-The Skeptic Protocol (`agent-methodology/skeptic-protocol.md`) operationalizes this goal with the full loop definition, escalation rules, sign-off format, and adversarial brief templates.
+The Skeptic Protocol (`content/references/skeptic-protocol.md`) operationalizes this goal with the full loop definition, escalation rules, sign-off format, and adversarial brief templates.
 
 ---
 

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -131,7 +131,7 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 9. **Repeat steps 4–8** until the Skeptic grants sign-off:
    > "No unresolved Critical or Major findings. Sign-off granted."
 
-10. **QA gate check (conditional).** After sign-off is granted and any minor fixes are applied, the conductor checks the QA gate condition (see agent-methodology.md QA Gate section). If the project has qa.md (resolved via `.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) with trigger patterns matching the diff, spawn `qa-engineer` before reporting back. QA failure routes back to an engineer for fixes, then re-runs QA. If no QA gate applies, proceed directly to step 11.
+10. **QA gate check (conditional).** After sign-off is granted and any minor fixes are applied, the conductor checks the QA gate condition (see METHODOLOGY.md §QA Gate). If the project has qa.md (resolved via `.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) with trigger patterns matching the diff, spawn `qa-engineer` before reporting back. QA failure routes back to an engineer for fixes, then re-runs QA. If no QA gate applies, proceed directly to step 11.
 
 11. **Primary agent reports back** with:
     - The final implementation

--- a/content/references/subagent-protocol.md
+++ b/content/references/subagent-protocol.md
@@ -385,7 +385,7 @@ The Subagent Protocol does not replace The Skeptic Protocol — it provides the 
 
 ## 10. Input Contract
 
-When spawning an `engineer` Worker on an Elevated-risk task, the conductor includes an execution contract block in the spawn prompt. The canonical template lives in `agent-methodology.md` (Worker preamble section). Required: outputs, tool_scope, completion_conditions. Optional: budget (advisory, not enforced). Conditional: output_paths (required when pre-specified by the architect plan, otherwise "conductor-directed").
+When spawning an `engineer` Worker on an Elevated-risk task, the conductor includes an execution contract block in the spawn prompt. The canonical template lives in `METHODOLOGY.md` (Worker preamble section). Required: outputs, tool_scope, completion_conditions. Optional: budget (advisory, not enforced). Conditional: output_paths (required when pre-specified by the architect plan, otherwise "conductor-directed").
 
 For non-Tier-2 spawns, the conductor also passes a `model` param in the Agent tool call (`haiku` for Tier 1, `opus` for Tier 3). This param is omitted for Tier 2 (default). Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 

--- a/content/sections/README.md
+++ b/content/sections/README.md
@@ -66,17 +66,17 @@ Bold-prose paragraph leads (e.g. `**Conductor rule for Trivial:**`) are NOT cove
 
 ## Known Wave 1 regressions
 
-The Wave 1 PR that introduced this directory deletes `content/rules/agent-methodology.md`. As of that PR, three sibling adapter scripts still reference the deleted path and will fail until Wave 2 lands:
+The Wave 1 PR that introduced this directory deletes the now-renamed `content/rules/METHODOLOGY.md`. As of that PR, three sibling adapter scripts still reference the deleted path and will fail until Wave 2 lands:
 
-- `.gemini/build.sh` (line ~55) cats `content/rules/agent-methodology.md`
-- `.kimi/build.sh` (line ~32) cats `content/rules/agent-methodology.md`
+- `.gemini/build.sh` (line ~55) cats `content/rules/METHODOLOGY.md` (deleted path)
+- `.kimi/build.sh` (line ~32) cats `content/rules/METHODOLOGY.md` (deleted path)
 - `.opencode/install.sh` (line ~322) references the deleted path
 
 If you are on the Wave-1 branch, do NOT run those adapter builds. Wave 2 (Codex/Gemini/Cursor adapter migrations) plus the Kimi and OpenCode catch-ups documented here will close all three.
 
 ## Existing-installation upgrade path
 
-If you previously installed the agentic-engineering skill (via `bash .claude/install.sh`), your `~/.claude/CLAUDE.md` contains a managed block with `@skills/agentic-engineering/rules/agent-methodology.md`. After pulling Wave 1, that import points at a deleted file. Re-run `bash .claude/install.sh` once - the script's regex sub rewrites the managed block to import `@skills/agentic-engineering/METHODOLOGY.md` cleanly. The skill directory itself is symlinked from the repo, so its content updates automatically on `git pull`; only the `@`-import line in `CLAUDE.md` is stale until install re-runs.
+If you previously installed the agentic-engineering skill (via `bash .claude/install.sh`), your `~/.claude/CLAUDE.md` contains a managed block with `@skills/agentic-engineering/METHODOLOGY.md`. After pulling Wave 1, that import points at a deleted file. Re-run `bash .claude/install.sh` once - the script's regex sub rewrites the managed block to import `@skills/agentic-engineering/METHODOLOGY.md` cleanly. The skill directory itself is symlinked from the repo, so its content updates automatically on `git pull`; only the `@`-import line in `CLAUDE.md` is stale until install re-runs.
 
 ## Baseline SHA semantics
 

--- a/docs/planning/p0-gemini-adapter.md
+++ b/docs/planning/p0-gemini-adapter.md
@@ -1,5 +1,7 @@
 # P0 Gemini Adapter - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 The agentic-engineering repo ships adapters for Claude Code (`.claude/`), Cursor (`.cursor/`), and Codex CLI (`.codex/`). Google's Gemini CLI is absent. This is a concrete gap: OMC's multi-provider worker pool (`omc team N:provider`) treats Codex and Gemini as interchangeable worker backends. Without a Gemini adapter, this repo is Claude-plus-two rather than genuinely provider-agnostic, and any future parallel fan-out primitive built here cannot use Gemini workers without ad hoc configuration that lives outside the methodology.

--- a/docs/planning/p0-persistence-loop.md
+++ b/docs/planning/p0-persistence-loop.md
@@ -1,5 +1,7 @@
 # P0 Persistence Loop - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 `/implement-ticket` is a one-shot command: it runs Engineer -> Skeptic -> QA once and then exits, leaving re-routing on Critical and Major findings as ad-hoc prose scattered across Phase 5, 6, and 6b. The current wording says "route back to a fresh engineer agent to fix; re-run Skeptic after" for Critical, and "route back to engineer unless there's a strong reason to defer; re-run Skeptic" for Major - but neither specifies how many times this may repeat, what state carries forward between attempts, or what happens if the loop diverges. In practice, the conductor makes a judgment call each time, which means the number of iterations is unbounded, prior findings may be re-raised on re-review (wasting review cycles), and there is no contract a user can rely on.

--- a/docs/planning/p1-parallel-fanout.md
+++ b/docs/planning/p1-parallel-fanout.md
@@ -1,5 +1,7 @@
 # P1 Parallel Fan-out Primitive - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 The agentic-engineering protocol can identify independent subtasks (via `orchestration-planner`) and can spawn engineers into isolated worktrees (Phase 5 of `/implement-ticket`), but the two capabilities are not connected into a first-class primitive. What exists today is a manual, two-engineer sketch: the conductor creates worktrees by hand, spawns agents in a single message, and then merges sequentially. There is no structured join condition, no worker-to-conductor signaling, no partial failure path, and no formal relationship to the Skeptic review loop or to the P0 persistence work.

--- a/docs/planning/p1-path1-restructure-handoff.md
+++ b/docs/planning/p1-path1-restructure-handoff.md
@@ -1,3 +1,5 @@
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 <!--
 Purpose: Handoff document for Path 1 adapter-restructure project. Captures
          architectural rationale, post-Wave-1 state, known regressions on main,

--- a/docs/planning/p1-shared-task-state.md
+++ b/docs/planning/p1-shared-task-state.md
@@ -1,5 +1,7 @@
 # P1 Shared Task-State File - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 The current orchestration model is fully conductor-centric: all task state lives in the conductor's in-context working memory. The conductor spawns workers, waits for returns, synthesizes results, and advances to the next phase. This works for single-session linear workflows but breaks in three distinct ways:

--- a/docs/planning/p2-rate-limit-resumer.md
+++ b/docs/planning/p2-rate-limit-resumer.md
@@ -1,5 +1,7 @@
 # P2 Rate-Limit Resumer and HUD - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 Long-running jobs - specifically the persistence loop introduced in P0 - die silently when a Claude API rate limit or session expiry fires mid-iteration. There is no mechanism to detect the interruption type, preserve the loop's in-context state to disk, or restart where work left off. The result is lost iteration progress: everything from the current Engineer fix pass, any LOOP_STATE the conductor had accumulated, and the findings_log entries that took multiple Skeptic rounds to build up.

--- a/docs/planning/p2-self-improving-harness.md
+++ b/docs/planning/p2-self-improving-harness.md
@@ -1,5 +1,7 @@
 # P2 Self-Improving Harness - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 agentic-engineering is a harness: a bundle of named agents (`content/agents/*.md`), commands (`content/commands/*.md`), and rules (`content/rules/*.md`) that shape how a coding agent does software work. Today, every change to that harness is hand-authored. There is no way to measure whether a given edit made the Skeptic sharper, the conductor's routing smarter, or `/init-project` more accurate - we rely on human review and anecdotal feel. This blocks two things:

--- a/docs/planning/p2-tier-routing.md
+++ b/docs/planning/p2-tier-routing.md
@@ -1,5 +1,7 @@
 # P2 Cost-Aware Tier Routing - Design Plan
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 ## Problem statement
 
 12 out of 13 agents in this repo hardcode `model: claude-sonnet-4-6` in frontmatter; one (`adr-drift-detector`) hardcodes `model: claude-sonnet-4-5`. The mixed state demonstrates that model staleness is already a live problem. The Codex adapter intentionally omits the model field so agents inherit the session model. This means every subagent - from a trivial investigator read to a high-stakes security audit - runs at identical cost. Smart routing picks Haiku for cheap steps and Opus for hard ones, cutting spend 30-50%. We lack any equivalent.

--- a/docs/research/harness-engineering-rise.md
+++ b/docs/research/harness-engineering-rise.md
@@ -1,5 +1,7 @@
 # Rethinking AI Agents: The Rise of Harness Engineering
 
+> Note: References to "agent-methodology.md" in this historical doc refer to what is now METHODOLOGY.md (assembled from content/sections/). See content/sections/README.md.
+
 **Source:** https://youtu.be/Xxuxg8PcBvc (YouTube, uploader: PY, 2026-04-14, 11:45)
 **Date Researched:** 2026-04-15
 **Category:** agentic-frameworks


### PR DESCRIPTION
## Summary

- Renames all `agent-methodology` references to `METHODOLOGY` across ~130 occurrences in `content/`, `.claude/commands/`, `.codex/commands/`, `.cursor/commands/`
- Converts `agent-methodology.md#<anchor>` URL-style citations to `METHODOLOGY.md §<heading>` section-anchor citations in all `representation-audit.md` calibration specimens (8 files x same change)
- Drops the `rules/` segment from path refs: `~/.claude/skills/agentic-engineering/rules/agent-methodology.md` -> `~/.claude/skills/agentic-engineering/METHODOLOGY.md`
- Adds a single footnote to 9 historical docs in `docs/research/` and `docs/planning/p*-*.md` noting the rename; body references left unchanged per spec

## Validation grep (must be zero matches)

```
grep -rn 'agent-methodology' \
  content/ .claude/commands/ .codex/commands/ .cursor/commands/ \
  README.md ADAPTERS.md update.sh
```

Result: **ZERO MATCHES**

## Drift check

```
bash scripts/check-methodology-drift.sh
```

Result: `methodology drift check: OK (49f212b3...)` - exit code **0**

## §-anchor citation verification

All rewritten citations in `representation-audit.md` (across all 4 copies) verified against assembled `METHODOLOGY.md`:
- `METHODOLOGY.md §Risk Classification > Low signals` - resolves at line 495
- `METHODOLOGY.md §Delegation > spawn-threshold table` - resolves at line 151
- `METHODOLOGY.md §Delegation > Worker preamble` - resolves at line 205
- `METHODOLOGY.md §QA Gate` - resolves at line 601
- `METHODOLOGY.md §Events log` - resolves at line 653
- `METHODOLOGY.md §Worktree Lifecycle` - resolves at line 696
- `METHODOLOGY.md §Delegation > spawn-threshold table > file-renaming row` - resolves at line 161