### PR TITLE
feat(auto-harness): switch keep-metric from median-of-medians to mean-of-medians

### DIFF
--- a/evals/auto/README.md
+++ b/evals/auto/README.md
@@ -51,7 +51,7 @@ The CLI aborts before spawning any agent if any of these is false:
    allowlist and locked deny-list; check LOC <= `max_edit_loc`.
 5. Apply the diff via `git apply --index`, commit it on the working
    branch, and run `python -m evals.runner.cli run <component>`.
-6. Aggregate the freshly-written TSV rows (median-of-fixture-medians)
+6. Aggregate the freshly-written TSV rows (mean-of-fixture-medians)
    into a scalar. Compare to the prior baseline: if `delta >=
    max(pooled_stdev, 0.02)`, keep the commit. Otherwise `git reset
    --hard` back to the previous base.

--- a/evals/auto/components.yaml
+++ b/evals/auto/components.yaml
@@ -8,7 +8,11 @@
 #           the primary gate - but locked documents the verifier-adjacent
 #           surfaces that must not be touched by the loop).
 # max_edit_loc: cap on (added + removed) lines per single proposed diff.
-# keep_delta_rule: prose description; the apply/keep logic lives in loop.py.
+# keep_delta_rule: human-readable label only; this string is NOT parsed or
+#                  evaluated. The actual keep decision is computed in loop.py
+#                  (`_keep_delta_threshold` + the `delta >= threshold` check).
+#                  Updating the prose here documents intent but does not change
+#                  behavior - all components share the same threshold formula.
 # max_iterations: default cap if the CLI does not override.
 # whole_file_replacement: if false, the diff must apply via `git apply` to
 #                         the existing file (no full-file rewrites).

--- a/evals/auto/components.yaml
+++ b/evals/auto/components.yaml
@@ -21,7 +21,7 @@ skeptic:
     - content/rules/skeptic-protocol.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -34,7 +34,7 @@ conductor:
     - content/commands/implement-ticket.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -46,7 +46,7 @@ init-project:
     - content/rules/skeptic-protocol.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -58,7 +58,7 @@ wrap:
     - content/rules/skeptic-protocol.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -70,7 +70,7 @@ debugger:
     - content/rules/skeptic-protocol.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -81,7 +81,7 @@ qa-engineer:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -93,7 +93,7 @@ architect:
     - content/rules/module-manifest.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -105,7 +105,7 @@ release-orchestrator:
     - content/rules/module-manifest.md
     - evals/**
   max_edit_loc: 25
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -117,7 +117,7 @@ update-agentic-engineering:
     - .claude/build.sh
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -129,7 +129,7 @@ perf-analyst:
     - content/rules/module-manifest.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -140,7 +140,7 @@ adr-generator:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 25
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -151,7 +151,7 @@ adr-drift-detector:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 30
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -162,7 +162,7 @@ dependency-auditor:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -173,7 +173,7 @@ representation-audit:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -184,7 +184,7 @@ investigator:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -195,7 +195,7 @@ security-auditor:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 20
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: false
 
@@ -206,7 +206,7 @@ memory-update:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -218,7 +218,7 @@ implement-ticket:
     - content/rules/module-manifest.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -229,7 +229,7 @@ prune-harness:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true
 
@@ -240,6 +240,6 @@ cleanup-worktrees:
     - content/rules/agent-methodology.md
     - evals/**
   max_edit_loc: 40
-  keep_delta_rule: "median_improvement >= max(pooled_stdev, 0.02)"
+  keep_delta_rule: "mean_improvement >= max(pooled_stdev, 0.02)"
   max_iterations: 10
   whole_file_replacement: true

--- a/evals/auto/program.md
+++ b/evals/auto/program.md
@@ -16,7 +16,7 @@ applies, measures, and decides to keep or revert.
 
 ## Current metric
 
-- Baseline scalar (median-of-fixture-medians): {{BASELINE_METRIC}}
+- Baseline scalar (mean-of-fixture-medians): {{BASELINE_METRIC}}
 - Pooled stdev across fixtures: {{POOLED_STDEV}}
 - Keep threshold: an edit is kept only if the post-edit scalar improves
   by at least max(pooled_stdev, 0.02). Propose something plausibly

--- a/evals/auto/runner_shim.py
+++ b/evals/auto/runner_shim.py
@@ -1,7 +1,7 @@
 """
 Purpose: Invoke evals.runner.cli as a subprocess for a given component, then
          read back the N freshly-appended rows from the component's TSV and
-         aggregate them to a single scalar (median-of-fixture-medians) plus a
+         aggregate them to a single scalar (mean-of-fixture-medians) plus a
          pooled stdev estimate.
 
 Public API:
@@ -23,11 +23,12 @@ Failure modes: run_component propagates CLI failure via returncode. aggregate_la
 
 Performance: the subprocess dominates; shim overhead is negligible.
 
-Aggregation choice: median-of-fixture-medians.
+Aggregation choice: mean-of-fixture-medians.
   For each of the component's fixtures, evals/runner already writes
   primary_score_median and primary_score_stdev aggregating its N internal runs.
-  We take the median across fixtures as the scalar the loop optimizes. This
-  is robust to a single fixture spiking or floor-clipping. Pooled stdev is
+  We take the mean across fixtures as the scalar the loop optimizes. This
+  is sensitive to all fixture scores and avoids suppressing genuine improvements
+  on the majority when one fixture sits at an extreme. Pooled stdev is
   the root-mean-square of per-fixture stdevs (sqrt(mean(stdev**2))), used as
   one side of the keep-delta threshold: delta >= max(pooled_stdev, 0.02).
 """
@@ -144,7 +145,7 @@ def aggregate_latest(
         except (KeyError, ValueError) as e:
             raise ValueError(f"malformed TSV row: {e}") from e
         cost += _row_cost(r)
-    metric = statistics.median(medians)
+    metric = statistics.mean(medians)
     pooled_stdev = math.sqrt(sum(s * s for s in stdevs) / len(stdevs)) if stdevs else 0.0
     return {
         "metric": float(metric),

--- a/evals/auto/tests/test_runner_shim.py
+++ b/evals/auto/tests/test_runner_shim.py
@@ -41,10 +41,10 @@ def _row(median, stdev, cost_per_run=0.0):
     }
 
 
-def test_median_of_medians_and_pooled_stdev(tmp_path: Path):
+def test_mean_of_medians_and_pooled_stdev(tmp_path: Path):
     # Simulate a component with 3 fixtures and two full baseline runs worth of rows.
     # aggregate_latest should pick the last n_fixtures=3 and compute:
-    #   median of [0.5, 0.9, 0.7] = 0.7
+    #   mean of [0.5, 0.9, 0.7] = 0.7
     #   pooled_stdev = sqrt((0.1^2 + 0.0^2 + 0.05^2)/3) ~ 0.0645
     repo = tmp_path
     tsv = repo / "evals" / "results" / "fake.tsv"
@@ -62,6 +62,20 @@ def test_median_of_medians_and_pooled_stdev(tmp_path: Path):
     assert abs(out["metric"] - 0.7) < 1e-9
     # Pooled stdev: sqrt((0.01 + 0 + 0.0025) / 3) = sqrt(0.004166...) ~ 0.06455
     assert abs(out["pooled_stdev"] - 0.06454972) < 1e-5
+
+
+def test_mean_differs_from_median_on_asymmetric_input(tmp_path: Path):
+    # Asymmetric fixture scores: [0.5, 0.5, 1.0]
+    # mean = (0.5 + 0.5 + 1.0) / 3 = 0.6667, median = 0.5
+    # Verifies the aggregation uses mean, not median.
+    repo = tmp_path
+    tsv = repo / "evals" / "results" / "fake.tsv"
+    rows = [_row(0.5, 0.0), _row(0.5, 0.0), _row(1.0, 0.0)]
+    _write_tsv(tsv, rows)
+    out = aggregate_latest(repo, "fake", n_fixtures=3)
+    expected_mean = (0.5 + 0.5 + 1.0) / 3
+    assert abs(out["metric"] - expected_mean) < 1e-9, f"expected mean ~{expected_mean}, got {out['metric']}"
+    assert abs(out["metric"] - 0.5) > 1e-6, "metric should not equal the median (0.5)"
 
 
 def test_cost_summed_from_per_run_diagnostics(tmp_path: Path):


### PR DESCRIPTION
## Why

The harness keep-metric was median-of-fixture-medians. When >=half the fixtures sit at ceiling 1.0, lifting one below-ceiling fixture is invisible: median stays 1.0, delta = 0, no keep.

Today we observed this on three Tier A components:
- prune-harness (ph-004 at 0.6, others 1.0): plateau, 0 keeps
- update-agentic-engineering (uae-004 at 0.8, others 1.0): plateau, 0 keeps
- memory-update (mu-001 at 0.85, others 1.0): plateau, 0 keeps

Mean-of-medians registers single-fixture improvements proportional to their share of the corpus.

## What changed

- `evals/auto/runner_shim.py:147`: `statistics.median(medians)` -> `statistics.mean(medians)`. Module docstring + comment updated.
- `evals/auto/tests/test_runner_shim.py`: renamed test, added `test_mean_differs_from_median_on_asymmetric_input` to lock in the choice.
- `evals/auto/components.yaml`: 21 `keep_delta_rule` prose entries updated. Header comment expanded to clarify the field is documentation-only.
- `evals/auto/README.md` and `evals/auto/program.md`: stale 'median-of-fixture-medians' references updated. The program.md fix is load-bearing - that string is the editor prompt template.

## Risks

- Outlier-induced regression: median was robust against a single fixture spiking. Mean is not. The 0.02 floor on threshold doesn't protect against this. **Accepted tradeoff** given the visibility unlock.
- pooled_stdev relationship to threshold remains the same formula (RMS of per-fixture stdevs); SE-of-mean would be tighter (`pooled_stdev / sqrt(N)`), so the existing threshold is conservative under mean.

## Verification

- 42/42 tests pass
- New asymmetric-input test would catch a revert to median
- Backward compat confirmed: historical TSVs and state JSONs are inert
- Skeptic review: 3 Major findings raised, all addressed in commit 353732f

## Test plan

- [x] All harness tests pass
- [x] Skeptic findings addressed
- [ ] Re-run prune-harness, update-agentic-engineering, memory-update to confirm metric changes