### PR TITLE
docs: add planning-tier slide deck + partial-rebuild deploy guidance

### DIFF
--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -868,12 +868,13 @@
   <a class="deck-index-link" href="slides/autonomy-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">06</span> Autonomy</a>
   <a class="deck-index-link" href="slides/agent-team-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">07</span> Agent Team</a>
   <a class="deck-index-link" href="slides/orchestration-planner-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">08</span> Orchestration Planner</a>
-  <a class="deck-index-link" href="slides/parallel-fanout-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">09</span> Parallel Fan-out</a>
-  <a class="deck-index-link" href="slides/skeptic-protocol-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">10</span> Skeptic Protocol</a>
-  <a class="deck-index-link" href="slides/quality-assurance-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">11</span> Quality Assurance</a>
-  <a class="deck-index-link" href="slides/work-tracking-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">12</span> Work Tracking</a>
-  <a class="deck-index-link" href="slides/skill-creator-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">13</span> Skill Creator</a>
-  <a class="deck-index-link" href="slides/contributing-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">14</span> Contributing</a>
+  <a class="deck-index-link" href="slides/planning-tier-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">09</span> Planning Artifacts</a>
+  <a class="deck-index-link" href="slides/parallel-fanout-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">10</span> Parallel Fan-out</a>
+  <a class="deck-index-link" href="slides/skeptic-protocol-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">11</span> Skeptic Protocol</a>
+  <a class="deck-index-link" href="slides/quality-assurance-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">12</span> Quality Assurance</a>
+  <a class="deck-index-link" href="slides/work-tracking-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">13</span> Work Tracking</a>
+  <a class="deck-index-link" href="slides/skill-creator-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">14</span> Skill Creator</a>
+  <a class="deck-index-link" href="slides/contributing-slides.html" target="_blank" rel="noopener noreferrer"><span class="deck-ord">15</span> Contributing</a>
 </nav>
 
 <div class="diagram">
@@ -1141,7 +1142,7 @@
           </ul>
         </div>
         <div class="rel-card" style="border-color: rgba(26,90,122,0.25); margin-top: 10px;">
-          <h4 style="color: var(--sky);">Planning Artifacts</h4>
+          <h4 style="color: var(--sky);">Planning Artifacts <a class="slide-link" href="slides/planning-tier-slides.html" target="_blank" rel="noopener noreferrer">slides</a></h4>
           <ul>
             <li><strong>Promotion gate (mechanical)</strong> - sits between orchestration-planner output and the first engineer spawn. Trigger table: 0-1 Elevated units = no artifact; 2-5 Elevated units = Brief required; 6+ Elevated units OR cross-track OR multi-session = Plan required. Trivial units do not count toward thresholds. "Cross-track" = distinct depth-1 directories each with their own <code>AGENTS.md</code>; cross-track or architecture-decision-constraining work additionally requires an <strong>ADR</strong> alongside the Plan.</li>
             <li><strong>Brief template</strong> - one-screen (~15-20 lines) at <code>docs/planning/&lt;slug&gt;.md</code>. Fields: Problem, Success criteria (max 4 bullets), Non-goals (max 3 bullets), Constraints (hard only), Verification (single non-skippable line - "cannot specify" blocks sign-off), Linked artifacts.</li>

--- a/docs/slides/planning-tier-slides.html
+++ b/docs/slides/planning-tier-slides.html
@@ -1,0 +1,2283 @@
+<!DOCTYPE html><html lang="en-US"><head><title>Planning Artifacts</title><meta property="og:title" content="Planning Artifacts"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"><meta name="apple-mobile-web-app-capable" content="yes"><meta http-equiv="X-UA-Compatible" content="ie=edge"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><style>@media screen{body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{appearance:none;background-color:initial;border:0;color:inherit;cursor:pointer;font-size:inherit;opacity:.8;outline:none;padding:0;transition:opacity .2s linear;-webkit-tap-highlight-color:transparent}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:disabled{cursor:not-allowed;opacity:.15!important}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover{opacity:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:active{opacity:.6}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:not(:disabled){transition:none}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-prev{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNNjggOTAgMjggNTBsNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-next{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJtMzIgOTAgNDAtNDAtNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNNDAgNzBIMjBWNTBtMjAgMEwyMCA3MG00MC00MGgyMHYyMG0tMjAgMCAyMC0yMCIgY2xhc3M9ImEiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen]{background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNMjAgNTBoMjB2MjBtLTIwIDAgMjAtMjBtNDAgMEg2MFYzMG0yMCAwTDYwIDUwIiBjbGFzcz0iYSIvPjwvc3ZnPg==")}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNODcuOCA0Ny41Qzg5IDUwIDg3LjcgNTIgODUgNTJIMzVhOC43IDguNyAwIDAgMS03LjItNC41bC0xNS42LTMxQzExIDE0IDEyLjIgMTIgMTUgMTJoNTBhOC44IDguOCAwIDAgMSA3LjIgNC41ek02MCA1MnYzNm0tMTAgMGgyME00NSA0MmgyMCIvPjwvc3ZnPg==") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-bigger{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODBNNTIgOTBWMTAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-smaller{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4O3J4OjVweDtyeTo1cHg7d2lkdGg6MjVweDtoZWlnaHQ6MjVweH08L3N0eWxlPjwvZGVmcz48cmVjdCB4PSIyMCIgeT0iMjAiIGNsYXNzPSJhIi8+PHJlY3QgeD0iNTUiIHk9IjIwIiBjbGFzcz0iYSIvPjxyZWN0IHg9IjIwIiB5PSI1NSIgY2xhc3M9ImEiLz48cmVjdCB4PSI1NSIgeT0iNTUiIGNsYXNzPSJhIi8+PC9zdmc+") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}}@keyframes __bespoke_marp_transition_reduced_outgoing__{0%{opacity:1}to{opacity:0}}@keyframes __bespoke_marp_transition_reduced_incoming__{0%{mix-blend-mode:plus-lighter;opacity:0}to{mix-blend-mode:plus-lighter;opacity:1}}.bespoke-marp-note,.bespoke-marp-osc,.bespoke-progress-parent{display:none;transition:none}@media screen{::view-transition-group(*){animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-timing-function:ease}::view-transition-new(*),::view-transition-old(*){animation-delay:0s;animation-direction:var(--marp-bespoke-transition-animation-direction,normal);animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-fill-mode:both;animation-name:var(--marp-bespoke-transition-animation-name,var(--marp-bespoke-transition-animation-name-fallback,__bespoke_marp_transition_no_animation__));mix-blend-mode:normal}::view-transition-old(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_outgoing__;animation-timing-function:ease}::view-transition-new(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_incoming__;animation-timing-function:ease}::view-transition-new(root),::view-transition-old(root){animation-timing-function:linear}::view-transition-new(__bespoke_marp_transition_osc__),::view-transition-old(__bespoke_marp_transition_osc__){animation-duration:0s!important;animation-name:__bespoke_marp_transition_osc__!important}::view-transition-new(__bespoke_marp_transition_osc__){opacity:0!important}.bespoke-marp-transition-warming-up::view-transition-group(*),.bespoke-marp-transition-warming-up::view-transition-new(*),.bespoke-marp-transition-warming-up::view-transition-old(*){animation-play-state:paused!important}body,html{height:100%;margin:0}body{background:#000;overflow:hidden}svg.bespoke-marp-slide{content-visibility:hidden;interactivity:inert;opacity:0;pointer-events:none;z-index:-1}svg.bespoke-marp-slide:not(.bespoke-marp-active) *{view-transition-name:none!important}svg.bespoke-marp-slide.bespoke-marp-active{content-visibility:visible;interactivity:auto;opacity:1;pointer-events:auto;z-index:0}svg.bespoke-marp-slide.bespoke-marp-active.bespoke-marp-active-ready *{animation-name:__bespoke_marp__!important}@supports not (content-visibility:hidden){svg.bespoke-marp-slide[data-bespoke-marp-load=hideable]{display:none}svg.bespoke-marp-slide[data-bespoke-marp-load=hideable].bespoke-marp-active{display:block}}}@media screen and (prefers-reduced-motion:reduce){svg.bespoke-marp-slide *{view-transition-name:none!important}}@media screen{[data-bespoke-marp-fragment=inactive]{visibility:hidden}body[data-bespoke-view=""] .bespoke-marp-parent,body[data-bespoke-view=next] .bespoke-marp-parent{inset:0;position:absolute}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc{background:#000000a6;border-radius:7px;bottom:50px;color:#fff;contain:paint;display:block;font-family:Helvetica,Arial,sans-serif;font-size:16px;left:50%;line-height:0;opacity:1;padding:12px;position:absolute;touch-action:manipulation;transform:translateX(-50%);transition:opacity .2s linear;-webkit-user-select:none;user-select:none;view-transition-name:__bespoke_marp_transition_osc__;white-space:nowrap;will-change:transform;z-index:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*){margin-left:6px}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child){margin-left:0}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span{opacity:.8}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page]{display:inline-block;min-width:140px;text-align:center}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev]{height:32px;line-height:32px;width:32px}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive{cursor:none}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc{opacity:0;pointer-events:none}body[data-bespoke-view=""] svg.bespoke-marp-slide,body[data-bespoke-view=next] svg.bespoke-marp-slide{height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent{background:#222;display:flex;height:5px;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent+:where(.bespoke-marp-parent){top:5px}body[data-bespoke-view=""] .bespoke-progress-parent .bespoke-progress-bar{background:#0288d1;flex:0 0 0;transition:flex-basis .2s cubic-bezier(0,1,1,1)}body[data-bespoke-view=next]{background:#0000}body[data-bespoke-view=presenter]{background:#161616}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container{display:grid;font-family:Helvetica,Arial,sans-serif;grid-template:"current dragbar next" minmax(140px,1fr) "current dragbar note" 2fr "info    dragbar note" 3em;grid-template-columns:minmax(3px,var(--bespoke-marp-presenter-split-ratio,66%)) 0 minmax(3px,1fr);height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent){grid-area:current;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide){height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide).bespoke-marp-active{filter:drop-shadow(0 3px 10px rgba(0,0,0,.5))}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container{background:#0288d1;cursor:col-resize;grid-area:dragbar;margin-left:-3px;opacity:0;position:relative;transition:opacity .4s linear .1s;width:6px;z-index:10}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container:hover{opacity:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container.active{opacity:1;transition-delay:0s}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container{background:#222;cursor:pointer;display:none;grid-area:next;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container iframe.bespoke-marp-presenter-next{background:#0000;border:0;display:block;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;interactivity:inert;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container{background:#222;color:#eee;grid-area:note;position:relative;z-index:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper{display:block;inset:0;position:absolute}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons{background:#000000a6;border-radius:4px;bottom:0;display:flex;gap:4px;margin:12px;opacity:0;padding:6px;pointer-events:none;position:absolute;right:0;transition:opacity .2s linear}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons:focus-within,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper:focus-within+.bespoke-marp-presenter-note-buttons,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container:hover .bespoke-marp-presenter-note-buttons{opacity:1;pointer-events:auto}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note{box-sizing:border-box;font-size:calc(1.1em*var(--bespoke-marp-note-font-scale, 1));height:calc(100% - 40px);margin:20px;overflow:auto;padding-right:3px;white-space:pre-wrap;width:calc(100% - 40px);word-wrap:break-word;scrollbar-color:#eeeeee80 #0000;scrollbar-width:thin}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar{width:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-track{background:#0000}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-thumb{background:#eeeeee80;border-radius:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note:empty{pointer-events:none}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:first-child{margin-top:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:last-child{margin-bottom:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container{align-items:center;box-sizing:border-box;color:#eee;display:flex;flex-wrap:nowrap;grid-area:info;justify-content:center;overflow:hidden;padding:0 10px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{box-sizing:border-box;display:block;padding:0 10px;white-space:nowrap;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area{order:2;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page{display:inline-block;min-width:120px;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time{color:#999;order:1;text-align:left}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{color:#999;order:3;text-align:right}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer:hover{cursor:pointer}body[data-bespoke-view=overview]{background:#161616;overflow:auto}body[data-bespoke-view=overview] [data-bespoke-marp-fragment=inactive]{visibility:visible}body[data-bespoke-view=overview] .bespoke-marp-overview-header{backdrop-filter:blur(4px);background:#222222d9;box-shadow:0 3px 10px #00000080;box-sizing:border-box;display:flex;height:48px;inset:0 0 auto;justify-content:flex-end;padding:10px;position:fixed;z-index:1}body[data-bespoke-view=overview] button.bespoke-marp-overview-close{height:28px;line-height:28px;transform:rotate(45deg);width:28px}body[data-bespoke-view=overview] .bespoke-marp-parent{display:grid;gap:40px;grid-template-columns:repeat(auto-fit,minmax(0,240px));justify-content:space-around;padding:30px}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide{--bov-selected:#0000;--bov-focus:#161616;--bov-focus-outline:#0000;background-image:conic-gradient(#161616 0 0),conic-gradient(var(--bov-focus) 0 0),conic-gradient(var(--bov-focus-outline) 0 0),conic-gradient(var(--bov-selected) 0 0);background-position:5px 5px,3px 3px,2px 2px,0 0;background-repeat:no-repeat;background-size:calc(100% - 10px) calc(100% - 10px),calc(100% - 6px) calc(100% - 6px),calc(100% - 4px) calc(100% - 4px),100% 100%;content-visibility:visible;cursor:pointer;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));margin:-6px;padding:6px;interactivity:auto;opacity:1;outline:0;pointer-events:auto;scroll-margin-block:30px;width:100%;z-index:0}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide *,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active *{pointer-events:none;interactivity:inert}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus-outline:#161616}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus:#999}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active{--bov-focus:#eee}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active{--bov-selected:#0288d1}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent{padding-top:78px}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent svg.bespoke-marp-slide{scroll-margin-top:78px}.bespoke-marp-overview{background:#000000a6;inset:0;opacity:0;pointer-events:none;position:fixed;transition:opacity .1s ease;z-index:10}.bespoke-marp-overview iframe{background:#222;border:0;display:block;height:100%;left:0;position:absolute;top:0;width:100%}.bespoke-marp-overview[data-open="1"]{opacity:1;pointer-events:auto}}@media print{.bespoke-marp-overview,.bespoke-marp-presenter-info-container,.bespoke-marp-presenter-next-container,.bespoke-marp-presenter-note-container{display:none}}</style><style>div#\:\$p > svg > foreignObject > section{width:1280px;height:720px;box-sizing:border-box;overflow:hidden;position:relative;scroll-snap-align:center center;-webkit-text-size-adjust:100%;text-size-adjust:100%}div#\:\$p > svg > foreignObject > section::after{bottom:0;content:attr(data-marpit-pagination);padding:inherit;pointer-events:none;position:absolute;right:0}div#\:\$p > svg > foreignObject > section:not([data-marpit-pagination])::after{display:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:2em;margin-block:0.67em}div#\:\$p > svg > foreignObject > section video::-webkit-media-controls{will-change:transform}@page {size:1280px 720px;margin:0}@media print{html, body{background-color:#fff;margin:0;page-break-inside:avoid;break-inside:avoid-page}div#\:\$p > svg > foreignObject > section{page-break-before:always;break-before:page}div#\:\$p > svg > foreignObject > section, div#\:\$p > svg > foreignObject > section *{-webkit-print-color-adjust:exact!important;animation-delay:0s!important;animation-duration:0s!important;color-adjust:exact!important;print-color-adjust:exact!important;transition:none!important}div#\:\$p > svg[data-marpit-svg]{display:block;height:100vh;width:100vw}}div#\:\$p > svg > foreignObject > :where(section){container-type:size}div#\:\$p > svg > foreignObject > section img[data-marp-twemoji]{background:transparent;height:1em;margin:0 .05em 0 .1em;vertical-align:-.1em;width:1em}div#\:\$p > svg > foreignObject > section{--fgColor-danger:light-dark(#d1242f, #f85149);--bgColor-attention-muted:light-dark(#fff8c5, #bb800926);--bgColor-muted:light-dark(#f6f8fa, #151b23);--bgColor-neutral-muted:light-dark(#818b981f, #656c7633);--borderColor-accent-emphasis:light-dark(#0969da, #1f6feb);--borderColor-attention-emphasis:light-dark(#9a6700, #9e6a03);--borderColor-danger-emphasis:light-dark(#cf222e, #da3633);--borderColor-default:light-dark(#d1d9e0, #3d444d);--borderColor-done-emphasis:light-dark(#8250df, #8957e5);--borderColor-success-emphasis:light-dark(#1a7f37, #238636);--color-prettylights-syntax-brackethighlighter-angle:light-dark(#59636e, #9198a1);--color-prettylights-syntax-brackethighlighter-unmatched:light-dark(#82071e, #f85149);--color-prettylights-syntax-carriage-return-bg:light-dark(#cf222e, #b62324);--color-prettylights-syntax-carriage-return-text:light-dark(#f6f8fa, #f0f6fc);--color-prettylights-syntax-comment:light-dark(#59636e, #9198a1);--color-prettylights-syntax-constant:light-dark(#0550ae, #79c0ff);--color-prettylights-syntax-constant-other-reference-link:light-dark(#0a3069, #a5d6ff);--color-prettylights-syntax-entity:light-dark(#6639ba, #d2a8ff);--color-prettylights-syntax-entity-tag:light-dark(#0550ae, #7ee787);--color-prettylights-syntax-invalid-illegal-text:light-dark(var(--fgColor-danger), var(--fgColor-danger));--color-prettylights-syntax-keyword:light-dark(#cf222e, #ff7b72);--color-prettylights-syntax-markup-changed-bg:light-dark(#ffd8b5, #5a1e02);--color-prettylights-syntax-markup-changed-text:light-dark(#953800, #ffdfb6);--color-prettylights-syntax-markup-deleted-bg:light-dark(#ffebe9, #67060c);--color-prettylights-syntax-markup-deleted-text:light-dark(#82071e, #ffdcd7);--color-prettylights-syntax-markup-heading:light-dark(#0550ae, #1f6feb);--color-prettylights-syntax-markup-ignored-bg:light-dark(#0550ae, #1158c7);--color-prettylights-syntax-markup-ignored-text:light-dark(#d1d9e0, #f0f6fc);--color-prettylights-syntax-markup-inserted-bg:light-dark(#dafbe1, #033a16);--color-prettylights-syntax-markup-inserted-text:light-dark(#116329, #aff5b4);--color-prettylights-syntax-markup-list:light-dark(#3b2300, #f2cc60);--color-prettylights-syntax-meta-diff-range:light-dark(#8250df, #d2a8ff);--color-prettylights-syntax-string:light-dark(#0a3069, #a5d6ff);--color-prettylights-syntax-string-regexp:light-dark(#116329, #7ee787);--color-prettylights-syntax-sublimelinter-gutter-mark:light-dark(#818b98, #3d444d);--color-prettylights-syntax-variable:light-dark(#953800, #ffa657);--fgColor-accent:light-dark(#0969da, #4493f8);--fgColor-attention:light-dark(#9a6700, #d29922);--fgColor-done:light-dark(#8250df, #ab7df8);--fgColor-muted:light-dark(#59636e, #9198a1);--fgColor-success:light-dark(#1a7f37, #3fb950);--bgColor-default:light-dark(#fff, #0d1117);--borderColor-muted:light-dark(#d1d9e0b3, #3d444db3);--color-prettylights-syntax-invalid-illegal-bg:light-dark(var(--bgColor-danger-muted), var(--bgColor-danger-muted));--color-prettylights-syntax-markup-bold:light-dark(#1f2328, #f0f6fc);--color-prettylights-syntax-markup-italic:light-dark(#1f2328, #f0f6fc);--color-prettylights-syntax-storage-modifier-import:light-dark(#1f2328, #f0f6fc);--fgColor-default:light-dark(#1f2328, #f0f6fc);--focus-outlineColor:light-dark(var(--borderColor-accent-emphasis), var(--borderColor-accent-emphasis));--borderColor-neutral-muted:light-dark(var(--borderColor-muted), var(--borderColor-muted));--base-size-16:calc(var(--marpit-root-font-size, 1rem) * 1);--base-size-24:calc(var(--marpit-root-font-size, 1rem) * 1.5);--base-size-4:calc(var(--marpit-root-font-size, 1rem) * 0.25);--base-size-40:calc(var(--marpit-root-font-size, 1rem) * 2.5);--base-size-8:calc(var(--marpit-root-font-size, 1rem) * 0.5);--base-text-weight-medium:500;--base-text-weight-normal:400;--base-text-weight-semibold:600;--fontStack-monospace:ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;--fontStack-sansSerif:-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";}/*!
+ * Marp default theme.
+ *
+ * @theme default
+ * @author Yuki Hattori
+ *
+ * @auto-scaling true
+ * @size 16:9 1280px 720px
+ * @size 4:3 960px 720px
+ */div#\:\$p > svg > foreignObject > section [data-theme=light],div#\:\$p > svg > foreignObject > section{color-scheme:light}div#\:\$p > svg > foreignObject > section [data-theme=dark],div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background-color:var(--bgColor-default);color:var(--fgColor-default);font-family:var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");font-size:16px;font-weight:var(--base-text-weight-normal, 400);line-height:1.5;margin:0;word-wrap:break-word}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:16px}div#\:\$p > svg > foreignObject > section a{text-decoration:underline;text-underline-offset:calc(var(--marpit-root-font-size, 1rem) * .2)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link:before{background-color:currentColor;content:" ";display:inline-block;height:16px;-webkit-mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');width:16px}div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section figcaption,div#\:\$p > svg > foreignObject > section figure{display:block}div#\:\$p > svg > foreignObject > section summary{display:list-item}div#\:\$p > svg > foreignObject > section [hidden]{display:none!important}div#\:\$p > svg > foreignObject > section a{background-color:transparent;color:var(--fgColor-accent);text-decoration:none}div#\:\$p > svg > foreignObject > section abbr[title]{border-bottom:none;-webkit-text-decoration:underline dotted;text-decoration:underline dotted}div#\:\$p > svg > foreignObject > section b,div#\:\$p > svg > foreignObject > section strong{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section dfn{font-style:italic}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){border-bottom:1px solid var(--borderColor-muted);font-size:2em;font-weight:var(--base-text-weight-semibold, 600);margin:.67em 0;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section mark{background-color:var(--bgColor-attention-muted);color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section small{font-size:90%}div#\:\$p > svg > foreignObject > section sub,div#\:\$p > svg > foreignObject > section sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}div#\:\$p > svg > foreignObject > section sub{bottom:-.25em}div#\:\$p > svg > foreignObject > section sup{top:-.5em}div#\:\$p > svg > foreignObject > section img{border-style:none;box-sizing:content-box;max-width:100%}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section kbd,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp{font-family:monospace;font-size:1em}div#\:\$p > svg > foreignObject > section figure{margin:1em var(--base-size-40)}div#\:\$p > svg > foreignObject > section hr{background:transparent;background-color:var(--borderColor-default);border:0;box-sizing:content-box;height:.25em;margin:var(--base-size-24) 0;overflow:hidden;padding:0}div#\:\$p > svg > foreignObject > section input{font:inherit;font-family:inherit;font-size:inherit;line-height:inherit;margin:0;overflow:visible}div#\:\$p > svg > foreignObject > section [type=button],div#\:\$p > svg > foreignObject > section [type=reset],div#\:\$p > svg > foreignObject > section [type=submit]{-webkit-appearance:button;-moz-appearance:button;appearance:button}div#\:\$p > svg > foreignObject > section [type=checkbox],div#\:\$p > svg > foreignObject > section [type=radio]{box-sizing:border-box;padding:0}div#\:\$p > svg > foreignObject > section [type=number]::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section [type=number]::-webkit-outer-spin-button{height:auto}div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-cancel-button,div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-decoration{-webkit-appearance:none;appearance:none}div#\:\$p > svg > foreignObject > section ::-webkit-input-placeholder{color:inherit;opacity:.54}div#\:\$p > svg > foreignObject > section ::-webkit-file-upload-button{-webkit-appearance:button;appearance:button;font:inherit}div#\:\$p > svg > foreignObject > section a:hover{text-decoration:underline}div#\:\$p > svg > foreignObject > section ::-moz-placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section ::placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section hr:after,div#\:\$p > svg > foreignObject > section hr:before{content:"";display:table}div#\:\$p > svg > foreignObject > section hr:after{clear:both}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;border-spacing:0;display:block;font-variant:tabular-nums;max-width:100%;overflow:auto;width:-moz-max-content;width:max-content}div#\:\$p > svg > foreignObject > section td,div#\:\$p > svg > foreignObject > section th{padding:0}div#\:\$p > svg > foreignObject > section details summary{cursor:pointer}div#\:\$p > svg > foreignObject > section [role=button]:focus,div#\:\$p > svg > foreignObject > section a:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=radio]:focus:not(:focus-visible){outline:1px solid transparent}div#\:\$p > svg > foreignObject > section [role=button]:focus-visible,div#\:\$p > svg > foreignObject > section a:focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section a:not([class]):focus,div#\:\$p > svg > foreignObject > section a:not([class]):focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{outline-offset:0}div#\:\$p > svg > foreignObject > section kbd{background-color:var(--bgColor-muted);border-bottom-color:var(--borderColor-neutral-muted);border:1px solid var(--borderColor-neutral-muted);border-radius:6px;box-shadow:inset 0 -1px 0 var(--borderColor-neutral-muted);color:var(--fgColor-default);display:inline-block;font:11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);line-height:10px;padding:var(--base-size-4);vertical-align:middle}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-weight:var(--base-text-weight-semibold, 600);line-height:1.25;margin-bottom:var(--base-size-16);margin-top:var(--base-size-24)}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:1px solid var(--borderColor-muted);font-size:1.5em;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.25em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:.875em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){color:var(--fgColor-muted);font-size:.85em;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section p{margin-bottom:10px;margin-top:0}div#\:\$p > svg > foreignObject > section blockquote{border-left:.25em solid var(--borderColor-default);color:var(--fgColor-muted);margin:0;padding:0 1em}div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section ul{margin-bottom:0;margin-top:0;padding-left:2em}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ul ol{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol ol ol,div#\:\$p > svg > foreignObject > section ol ul ol,div#\:\$p > svg > foreignObject > section ul ol ol,div#\:\$p > svg > foreignObject > section ul ul ol{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section dd{margin-left:0}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp,div#\:\$p > svg > foreignObject > section tt{font-family:var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);font-size:12px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){margin-bottom:0;margin-top:0;word-wrap:normal}div#\:\$p > svg > foreignObject > section .octicon{display:inline-block;fill:currentColor;overflow:visible!important;vertical-align:text-bottom}div#\:\$p > svg > foreignObject > section input::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section input::-webkit-outer-spin-button{-webkit-appearance:none;appearance:none;margin:0}div#\:\$p > svg > foreignObject > section .mr-2{margin-right:var(--base-size-8, 8px)!important}div#\:\$p > svg > foreignObject > section:after,div#\:\$p > svg > foreignObject > section:before{display:table}div#\:\$p > svg > foreignObject > section:after{clear:both}div#\:\$p > svg > foreignObject > section>:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section>:last-child{margin-bottom:0!important}div#\:\$p > svg > foreignObject > section a:not([href]){color:inherit;text-decoration:none}div#\:\$p > svg > foreignObject > section .absent{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section .anchor{float:left;line-height:1;margin-left:-20px;padding-right:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .anchor:focus{outline:none}div#\:\$p > svg > foreignObject > section blockquote,div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section dl,div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section p,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section table,div#\:\$p > svg > foreignObject > section ul{margin-bottom:var(--base-size-16);margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) .octicon-link{color:var(--fgColor-default);vertical-align:middle;visibility:hidden}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor{text-decoration:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link{visibility:visible}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) code,div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) tt,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) code,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) tt,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) code,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) tt,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) code,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) tt,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) code,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) tt,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) code,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) tt{font-size:inherit;padding:0 .2em}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6){display:inline-block}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6) .anchor{margin-left:-40px}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2){border-bottom:0;padding-bottom:0}div#\:\$p > svg > foreignObject > section ol.no-list,div#\:\$p > svg > foreignObject > section ul.no-list{list-style-type:none;padding:0}div#\:\$p > svg > foreignObject > section ol[type="a s"]{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section ol[type="A s"]{list-style-type:upper-alpha}div#\:\$p > svg > foreignObject > section ol[type="i s"]{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol[type="I s"]{list-style-type:upper-roman}div#\:\$p > svg > foreignObject > section div>ol:not([type]),div#\:\$p > svg > foreignObject > section ol[type="1"]{list-style-type:decimal}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ol ul,div#\:\$p > svg > foreignObject > section ul ol,div#\:\$p > svg > foreignObject > section ul ul{margin-bottom:0;margin-top:0}div#\:\$p > svg > foreignObject > section li>p{margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section li+li{margin-top:.25em}div#\:\$p > svg > foreignObject > section dl{padding:0}div#\:\$p > svg > foreignObject > section dl dt{font-size:1em;font-style:italic;font-weight:var(--base-text-weight-semibold, 600);margin-top:var(--base-size-16);padding:0}div#\:\$p > svg > foreignObject > section dl dd{margin-bottom:var(--base-size-16);padding:0 var(--base-size-16)}div#\:\$p > svg > foreignObject > section table th{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border:1px solid var(--borderColor-default);padding:6px 13px}div#\:\$p > svg > foreignObject > section table td>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section table tr{background-color:var(--bgColor-default);border-top:1px solid var(--borderColor-muted)}div#\:\$p > svg > foreignObject > section table tr:nth-child(2n){background-color:var(--bgColor-muted)}div#\:\$p > svg > foreignObject > section table img{background-color:transparent}div#\:\$p > svg > foreignObject > section img[align=right]{padding-left:20px}div#\:\$p > svg > foreignObject > section img[align=left]{padding-right:20px}div#\:\$p > svg > foreignObject > section .emoji{background-color:transparent;max-width:none;vertical-align:text-top}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame,div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){border:1px solid var(--borderColor-default);float:left;margin:13px 0 0;padding:7px;width:auto}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) img{display:block;float:left}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) :is(span, marp-span){clear:both;color:var(--fgColor-default);display:block;padding:5px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center :is(span, marp-span) img{margin:0 auto;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right>:is(span, marp-span){display:block;margin:13px 0 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right :is(span, marp-span) img{margin:0;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left{display:block;float:left;margin-right:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left :is(span, marp-span){margin:13px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right{display:block;float:right;margin-left:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section tt{background-color:var(--bgColor-neutral-muted);border-radius:6px;font-size:85%;margin:0;padding:.2em .4em;white-space:break-spaces}div#\:\$p > svg > foreignObject > section code br,div#\:\$p > svg > foreignObject > section tt br{display:none}div#\:\$p > svg > foreignObject > section del code{text-decoration:inherit}div#\:\$p > svg > foreignObject > section samp{font-size:85%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{font-size:100%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent;border:0;margin:0;padding:0;white-space:pre;word-break:normal}div#\:\$p > svg > foreignObject > section .highlight{margin-bottom:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre){margin-bottom:0;word-break:normal}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background-color:var(--bgColor-muted);border-radius:6px;color:var(--fgColor-default);font-size:85%;line-height:1.45;overflow:auto;padding:var(--base-size-16)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) tt{display:inline;line-height:inherit;margin:0;overflow:visible;padding:0;word-wrap:normal;background-color:transparent;border:0}div#\:\$p > svg > foreignObject > section .csv-data td,div#\:\$p > svg > foreignObject > section .csv-data th{font-size:12px;line-height:1;overflow:hidden;padding:5px;text-align:left;white-space:nowrap}div#\:\$p > svg > foreignObject > section .csv-data .blob-num{background:var(--bgColor-default);border:0;padding:10px var(--base-size-8) 9px;text-align:right}div#\:\$p > svg > foreignObject > section .csv-data tr{border-top:0}div#\:\$p > svg > foreignObject > section .csv-data th{background:var(--bgColor-muted);border-top:0;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:before{content:"["}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:after{content:"]"}div#\:\$p > svg > foreignObject > section .footnotes{border-top:1px solid var(--borderColor-default);color:var(--fgColor-muted);font-size:12px}div#\:\$p > svg > foreignObject > section div#\:\$p > svg > foreignObject > section section.footnotes{--marpit-root-font-size:12px}div#\:\$p > svg > foreignObject > section .footnotes ol,div#\:\$p > svg > foreignObject > section .footnotes ol ul{padding-left:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes ol ul{display:inline-block;margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes li{position:relative}div#\:\$p > svg > foreignObject > section .footnotes li:target:before{border:2px solid var(--borderColor-accent-emphasis);border-radius:6px;bottom:calc(var(--base-size-8)*-1);content:"";left:calc(var(--base-size-24)*-1);pointer-events:none;position:absolute;right:calc(var(--base-size-8)*-1);top:calc(var(--base-size-8)*-1)}div#\:\$p > svg > foreignObject > section .footnotes li:target{color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section .footnotes .data-footnote-backref g-emoji{font-family:monospace}div#\:\$p > svg > foreignObject > section .pl-c{color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section .pl-c1,div#\:\$p > svg > foreignObject > section .pl-s .pl-v{color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section .pl-e,div#\:\$p > svg > foreignObject > section .pl-en{color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section .pl-s .pl-s1,div#\:\$p > svg > foreignObject > section .pl-smi{color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section .pl-ent{color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section .pl-k{color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section .pl-pds,div#\:\$p > svg > foreignObject > section .pl-s,div#\:\$p > svg > foreignObject > section .pl-s .pl-pse .pl-s1,div#\:\$p > svg > foreignObject > section .pl-sr,div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sra,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sre{color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section .pl-smw,div#\:\$p > svg > foreignObject > section .pl-v{color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section .pl-bu{color:var(--color-prettylights-syntax-brackethighlighter-unmatched)}div#\:\$p > svg > foreignObject > section .pl-ii{background-color:var(--color-prettylights-syntax-invalid-illegal-bg);color:var(--color-prettylights-syntax-invalid-illegal-text)}div#\:\$p > svg > foreignObject > section .pl-c2{background-color:var(--color-prettylights-syntax-carriage-return-bg);color:var(--color-prettylights-syntax-carriage-return-text)}div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce{color:var(--color-prettylights-syntax-string-regexp);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ml{color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section .pl-mh,div#\:\$p > svg > foreignObject > section .pl-mh .pl-en,div#\:\$p > svg > foreignObject > section .pl-ms{color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-mi{color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section .pl-mb{color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-md{background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section .pl-mi1{background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section .pl-mc{background-color:var(--color-prettylights-syntax-markup-changed-bg);color:var(--color-prettylights-syntax-markup-changed-text)}div#\:\$p > svg > foreignObject > section .pl-mi2{background-color:var(--color-prettylights-syntax-markup-ignored-bg);color:var(--color-prettylights-syntax-markup-ignored-text)}div#\:\$p > svg > foreignObject > section .pl-mdr{color:var(--color-prettylights-syntax-meta-diff-range);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ba{color:var(--color-prettylights-syntax-brackethighlighter-angle)}div#\:\$p > svg > foreignObject > section .pl-sg{color:var(--color-prettylights-syntax-sublimelinter-gutter-mark)}div#\:\$p > svg > foreignObject > section .pl-corl{color:var(--color-prettylights-syntax-constant-other-reference-link);text-decoration:underline}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section button:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section summary:focus:not(:focus-visible){box-shadow:none;outline:none}div#\:\$p > svg > foreignObject > section [tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section details-dialog:focus:not(:focus-visible){outline:none}div#\:\$p > svg > foreignObject > section g-emoji{display:inline-block;font-family:Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;font-size:1em;font-style:normal!important;font-weight:var(--base-text-weight-normal, 400);line-height:1;min-width:1ch;vertical-align:-.075em}div#\:\$p > svg > foreignObject > section g-emoji img{height:1em;width:1em}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote){display:block}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):not(:has(.snippet-clipboard-content,>:is(pre, marp-pre))){width:-moz-fit-content;width:fit-content}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):has(.snippet-clipboard-content,>:is(pre, marp-pre)):focus-visible{outline:2px solid var(--focus-outlineColor);outline-offset:2px}div#\:\$p > svg > foreignObject > section .task-list-item{list-style-type:none}div#\:\$p > svg > foreignObject > section .task-list-item label{font-weight:var(--base-text-weight-normal, 400)}div#\:\$p > svg > foreignObject > section .task-list-item.enabled label{cursor:pointer}div#\:\$p > svg > foreignObject > section .task-list-item+.task-list-item{margin-top:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .task-list-item .handle{display:none}div#\:\$p > svg > foreignObject > section .task-list-item-checkbox{margin:0 .2em .25em -1.4em;vertical-align:middle}div#\:\$p > svg > foreignObject > section ul:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section ol:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section .contains-task-list:focus-within .task-list-item-convert-container,div#\:\$p > svg > foreignObject > section .contains-task-list:hover .task-list-item-convert-container{clip-path:none;display:block;height:24px;overflow:visible;width:auto}div#\:\$p > svg > foreignObject > section ::-webkit-calendar-picker-indicator{filter:invert(50%)}div#\:\$p > svg > foreignObject > section .markdown-alert{border-left:.25em solid var(--borderColor-default);color:inherit;margin-bottom:var(--base-size-16);padding:var(--base-size-8) var(--base-size-16)}div#\:\$p > svg > foreignObject > section .markdown-alert>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section .markdown-alert>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section .markdown-alert .markdown-alert-title{align-items:center;display:flex;font-weight:var(--base-text-weight-medium, 500);line-height:1}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note{border-left-color:var(--borderColor-accent-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note .markdown-alert-title{color:var(--fgColor-accent)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important{border-left-color:var(--borderColor-done-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important .markdown-alert-title{color:var(--fgColor-done)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning{border-left-color:var(--borderColor-attention-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning .markdown-alert-title{color:var(--fgColor-attention)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip{border-left-color:var(--borderColor-success-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip .markdown-alert-title{color:var(--fgColor-success)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution{border-left-color:var(--borderColor-danger-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution .markdown-alert-title{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section>:first-child>.heading-element:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre):has(+.zeroclipboard-container){min-height:52px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:var(--h1-color);font-size:1.6em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:none}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-size:1.3em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1.05em}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-size:.9em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--heading-strong-color);font-weight:inherit}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6)::part(auto-scaling){max-height:563px}div#\:\$p > svg > foreignObject > section hr{height:0;padding-top:.25em}div#\:\$p > svg > foreignObject > section img{background-color:transparent}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){border:1px solid var(--borderColor-default);line-height:1.15;overflow:visible}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)::part(auto-scaling){max-height:529px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-doctag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-tag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-variable),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-type),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable.language_){color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_.inherited__),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.function_){color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attribute),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-literal),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-number),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-operator),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-class),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-id),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable){color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-string),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-regexp),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-string){color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-built_in),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-symbol){color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-code),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-comment),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-formula){color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-name),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-quote),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-pseudo),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-tag){color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-subst){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-section){color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-bullet){color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-emphasis){color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-strong){color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-addition){background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-deletion){background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header{color:var(--header-footer-color);font-size:18px;left:30px;margin:0;position:absolute}div#\:\$p > svg > foreignObject > section header{top:21px}div#\:\$p > svg > foreignObject > section footer{bottom:21px}div#\:\$p > svg > foreignObject > section{--h1-color:light-dark(#246, #cee7ff);--header-footer-color:light-dark(hsla(0,0%,40%,.75), hsla(0,0%,60%,.75));--heading-strong-color:light-dark(#48c, #7bf);--paginate-color:light-dark(#777, #999);--base-size-4:4px;--base-size-8:8px;--base-size-16:16px;--base-size-24:24px;--base-size-40:40px;align-items:stretch;display:block;flex-flow:column nowrap;font-size:29px;height:720px;padding:78.5px;place-content:safe center center;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:29px}div#\:\$p > svg > foreignObject > section>:last-child,div#\:\$p > svg > foreignObject > section[data-footer]>:nth-last-child(2){margin-bottom:0}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:after{bottom:21px;color:var(--paginate-color);font-size:24px;padding:0;position:absolute;right:30px}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:24px}div#\:\$p > svg > foreignObject > section[data-color] :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section[data-color] :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section[data-color] :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section[data-color] :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section[data-color] :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section[data-color] :is(h6, marp-h6){color:currentcolor}div#\:\$p > svg > foreignObject > section{font-family:'Helvetica Neue', Arial, sans-serif;background:#faf8f3}div#\:\$p > svg > foreignObject > section.lead{display:flex;flex-direction:column;justify-content:center;text-align:center;background:#faf8f3;color:#1a1a1f}div#\:\$p > svg > foreignObject > section.lead :is(h1, marp-h1){font-size:2.5em;margin-bottom:0.2em;color:#224466}div#\:\$p > svg > foreignObject > section.lead p{font-size:1.2em;opacity:0.85}div#\:\$p > svg > foreignObject > section.highlight{background:#faf8f3}div#\:\$p > svg > foreignObject > section .columns{display:grid;grid-template-columns:1fr 1fr;gap:1.5em;margin-bottom:0.8em}div#\:\$p > svg > foreignObject > section .columns-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:1em;margin-bottom:0.8em}div#\:\$p > svg > foreignObject > section .card{background:white;border-radius:12px;padding:1.2em;box-shadow:0 2px 8px rgba(0,0,0,0.08);border-left:4px solid #b5451f}div#\:\$p > svg > foreignObject > section .stat{font-size:2.5em;font-weight:bold;color:#b5451f}div#\:\$p > svg > foreignObject > section section.stat{--marpit-root-font-size: 2.5em}div#\:\$p > svg > foreignObject > section .label{font-size:0.9em;color:#666;margin-top:0.2em}div#\:\$p > svg > foreignObject > section section.label{--marpit-root-font-size: 0.9em}div#\:\$p > svg > foreignObject > section .callout{background:#faf0e8;border-left:4px solid #b5451f;padding:0.8em 1.2em;border-radius:0 8px 8px 0;margin:0.4em 0 0.8em 0}div#\:\$p > svg > foreignObject > section blockquote{border-left:4px solid #b5451f;padding-left:1em;color:#555;font-style:italic}div#\:\$p > svg > foreignObject > section .numbered{display:grid;grid-template-columns:auto 1fr;gap:0.5em 0.9em;align-items:baseline;margin:0.3em 0 0.6em 0}div#\:\$p > svg > foreignObject > section .numbered .n{font-weight:bold;color:#b5451f;font-size:1.1em}div#\:\$p > svg > foreignObject > section .numbered div#\:\$p > svg > foreignObject > section section.n{--marpit-root-font-size: 1.1em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-ZYLUER3E] p{font-size:0.9em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-ZYLUER3E] .callout{font-size:0.88em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-ZYLUER3E] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.88em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-ZYLUER3E] ul{font-size:0.88em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-ZYLUER3E] ul li{margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-KEO4Axbw] :is(pre, marp-pre){font-size:0.78em;background:#f0ede6;border-radius:8px;padding:0.8em 1.2em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-KEO4Axbw] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.6em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-KEO4Axbw] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-sMAQRPIp] table{font-size:0.82em;width:100%;border-collapse:collapse;margin-top:0.4em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-sMAQRPIp] th{background:#f0ede6;padding:0.5em 0.8em;text-align:left}div#\:\$p > svg > foreignObject > section[data-marpit-scope-sMAQRPIp] td{padding:0.45em 0.8em;border-bottom:1px solid #e8e4da;vertical-align:top}div#\:\$p > svg > foreignObject > section[data-marpit-scope-sMAQRPIp] .callout{font-size:0.8em;padding:0.4em 1em;margin-top:0.6em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-sMAQRPIp] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.8em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-gEJcEY65] :is(pre, marp-pre){font-size:0.78em;background:#f0ede6;border-radius:8px;padding:0.8em 1.2em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-gEJcEY65] p{font-size:0.88em;margin:0.25em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-Ib6HdoSh] .card{font-size:0.85em;line-height:1.5}div#\:\$p > svg > foreignObject > section[data-marpit-scope-Ib6HdoSh] div#\:\$p > svg > foreignObject > section section.card{--marpit-root-font-size: 0.85em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-Ib6HdoSh] ul li{margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-Ib6HdoSh] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-Ib6HdoSh] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xvSB5Slv] :is(pre, marp-pre){font-size:0.82em;background:#f0ede6;border-radius:8px;padding:0.8em 1.2em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xvSB5Slv] p{font-size:0.88em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xvSB5Slv] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xvSB5Slv] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-FiaB5w32] :is(pre, marp-pre){font-size:0.76em;background:#f0ede6;border-radius:8px;padding:0.8em 1.2em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-FiaB5w32] p{font-size:0.88em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-FiaB5w32] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-FiaB5w32] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-PPraTscH] .columns{gap:1.2em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-PPraTscH] .card{font-size:0.82em;line-height:1.5}div#\:\$p > svg > foreignObject > section[data-marpit-scope-PPraTscH] div#\:\$p > svg > foreignObject > section section.card{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-PPraTscH] ul li{margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xWBheyYk] :is(pre, marp-pre){font-size:0.8em;background:#f0ede6;border-radius:8px;padding:0.8em 1.2em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xWBheyYk] p{font-size:0.88em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xWBheyYk] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-xWBheyYk] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-fvezfTp4] p{font-size:0.9em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-fvezfTp4] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-fvezfTp4] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-fvezfTp4] ul{font-size:0.88em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-fvezfTp4] ul li{margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-NMcVQDlc] p{font-size:0.9em;margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-scope-NMcVQDlc] .callout{font-size:0.82em;padding:0.5em 1em;margin-top:0.5em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-NMcVQDlc] div#\:\$p > svg > foreignObject > section section.callout{--marpit-root-font-size: 0.82em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-NMcVQDlc] ul{font-size:0.88em}div#\:\$p > svg > foreignObject > section[data-marpit-scope-NMcVQDlc] ul li{margin:0.3em 0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
+</style></head><body><div class="bespoke-marp-osc"><button data-bespoke-marp-osc="prev" tabindex="-1" title="Previous slide">Previous slide</button><span data-bespoke-marp-osc="page"></span><button data-bespoke-marp-osc="next" tabindex="-1" title="Next slide">Next slide</button><button data-bespoke-marp-osc="fullscreen" tabindex="-1" title="Toggle fullscreen (f)">Toggle fullscreen</button><button data-bespoke-marp-osc="overview" tabindex="-1" title="Toggle overview view (o)">Toggle overview view</button><button data-bespoke-marp-osc="presenter" tabindex="-1" title="Open presenter view (p)">Open presenter view</button></div><div id=":$p"><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="1" data-paginate="true" data-class="lead" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" class="lead" data-marpit-pagination="1" style="--paginate:true;--class:lead;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h1 id="planning-artifacts">Planning Artifacts</h1>
+<p>Tiered Brief / Plan promotion gate</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="2" data-marpit-scope-ZYLUER3E="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="2" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="the-gap-planning-artifacts-close">The gap planning artifacts close</h2>
+
+<p>Before planning artifacts, the methodology had three layers producing forward artifacts:</p>
+<ul>
+<li><strong>architect</strong> - produces &quot;what to build&quot;</li>
+<li><strong>orchestration-planner</strong> - produces &quot;how to decompose it&quot;</li>
+<li><strong>engineer</strong> - implements the units</li>
+</ul>
+<p>What was missing: a committed answer to &quot;what problem are we solving and how will we know it is done?&quot;</p>
+<p>Without that commitment, multi-unit fan-out and cross-session resume suffered from drift - each engineer spawned against an informal interpretation of the original ticket rather than a locked problem statement, success criteria, and verification plan.</p>
+<div class="callout">
+Planning artifacts add the missing layer: a gate that commits to the framing before the first engineer spawns and keeps that commitment alive through fan-out and resume.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="3" data-marpit-scope-KEO4Axbw="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="3" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="where-it-sits-in-the-flow">Where it sits in the flow</h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Risk classified Elevated
+  -&gt; architect
+  -&gt; Skeptic on architect plan
+  -&gt; Open Questions resolved
+  -&gt; orchestration-planner
+  -&gt; [PROMOTION CHECK]  &lt;-- new step
+       0-1 Elevated units:   no artifact (current behavior)
+       2-5 Elevated units:   Brief -&gt; Skeptic on Brief
+       6+ Elevated units:    Plan  -&gt; Skeptic on Plan
+       cross-track / multi-session: Plan (+ ADR if arch-decision-constraining)
+  -&gt; engineer(s) spawned with brief_path / plan_path in execution contract
+</code></pre>
+<div class="callout">
+The promotion check is downstream of the planner (unit count is known) and upstream of the first engineer spawn (no work has started). It is a gate, not a suggestion.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-marpit-scope-sMAQRPIp="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="4" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="trigger-table">Trigger table</h2>
+
+<table>
+<thead>
+<tr>
+<th>Condition</th>
+<th>Artifact required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0-1 Elevated units (or planner skipped)</td>
+<td>None - architect plan only</td>
+</tr>
+<tr>
+<td>2-5 Elevated units</td>
+<td>Brief + architect plan</td>
+</tr>
+<tr>
+<td>6+ Elevated units OR cross-track OR multi-session</td>
+<td>Plan (Brief + assembled artifacts + 3 coverage docs)</td>
+</tr>
+<tr>
+<td>Cross-track OR architecture-decision-constraining</td>
+<td>Plan + ADR</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Unit counting rule:</strong> only units whose risk is Elevated or above count. Trivial units in a mixed-risk plan contribute zero.</p>
+<p><strong>&quot;Cross-track&quot; definition (mechanical):</strong> a depth-1 directory under the repo root that has its own <code>AGENTS.md</code>. Nested <code>AGENTS.md</code> files (e.g. <code>helios/factory/AGENTS.md</code>) do not create new tracks.</p>
+<div class="callout">
+All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="5" data-marpit-scope-gEJcEY65="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="5" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="brief-template">Brief template</h2>
+
+<p>Canonical path: <code>docs/planning/&lt;slug&gt;.md</code>. Must fit on one screen (~15-20 lines).</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-markdown"><span class="hljs-section"># Brief: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">feature</span> <span class="hljs-attr">name</span>&gt;</span></span></span>
+
+<span class="hljs-strong">**Problem:**</span>           &lt;1-2 sentences. Behavior gap in user/system terms, not implementation terms.&gt;
+
+<span class="hljs-strong">**Success criteria:**</span>  <span class="language-xml">&lt;Bulleted, observable from outside. Max 4 bullets.&gt;</span>
+<span class="hljs-bullet">-</span> <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">criterion</span> <span class="hljs-attr">1</span>&gt;</span></span>
+<span class="hljs-bullet">-</span> <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">criterion</span> <span class="hljs-attr">2</span>&gt;</span></span>
+
+<span class="hljs-strong">**Non-goals:**</span>         <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">What</span> <span class="hljs-attr">this</span> <span class="hljs-attr">explicitly</span> <span class="hljs-attr">does</span> <span class="hljs-attr">NOT</span> <span class="hljs-attr">do.</span> <span class="hljs-attr">Max</span> <span class="hljs-attr">3</span> <span class="hljs-attr">bullets.</span>&gt;</span></span>
+<span class="hljs-bullet">-</span> <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">non-goal</span> <span class="hljs-attr">1</span>&gt;</span></span>
+
+<span class="hljs-strong">**Constraints:**</span>       <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">Hard</span> <span class="hljs-attr">constraints</span> <span class="hljs-attr">only</span> <span class="hljs-attr">-</span> <span class="hljs-attr">contracts</span>, <span class="hljs-attr">perf</span> <span class="hljs-attr">budgets</span>, <span class="hljs-attr">compat</span> <span class="hljs-attr">targets</span>, <span class="hljs-attr">deadlines.</span>&gt;</span></span>
+
+<span class="hljs-strong">**Verification:**</span>      <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">Single</span> <span class="hljs-attr">non-skippable</span> <span class="hljs-attr">line.</span> <span class="hljs-attr">Tests</span>, <span class="hljs-attr">gates</span>, <span class="hljs-attr">qa.md</span> <span class="hljs-attr">trigger</span> <span class="hljs-attr">patterns</span>,
+                        <span class="hljs-attr">and</span> <span class="hljs-attr">regression</span> <span class="hljs-attr">tests</span> <span class="hljs-attr">required</span> <span class="hljs-attr">by</span> <span class="hljs-attr">.agentic</span>/<span class="hljs-attr">findings.md</span> <span class="hljs-attr">that</span> <span class="hljs-attr">prove</span> <span class="hljs-attr">this</span> <span class="hljs-attr">is</span> <span class="hljs-attr">done.</span>
+                        &quot;<span class="hljs-attr">Cannot</span> <span class="hljs-attr">specify</span>&quot; <span class="hljs-attr">is</span> <span class="hljs-attr">itself</span> <span class="hljs-attr">a</span> <span class="hljs-attr">planning</span> <span class="hljs-attr">gap</span> <span class="hljs-attr">and</span> <span class="hljs-attr">blocks</span> <span class="hljs-attr">Skeptic</span> <span class="hljs-attr">sign-off.</span>&gt;</span></span>
+
+<span class="hljs-strong">**Linked artifacts:**</span>  architect-plan: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">path</span>&gt;</span></span>; orchestration: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">path</span> <span class="hljs-attr">or</span> <span class="hljs-attr">inline</span> <span class="hljs-attr">JSONL</span> <span class="hljs-attr">block</span>&gt;</span></span>
+</code></pre>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-marpit-scope-Ib6HdoSh="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="6" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="brief-field-guidance">Brief field guidance</h2>
+<div class="card">
+<ul>
+<li><strong>Problem</strong> - behavior gap, not solution. If you wrote &quot;add X&quot;, restate as &quot;users cannot Y&quot;.</li>
+<li><strong>Success criteria</strong> - pass/fail testable from outside. Drives Skeptic completion review.</li>
+<li><strong>Non-goals</strong> - written to defeat the most likely scope-creep direction.</li>
+<li><strong>Constraints</strong> - list only what would change the architect's design if violated.</li>
+<li><strong>Verification</strong> - non-skippable. Name the concrete tests, gates, qa.md trigger patterns, and regression tests required by the findings flywheel. If verification cannot be specified at planning time, that is a planning gap - the Brief is not Skeptic-eligible until verification is named.</li>
+<li><strong>Linked artifacts</strong> - makes the Brief auditable against its own inputs.</li>
+</ul>
+</div>
+<div class="callout">
+&lt;=20 lines total. If the Brief exceeds one screen, it is not a Brief - it is a mini-spec and should be reworked. The Brief is a commitment, not a design document.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="7" data-marpit-scope-xvSB5Slv="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="7" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="plan-tier-directory">Plan-tier directory</h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>docs/planning/&lt;slug&gt;/
+  brief.md                  # Brief template (assembled)
+  architect-plan.md         # architect's existing output, as-is (assembled)
+  orchestration.jsonl       # orchestration-planner output, verbatim (assembled)
+  risk-register.md          # &lt;=10 lines, conductor-authored (coverage)
+  rollback.md               # &lt;=10 lines, conductor-authored (coverage)
+  verification-gate.md      # see template, conductor-authored (coverage)
+</code></pre>
+<p>Most of the Plan is stapled artifacts. Only 3 short files are conductor-authored:</p>
+<ul>
+<li><code>risk-register.md</code> - operational risk, not covered by the architect plan</li>
+<li><code>rollback.md</code> - procedure to undo, not covered anywhere upstream</li>
+<li><code>verification-gate.md</code> - trigger for rollback; owns the &quot;how we know it failed&quot; signal</li>
+</ul>
+<div class="callout">
+If any of the three authored files exceeds 10 lines, the Plan is too large. Split into multiple Briefs.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-marpit-scope-FiaB5w32="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="8" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="verification-gate">Verification gate</h2>
+
+<p><code>verification-gate.md</code> template:</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-markdown"><span class="hljs-section"># Verification Gate</span>
+
+<span class="hljs-strong">**Tests that must pass:**</span>
+<span class="hljs-bullet">-</span> Unit: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">commands</span> <span class="hljs-attr">or</span> &quot;<span class="hljs-attr">n</span>/<span class="hljs-attr">a</span>&quot;&gt;</span></span>
+<span class="hljs-bullet">-</span> Integration: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">commands</span> <span class="hljs-attr">or</span> &quot;<span class="hljs-attr">n</span>/<span class="hljs-attr">a</span>&quot;&gt;</span></span>
+<span class="hljs-bullet">-</span> E2E: <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">commands</span> <span class="hljs-attr">or</span> &quot;<span class="hljs-attr">n</span>/<span class="hljs-attr">a</span>&quot;&gt;</span></span>
+
+<span class="hljs-strong">**qa-engineer triggered?**</span> <span class="language-xml">&lt;yes/no&gt;</span>. If yes, list qa.md trigger patterns and the units they apply to.
+
+<span class="hljs-strong">**Manual smoke check:**</span> <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">single</span> <span class="hljs-attr">paragraph</span> <span class="hljs-attr">or</span> &quot;<span class="hljs-attr">none</span>&quot;&gt;</span></span>
+
+<span class="hljs-strong">**Rollback signal:**</span> <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">how</span> <span class="hljs-attr">we</span> <span class="hljs-attr">know</span> <span class="hljs-attr">post-merge</span> <span class="hljs-attr">this</span> <span class="hljs-attr">needs</span> <span class="hljs-attr">revert</span> <span class="hljs-attr">-</span> <span class="hljs-attr">what</span> <span class="hljs-attr">alarm</span>, <span class="hljs-attr">metric</span>, <span class="hljs-attr">or</span> <span class="hljs-attr">user</span> <span class="hljs-attr">signal.</span>
+                      <span class="hljs-attr">This</span> <span class="hljs-attr">hands</span> <span class="hljs-attr">off</span> <span class="hljs-attr">to</span> <span class="hljs-attr">rollback.md.</span>&gt;</span></span>
+
+<span class="hljs-strong">**New regression tests required by findings flywheel?**</span> <span class="language-xml">&lt;yes/no&gt;</span>. If yes, list .agentic/findings.md
+<span class="hljs-code">                      entry IDs and the test files that will hold the regression.
+</span></code></pre>
+<div class="callout">
+<strong>Split of responsibility:</strong> verification-gate.md owns the trigger (the signal that says "something went wrong"). rollback.md owns the procedure (the steps to undo). They are complementary, not overlapping.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-marpit-scope-PPraTscH="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="9" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="gate-semantics">Gate semantics</h2>
+<div class="columns">
+<div>
+<p><strong>Blocks engineer spawn:</strong></p>
+<div class="card" style="border-left-color: #c0392b;">
+<ul>
+<li>Missing required artifact at any tier</li>
+<li>Brief or Plan has Skeptic findings open (Critical or Major)</li>
+<li>Open Questions section non-empty (same hard gate as architect plan)</li>
+<li>Verification gate field set to &quot;cannot specify&quot;</li>
+</ul>
+</div>
+</div>
+<div>
+<p><strong>Does NOT block:</strong></p>
+<div class="card" style="border-left-color: #2d5a3d;">
+<ul>
+<li>Risk class = Elevated single-unit (no Brief required - architect plan is the artifact; current behavior preserved)</li>
+<li>Trivial units in any plan</li>
+<li>Low-risk work (no Brief at any threshold)</li>
+</ul>
+</div>
+</div>
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-marpit-scope-xWBheyYk="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="10" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="worker-contract-additions">Worker contract additions</h2>
+
+<p>Two new optional fields in the execution contract:</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>- outputs: ...
+- budget: ...
+- tool_scope: ...
+- completion_conditions: ...
+- output_paths: ...
+- brief_path: docs/planning/&lt;slug&gt;.md        &lt;-- new (Brief tier)
+- plan_path:  docs/planning/&lt;slug&gt;/          &lt;-- new (Plan tier)
+</code></pre>
+<p>When populated, the engineer:</p>
+<ol>
+<li>Reads the Brief or Plan before starting any implementation.</li>
+<li>Treats success criteria and verification gate as authoritative alongside the architect plan.</li>
+<li>Returns <code>BLOCKED</code> on Brief-vs-architect-plan conflict (rather than guessing).</li>
+</ol>
+<div class="callout">
+brief_path and plan_path are populated by the conductor at spawn time. Workers do not discover or locate these themselves.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="11" data-marpit-scope-fvezfTp4="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="11" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="mid-flight-retroactive-brief">Mid-flight retroactive Brief</h2>
+
+<p>A task can be promoted upward mid-work. It cannot be demoted.</p>
+<p>When escalation fires (e.g., a 3-unit Brief-tier task is re-planned into 8 units):</p>
+<ul>
+<li>The in-flight engineer is allowed to return.</li>
+<li>Already-completed units are <strong>not</strong> retroactively re-reviewed.</li>
+<li>The retroactive Brief (or Plan) is authored <strong>before</strong> the next engineer spawn.</li>
+<li>The retroactive artifact governs all subsequent units.</li>
+<li>The Skeptic pass on the retroactive artifact runs to completion before the next worker spawns.</li>
+<li><code>.agentic/loop-state.json</code> <code>promotion_tier</code> is updated to reflect the new tier.</li>
+</ul>
+<div class="callout">
+"Retroactive" means the Brief was not written at the start because the shape wasn't yet known. It is not a failure mode - it is the correct protocol for tasks whose scope expands during execution.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-marpit-scope-NMcVQDlc="" data-paginate="true" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" data-marpit-pagination="12" style="--paginate:true;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h2 id="3rd-resume-auto-promotion">3rd-resume auto-promotion</h2>
+
+<p>Trigger: <code>.agentic/loop-state.json</code> records a third resume of a Brief-tier task.</p>
+<p>When it fires, the conductor authors the missing Plan-tier artifacts before the next worker spawn:</p>
+<ul>
+<li><code>risk-register.md</code></li>
+<li><code>rollback.md</code></li>
+<li><code>verification-gate.md</code></li>
+</ul>
+<p>The trigger is <strong>mechanical</strong> - tracked by resume-count in the loop-state file. It fires regardless of whether the operator notices the session span.</p>
+<p>Rationale: anything that has survived three resume cycles is demonstrably multi-session work. The risk register and rollback procedure exist precisely because multi-session tasks have higher blast radius when they go wrong.</p>
+<div class="callout">
+Auto-promotion is not a penalty. It is an acknowledgment that the task's actual scope exceeded the initial estimate, and the artifact set should match the real scope.
+</div>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="13" data-paginate="true" data-class="lead" data-theme="default" data-style="section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+" lang="en-US" class="lead" data-marpit-pagination="13" style="--paginate:true;--class:lead;--theme:default;--style:section {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: #faf8f3;
+}
+section.lead {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #faf8f3;
+  color: #1a1a1f;
+}
+section.lead h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.2em;
+  color: #224466;
+}
+section.lead p {
+  font-size: 1.2em;
+  opacity: 0.85;
+}
+section.highlight {
+  background: #faf8f3;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5em;
+  margin-bottom: 0.8em;
+}
+.columns-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+  margin-bottom: 0.8em;
+}
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  border-left: 4px solid #b5451f;
+}
+.stat {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #b5451f;
+}
+.label {
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.2em;
+}
+.callout {
+  background: #faf0e8;
+  border-left: 4px solid #b5451f;
+  padding: 0.8em 1.2em;
+  border-radius: 0 8px 8px 0;
+  margin: 0.4em 0 0.8em 0;
+}
+blockquote {
+  border-left: 4px solid #b5451f;
+  padding-left: 1em;
+  color: #555;
+  font-style: italic;
+}
+.numbered {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5em 0.9em;
+  align-items: baseline;
+  margin: 0.3em 0 0.6em 0;
+}
+.numbered .n {
+  font-weight: bold;
+  color: #b5451f;
+  font-size: 1.1em;
+}
+;" data-marpit-pagination-total="13">
+<h1 id="plan-once-resume-often-verify-always">Plan once. Resume often. Verify always.</h1>
+<p>github.com/Solara6/agentic-engineering</p>
+</section>
+<script>!function(){"use strict";const t={h1:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"1"},style:"display: block; font-size: 2em; margin-block-start: 0.67em; margin-block-end: 0.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h2:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"2"},style:"display: block; font-size: 1.5em; margin-block-start: 0.83em; margin-block-end: 0.83em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h3:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"3"},style:"display: block; font-size: 1.17em; margin-block-start: 1em; margin-block-end: 1em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h4:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"4"},style:"display: block; margin-block-start: 1.33em; margin-block-end: 1.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h5:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"5"},style:"display: block; font-size: 0.83em; margin-block-start: 1.67em; margin-block-end: 1.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h6:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"6"},style:"display: block; font-size: 0.67em; margin-block-start: 2.33em; margin-block-end: 2.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},span:{proto:()=>HTMLSpanElement},pre:{proto:()=>HTMLElement,style:"display: block; font-family: monospace; white-space: pre; margin: 1em 0; --marp-auto-scaling-white-space: pre;"}},e="data-marp-auto-scaling-wrapper",i="data-marp-auto-scaling-svg",n="data-marp-auto-scaling-container";class s extends HTMLElement{container;containerSize;containerObserver;svg;svgComputedStyle;svgPreserveAspectRatio="xMinYMid meet";wrapper;wrapperSize;wrapperObserver;constructor(){super();const t=t=>([e])=>{const{width:i,height:n}=e.contentRect;this[t]={width:i,height:n},this.updateSVGRect()};this.attachShadow({mode:"open"}),this.containerObserver=new ResizeObserver(t("containerSize")),this.wrapperObserver=new ResizeObserver((...e)=>{t("wrapperSize")(...e),this.flushSvgDisplay()})}static get observedAttributes(){return["data-downscale-only"]}connectedCallback(){this.shadowRoot.innerHTML=`\n<style>\n  svg[${i}] { display: block; width: 100%; height: auto; vertical-align: top; }\n  span[${n}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }\n</style>\n<div ${e}>\n  <svg part="svg" ${i}>\n    <foreignObject><span ${n}><slot></slot></span></foreignObject>\n  </svg>\n</div>\n    `.split(/\n\s*/).join(""),this.wrapper=this.shadowRoot.querySelector(`div[${e}]`)??void 0;const t=this.svg;this.svg=this.wrapper?.querySelector(`svg[${i}]`)??void 0,this.svg!==t&&(this.svgComputedStyle=this.svg?window.getComputedStyle(this.svg):void 0),this.container=this.svg?.querySelector(`span[${n}]`)??void 0,this.observe()}disconnectedCallback(){this.svg=void 0,this.svgComputedStyle=void 0,this.wrapper=void 0,this.container=void 0,this.observe()}attributeChangedCallback(){this.observe()}flushSvgDisplay(){const{svg:t}=this;t&&(t.style.display="inline",requestAnimationFrame(()=>{t.style.display=""}))}observe(){this.containerObserver.disconnect(),this.wrapperObserver.disconnect(),this.wrapper&&this.wrapperObserver.observe(this.wrapper),this.container&&this.containerObserver.observe(this.container),this.svgComputedStyle&&this.observeSVGStyle(this.svgComputedStyle)}observeSVGStyle(t){const e=()=>{const i=(()=>{const e=t.getPropertyValue("--preserve-aspect-ratio");if(e)return e.trim();return`x${(({textAlign:t,direction:e})=>{if(t.endsWith("left"))return"Min";if(t.endsWith("right"))return"Max";if("start"===t||"end"===t){let i="rtl"===e;return"end"===t&&(i=!i),i?"Max":"Min"}return"Mid"})(t)}YMid meet`})();i!==this.svgPreserveAspectRatio&&(this.svgPreserveAspectRatio=i,this.updateSVGRect()),t===this.svgComputedStyle&&requestAnimationFrame(e)};e()}updateSVGRect(){let t=Math.ceil(this.containerSize?.width??0);const e=Math.ceil(this.containerSize?.height??0);void 0!==this.dataset.downscaleOnly&&(t=Math.max(t,this.wrapperSize?.width??0));const i=this.svg?.querySelector(":scope > foreignObject");if(i?.setAttribute("width",`${t}`),i?.setAttribute("height",`${e}`),this.svg&&(this.svg.setAttribute("viewBox",`0 0 ${t} ${e}`),this.svg.setAttribute("preserveAspectRatio",this.svgPreserveAspectRatio),this.svg.style.height=t<=0||e<=0?"0":""),this.container){const t=this.svgPreserveAspectRatio.toLowerCase();this.container.style.marginLeft=t.startsWith("xmid")||t.startsWith("xmax")?"auto":"0",this.container.style.marginRight=t.startsWith("xmi")?"auto":"0"}}}const r=(t,{attrs:e={},style:i})=>class extends t{constructor(...t){super(...t);for(const[t,i]of Object.entries(e))this.hasAttribute(t)||this.setAttribute(t,i);this._shadow()}static get observedAttributes(){return["data-auto-scaling"]}connectedCallback(){this._update()}attributeChangedCallback(){this._update()}_shadow(){if(!this.shadowRoot)try{this.attachShadow({mode:"open"})}catch(t){if(!(t instanceof Error&&"NotSupportedError"===t.name))throw t}return this.shadowRoot}_update(){const t=this._shadow();if(t){const e=i?`<style>:host { ${i} }</style>`:"";let n="<slot></slot>";const{autoScaling:s}=this.dataset;if(void 0!==s){n=`<marp-auto-scaling exportparts="svg:auto-scaling" ${"downscale-only"===s?"data-downscale-only":""}>${n}</marp-auto-scaling>`}t.innerHTML=e+n}}};let o;const a=Symbol(),l=()=>o??(o=!!document.createElement("div",{is:"marp-auto-scaling"}).outerHTML.startsWith("<div is"),o);let c;const d="marpitSVGPolyfill:setZoomFactor,",h=Symbol(),g=Symbol();const p=()=>{const t="Apple Computer, Inc."===navigator.vendor,e=t?[v]:[],i={then:e=>(t?(async()=>{if(void 0===c){const t=document.createElement("canvas");t.width=10,t.height=10;const e=t.getContext("2d"),i=new Image(10,10),n=new Promise(t=>{i.addEventListener("load",()=>t())});i.crossOrigin="anonymous",i.src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%201%201%22%3E%3CforeignObject%20width%3D%221%22%20height%3D%221%22%20requiredExtensions%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%3E%3Cdiv%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%20style%3D%22width%3A%201px%3B%20height%3A%201px%3B%20background%3A%20red%3B%20position%3A%20relative%22%3E%3C%2Fdiv%3E%3C%2FforeignObject%3E%3C%2Fsvg%3E",await n,e.drawImage(i,0,0),c=e.getImageData(5,5,1,1).data[3]<128}return c})().then(t=>{null==e||e(t?[v]:[])}):null==e||e([]),i)};return Object.assign(e,i)};let m,u;function v(t){const e="object"==typeof t&&t.target||document,i="object"==typeof t?t.zoom:t;window[g]||(Object.defineProperty(window,g,{configurable:!0,value:!0}),document.body.style.zoom=1.0001,document.body.offsetHeight,document.body.style.zoom=1,window.addEventListener("message",({data:t,origin:e})=>{if(e===window.origin)try{if(t&&"string"==typeof t&&t.startsWith(d)){const[,e]=t.split(","),i=Number.parseFloat(e);Number.isNaN(i)||(u=i)}}catch(t){console.error(t)}}));let n=!1;Array.from(e.querySelectorAll("svg[data-marpit-svg]"),t=>{var e,s,r,o;t.style.transform||(t.style.transform="translateZ(0)");const a=i||u||t.currentScale||1;m!==a&&(m=a,n=a);const l=t.getBoundingClientRect(),{length:c}=t.children;for(let i=0;i<c;i+=1){const n=t.children[i];if(n.getScreenCTM){const t=n.getScreenCTM();if(t){const i=null!==(s=null===(e=n.x)||void 0===e?void 0:e.baseVal.value)&&void 0!==s?s:0,c=null!==(o=null===(r=n.y)||void 0===r?void 0:r.baseVal.value)&&void 0!==o?o:0,d=n.children.length;for(let e=0;e<d;e+=1){const s=n.children[e];if("SECTION"===s.tagName){const{style:e}=s;e.transformOrigin||(e.transformOrigin=`${-i}px ${-c}px`),e.transform=`scale(${a}) matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.e-l.left}, ${t.f-l.top}) translateZ(0.0001px)`;break}}}}}}),!1!==n&&Array.from(e.querySelectorAll("iframe"),({contentWindow:t})=>{null==t||t.postMessage(`${d}${n}`,"null"===window.origin?"*":window.origin)})}function w({once:t=!1,target:e=document}={}){const i=function(t=document){if(t[h])return t[h];let e=!0;const i=()=>{e=!1,delete t[h]};Object.defineProperty(t,h,{configurable:!0,value:i});let n=[],s=!1;(async()=>{try{n=await p()}finally{s=!0}})();const r=()=>{for(const e of n)e({target:t});s&&0===n.length||e&&window.requestAnimationFrame(r)};return r(),i}(e);return t?(i(),()=>{}):i}m=1,u=void 0;const b=Symbol(),y=(e=document)=>{if("undefined"==typeof window)throw new Error("Marp Core's browser script is valid only in browser context.");if(((e=document)=>{const i=window[a];i||customElements.define("marp-auto-scaling",s);for(const n of Object.keys(t)){const s=`marp-${n}`,o=t[n].proto();l()&&o!==HTMLElement?i||customElements.define(s,r(o,{style:t[n].style}),{extends:n}):(i||customElements.define(s,r(HTMLElement,t[n])),e.querySelectorAll(`${n}[is="${s}"]`).forEach(t=>{t.outerHTML=t.outerHTML.replace(new RegExp(`^<${n}`,"i"),`<${s}`).replace(new RegExp(`</${n}>$`,"i"),`</${s}>`)}))}window[a]=!0})(e),e[b])return e[b];const i=w({target:e}),n=()=>{i(),delete e[b]},o=Object.assign(n,{cleanup:n,update:()=>y(e)});return Object.defineProperty(e,b,{configurable:!0,value:o}),o},f=document.currentScript;y(f?f.getRootNode():document)}();
+</script></foreignObject></svg></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
+!function(){"use strict";function e(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var t,n,r=(n||(n=1,t={from:function(e,t){var n,r=1===(e.parent||e).nodeType?e.parent||e:document.querySelector(e.parent||e),o=[].filter.call("string"==typeof e.slides?r.querySelectorAll(e.slides):e.slides||r.children,function(e){return"SCRIPT"!==e.nodeName}),i={},a=function(e,t){return(t=t||{}).index=o.indexOf(e),t.slide=e,t},s=function(e,t){i[e]=(i[e]||[]).filter(function(e){return e!==t})},l=function(e,t){return(i[e]||[]).reduce(function(e,n){return e&&!1!==n(t)},!0)},c=function(e,t){o[e]&&(n&&l("deactivate",a(n,t)),n=o[e],l("activate",a(n,t)))},d=function(e,t){var r=o.indexOf(n)+e;l(e>0?"next":"prev",a(n,t))&&c(r,t)},u={off:s,on:function(e,t){return(i[e]||(i[e]=[])).push(t),s.bind(null,e,t)},fire:l,slide:function(e,t){if(!arguments.length)return o.indexOf(n);l("slide",a(o[e],t))&&c(e,t)},next:d.bind(null,1),prev:d.bind(null,-1),parent:r,slides:o,destroy:function(e){l("destroy",a(n,e)),i={}}};return(t||[]).forEach(function(e){e(u)}),n||c(0),u}}),t),o=e(r);const i=document.body,a=(...e)=>history.replaceState(...e),s="",l="presenter",c="next",d="overview",u=["",l,d,c],f="bespoke-marp-",m=`data-${f}`,g=(e,{protocol:t,host:n,pathname:r,hash:o}=location)=>{const i=e.toString();return`${t}//${n}${r}${i?"?":""}${i}${o}`},p=()=>i.dataset.bespokeView,v=e=>new URLSearchParams(location.search).get(e),h=(e,t={})=>{const n={location,setter:a,...t},r=new URLSearchParams(n.location.search);for(const t of Object.keys(e)){const n=e[t];"string"==typeof n?r.set(t,n):r.delete(t)}try{n.setter({...window.history.state??{}},"",g(r,n.location))}catch(e){console.error(e)}},w=(()=>{const e="bespoke-marp";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch{return!1}})(),y=e=>{try{return localStorage.getItem(e)}catch{return null}},b=(e,t)=>{try{return localStorage.setItem(e,t),!0}catch{return!1}},k=e=>{try{return localStorage.removeItem(e),!0}catch{return!1}},x=(e,t)=>{const n="aria-hidden";t?e.setAttribute(n,"true"):e.removeAttribute(n)},E=e=>{e.parent.classList.add(`${f}parent`),e.slides.forEach(e=>e.classList.add(`${f}slide`)),e.on("activate",t=>{const n=`${f}active`,r=t.slide,o=r.classList,i=!o.contains(n);if(e.slides.forEach(e=>{e.classList.remove(n),x(e,!0)}),o.add(n),x(r,!1),i){const e=`${n}-ready`;o.add(e),document.body.clientHeight,o.remove(e)}})},$=e=>{let t=0,n=0;Object.defineProperty(e,"fragments",{enumerable:!0,value:e.slides.map(e=>[null,...e.querySelectorAll("[data-marpit-fragment]")])});const r=r=>void 0!==e.fragments[t][n+r],o=(r,o)=>{t=r,n=o,e.fragments.forEach((e,t)=>{e.forEach((e,n)=>{if(null==e)return;const i=t<r||t===r&&n<=o;e.setAttribute(`${m}fragment`,(i?"":"in")+"active");const a=`${m}current-fragment`;t===r&&n===o?e.setAttribute(a,"current"):e.removeAttribute(a)})}),e.fragmentIndex=o;const i={slide:e.slides[r],index:r,fragments:e.fragments[r],fragmentIndex:o};e.fire("fragment",i)};e.on("next",({fragment:i=!0})=>{if(i){if(r(1))return o(t,n+1),!1;const i=t+1;e.fragments[i]&&o(i,0)}else{const r=e.fragments[t].length;if(n+1<r)return o(t,r-1),!1;const i=e.fragments[t+1];i&&o(t+1,i.length-1)}}),e.on("prev",({fragment:i=!0})=>{if(r(-1)&&i)return o(t,n-1),!1;const a=t-1;e.fragments[a]&&o(a,e.fragments[a].length-1)}),e.on("slide",({index:t,fragment:n})=>{let r=0;if(void 0!==n){const o=e.fragments[t];if(o){const{length:e}=o;r=-1===n?e-1:Math.min(Math.max(n,0),e-1)}}o(t,r)}),o(0,0)},L=document,S=()=>!(!L.fullscreenEnabled&&!L.webkitFullscreenEnabled),P=()=>!(!L.fullscreenElement&&!L.webkitFullscreenElement),_=e=>{e.fullscreen=()=>{S()&&(async()=>{P()?(L.exitFullscreen||L.webkitExitFullscreen)?.call(L):((e=L.body)=>{(e.requestFullscreen||e.webkitRequestFullscreen)?.call(e)})()})()},document.addEventListener("keydown",t=>{"f"!==t.key&&"F11"!==t.key||t.altKey||t.ctrlKey||t.metaKey||!S()||(e.fullscreen(),t.preventDefault())})},O=`${f}inactive`,T=(e=2e3)=>({parent:t,fire:n})=>{const r=t.classList,o=e=>n(`marp-${e?"":"in"}active`);let i;const a=()=>{i&&clearTimeout(i),i=setTimeout(()=>{r.add(O),o()},e),r.contains(O)&&(r.remove(O),o(!0))};for(const e of["mousedown","mousemove","touchend"])document.addEventListener(e,a);setTimeout(a,0)},I=["AUDIO","BUTTON","INPUT","SELECT","TEXTAREA","VIDEO"],M=e=>{e.parent.addEventListener("keydown",e=>{if(!e.target)return;const t=e.target;(I.includes(t.nodeName)||"true"===t.contentEditable)&&e.stopPropagation()})},A=e=>{window.addEventListener("load",()=>{for(const t of e.slides){const e=t.querySelector("marp-auto-scaling, [data-auto-scaling], [data-marp-fitting]");t.setAttribute(`${m}load`,e?"":"hideable")}})},C=({interval:e=250}={})=>t=>{document.addEventListener("keydown",e=>{if(" "===e.key&&e.shiftKey)t.prev();else if("ArrowLeft"===e.key||"ArrowUp"===e.key||"PageUp"===e.key)t.prev({fragment:!e.shiftKey});else if(" "!==e.key||e.shiftKey)if("ArrowRight"===e.key||"ArrowDown"===e.key||"PageDown"===e.key)t.next({fragment:!e.shiftKey});else if("End"===e.key)t.slide(t.slides.length-1,{fragment:-1});else{if("Home"!==e.key)return;t.slide(0)}else t.next();e.preventDefault()});let n,r,o=0;t.parent.addEventListener("wheel",i=>{let a=!1;const s=(e,t)=>{e&&(a=a||((e,t)=>((e,t)=>{const n="X"===t?"Width":"Height";return e[`client${n}`]<e[`scroll${n}`]})(e,t)&&((e,t)=>{const{overflow:n}=e,r=e[`overflow${t}`];return"auto"===n||"scroll"===n||"auto"===r||"scroll"===r})(getComputedStyle(e),t))(e,t)),e?.parentElement&&s(e.parentElement,t)};if(0!==i.deltaX&&s(i.target,"X"),0!==i.deltaY&&s(i.target,"Y"),a)return;i.preventDefault();const l=Math.sqrt(i.deltaX**2+i.deltaY**2);if(void 0!==i.wheelDelta){if(void 0===i.webkitForce&&Math.abs(i.wheelDelta)<40)return;if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<4)return}else if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<12)return;r&&clearTimeout(r),r=setTimeout(()=>{n=0},e);const c=Date.now()-o<e,d=l<=n;if(n=l,c||d)return;let u;(i.deltaX>0||i.deltaY>0)&&(u="next"),(i.deltaX<0||i.deltaY<0)&&(u="prev"),u&&(t[u](),o=Date.now())})},D=(e=`.${f}osc`)=>{const t=document.querySelector(e);if(!t)return()=>{};const n=(e,n)=>{t.querySelectorAll(`[${m}osc=${JSON.stringify(e)}]`).forEach(n)};if(S()||n("fullscreen",e=>e.style.display="none"),!w){const e=(e,t)=>{e.disabled=!0,e.title=`${t} is disabled due to restricted localStorage.`};n("presenter",t=>e(t,"Presenter view")),n("overview",t=>e(t,"Overview view"))}return e=>{t.addEventListener("click",t=>{if(t.target instanceof HTMLElement){const{bespokeMarpOsc:n}=t.target.dataset;n&&t.target.blur();const r={fragment:!t.shiftKey};"next"===n?e.next(r):"prev"===n?e.prev(r):"fullscreen"===n?e?.fullscreen():"presenter"===n?e.openPresenterView():"overview"===n&&e.toggleOverviewView()}}),e.parent.appendChild(t),e.on("activate",({index:t})=>{n("page",n=>n.textContent=`Page ${t+1} of ${e.slides.length}`)}),e.on("fragment",({index:t,fragments:r,fragmentIndex:o})=>{n("prev",e=>e.disabled=0===t&&0===o),n("next",n=>n.disabled=t===e.slides.length-1&&o===r.length-1)}),e.on("marp-active",()=>x(t,!1)),e.on("marp-inactive",()=>x(t,!0)),S()&&(e=>{for(const t of["","webkit"])L.addEventListener(t+"fullscreenchange",e)})(()=>n("fullscreen",e=>e.classList.toggle("exit",S()&&P())))}},N=e=>{if(e.syncKey&&"string"==typeof e.syncKey)return!0;throw new Error("The current instance of Bespoke.js is incompatible with Marp bespoke sync plugin.")},B=(e={})=>{const t=e.key||window.history.state?.marpBespokeSyncKey||Math.random().toString(36).slice(2),n=`bespoke-marp-sync-${t}`;var r;r={marpBespokeSyncKey:t},h({},{setter:(e,...t)=>a({...e,...r},...t)});const o=()=>{const e=y(n);return e?JSON.parse(e):Object.create(null)},i=e=>{const t=o(),r={...t,...e(t)};return b(n,JSON.stringify(r)),r},s=()=>{window.removeEventListener("pageshow",s),i(e=>({reference:(e.reference||0)+1}))};return e=>{s(),Object.defineProperty(e,"syncKey",{value:t,enumerable:!0});let r=!0;setTimeout(()=>{e.on("fragment",e=>{r&&i(()=>({index:e.index,fragmentIndex:e.fragmentIndex}))})},0),window.addEventListener("storage",t=>{if(t.key===n&&t.oldValue&&t.newValue){const n=JSON.parse(t.oldValue),o=JSON.parse(t.newValue);if(n.index!==o.index||n.fragmentIndex!==o.fragmentIndex)try{r=!1,e.slide(o.index,{fragment:o.fragmentIndex,forSync:!0})}finally{r=!0}}});const a=()=>{const{reference:e}=o();void 0===e||e<=1?k(n):i(()=>({reference:e-1}))};window.addEventListener("pagehide",e=>{e.persisted&&window.addEventListener("pageshow",s),a()}),e.on("destroy",a)}},K=e=>{w&&document.addEventListener("keydown",t=>{("o"!==t.key||t.altKey||t.ctrlKey||t.metaKey)&&"Escape"!==t.key||(t.preventDefault(),e())})};let q=null;const V=({closeOnSelect:e=!0}={})=>t=>{N(t);const n=n=>{const r=(()=>{if(!q||!q.isConnected){q=document.createElement("div"),q.className=`${f}overview`,q.inert=!0;const n=document.createElement("iframe");n.src=(()=>{const n=new URLSearchParams(location.search);return n.set("view","overview"),n.set("sync",t.syncKey),e&&n.set("closeOnSelect","1"),g(n)})(),q.append(n),document.body.append(q)}return q})(),o=n??!r.dataset.open;setTimeout(()=>{if(r.dataset.open=o?"1":"",r.inert=!o,t.skipTransition=o,o){const e=r.querySelector("iframe");try{e?.contentWindow?.focus()}catch{e?.focus()}}else window.focus()},0)};Object.defineProperties(t,{toggleOverviewView:{enumerable:!0,value:n}}),window.addEventListener("message",e=>{e.origin===window.origin&&"closeOverview"===e.data&&n(!1)}),K(n)},j=e=>{const{title:t}=document;document.title="[Overview]"+(t?` - ${t}`:"");const n=!!v("closeOnSelect"),r=()=>{window.parent.postMessage("closeOverview","null"===window.origin?"*":window.origin)};if(e.slides.forEach((t,o)=>{t.tabIndex=0;const i=()=>{e.slide(o,{fragment:-1}),n&&r()};t.addEventListener("click",i),t.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),i())})}),window.addEventListener("keydown",t=>{const n=e.slide(),r=t=>{const r=t=>{const n=e.slides[t].getBoundingClientRect();return[Math.round((n.left+n.right)/2),Math.round((n.top+n.bottom)/2)]};let o=null,i=n;do{const e=r(i);if(o){if(Math.abs(e[0]-o[0])<2)return i}else o=e;i+=t}while(i>=0&&i<e.slides.length);return n};if("ArrowLeft"===t.key)e.slide(Math.max(n-1,0),{fragment:-1});else if("ArrowRight"===t.key)e.slide(Math.min(n+1,e.slides.length-1),{fragment:-1});else if("ArrowUp"===t.key)e.slide(r(-1),{fragment:-1});else if("ArrowDown"===t.key)e.slide(r(1),{fragment:-1});else if("End"===t.key)e.slide(e.slides.length-1,{fragment:-1});else{if("Home"!==t.key)return;e.slide(0,{fragment:-1})}t.preventDefault();const o=e.slide();e.slides[o]?.focus?.(),e.slides[o]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),e.on("slide",({index:t})=>{e.slides[t]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),window.parent!==window){K(r);const e=document.createElement("header");e.className=`${f}overview-header`;const t=document.createElement("button");t.className=`${f}overview-close`,t.type="button",t.title="Close overview",t.textContent=t.title,t.addEventListener("click",r),e.append(t),document.body.prepend(e)}},F=()=>{const e=p();return{[s]:V(),[l]:V({closeOnSelect:!1}),[d]:j}[e]},U=e=>{window.addEventListener("message",t=>{if(t.origin!==window.origin)return;const[n,r]=t.data.split(":");if("navigate"===n){const[t,n]=r.split(",");let o=Number.parseInt(t,10),i=Number.parseInt(n,10)+1;i>=e.fragments[o].length&&(o+=1,i=0),e.slide(o,{fragment:i})}})};var R,X,H,W,J,Y,z,G={exports:{}},Q=(R||(R=1,G.exports=(X=["area","base","br","col","command","embed","hr","img","input","keygen","link","meta","param","source","track","wbr"],H=function(e){return String(e).replace(/[&<>"']/g,function(e){return"&"+W[e]+";"})},W={"&":"amp","<":"lt",">":"gt",'"':"quot","'":"apos"},J="dangerouslySetInnerHTML",Y={className:"class",htmlFor:"for"},z={},function(e,t){var n=[],r="";t=t||{};for(var o=arguments.length;o-- >2;)n.push(arguments[o]);if("function"==typeof e)return t.children=n.reverse(),e(t);if(e){if(r+="<"+e,t)for(var i in t)!1!==t[i]&&null!=t[i]&&i!==J&&(r+=" "+(Y[i]?Y[i]:H(i))+'="'+H(t[i])+'"');r+=">"}if(-1===X.indexOf(e)){if(t[J])r+=t[J].__html;else for(;n.length;){var a=n.pop();if(a)if(a.pop)for(var s=a.length;s--;)n.push(a[s]);else r+=!0===z[a]?a:H(a)}r+=e?"</"+e+">":""}return z[r]=!0,r})),G.exports),Z=e(Q);const ee=({children:e})=>Z(null,null,...e),te=`${f}presenter-`,ne={container:`${te}container`,dragbar:`${te}dragbar-container`,next:`${te}next`,nextContainer:`${te}next-container`,noteContainer:`${te}note-container`,noteWrapper:`${te}note-wrapper`,noteButtons:`${te}note-buttons`,infoContainer:`${te}info-container`,infoPageArea:`${te}info-page-area`,infoPage:`${te}info-page`,infoPagePrev:`${te}info-page-prev`,infoPageNext:`${te}info-page-next`,noteButtonsBigger:`${te}note-bigger`,noteButtonsSmaller:`${te}note-smaller`,infoTime:`${te}info-time`,infoTimer:`${te}info-timer`},re=e=>{const{title:t}=document;document.title="[Presenter view]"+(t?` - ${t}`:"");const n={},r=e=>(n[e]=n[e]||document.querySelector(`.${e}`),n[e]);document.body.appendChild((e=>{const t=document.createElement("div");return t.className=ne.container,t.appendChild(e),t.insertAdjacentHTML("beforeend",Z(ee,null,Z("div",{class:ne.nextContainer},Z("iframe",{class:ne.next,src:"?view=next"})),Z("div",{class:ne.dragbar}),Z("div",{class:ne.noteContainer},Z("div",{class:ne.noteWrapper}),Z("div",{class:ne.noteButtons},Z("button",{class:ne.noteButtonsSmaller,tabindex:"-1",title:"Smaller notes font size"},"Smaller notes font size"),Z("button",{class:ne.noteButtonsBigger,tabindex:"-1",title:"Bigger notes font size"},"Bigger notes font size"))),Z("div",{class:ne.infoContainer},Z("div",{class:ne.infoPageArea},Z("button",{class:ne.infoPagePrev,tabindex:"-1",title:"Previous"},"Previous"),Z("button",{class:ne.infoPage}),Z("button",{class:ne.infoPageNext,tabindex:"-1",title:"Next"},"Next")),Z("time",{class:ne.infoTime,title:"Current time"}),Z("time",{class:ne.infoTimer,title:"Timer"})))),t})(e.parent)),(e=>{let t=!1;r(ne.dragbar).addEventListener("mousedown",()=>{t=!0,r(ne.dragbar).classList.add("active")}),window.addEventListener("mouseup",()=>{t=!1,r(ne.dragbar).classList.remove("active")}),window.addEventListener("mousemove",e=>{if(!t)return;const n=e.clientX/document.documentElement.clientWidth*100;r(ne.container).style.setProperty("--bespoke-marp-presenter-split-ratio",`${Math.max(0,Math.min(100,n))}%`)}),r(ne.nextContainer).addEventListener("click",()=>e.next());const n=r(ne.next),o=(i=n,(e,t)=>i.contentWindow?.postMessage(`navigate:${e},${t}`,"null"===window.origin?"*":window.origin));var i;n.addEventListener("load",()=>{r(ne.nextContainer).classList.add("active"),o(e.slide(),e.fragmentIndex),e.on("fragment",({index:e,fragmentIndex:t})=>o(e,t))});const a=document.querySelectorAll(".bespoke-marp-note");a.forEach(e=>{e.addEventListener("keydown",e=>e.stopPropagation()),r(ne.noteWrapper).appendChild(e)}),e.on("activate",()=>a.forEach(t=>t.classList.toggle("active",t.dataset.index==e.slide())));let s=0;const l=e=>{s=Math.max(-5,s+e),r(ne.noteContainer).style.setProperty("--bespoke-marp-note-font-scale",(1.2**s).toFixed(4))},c=()=>l(1),d=()=>l(-1),u=r(ne.noteButtonsBigger),f=r(ne.noteButtonsSmaller);u.addEventListener("click",()=>{u.blur(),c()}),f.addEventListener("click",()=>{f.blur(),d()}),document.addEventListener("keydown",e=>{"+"===e.key&&c(),"-"===e.key&&d()},!0);const m=r(ne.infoPage);e.on("activate",({index:t})=>{m.textContent=`${t+1} / ${e.slides.length}`}),m.addEventListener("click",()=>{m.blur(),e.toggleOverviewView()});const g=r(ne.infoPagePrev),p=r(ne.infoPageNext);g.addEventListener("click",t=>{g.blur(),e.prev({fragment:!t.shiftKey})}),p.addEventListener("click",t=>{p.blur(),e.next({fragment:!t.shiftKey})}),e.on("fragment",({index:t,fragments:n,fragmentIndex:r})=>{g.disabled=0===t&&0===r,p.disabled=t===e.slides.length-1&&r===n.length-1});let v=new Date;const h=()=>{const e=new Date,t=e=>`${Math.floor(e)}`.padStart(2,"0"),n=e.getTime()-v.getTime(),o=t(n/1e3%60),i=t(n/1e3/60%60),a=t(n/36e5%24);r(ne.infoTime).textContent=e.toLocaleTimeString(),r(ne.infoTimer).textContent=`${a}:${i}:${o}`};h(),setInterval(h,250),r(ne.infoTimer).addEventListener("click",()=>{v=new Date})})(e)},oe=e=>{N(e),Object.defineProperties(e,{openPresenterView:{enumerable:!0,value:ie},presenterUrl:{enumerable:!0,get:ae}}),w&&document.addEventListener("keydown",t=>{"p"!==t.key||t.altKey||t.ctrlKey||t.metaKey||(t.preventDefault(),e.openPresenterView())})};function ie(){const{max:e,floor:t}=Math,n=e(t(.85*window.innerWidth),640),r=e(t(.85*window.innerHeight),360);return window.open(this.presenterUrl,te+this.syncKey,`width=${n},height=${r},menubar=no,toolbar=no`)}function ae(){const e=new URLSearchParams(location.search);return e.set("view","presenter"),e.set("sync",this.syncKey),g(e)}const se=e=>{const t=p();return t===c&&e.appendChild(document.createElement("span")),{[s]:oe,[l]:re,[c]:U}[t]},le=e=>{e.on("activate",t=>{document.querySelectorAll(".bespoke-progress-parent > .bespoke-progress-bar").forEach(n=>{n.style.flexBasis=100*t.index/(e.slides.length-1)+"%"})})},ce=e=>{const t=Number.parseInt(e,10);return Number.isNaN(t)?null:t},de=(e={})=>{const t={history:!0,...e};return e=>{let n=!0;const r=e=>{const t=n;try{return n=!0,e()}finally{n=t}},o=(t={fragment:!0})=>{let n=t.fragment?ce(v("f")||""):null;((t,n)=>{const{min:r,max:o}=Math,{fragments:i,slides:a}=e,s=o(0,r(t,a.length-1)),l=o(0,r(n||0,i[s].length-1));s===e.slide()&&l===e.fragmentIndex||e.slide(s,{fragment:l})})((()=>{if(location.hash){const[t]=location.hash.slice(1).split(":~:");if(/^\d+$/.test(t))return(ce(t)??1)-1;const r=document.getElementById(t)||document.querySelector(`a[name="${CSS.escape(t)}"]`);if(r){const{length:t}=e.slides;for(let o=0;o<t;o+=1)if(e.slides[o].contains(r)){const t=e.fragments?.[o],i=r.closest("[data-marpit-fragment]");if(t&&i){const e=t.indexOf(i);e>=0&&(n=e)}return o}}}return 0})(),n)};e.on("fragment",({index:e,fragmentIndex:r})=>{n||h({f:0===r||r.toString()},{location:{...location,hash:`#${e+1}`},setter:(...e)=>t.history?history.pushState(...e):history.replaceState(...e)})}),setTimeout(()=>{o(),window.addEventListener("hashchange",()=>r(()=>{o({fragment:!1}),h({f:void 0})})),window.addEventListener("popstate",()=>{n||r(()=>o())}),n=!1},0)}},{PI:ue,abs:fe,sqrt:me,atan2:ge}=Math,pe={passive:!0},ve=({slope:e=-.7,swipeThreshold:t=30}={})=>n=>{let r;const o=n.parent,i=e=>{const t=o.getBoundingClientRect();return{x:e.pageX-(t.left+t.right)/2,y:e.pageY-(t.top+t.bottom)/2}};o.addEventListener("touchstart",({touches:e})=>{r=1===e.length?i(e[0]):void 0},pe),o.addEventListener("touchmove",e=>{if(r)if(1===e.touches.length){e.preventDefault();const t=i(e.touches[0]),n=t.x-r.x,o=t.y-r.y;r.delta=me(fe(n)**2+fe(o)**2),r.radian=ge(n,o)}else r=void 0}),o.addEventListener("touchend",o=>{if(r){if(r.delta&&r.delta>=t&&r.radian){const t=(r.radian-e+ue)%(2*ue)-ue;n[t<0?"next":"prev"](),o.stopPropagation()}r=void 0}},pe)},he=new Map;he.clear(),he.set("none",{backward:{both:void 0,incoming:void 0,outgoing:void 0},forward:{both:void 0,incoming:void 0,outgoing:void 0}});const we={both:"",outgoing:"outgoing-",incoming:"incoming-"},ye={forward:"",backward:"-backward"},be=e=>`--marp-bespoke-transition-animation-${e}`,ke=e=>`--marp-transition-${e}`,xe=be("name"),Ee=be("duration"),$e=e=>new Promise(t=>{const n={},r=document.createElement("div"),o=e=>{r.remove(),t(e)};r.addEventListener("animationstart",()=>o(n)),Object.assign(r.style,{animationName:e,animationDuration:"1s",animationFillMode:"both",animationPlayState:"paused",position:"absolute",pointerEvents:"none"}),document.body.appendChild(r);const i=getComputedStyle(r).getPropertyValue(ke("duration"));i&&Number.parseFloat(i)>=0&&(n.defaultDuration=i),((e,t)=>{requestAnimationFrame(()=>{e.style.animationPlayState="running",requestAnimationFrame(()=>t(void 0))})})(r,o)}),Le=async e=>he.has(e)?he.get(e):(e=>{const t={},n=[];for(const[r,o]of Object.entries(we))for(const[i,a]of Object.entries(ye)){const s=`marp-${o}transition${a}-${e}`;n.push($e(s).then(e=>{t[i]=t[i]||{},t[i][r]=e?{...e,name:s}:void 0}))}return Promise.all(n).then(()=>t)})(e).then(t=>(he.set(e,t),t)),Se=e=>Object.values(e).flatMap(Object.values).every(e=>!e),Pe=(e,{type:t,backward:n})=>{const r=e[n?"backward":"forward"],o=(()=>{const e=r[t],n=e=>({[xe]:e.name});if(e)return n(e);if(r.both){const e=n(r.both);return"incoming"===t&&(e[be("direction")]="reverse"),e}})();return!o&&n?Pe(e,{type:t,backward:!1}):o||{[xe]:"__bespoke_marp_transition_no_animation__"}},_e=e=>{if(e)try{const t=JSON.parse(e);if((e=>{if("object"!=typeof e)return!1;const t=e;return"string"==typeof t.name&&(void 0===t.duration||"string"==typeof t.duration)})(t))return t}catch{}},Oe="_tSId",Te="_tA",Ie="bespoke-marp-transition-warming-up",Me=window.matchMedia("(prefers-reduced-motion: reduce)"),Ae="__bespoke_marp_transition_reduced_outgoing__",Ce="__bespoke_marp_transition_reduced_incoming__",De={forward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}},backward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}}},Ne=e=>{if(!document.startViewTransition)return;const t=t=>(void 0!==t&&(e._tD=t),e._tD);let n;t(!1),((...e)=>{CSS.registerProperty({name:ke("duration"),syntax:"<time>",inherits:!0,initialValue:"-1s"});const t=[...new Set(e).values()];return Promise.all(t.map(e=>Le(e))).then()})(...Array.from(document.querySelectorAll("section[data-transition], section[data-transition-back]")).flatMap(e=>[e.dataset.transition,e.dataset.transitionBack].flatMap(e=>{const t=_e(e);return[t?.name,t?.builtinFallback?`__builtin__${t.name}`:void 0]}).filter(e=>!!e))).then(()=>{document.querySelectorAll("style").forEach(e=>{e.innerHTML=e.innerHTML.replace(/--marp-transition-duration:[^;}]*[;}]/g,e=>e.slice(0,-1)+"!important"+e.slice(-1))})});const r=(n,{back:r,cond:o})=>i=>{const a=t();if(a)return!!i[Te]||!("object"!=typeof a||(a.skipTransition(),!i.forSync));if(e.skipTransition)return!0;if(!o(i))return!0;const s=e.slides[e.slide()],l=()=>i.back??r,c="data-transition"+(l()?"-back":""),d=s.querySelector(`section[${c}]`);if(!d)return!0;const u=_e(d.getAttribute(c)??void 0);return!u||((async(e,{builtinFallback:t=!0}={})=>{let n=await Le(e);if(Se(n)){if(!t)return;return n=await Le(`__builtin__${e}`),Se(n)?void 0:n}return n})(u.name,{builtinFallback:u.builtinFallback}).then(e=>{if(!e){t(!0);try{n(i)}finally{t(!1)}return}let r=e;Me.matches&&(console.warn("Use a constant animation to transition because preferring reduced motion by viewer has detected."),r=De);const o=document.getElementById(Oe);o&&o.remove();const a=document.createElement("style");a.id=Oe,document.head.appendChild(a),((e,t)=>{const n=[`:root{${ke("direction")}:${t.backward?-1:1};}`,":root:has(.bespoke-marp-inactive){cursor:none;}"],r=t=>{const n=e[t].both?.defaultDuration||e[t].outgoing?.defaultDuration||e[t].incoming?.defaultDuration;return"forward"===t?n:n||r("forward")},o=t.duration||r(t.backward?"backward":"forward");void 0!==o&&n.push(`::view-transition-group(*){${Ee}:${o};}`);const i=e=>Object.entries(e).map(([e,t])=>`${e}:${t};`).join("");return n.push(`::view-transition-old(root){${i(Pe(e,{...t,type:"outgoing"}))}}`,`::view-transition-new(root){${i(Pe(e,{...t,type:"incoming"}))}}`),n})(r,{backward:l(),duration:u.duration}).forEach(e=>a.sheet?.insertRule(e));const s=document.documentElement.classList;s.add(Ie);let c=!1;const d=()=>{c||(n(i),c=!0,s.remove(Ie))},f=()=>{t(!1),a.remove(),s.remove(Ie)};try{t(!0);const e=document.startViewTransition(d);t(e),e.finished.finally(f)}catch(e){console.error(e),d(),f()}}),!1)};e.on("prev",r(t=>e.prev({...t,[Te]:!0}),{back:!0,cond:e=>e.index>0&&!((e.fragment??1)&&n.fragmentIndex>0)})),e.on("next",r(t=>e.next({...t,[Te]:!0}),{cond:t=>t.index+1<e.slides.length&&!(n.fragmentIndex+1<n.fragments.length)})),setTimeout(()=>{e.on("slide",r(t=>e.slide(t.index,{...t,[Te]:!0}),{cond:t=>{const n=e.slide();return t.index!==n&&(t.back=t.index<n,!0)}}))},0),e.on("fragment",e=>{n=e})};let Be;const Ke=()=>(void 0===Be&&(Be="wakeLock"in navigator&&navigator.wakeLock),Be),qe=async()=>{const e=Ke();if(e)try{return await e.request("screen")}catch(e){console.warn(e)}return null},Ve=async()=>{if(!Ke())return;let e;const t=()=>{e&&"visible"===document.visibilityState&&qe()};for(const e of["visibilitychange","fullscreenchange"])document.addEventListener(e,t);return e=await qe(),e};((e=document.getElementById(":$p"))=>{(()=>{const e=v("view");i.dataset.bespokeView=u.some(t=>t&&t===e)?e:""})();const t=(e=>{const t=v(e);return h({[e]:void 0}),t})("sync")||void 0;o.from(e,((...e)=>{const t=u.findIndex(e=>p()===e);return e.map(([e,n])=>e[t]&&n).filter(e=>e)})([[1,1,1,0],B({key:t})],[[1,1,0,1],se(e)],[[1,1,0,0],M],[[1,1,1,1],E],[[1,0,0,0],T()],[[1,1,1,1],A],[[1,1,1,1],de({history:!1})],[[1,1,0,0],C()],[[1,1,1,0],_],[[1,0,0,0],le],[[1,1,0,0],ve()],[[1,0,0,0],D()],[[1,1,1,0],F()],[[1,0,0,0],Ne],[[1,1,1,1],$],[[1,1,1,0],Ve]))})()}();</script></body></html>

--- a/docs/slides/planning-tier-slides.md
+++ b/docs/slides/planning-tier-slides.md
@@ -1,0 +1,421 @@
+---
+marp: true
+theme: default
+paginate: true
+style: |
+  section {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    background: #faf8f3;
+  }
+  section.lead {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    background: #faf8f3;
+    color: #1a1a1f;
+  }
+  section.lead h1 {
+    font-size: 2.5em;
+    margin-bottom: 0.2em;
+    color: #224466;
+  }
+  section.lead p {
+    font-size: 1.2em;
+    opacity: 0.85;
+  }
+  section.highlight {
+    background: #faf8f3;
+  }
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5em;
+    margin-bottom: 0.8em;
+  }
+  .columns-3 {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 1em;
+    margin-bottom: 0.8em;
+  }
+  .card {
+    background: white;
+    border-radius: 12px;
+    padding: 1.2em;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    border-left: 4px solid #b5451f;
+  }
+  .stat {
+    font-size: 2.5em;
+    font-weight: bold;
+    color: #b5451f;
+  }
+  .label {
+    font-size: 0.9em;
+    color: #666;
+    margin-top: 0.2em;
+  }
+  .callout {
+    background: #faf0e8;
+    border-left: 4px solid #b5451f;
+    padding: 0.8em 1.2em;
+    border-radius: 0 8px 8px 0;
+    margin: 0.4em 0 0.8em 0;
+  }
+  blockquote {
+    border-left: 4px solid #b5451f;
+    padding-left: 1em;
+    color: #555;
+    font-style: italic;
+  }
+  .numbered {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5em 0.9em;
+    align-items: baseline;
+    margin: 0.3em 0 0.6em 0;
+  }
+  .numbered .n {
+    font-weight: bold;
+    color: #b5451f;
+    font-size: 1.1em;
+  }
+---
+
+<!-- _class: lead -->
+
+# Planning Artifacts
+
+Tiered Brief / Plan promotion gate
+
+---
+
+## The gap planning artifacts close
+
+<style scoped>
+  p { font-size: 0.9em; margin: 0.3em 0; }
+  .callout { font-size: 0.88em; padding: 0.5em 1em; margin-top: 0.5em; }
+  ul { font-size: 0.88em; }
+  ul li { margin: 0.3em 0; }
+</style>
+
+Before planning artifacts, the methodology had three layers producing forward artifacts:
+
+- **architect** - produces "what to build"
+- **orchestration-planner** - produces "how to decompose it"
+- **engineer** - implements the units
+
+What was missing: a committed answer to "what problem are we solving and how will we know it is done?"
+
+Without that commitment, multi-unit fan-out and cross-session resume suffered from drift - each engineer spawned against an informal interpretation of the original ticket rather than a locked problem statement, success criteria, and verification plan.
+
+<div class="callout">
+Planning artifacts add the missing layer: a gate that commits to the framing before the first engineer spawns and keeps that commitment alive through fan-out and resume.
+</div>
+
+---
+
+## Where it sits in the flow
+
+<style scoped>
+  pre { font-size: 0.78em; background: #f0ede6; border-radius: 8px; padding: 0.8em 1.2em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.6em; }
+</style>
+
+```
+Risk classified Elevated
+  -> architect
+  -> Skeptic on architect plan
+  -> Open Questions resolved
+  -> orchestration-planner
+  -> [PROMOTION CHECK]  <-- new step
+       0-1 Elevated units:   no artifact (current behavior)
+       2-5 Elevated units:   Brief -> Skeptic on Brief
+       6+ Elevated units:    Plan  -> Skeptic on Plan
+       cross-track / multi-session: Plan (+ ADR if arch-decision-constraining)
+  -> engineer(s) spawned with brief_path / plan_path in execution contract
+```
+
+<div class="callout">
+The promotion check is downstream of the planner (unit count is known) and upstream of the first engineer spawn (no work has started). It is a gate, not a suggestion.
+</div>
+
+---
+
+## Trigger table
+
+<style scoped>
+  table { font-size: 0.82em; width: 100%; border-collapse: collapse; margin-top: 0.4em; }
+  th { background: #f0ede6; padding: 0.5em 0.8em; text-align: left; }
+  td { padding: 0.45em 0.8em; border-bottom: 1px solid #e8e4da; vertical-align: top; }
+  .callout { font-size: 0.8em; padding: 0.4em 1em; margin-top: 0.6em; }
+</style>
+
+| Condition | Artifact required |
+|---|---|
+| 0-1 Elevated units (or planner skipped) | None - architect plan only |
+| 2-5 Elevated units | Brief + architect plan |
+| 6+ Elevated units OR cross-track OR multi-session | Plan (Brief + assembled artifacts + 3 coverage docs) |
+| Cross-track OR architecture-decision-constraining | Plan + ADR |
+
+**Unit counting rule:** only units whose risk is Elevated or above count. Trivial units in a mixed-risk plan contribute zero.
+
+**"Cross-track" definition (mechanical):** a depth-1 directory under the repo root that has its own `AGENTS.md`. Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks.
+
+<div class="callout">
+All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.
+</div>
+
+---
+
+## Brief template
+
+<style scoped>
+  pre { font-size: 0.78em; background: #f0ede6; border-radius: 8px; padding: 0.8em 1.2em; margin: 0.3em 0; }
+  p { font-size: 0.88em; margin: 0.25em 0; }
+</style>
+
+Canonical path: `docs/planning/<slug>.md`. Must fit on one screen (~15-20 lines).
+
+```markdown
+# Brief: <feature name>
+
+**Problem:**           <1-2 sentences. Behavior gap in user/system terms, not implementation terms.>
+
+**Success criteria:**  <Bulleted, observable from outside. Max 4 bullets.>
+- <criterion 1>
+- <criterion 2>
+
+**Non-goals:**         <What this explicitly does NOT do. Max 3 bullets.>
+- <non-goal 1>
+
+**Constraints:**       <Hard constraints only - contracts, perf budgets, compat targets, deadlines.>
+
+**Verification:**      <Single non-skippable line. Tests, gates, qa.md trigger patterns,
+                        and regression tests required by .agentic/findings.md that prove this is done.
+                        "Cannot specify" is itself a planning gap and blocks Skeptic sign-off.>
+
+**Linked artifacts:**  architect-plan: <path>; orchestration: <path or inline JSONL block>
+```
+
+---
+
+## Brief field guidance
+
+<style scoped>
+  .card { font-size: 0.85em; line-height: 1.5; }
+  ul li { margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+</style>
+
+<div class="card">
+
+- **Problem** - behavior gap, not solution. If you wrote "add X", restate as "users cannot Y".
+- **Success criteria** - pass/fail testable from outside. Drives Skeptic completion review.
+- **Non-goals** - written to defeat the most likely scope-creep direction.
+- **Constraints** - list only what would change the architect's design if violated.
+- **Verification** - non-skippable. Name the concrete tests, gates, qa.md trigger patterns, and regression tests required by the findings flywheel. If verification cannot be specified at planning time, that is a planning gap - the Brief is not Skeptic-eligible until verification is named.
+- **Linked artifacts** - makes the Brief auditable against its own inputs.
+
+</div>
+
+<div class="callout">
+<=20 lines total. If the Brief exceeds one screen, it is not a Brief - it is a mini-spec and should be reworked. The Brief is a commitment, not a design document.
+</div>
+
+---
+
+## Plan-tier directory
+
+<style scoped>
+  pre { font-size: 0.82em; background: #f0ede6; border-radius: 8px; padding: 0.8em 1.2em; margin: 0.3em 0; }
+  p { font-size: 0.88em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+</style>
+
+```
+docs/planning/<slug>/
+  brief.md                  # Brief template (assembled)
+  architect-plan.md         # architect's existing output, as-is (assembled)
+  orchestration.jsonl       # orchestration-planner output, verbatim (assembled)
+  risk-register.md          # <=10 lines, conductor-authored (coverage)
+  rollback.md               # <=10 lines, conductor-authored (coverage)
+  verification-gate.md      # see template, conductor-authored (coverage)
+```
+
+Most of the Plan is stapled artifacts. Only 3 short files are conductor-authored:
+
+- `risk-register.md` - operational risk, not covered by the architect plan
+- `rollback.md` - procedure to undo, not covered anywhere upstream
+- `verification-gate.md` - trigger for rollback; owns the "how we know it failed" signal
+
+<div class="callout">
+If any of the three authored files exceeds 10 lines, the Plan is too large. Split into multiple Briefs.
+</div>
+
+---
+
+## Verification gate
+
+<style scoped>
+  pre { font-size: 0.76em; background: #f0ede6; border-radius: 8px; padding: 0.8em 1.2em; margin: 0.3em 0; }
+  p { font-size: 0.88em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+</style>
+
+`verification-gate.md` template:
+
+```markdown
+# Verification Gate
+
+**Tests that must pass:**
+- Unit: <commands or "n/a">
+- Integration: <commands or "n/a">
+- E2E: <commands or "n/a">
+
+**qa-engineer triggered?** <yes/no>. If yes, list qa.md trigger patterns and the units they apply to.
+
+**Manual smoke check:** <single paragraph or "none">
+
+**Rollback signal:** <how we know post-merge this needs revert - what alarm, metric, or user signal.
+                      This hands off to rollback.md.>
+
+**New regression tests required by findings flywheel?** <yes/no>. If yes, list .agentic/findings.md
+                      entry IDs and the test files that will hold the regression.
+```
+
+<div class="callout">
+<strong>Split of responsibility:</strong> verification-gate.md owns the trigger (the signal that says "something went wrong"). rollback.md owns the procedure (the steps to undo). They are complementary, not overlapping.
+</div>
+
+---
+
+## Gate semantics
+
+<style scoped>
+  .columns { gap: 1.2em; }
+  .card { font-size: 0.82em; line-height: 1.5; }
+  ul li { margin: 0.3em 0; }
+</style>
+
+<div class="columns">
+<div>
+
+**Blocks engineer spawn:**
+
+<div class="card" style="border-left-color: #c0392b;">
+
+- Missing required artifact at any tier
+- Brief or Plan has Skeptic findings open (Critical or Major)
+- Open Questions section non-empty (same hard gate as architect plan)
+- Verification gate field set to "cannot specify"
+
+</div>
+</div>
+<div>
+
+**Does NOT block:**
+
+<div class="card" style="border-left-color: #2d5a3d;">
+
+- Risk class = Elevated single-unit (no Brief required - architect plan is the artifact; current behavior preserved)
+- Trivial units in any plan
+- Low-risk work (no Brief at any threshold)
+
+</div>
+</div>
+</div>
+
+---
+
+## Worker contract additions
+
+<style scoped>
+  pre { font-size: 0.8em; background: #f0ede6; border-radius: 8px; padding: 0.8em 1.2em; margin: 0.3em 0; }
+  p { font-size: 0.88em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+</style>
+
+Two new optional fields in the execution contract:
+
+```
+- outputs: ...
+- budget: ...
+- tool_scope: ...
+- completion_conditions: ...
+- output_paths: ...
+- brief_path: docs/planning/<slug>.md        <-- new (Brief tier)
+- plan_path:  docs/planning/<slug>/          <-- new (Plan tier)
+```
+
+When populated, the engineer:
+
+1. Reads the Brief or Plan before starting any implementation.
+2. Treats success criteria and verification gate as authoritative alongside the architect plan.
+3. Returns `BLOCKED` on Brief-vs-architect-plan conflict (rather than guessing).
+
+<div class="callout">
+brief_path and plan_path are populated by the conductor at spawn time. Workers do not discover or locate these themselves.
+</div>
+
+---
+
+## Mid-flight retroactive Brief
+
+<style scoped>
+  p { font-size: 0.9em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+  ul { font-size: 0.88em; }
+  ul li { margin: 0.3em 0; }
+</style>
+
+A task can be promoted upward mid-work. It cannot be demoted.
+
+When escalation fires (e.g., a 3-unit Brief-tier task is re-planned into 8 units):
+
+- The in-flight engineer is allowed to return.
+- Already-completed units are **not** retroactively re-reviewed.
+- The retroactive Brief (or Plan) is authored **before** the next engineer spawn.
+- The retroactive artifact governs all subsequent units.
+- The Skeptic pass on the retroactive artifact runs to completion before the next worker spawns.
+- `.agentic/loop-state.json` `promotion_tier` is updated to reflect the new tier.
+
+<div class="callout">
+"Retroactive" means the Brief was not written at the start because the shape wasn't yet known. It is not a failure mode - it is the correct protocol for tasks whose scope expands during execution.
+</div>
+
+---
+
+## 3rd-resume auto-promotion
+
+<style scoped>
+  p { font-size: 0.9em; margin: 0.3em 0; }
+  .callout { font-size: 0.82em; padding: 0.5em 1em; margin-top: 0.5em; }
+  ul { font-size: 0.88em; }
+  ul li { margin: 0.3em 0; }
+</style>
+
+Trigger: `.agentic/loop-state.json` records a third resume of a Brief-tier task.
+
+When it fires, the conductor authors the missing Plan-tier artifacts before the next worker spawn:
+
+- `risk-register.md`
+- `rollback.md`
+- `verification-gate.md`
+
+The trigger is **mechanical** - tracked by resume-count in the loop-state file. It fires regardless of whether the operator notices the session span.
+
+Rationale: anything that has survived three resume cycles is demonstrably multi-session work. The risk register and rollback procedure exist precisely because multi-session tasks have higher blast radius when they go wrong.
+
+<div class="callout">
+Auto-promotion is not a penalty. It is an acknowledgment that the task's actual scope exceeded the initial estimate, and the artifact set should match the real scope.
+</div>
+
+---
+
+<!-- _class: lead -->
+
+# Plan once. Resume often. Verify always.
+
+github.com/Solara6/agentic-engineering

--- a/docs/technical/deploy.md
+++ b/docs/technical/deploy.md
@@ -45,6 +45,16 @@ The `-I` flag (input directory) is required by marp v4 when batching a directory
 
 To discard a no-op rebuild diff: `git checkout -- docs/slides/`.
 
+### Partial rebuild (one or two decks changed)
+
+When only specific decks changed, rebuild per-file rather than batch to avoid the ~62-line no-op CSS-hash diff across untouched decks:
+
+```bash
+marp docs/slides/<changed-deck>.md --html --output docs/slides/<changed-deck>.html
+```
+
+Verify the output with `git status docs/slides/` before committing - only the changed deck's html should be dirty. The batch `-I` command remains the correct path for full rebuilds (e.g., after a Marp CLI upgrade or theme change).
+
 ### 3. Link to the existing project
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-on to PR #42 (hub html mirror). Adds the Planning Artifacts slide deck and documents per-file marp invocation as the partial-rebuild path.

## Edits

- **NEW** \`docs/slides/planning-tier-slides.md\` - 13-slide Marp deck anchored to \`content/sections/03-planning-artifacts.md\` substance: lead, why, where-it-sits flow diagram, trigger table (4 rows including ADR row), Brief template (6 fields), Brief field guidance, Plan-tier directory layout (6 files), verification gate (non-skippable + verification-gate-vs-rollback complementarity), gate semantics, Worker contract \`brief_path\`/\`plan_path\` additions, mid-flight retroactive Brief, 3rd-resume auto-promotion, closing
- **NEW** \`docs/slides/planning-tier-slides.html\` - built via per-file \`marp\` invocation
- \`docs/technical/deploy.md\` - new "Partial rebuild" sub-section under Section 2, documenting per-file marp; existing \`-I\` batch guidance preserved as the full-rebuild path
- \`docs/agentic-engineering.html\` - deck nav: new entry at position 09, renumber former 09-14 to 10-15; \`slide-link\` added to the Planning Artifacts deep-dive card heading

## Reviews

- Engineer Skeptic: 0 Critical, 0 Major, 0 Minor. All 13 slides verified anchored to \`03-planning-artifacts.md\` substance (no drift to general agent-flow content).

## Test plan

- [x] Per-file marp invocation - only \`planning-tier-slides.html\` is new in \`docs/slides/\`; no other deck html touched
- [x] Frontmatter + CSS block byte-for-byte identical to \`profiles-slides.md\` template
- [x] Deck nav renumber correct (09 = new, 10-15 = shifted)
- [x] Planning Artifacts card slide-link matches Parallel Fan-out pattern
- [ ] Vercel preview renders cleanly