### PR TITLE
feat(auto-harness): inject corpus-level dimension signal into editor brief

### DIFF
--- a/evals/auto/editor.py
+++ b/evals/auto/editor.py
@@ -41,7 +41,7 @@ def build_brief(template: str, context: Dict[str, object]) -> str:
     """
     out = template
     required = ("COMPONENT", "EDITABLE_FILES", "LOCKED_FILES", "BASELINE_METRIC",
-                "POOLED_STDEV", "MAX_EDIT_LOC")
+                "POOLED_STDEV", "MAX_EDIT_LOC", "DIMENSION_SIGNAL")
     for key in required:
         if key not in context:
             raise KeyError(f"build_brief: missing required context key {key!r}")

--- a/evals/auto/loop.py
+++ b/evals/auto/loop.py
@@ -223,8 +223,16 @@ def _restore_results(repo_root: Path, preserved: Dict[Path, str]) -> None:
 
 _NO_SIGNAL_LINE = "  (no dimension signal available for this component)"
 _BOTTOM_K = 3
-# Maximum number of fixture rows to scan when computing dimension averages.
+# Minimum number of fixture rows to scan when computing dimension averages.
+# `n_scan = max(n_fixtures, _DIMENSION_SCAN_ROWS)` floors the read at this many
+# rows so very small corpora still get a useful sample.
 _DIMENSION_SCAN_ROWS = 20
+# Dimensions whose mean score is at or above this threshold are considered
+# saturated (no addressable headroom) and excluded from the surfaced signal.
+_SATURATION_THRESHOLD = 0.95
+# Dimensions backed by fewer than this many non-vacuous runs are statistical
+# noise (one fixture's quirk, not a corpus pattern) and excluded.
+_MIN_RUN_COUNT = 2
 
 
 def _build_dimension_signal(
@@ -332,8 +340,17 @@ def _build_dimension_signal(
     if not qualifying:
         return _NO_SIGNAL_LINE
 
-    # Compute mean per dimension and sort ascending (worst first).
+    # Compute mean per dimension. Filter out saturated dims (no addressable
+    # headroom) and statistical-noise dims (single-run signals).
     averages = [(dim, sum(sc) / len(sc), len(sc)) for dim, sc in qualifying.items()]
+    averages = [
+        (dim, avg, count)
+        for dim, avg, count in averages
+        if avg < _SATURATION_THRESHOLD and count >= _MIN_RUN_COUNT
+    ]
+    if not averages:
+        return _NO_SIGNAL_LINE
+
     averages.sort(key=lambda t: t[1])
     bottom = averages[:_BOTTOM_K]
 

--- a/evals/auto/loop.py
+++ b/evals/auto/loop.py
@@ -270,8 +270,18 @@ def _build_dimension_signal(
                 pass
 
     def _in_editable(dim_name: str) -> bool:
-        needle = dim_name.lower()
-        return any(needle in text for text in editable_texts)
+        # Try multiple casing/separator variants to handle the gap between
+        # scorer-internal snake_case names and human-facing prompt sections.
+        # E.g. dim "open_questions" should match "Open questions" / "open
+        # questions" / "open-questions" / "openQuestions" / "open_questions".
+        snake = dim_name.lower()
+        variants = {
+            snake,
+            snake.replace("_", " "),
+            snake.replace("_", "-"),
+            snake.replace("_", ""),
+        }
+        return any(any(v in text for v in variants) for text in editable_texts)
 
     # Accumulate: dim_name -> list of (score, count) per qualifying run.
     # Using parallel lists: dim_scores[dim] = list of float scores from non-vacuous runs.

--- a/evals/auto/loop.py
+++ b/evals/auto/loop.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -220,10 +221,129 @@ def _restore_results(repo_root: Path, preserved: Dict[Path, str]) -> None:
         path.write_text(content, encoding="utf-8")
 
 
+_NO_SIGNAL_LINE = "  (no dimension signal available for this component)"
+_BOTTOM_K = 3
+# Maximum number of fixture rows to scan when computing dimension averages.
+_DIMENSION_SCAN_ROWS = 20
+
+
+def _build_dimension_signal(
+    repo_root: Path,
+    component: str,
+    n_fixtures: int,
+    editable_paths: List[str],
+) -> str:
+    """Compute corpus-level per-dimension mean scores from the component's TSV.
+
+    Walks diagnostic_json.per_run[*].diagnostic for each row:
+      - Nested dict dimensions: any key whose value is a dict containing a
+        numeric 'score' key is treated as a dimension. If the dict also has
+        vacuous=True the run is excluded from that dimension's average.
+      - Flat float dimensions: any key whose value is a finite float in
+        [0.0, 1.0] is treated as a flat dimension (e.g. conductor's
+        decision_hit). These have no vacuous flag; all runs are counted.
+
+    Only dimensions whose name appears as a literal substring in at least one
+    editable file are included (prevents hallucinated section names reaching the
+    editor). Substring match is case-insensitive against the raw snake_case name.
+
+    Returns the bottom-K=3 worst-scoring qualifying dimensions formatted as
+    lines like:
+      - <dim_name>: avg <score> across <count> non-vacuous runs
+
+    Falls back to _NO_SIGNAL_LINE when no qualifying dimensions exist.
+    """
+    tsv_path = repo_root / "evals" / "results" / f"{component}.tsv"
+    n_scan = max(n_fixtures, _DIMENSION_SCAN_ROWS)
+    rows = runner_shim._read_last_rows(tsv_path, n_scan)
+    if not rows:
+        return _NO_SIGNAL_LINE
+
+    # Read editable file contents once (lowercase).
+    editable_texts: List[str] = []
+    for rel_path in editable_paths:
+        abs_path = repo_root / rel_path
+        if abs_path.exists():
+            try:
+                editable_texts.append(abs_path.read_text(encoding="utf-8").lower())
+            except OSError:
+                pass
+
+    def _in_editable(dim_name: str) -> bool:
+        needle = dim_name.lower()
+        return any(needle in text for text in editable_texts)
+
+    # Accumulate: dim_name -> list of (score, count) per qualifying run.
+    # Using parallel lists: dim_scores[dim] = list of float scores from non-vacuous runs.
+    dim_scores: Dict[str, List[float]] = {}
+
+    for row in rows:
+        raw = row.get("diagnostic_json") or ""
+        if not raw:
+            continue
+        try:
+            top = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        for pr in top.get("per_run") or []:
+            diag = pr.get("diagnostic")
+            if not isinstance(diag, dict):
+                continue
+            for dim_name, val in diag.items():
+                if isinstance(val, dict):
+                    # Nested dict dimension - must have numeric 'score'.
+                    score = val.get("score")
+                    if not isinstance(score, (int, float)):
+                        continue
+                    if not math.isfinite(float(score)):
+                        continue
+                    # Skip vacuous runs for this dimension.
+                    if val.get("vacuous") is True:
+                        continue
+                    if dim_name not in dim_scores:
+                        dim_scores[dim_name] = []
+                    dim_scores[dim_name].append(float(score))
+                elif isinstance(val, float) and math.isfinite(val) and 0.0 <= val <= 1.0:
+                    # Flat float dimension (e.g. conductor's decision_hit).
+                    if dim_name not in dim_scores:
+                        dim_scores[dim_name] = []
+                    dim_scores[dim_name].append(val)
+
+    if not dim_scores:
+        return _NO_SIGNAL_LINE
+
+    # Filter to dimensions that appear in editable files.
+    qualifying: Dict[str, List[float]] = {
+        dim: scores
+        for dim, scores in dim_scores.items()
+        if scores and _in_editable(dim)
+    }
+
+    if not qualifying:
+        return _NO_SIGNAL_LINE
+
+    # Compute mean per dimension and sort ascending (worst first).
+    averages = [(dim, sum(sc) / len(sc), len(sc)) for dim, sc in qualifying.items()]
+    averages.sort(key=lambda t: t[1])
+    bottom = averages[:_BOTTOM_K]
+
+    lines = [
+        f"  - {dim}: avg {avg:.3f} across {count} non-vacuous runs"
+        for dim, avg, count in bottom
+    ]
+    return "\n".join(lines)
+
+
 def _build_editor_context(cfg: LoopConfig) -> Dict[str, Any]:
     editable = cfg.component_cfg.get("editable") or []
     locked = cfg.component_cfg.get("locked") or []
     is_whole_file = cfg.component_cfg.get("whole_file_replacement", False)
+    dimension_signal = _build_dimension_signal(
+        cfg.repo_root,
+        cfg.component,
+        cfg.n_fixtures,
+        list(editable),
+    )
     return {
         "COMPONENT": cfg.component,
         "EDITABLE_FILES": "\n".join(f"  - {p}" for p in editable),
@@ -234,6 +354,7 @@ def _build_editor_context(cfg: LoopConfig) -> Dict[str, Any]:
         "WHOLE_FILE_MODE": "true" if is_whole_file else "false",
         "EDITOR_TIMEOUT_SEC": str(cfg.editor_timeout_sec),
         "OUTPUT_FORMAT_INSTRUCTIONS": _format_instructions(cfg.component, is_whole_file),
+        "DIMENSION_SIGNAL": dimension_signal,
     }
 
 

--- a/evals/auto/program.md
+++ b/evals/auto/program.md
@@ -31,10 +31,17 @@ to look for, not as section names to insert verbatim.
 
 {{DIMENSION_SIGNAL}}
 
-Targets the corpus-wide pattern. If your edit is motivated wholly by
-trying to move one of these averages, ensure the change is independently
-defensible: it should be a worthwhile improvement to the prompt even if
-no eval existed.
+Targets the corpus-wide pattern. If your edit is motivated wholly OR
+PARTLY by trying to move one of these averages, ensure the change is
+independently defensible: it should be a worthwhile improvement to the
+prompt even if no eval existed. (This matches the OVERFITTING-RULE
+verbatim - the rule applies to partial as well as full motivation.)
+
+A dimension scoring 0.95 or higher is effectively saturated and
+represents no addressable gap; treat saturated entries as filler, not
+targets. Counts in the line ("across N non-vacuous runs") indicate
+statistical weight - a dimension with a single run is one data point,
+not a corpus pattern.
 
 ## Budget
 

--- a/evals/auto/program.md
+++ b/evals/auto/program.md
@@ -22,6 +22,20 @@ applies, measures, and decides to keep or revert.
   by at least max(pooled_stdev, 0.02). Propose something plausibly
   bigger than noise.
 
+## Lowest-scoring dimensions (corpus-level)
+
+These are the worst-performing scoring dimensions averaged across all
+fixtures. Names are scorer-internal - they may or may not match section
+headers in your editable file. Treat them as hints about what kind of gap
+to look for, not as section names to insert verbatim.
+
+{{DIMENSION_SIGNAL}}
+
+Targets the corpus-wide pattern. If your edit is motivated wholly by
+trying to move one of these averages, ensure the change is independently
+defensible: it should be a worthwhile improvement to the prompt even if
+no eval existed.
+
 ## Budget
 
 - Maximum changed lines (added + removed) across the entire diff:

--- a/evals/auto/tests/test_dimension_signal.py
+++ b/evals/auto/tests/test_dimension_signal.py
@@ -1,0 +1,258 @@
+"""Unit tests for _build_dimension_signal in evals.auto.loop."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.auto.loop import _build_dimension_signal, _NO_SIGNAL_LINE
+
+
+# ---------------------------------------------------------------------------
+# TSV helpers
+# ---------------------------------------------------------------------------
+
+_TSV_HEADER = [
+    "commit", "component_content_hash", "fixture_hash",
+    "primary_score_median", "primary_score_stdev", "n_runs",
+    "status", "diagnostic_json", "description",
+]
+
+
+def _write_tsv(path: Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write("\t".join(_TSV_HEADER) + "\n")
+        for r in rows:
+            fh.write("\t".join(str(r.get(c, "")) for c in _TSV_HEADER) + "\n")
+
+
+def _make_row(per_run: list) -> dict:
+    diag = {"n_runs": len(per_run), "per_run": per_run}
+    return {
+        "commit": "abc123",
+        "component_content_hash": "x" * 64,
+        "fixture_hash": "y" * 64,
+        "primary_score_median": "0.8",
+        "primary_score_stdev": "0.1",
+        "n_runs": len(per_run),
+        "status": "ok",
+        "diagnostic_json": json.dumps(diag),
+        "description": "test",
+    }
+
+
+def _nested_dim(score: float, vacuous: bool = False) -> dict:
+    """Build a nested-dict dimension value (architect-style)."""
+    d: dict = {"score": score}
+    if vacuous:
+        d["vacuous"] = True
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Editable file fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo tree with an editable file containing known dimension names."""
+    results_dir = tmp_path / "evals" / "results"
+    results_dir.mkdir(parents=True)
+    editable_dir = tmp_path / "content" / "agents"
+    editable_dir.mkdir(parents=True)
+    agent_md = editable_dir / "mycomp.md"
+    agent_md.write_text(
+        "# mycomp\nopen_questions section\napproach_commit details\nsection_keywords here\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: bottom-K extraction from fabricated TSV with known dimensions
+# ---------------------------------------------------------------------------
+
+def test_bottom_k_extraction(tmp_repo: Path) -> None:
+    """Confirms worst dimensions are returned in ascending order."""
+    # Three dimensions: open_questions (worst), approach_commit (mid), section_keywords (best)
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": _nested_dim(0.1),
+                "approach_commit": _nested_dim(0.5),
+                "section_keywords": _nested_dim(0.9),
+            },
+            "primary": 0.8,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)] * 3  # 3 fixture rows
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 3, editable)
+
+    assert "open_questions" in result
+    assert "approach_commit" in result
+    assert "section_keywords" in result
+    # open_questions should appear before approach_commit (sorted ascending by avg)
+    assert result.index("open_questions") < result.index("approach_commit")
+    assert result.index("approach_commit") < result.index("section_keywords")
+    # Confirm format
+    assert "avg 0.100" in result
+    assert "non-vacuous runs" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 2: substring filter excludes dimensions not in editable file
+# ---------------------------------------------------------------------------
+
+def test_substring_filter_excludes_unknown_dims(tmp_repo: Path) -> None:
+    """Dimensions whose names don't appear in editable files are excluded."""
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": _nested_dim(0.1),   # in editable file
+                "zz_unknown_dim": _nested_dim(0.0),    # NOT in editable file
+            },
+            "primary": 0.7,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)] * 2
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 2, editable)
+
+    assert "open_questions" in result
+    assert "zz_unknown_dim" not in result
+
+
+# ---------------------------------------------------------------------------
+# Test 3: vacuous exclusion
+# ---------------------------------------------------------------------------
+
+def test_vacuous_runs_excluded(tmp_repo: Path) -> None:
+    """Vacuous=True runs are excluded from dimension averages."""
+    # open_questions: 2 vacuous runs (score=0.0) + 1 non-vacuous run (score=0.8)
+    # Average should be 0.8 (only counting the non-vacuous run).
+    per_run = [
+        {"diagnostic": {"open_questions": _nested_dim(0.0, vacuous=True)}, "primary": 0.5, "status": "ok"},
+        {"diagnostic": {"open_questions": _nested_dim(0.0, vacuous=True)}, "primary": 0.5, "status": "ok"},
+        {"diagnostic": {"open_questions": _nested_dim(0.8, vacuous=False)}, "primary": 0.8, "status": "ok"},
+    ]
+    rows = [_make_row(per_run)]
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 1, editable)
+
+    # avg should reflect only the 1 non-vacuous run with score 0.8
+    assert "open_questions" in result
+    assert "avg 0.800" in result
+    assert "1 non-vacuous runs" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 4: empty/missing TSV returns no-signal line
+# ---------------------------------------------------------------------------
+
+def test_missing_tsv_returns_no_signal(tmp_repo: Path) -> None:
+    """Missing TSV returns the no-signal fallback line."""
+    result = _build_dimension_signal(tmp_repo, "nonexistent_comp", 3, [])
+    assert result == _NO_SIGNAL_LINE
+
+
+def test_empty_tsv_returns_no_signal(tmp_repo: Path) -> None:
+    """TSV with no rows returns the no-signal fallback line."""
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, [])  # header only
+
+    result = _build_dimension_signal(tmp_repo, "mycomp", 1, ["content/agents/mycomp.md"])
+    assert result == _NO_SIGNAL_LINE
+
+
+# ---------------------------------------------------------------------------
+# Test 5: flat float dimensions (conductor-style)
+# ---------------------------------------------------------------------------
+
+def test_flat_float_dimensions(tmp_repo: Path) -> None:
+    """Flat float values in [0,1] are treated as dimensions."""
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": 0.2,   # flat float, in editable file
+                "cli_status": "ok",       # string - not a dimension
+                "latency_ms": 12345,      # int, not in [0,1] - not a dimension
+                "approach_commit": 0.7,   # flat float, in editable file
+            },
+            "primary": 0.7,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)] * 2
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 2, editable)
+
+    assert "open_questions" in result
+    assert "approach_commit" in result
+    assert "cli_status" not in result
+    assert "latency_ms" not in result
+
+
+# ---------------------------------------------------------------------------
+# Test 6: all dimensions are vacuous -> no signal
+# ---------------------------------------------------------------------------
+
+def test_all_vacuous_returns_no_signal(tmp_repo: Path) -> None:
+    """When every run for every dimension is vacuous, return no-signal."""
+    per_run = [
+        {"diagnostic": {"open_questions": _nested_dim(0.0, vacuous=True)}, "primary": 0.5, "status": "ok"},
+    ]
+    rows = [_make_row(per_run)]
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 1, editable)
+    assert result == _NO_SIGNAL_LINE
+
+
+# ---------------------------------------------------------------------------
+# Test 7: no matching editable file -> no signal
+# ---------------------------------------------------------------------------
+
+def test_no_editable_match_returns_no_signal(tmp_repo: Path) -> None:
+    """When no editable file contains any dimension name, return no-signal."""
+    per_run = [
+        {
+            "diagnostic": {
+                "zz_unknown_alpha": _nested_dim(0.1),
+                "zz_unknown_beta": _nested_dim(0.2),
+            },
+            "primary": 0.5,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)]
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 1, editable)
+    assert result == _NO_SIGNAL_LINE

--- a/evals/auto/tests/test_dimension_signal.py
+++ b/evals/auto/tests/test_dimension_signal.py
@@ -236,6 +236,42 @@ def test_all_vacuous_returns_no_signal(tmp_repo: Path) -> None:
 # Test 7: no matching editable file -> no signal
 # ---------------------------------------------------------------------------
 
+def test_variant_matching_for_human_section_headers(tmp_path: Path) -> None:
+    """Snake_case dimension names match space-separated and Title Case
+    section headers in the editable file (the common shape: scorer uses
+    'open_questions', prompt has '## Open questions')."""
+    results_dir = tmp_path / "evals" / "results"
+    results_dir.mkdir(parents=True)
+    editable_dir = tmp_path / "content" / "agents"
+    editable_dir.mkdir(parents=True)
+    agent_md = editable_dir / "comp.md"
+    # Editable file uses Title Case with spaces, NOT snake_case
+    agent_md.write_text(
+        "# Agent\n## Open questions\nGenuine ambiguities here.\n## Approach commit\n",
+        encoding="utf-8",
+    )
+
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": _nested_dim(0.1),
+                "approach_commit": _nested_dim(0.4),
+                "zz_truly_unknown": _nested_dim(0.0),
+            },
+            "primary": 0.5,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)]
+    tsv = results_dir / "comp.tsv"
+    _write_tsv(tsv, rows)
+
+    result = _build_dimension_signal(tmp_path, "comp", 1, ["content/agents/comp.md"])
+    assert "open_questions" in result, f"expected variant match for 'open_questions' against 'Open questions'; got: {result}"
+    assert "approach_commit" in result, f"expected variant match for 'approach_commit' against 'Approach commit'; got: {result}"
+    assert "zz_truly_unknown" not in result
+
+
 def test_no_editable_match_returns_no_signal(tmp_repo: Path) -> None:
     """When no editable file contains any dimension name, return no-signal."""
     per_run = [

--- a/evals/auto/tests/test_dimension_signal.py
+++ b/evals/auto/tests/test_dimension_signal.py
@@ -141,11 +141,12 @@ def test_substring_filter_excludes_unknown_dims(tmp_repo: Path) -> None:
 
 def test_vacuous_runs_excluded(tmp_repo: Path) -> None:
     """Vacuous=True runs are excluded from dimension averages."""
-    # open_questions: 2 vacuous runs (score=0.0) + 1 non-vacuous run (score=0.8)
-    # Average should be 0.8 (only counting the non-vacuous run).
+    # open_questions: 2 vacuous runs (score=0.0) + 2 non-vacuous runs (score=0.8)
+    # Average should be 0.8 (only counting the 2 non-vacuous runs).
     per_run = [
         {"diagnostic": {"open_questions": _nested_dim(0.0, vacuous=True)}, "primary": 0.5, "status": "ok"},
         {"diagnostic": {"open_questions": _nested_dim(0.0, vacuous=True)}, "primary": 0.5, "status": "ok"},
+        {"diagnostic": {"open_questions": _nested_dim(0.8, vacuous=False)}, "primary": 0.8, "status": "ok"},
         {"diagnostic": {"open_questions": _nested_dim(0.8, vacuous=False)}, "primary": 0.8, "status": "ok"},
     ]
     rows = [_make_row(per_run)]
@@ -156,10 +157,85 @@ def test_vacuous_runs_excluded(tmp_repo: Path) -> None:
     editable = ["content/agents/mycomp.md"]
     result = _build_dimension_signal(tmp_repo, "mycomp", 1, editable)
 
-    # avg should reflect only the 1 non-vacuous run with score 0.8
+    # avg should reflect only the 2 non-vacuous runs with score 0.8
     assert "open_questions" in result
     assert "avg 0.800" in result
-    assert "1 non-vacuous runs" in result
+    assert "2 non-vacuous runs" in result
+
+
+def test_single_run_dim_excluded_as_noise(tmp_repo: Path) -> None:
+    """A dimension backed by only 1 non-vacuous run is statistical noise
+    and excluded from the surfaced signal (min_run_count guard)."""
+    # open_questions appears in only 1 run. Should NOT surface.
+    # approach_commit appears in 3 runs - should surface.
+    per_run = [
+        {"diagnostic": {"open_questions": _nested_dim(0.0), "approach_commit": _nested_dim(0.2)}, "primary": 0.4, "status": "ok"},
+        {"diagnostic": {"approach_commit": _nested_dim(0.2)}, "primary": 0.4, "status": "ok"},
+        {"diagnostic": {"approach_commit": _nested_dim(0.2)}, "primary": 0.4, "status": "ok"},
+    ]
+    rows = [_make_row(per_run)]
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 1, editable)
+
+    assert "approach_commit" in result
+    assert "open_questions" not in result, f"single-run dim should be excluded as noise; got: {result}"
+
+
+def test_saturated_dims_excluded(tmp_repo: Path) -> None:
+    """Dimensions averaging at or above 0.95 are saturated (no headroom)
+    and excluded from the surfaced signal."""
+    # All 3 dims score >= 0.95: the helper should return _NO_SIGNAL_LINE.
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": _nested_dim(0.97),
+                "approach_commit": _nested_dim(0.99),
+                "section_keywords": _nested_dim(1.0),
+            },
+            "primary": 0.98,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)] * 2
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 2, editable)
+
+    assert result == _NO_SIGNAL_LINE
+
+
+def test_only_unsaturated_dims_surfaced(tmp_repo: Path) -> None:
+    """When some dims are saturated and some have headroom, only the
+    unsaturated ones are surfaced (no false-signal filler)."""
+    per_run = [
+        {
+            "diagnostic": {
+                "open_questions": _nested_dim(0.10),    # real gap
+                "approach_commit": _nested_dim(0.99),   # saturated, EXCLUDED
+                "section_keywords": _nested_dim(1.0),   # saturated, EXCLUDED
+            },
+            "primary": 0.6,
+            "status": "ok",
+        }
+    ]
+    rows = [_make_row(per_run)] * 2
+
+    tsv = tmp_repo / "evals" / "results" / "mycomp.tsv"
+    _write_tsv(tsv, rows)
+
+    editable = ["content/agents/mycomp.md"]
+    result = _build_dimension_signal(tmp_repo, "mycomp", 2, editable)
+
+    assert "open_questions" in result
+    assert "approach_commit" not in result
+    assert "section_keywords" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -262,11 +338,11 @@ def test_variant_matching_for_human_section_headers(tmp_path: Path) -> None:
             "status": "ok",
         }
     ]
-    rows = [_make_row(per_run)]
+    rows = [_make_row(per_run)] * 2  # 2 rows so each dim has count >= 2
     tsv = results_dir / "comp.tsv"
     _write_tsv(tsv, rows)
 
-    result = _build_dimension_signal(tmp_path, "comp", 1, ["content/agents/comp.md"])
+    result = _build_dimension_signal(tmp_path, "comp", 2, ["content/agents/comp.md"])
     assert "open_questions" in result, f"expected variant match for 'open_questions' against 'Open questions'; got: {result}"
     assert "approach_commit" in result, f"expected variant match for 'approach_commit' against 'Approach commit'; got: {result}"
     assert "zz_truly_unknown" not in result


### PR DESCRIPTION
## Why

The auto-harness editor agent was blind to per-fixture diagnostics. It saw only:
- Prompt under edit
- Editable + locked file lists
- BASELINE_METRIC scalar
- POOLED_STDEV scalar

When most fixtures were at ceiling and one lagged, the editor had no way to know which dimension was failing. Today's wins (architect, debugger) only happened because the gaps were visible in the prompt template structure. Components like prune-harness/uae/memory-update plateaued because the editor couldn't see the gap.

## What

Inject a corpus-level dimension signal showing the worst-scoring dimensions averaged across all fixtures.

- **Corpus-level only** - per-fixture diagnostics would violate OVERFITTING-RULE; corpus averages are stable under single-fixture removal.
- **Variant matching** - matches snake_case dim names against Title Case / hyphenated / spaced section headers in the editable file.
- **Saturation filter** - dims at avg >= 0.95 excluded (no addressable headroom).
- **Min-run guard** - dims with < 2 non-vacuous runs excluded as statistical noise.
- **Substring filter** - only surface dims whose name (in any variant) appears in at least one editable file.
- **Both shapes supported** - nested {score: float} dicts (architect/prune-harness) AND flat floats (conductor/skeptic).

## Verified output

architect: `open_questions: avg 0.000 across 15 non-vacuous runs` - exactly the real gap. Before saturation filter, also surfaced 2 noise 1.0 dims. After: clean signal.

## Skeptic loop

1. Initial: variant-match too strict (snake_case only) - editor saw only saturated dims for architect
2. Variant-match fix: snake/space/hyphen/concat
3. Skeptic: 2 Majors found - OVERFITTING-RULE wording weakened ('wholly' vs 'wholly or partly') + no saturation filter
4. Both Majors fixed; 12 tests pass (54 total in test suite)

## Test plan
- [x] All harness tests pass (54/54)
- [x] Architect signal verified: open_questions surfaces correctly
- [ ] Re-run plateau components to validate unlock