### PR TITLE
fix(wrap): replace lock auto-removal with wait-and-retry semantics

### DIFF
--- a/.claude/commands/wrap.md
+++ b/.claude/commands/wrap.md
@@ -54,10 +54,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -65,7 +68,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/.codex/commands/wrap.md
+++ b/.codex/commands/wrap.md
@@ -52,10 +52,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -63,7 +66,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/.cursor/commands/wrap.md
+++ b/.cursor/commands/wrap.md
@@ -52,10 +52,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -63,7 +66,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/.opencode/commands/wrap.md
+++ b/.opencode/commands/wrap.md
@@ -56,10 +56,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -67,7 +70,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/content/commands/wrap.md
+++ b/content/commands/wrap.md
@@ -52,10 +52,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -63,7 +66,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -1683,6 +1683,20 @@
           <li>Cleans up stale worktrees as final step - backed by the <code>/cleanup-worktrees</code> skill</li>
         </ul>
       </div>
+      <div class="rel-card" style="border-color: rgba(90,61,138,0.2); margin-top: 10px;">
+        <h4 style="color: var(--violet);">Concurrent-run protection (wrap.lock)</h4>
+        <p class="desc" style="font-size: 14px; margin-top: 0; max-width: none;">
+          /wrap acquires a project-local lock at <code>&lt;cwd&gt;/.agentic/wrap.lock</code> before writing any shared files. This prevents two simultaneous /wrap runs from clobbering each other.
+        </p>
+        <ul>
+          <li><strong>Lock acquisition</strong> - atomic <code>mkdir</code> (POSIX-safe); owner file written immediately with a UTC timestamp.</li>
+          <li><strong>Live lock (under 30 min old)</strong> - /wrap waits, polling every 5 seconds. Reports once to the user: "Another /wrap run is in progress. Waiting..." When the lock disappears it retries acquisition once. If a third session grabbed the lock between the poll and the retry, /wrap aborts with a live-lock message rather than waiting again.</li>
+          <li><strong>Stale lock (30+ min old)</strong> - /wrap does NOT auto-remove the lock. It reports the lock path, pid, and timestamp, instructs the user to remove it manually (<code>rm -rf &lt;cwd&gt;/.agentic/wrap.lock</code>), and aborts.</li>
+          <li><strong>Unreadable/malformed owner file</strong> - if the owner file is missing, unreadable, or contains no valid timestamp, /wrap treats the lock as stale, reports the lock path, instructs manual removal, and aborts.</li>
+          <li><strong>No PID liveness check</strong> - the timestamp is the authoritative signal; <code>ps -p</code> is omitted because Claude Code process hierarchies make PID reuse unreliable.</li>
+          <li><strong>Lock release</strong> - mandatory on every exit path (success, escalation, or abort). If /wrap aborts before acquiring the lock, no release is needed.</li>
+        </ul>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Live locks now cause /wrap to poll every 5s (up to 10 min) until released, then retry once - instead of aborting immediately
- Stale locks (>30 min) and unreadable/malformed owner files report to the user with the exact `rm -rf` command; no auto-removal
- PID liveness check (`ps -p`) removed - PID reuse makes it unreliable for Claude Code process hierarchies; timestamp is the sole signal
- Retry-after-clear failure path made explicit (if second mkdir fails, report and abort)
- Docs sync: new "Concurrent-run protection" card added to `docs/agentic-engineering.html`

## Root cause

The old protocol auto-removed any lock whose PID appeared dead. Claude Code sessions can share PIDs or have child processes that outlive the parent, making `ps -p` return DEAD for a live session. This allowed one /wrap invocation to steal another's lock mid-run.

## Test plan

- [ ] Start /wrap in project A, verify a second /wrap in the same project waits rather than aborting
- [ ] Let a /wrap run complete normally, verify lock is released and a subsequent run acquires cleanly
- [ ] Leave a lock older than 30 min, verify /wrap reports owner info and instructs manual removal
- [ ] Create a lock dir with no owner file, verify /wrap reports and instructs manual removal