### PR TITLE
chore: formalize conductor-vs-subagent worktree mental model

### DIFF
--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -316,7 +316,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -358,7 +358,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -129,19 +129,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -197,24 +184,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -377,9 +360,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -305,7 +305,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -366,7 +366,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -376,7 +376,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -934,7 +934,7 @@ A glossary is optional; not every project needs one. But once introduced, it is 
 
 ## Git Workflow
 
-The main working tree stays on `development` (or `develop`) at all times. All feature work happens in worktrees.
+**Conductor does not create worktrees for itself.** The conductor edits directly on its current branch. Worktrees are exclusively for subagents.
 
 **Base branch resolution** - resolve in this order before any work begins:
 1. Use `develop` if it exists.
@@ -943,24 +943,30 @@ The main working tree stays on `development` (or `develop`) at all times. All fe
 
 **Conductor preflight** - run this checklist before any work begins. Do not skip it when the user issues a direct command; commands are goals, not overrides for workflow hygiene.
 1. What branch is the working tree on? (`git branch --show-current`)
-2. Does this branch already contain unrelated commits? If yes, create a new worktree/branch instead of piling on.
+2. Does this branch already contain unrelated commits? If yes, start fresh from the base branch before proceeding.
 3. Are there uncommitted changes? If so, do they belong to the current task? Stash or commit unrelated work before proceeding.
 4. When was `origin` last fetched? Run `git fetch origin` if it has been more than a few minutes.
-5. Does this task need a new worktree? Any new feature, fix, or chore gets its own worktree branched from the resolved base branch.
 
-**Feature worktrees:** Each task or feature gets one worktree branched from `origin/development` (or `origin/develop`). Run `git fetch origin` before creating any worktree. Edit directly in the worktree - do not create sub-worktrees for individual changes.
+**Subagent worktrees:** Each parallel subagent gets its own worktree, branched from the conductor's current branch. Worktrees are created at `.agentic/worktrees/<branch-name>` under the project root (already gitignored via the `.agentic/` umbrella). The conductor merges each subagent branch back after sign-off and removes the worktree.
 
-**Parallel agent work:** When multiple agents need to work simultaneously on the same task, each parallel agent gets its own sub-worktree branching from the feature branch. Sub-worktrees are the parallelism tool, not the default for every edit.
+```bash
+# Create a subagent worktree:
+git worktree add .agentic/worktrees/<branch-name> -b <branch-name> HEAD
+
+# Remove after merge:
+git worktree remove .agentic/worktrees/<branch-name>
+git branch -d <branch-name>
+```
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the feature branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
-**Cleanup:** Remove worktrees after the branch is merged (PR merged) or the task is explicitly closed or cancelled without a merge. Do not leave stale worktrees. Between tasks, the main tree should be on `development` with no active worktrees.
+**Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 
-**Commit each fix immediately during testing.** Never accumulate uncommitted changes on the main working tree (`development`/`develop`) during live testing sessions. After each validated fix: create fix branch, commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes. The cost of a quick PR per fix is low; the cost of untangling a divergent working tree is high.
+**Commit each fix immediately during testing.** Never accumulate uncommitted changes during live testing sessions. After each validated fix: commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes.
 
-**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session creates its own worktree from `development`. The main tree stays on `development` as neutral ground - never move it to a feature branch.
+**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -960,7 +960,7 @@ git branch -d <branch-name>
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** After Skeptic sign-off, subagent branches merge back into the conductor's current branch. The conductor's branch (not the individual subagent branch) then opens a PR into `develop`/`development`. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
 **Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 

--- a/.codex/commands/brief.md
+++ b/.codex/commands/brief.md
@@ -314,7 +314,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -356,7 +356,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/.codex/commands/brief.md
+++ b/.codex/commands/brief.md
@@ -127,19 +127,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -195,24 +182,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -375,9 +358,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -303,7 +303,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -364,7 +364,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -374,7 +374,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/.cursor/commands/brief.md
+++ b/.cursor/commands/brief.md
@@ -314,7 +314,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -356,7 +356,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/.cursor/commands/brief.md
+++ b/.cursor/commands/brief.md
@@ -127,19 +127,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -195,24 +182,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -375,9 +358,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -303,7 +303,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -364,7 +364,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -374,7 +374,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -65,7 +65,7 @@ A glossary is optional; not every project needs one. But once introduced, it is 
 
 ## Git Workflow
 
-The main working tree stays on `development` (or `develop`) at all times. All feature work happens in worktrees.
+**Conductor does not create worktrees for itself.** The conductor edits directly on its current branch. Worktrees are exclusively for subagents.
 
 **Base branch resolution** - resolve in this order before any work begins:
 1. Use `develop` if it exists.
@@ -74,23 +74,29 @@ The main working tree stays on `development` (or `develop`) at all times. All fe
 
 **Conductor preflight** - run this checklist before any work begins. Do not skip it when the user issues a direct command; commands are goals, not overrides for workflow hygiene.
 1. What branch is the working tree on? (`git branch --show-current`)
-2. Does this branch already contain unrelated commits? If yes, create a new worktree/branch instead of piling on.
+2. Does this branch already contain unrelated commits? If yes, start fresh from the base branch before proceeding.
 3. Are there uncommitted changes? If so, do they belong to the current task? Stash or commit unrelated work before proceeding.
 4. When was `origin` last fetched? Run `git fetch origin` if it has been more than a few minutes.
-5. Does this task need a new worktree? Any new feature, fix, or chore gets its own worktree branched from the resolved base branch.
 
-**Feature worktrees:** Each task or feature gets one worktree branched from `origin/development` (or `origin/develop`). Run `git fetch origin` before creating any worktree. Edit directly in the worktree - do not create sub-worktrees for individual changes.
+**Subagent worktrees:** Each parallel subagent gets its own worktree, branched from the conductor's current branch. Worktrees are created at `.agentic/worktrees/<branch-name>` under the project root (already gitignored via the `.agentic/` umbrella). The conductor merges each subagent branch back after sign-off and removes the worktree.
 
-**Parallel agent work:** When multiple agents need to work simultaneously on the same task, each parallel agent gets its own sub-worktree branching from the feature branch. Sub-worktrees are the parallelism tool, not the default for every edit.
+```bash
+# Create a subagent worktree:
+git worktree add .agentic/worktrees/<branch-name> -b <branch-name> HEAD
+
+# Remove after merge:
+git worktree remove .agentic/worktrees/<branch-name>
+git branch -d <branch-name>
+```
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the feature branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
-**Cleanup:** Remove worktrees after the branch is merged (PR merged) or the task is explicitly closed or cancelled without a merge. Do not leave stale worktrees. Between tasks, the main tree should be on `development` with no active worktrees.
+**Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 
-**Commit each fix immediately during testing.** Never accumulate uncommitted changes on the main working tree (`development`/`develop`) during live testing sessions. After each validated fix: create fix branch, commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes. The cost of a quick PR per fix is low; the cost of untangling a divergent working tree is high.
+**Commit each fix immediately during testing.** Never accumulate uncommitted changes during live testing sessions. After each validated fix: commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes.
 
-**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session creates its own worktree from `development`. The main tree stays on `development` as neutral ground - never move it to a feature branch.
+**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -91,7 +91,7 @@ git branch -d <branch-name>
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** After Skeptic sign-off, subagent branches merge back into the conductor's current branch. The conductor's branch (not the individual subagent branch) then opens a PR into `develop`/`development`. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
 **Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -934,7 +934,7 @@ A glossary is optional; not every project needs one. But once introduced, it is 
 
 ## Git Workflow
 
-The main working tree stays on `development` (or `develop`) at all times. All feature work happens in worktrees.
+**Conductor does not create worktrees for itself.** The conductor edits directly on its current branch. Worktrees are exclusively for subagents.
 
 **Base branch resolution** - resolve in this order before any work begins:
 1. Use `develop` if it exists.
@@ -943,24 +943,30 @@ The main working tree stays on `development` (or `develop`) at all times. All fe
 
 **Conductor preflight** - run this checklist before any work begins. Do not skip it when the user issues a direct command; commands are goals, not overrides for workflow hygiene.
 1. What branch is the working tree on? (`git branch --show-current`)
-2. Does this branch already contain unrelated commits? If yes, create a new worktree/branch instead of piling on.
+2. Does this branch already contain unrelated commits? If yes, start fresh from the base branch before proceeding.
 3. Are there uncommitted changes? If so, do they belong to the current task? Stash or commit unrelated work before proceeding.
 4. When was `origin` last fetched? Run `git fetch origin` if it has been more than a few minutes.
-5. Does this task need a new worktree? Any new feature, fix, or chore gets its own worktree branched from the resolved base branch.
 
-**Feature worktrees:** Each task or feature gets one worktree branched from `origin/development` (or `origin/develop`). Run `git fetch origin` before creating any worktree. Edit directly in the worktree - do not create sub-worktrees for individual changes.
+**Subagent worktrees:** Each parallel subagent gets its own worktree, branched from the conductor's current branch. Worktrees are created at `.agentic/worktrees/<branch-name>` under the project root (already gitignored via the `.agentic/` umbrella). The conductor merges each subagent branch back after sign-off and removes the worktree.
 
-**Parallel agent work:** When multiple agents need to work simultaneously on the same task, each parallel agent gets its own sub-worktree branching from the feature branch. Sub-worktrees are the parallelism tool, not the default for every edit.
+```bash
+# Create a subagent worktree:
+git worktree add .agentic/worktrees/<branch-name> -b <branch-name> HEAD
+
+# Remove after merge:
+git worktree remove .agentic/worktrees/<branch-name>
+git branch -d <branch-name>
+```
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the feature branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
-**Cleanup:** Remove worktrees after the branch is merged (PR merged) or the task is explicitly closed or cancelled without a merge. Do not leave stale worktrees. Between tasks, the main tree should be on `development` with no active worktrees.
+**Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 
-**Commit each fix immediately during testing.** Never accumulate uncommitted changes on the main working tree (`development`/`develop`) during live testing sessions. After each validated fix: create fix branch, commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes. The cost of a quick PR per fix is low; the cost of untangling a divergent working tree is high.
+**Commit each fix immediately during testing.** Never accumulate uncommitted changes during live testing sessions. After each validated fix: commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes.
 
-**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session creates its own worktree from `development`. The main tree stays on `development` as neutral ground - never move it to a feature branch.
+**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -960,7 +960,7 @@ git branch -d <branch-name>
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** After Skeptic sign-off, subagent branches merge back into the conductor's current branch. The conductor's branch (not the individual subagent branch) then opens a PR into `develop`/`development`. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
 **Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 

--- a/.gemini/commands/brief.toml
+++ b/.gemini/commands/brief.toml
@@ -320,7 +320,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -362,7 +362,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/.gemini/commands/brief.toml
+++ b/.gemini/commands/brief.toml
@@ -133,19 +133,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -201,24 +188,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -381,9 +364,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -309,7 +309,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \\
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \\
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -370,7 +370,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -380,7 +380,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/.gemini/commands/wrap.toml
+++ b/.gemini/commands/wrap.toml
@@ -58,10 +58,13 @@ All steps are silent on success. Log each migration action taken (e.g. "Migrated
 1. Ensure `<cwd>/.agentic/` exists (`mkdir -p <cwd>/.agentic`).
 2. Attempt atomic acquisition: `mkdir <cwd>/.agentic/wrap.lock` (atomic on POSIX - succeeds only if the directory did not exist).
 3. **If `mkdir` succeeds**, immediately write owner metadata: `<cwd>/.agentic/wrap.lock/owner` containing two lines - the current process PID and an ISO8601 UTC timestamp (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`). Proceed.
-4. **If `mkdir` fails** (lock already held), read `<cwd>/.agentic/wrap.lock/owner`. Consider the lock stale if EITHER: (a) the PID is not running (`ps -p <pid>` returns non-zero), OR (b) the timestamp is older than 30 minutes. If stale, remove the lock dir (`rm -rf <cwd>/.agentic/wrap.lock`) and retry step 2 once. If the retry still fails, treat as live.
-5. **If the lock is live**, abort immediately. Tell the user: "Another /wrap run is in progress in this project (pid N, started at TIME). Wait for it to finish, then retry." Do not queue or wait. Do not proceed to any subsequent step.
+4. **If `mkdir` fails** (lock already held), attempt to read `<cwd>/.agentic/wrap.lock/owner` to get the owner PID and timestamp.
+   - **If the owner file cannot be read or parsed** (file missing, unreadable, or contains no valid ISO8601 timestamp): treat as stale. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` but its owner file could not be read or parsed. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step.
+   - **If the timestamp is older than 30 minutes**: treat as potentially stale, but do NOT remove the lock automatically. Report to the user: "A /wrap lock exists at `<cwd>/.agentic/wrap.lock` (pid N, started at TIME) and is older than 30 minutes. If no /wrap run is active, remove it manually: `rm -rf <cwd>/.agentic/wrap.lock`." Then abort. Do not proceed to any subsequent step. Rationale: only the process that wrote the lock should remove it - auto-removal risks clobbering a live run if the 30-minute heuristic is wrong.
+   - **If the timestamp is less than 30 minutes old** (live lock): wait for the lock to be released. Tell the user once: "Another /wrap run is in progress in this project (pid N, started at TIME). Waiting for it to finish..." Then poll: every 5 seconds check whether `<cwd>/.agentic/wrap.lock` still exists (e.g. `ls <cwd>/.agentic/wrap.lock`). When the directory disappears, retry the `mkdir` acquisition once (step 2). If that retry also fails (a third session acquired the lock between the poll and the retry), report a live-lock message and abort: "Another /wrap run acquired the lock before this session could. Try again when the other run finishes." Do not wait again. If the lock is still held after 10 minutes of waiting, report the same stale-lock message as the > 30-minute path and abort.
+5. Do not perform a PID liveness check (`ps -p`). PID reuse makes the check unreliable for Claude Code processes - the timestamp is the authoritative signal.
 
-The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind - the PID check catches most cases, but the timestamp backstop covers PID reuse.
+The 30-minute staleness heuristic exists because a crashed or force-killed /wrap may leave the lock dir behind. The timestamp backstop is the reliable signal; PID checks are omitted because Claude Code process hierarchies make `ps -p` results unreliable.
 
 **Lock release is mandatory on every exit path.** The lock dir MUST be removed (`rm -rf <cwd>/.agentic/wrap.lock`) before /wrap returns control to the user, on ALL of:
 - successful completion at Step 6;
@@ -69,7 +72,7 @@ The 30-minute staleness heuristic exists because a crashed or force-killed /wrap
 - compression failure or escalation at Part E;
 - any user-abort path (e.g. drift requiring input, Skeptic scope bail).
 
-If /wrap aborts before this lock step (e.g. at the active-Workers check above), no lock was acquired and no release is needed.
+If /wrap aborts before the lock is acquired (e.g. at the active-Workers check above, or because a live or stale lock was detected and the command aborted without acquiring), no lock was acquired and no release is needed.
 
 **Pre-flight path check:** Confirm `<cwd>/.agentic/` exists or can be created. The /wrap skill now writes project-local under `<cwd>/.agentic/` instead of the legacy `~/.claude/projects/[hash]/` hashed directories. No disambiguation needed - one canonical location per project.
 

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -934,7 +934,7 @@ A glossary is optional; not every project needs one. But once introduced, it is 
 
 ## Git Workflow
 
-The main working tree stays on `development` (or `develop`) at all times. All feature work happens in worktrees.
+**Conductor does not create worktrees for itself.** The conductor edits directly on its current branch. Worktrees are exclusively for subagents.
 
 **Base branch resolution** - resolve in this order before any work begins:
 1. Use `develop` if it exists.
@@ -943,24 +943,30 @@ The main working tree stays on `development` (or `develop`) at all times. All fe
 
 **Conductor preflight** - run this checklist before any work begins. Do not skip it when the user issues a direct command; commands are goals, not overrides for workflow hygiene.
 1. What branch is the working tree on? (`git branch --show-current`)
-2. Does this branch already contain unrelated commits? If yes, create a new worktree/branch instead of piling on.
+2. Does this branch already contain unrelated commits? If yes, start fresh from the base branch before proceeding.
 3. Are there uncommitted changes? If so, do they belong to the current task? Stash or commit unrelated work before proceeding.
 4. When was `origin` last fetched? Run `git fetch origin` if it has been more than a few minutes.
-5. Does this task need a new worktree? Any new feature, fix, or chore gets its own worktree branched from the resolved base branch.
 
-**Feature worktrees:** Each task or feature gets one worktree branched from `origin/development` (or `origin/develop`). Run `git fetch origin` before creating any worktree. Edit directly in the worktree - do not create sub-worktrees for individual changes.
+**Subagent worktrees:** Each parallel subagent gets its own worktree, branched from the conductor's current branch. Worktrees are created at `.agentic/worktrees/<branch-name>` under the project root (already gitignored via the `.agentic/` umbrella). The conductor merges each subagent branch back after sign-off and removes the worktree.
 
-**Parallel agent work:** When multiple agents need to work simultaneously on the same task, each parallel agent gets its own sub-worktree branching from the feature branch. Sub-worktrees are the parallelism tool, not the default for every edit.
+```bash
+# Create a subagent worktree:
+git worktree add .agentic/worktrees/<branch-name> -b <branch-name> HEAD
+
+# Remove after merge:
+git worktree remove .agentic/worktrees/<branch-name>
+git branch -d <branch-name>
+```
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the feature branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
-**Cleanup:** Remove worktrees after the branch is merged (PR merged) or the task is explicitly closed or cancelled without a merge. Do not leave stale worktrees. Between tasks, the main tree should be on `development` with no active worktrees.
+**Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 
-**Commit each fix immediately during testing.** Never accumulate uncommitted changes on the main working tree (`development`/`develop`) during live testing sessions. After each validated fix: create fix branch, commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes. The cost of a quick PR per fix is low; the cost of untangling a divergent working tree is high.
+**Commit each fix immediately during testing.** Never accumulate uncommitted changes during live testing sessions. After each validated fix: commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes.
 
-**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session creates its own worktree from `development`. The main tree stays on `development` as neutral ground - never move it to a feature branch.
+**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -960,7 +960,7 @@ git branch -d <branch-name>
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** After Skeptic sign-off, subagent branches merge back into the conductor's current branch. The conductor's branch (not the individual subagent branch) then opens a PR into `develop`/`development`. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
 **Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 

--- a/.opencode/commands/brief.md
+++ b/.opencode/commands/brief.md
@@ -131,19 +131,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -199,24 +186,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -379,9 +362,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/.opencode/commands/brief.md
+++ b/.opencode/commands/brief.md
@@ -318,7 +318,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -360,7 +360,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -307,7 +307,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -368,7 +368,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -378,7 +378,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 - Internal eval harness lives at `evals/` (Python 3.11, stdlib + pyyaml, git worktrees, shell-out to Codex CLI). Component-first approach per `docs/planning/p2-self-improving-harness.md`. See `evals/LEARNINGS.md` before starting work on any new component eval, and `evals/OVERFITTING-RULE.md` before shipping content/ edits motivated by eval scores.
 - Methodology source-of-truth lives in `content/sections/01-*.md` through `10-*.md`. The legacy `content/rules/agent-methodology.md` path no longer exists - edit `content/sections/` for any methodology change.
 - `scripts/build-methodology.sh` is the canonical methodology assembly script. Adapter builds (`.claude/build.sh`, `.codex/build.sh`, `.gemini/build.sh`, `.kimi/build.sh`) invoke it via `bash "$REPO_DIR/scripts/build-methodology.sh"`. `.cursor/build.sh` has a different output structure and does not use it.
+- `.claude/install.sh` manages `~/.claude/CLAUDE.md` via a `managed_content` Python string (lines ~364-380). Four @-import lines (METHODOLOGY.md plus 3 rules files under `rules/`) must appear in that string or rules will not auto-inject in Claude Code sessions. Re-run install.sh after any changes to that string.
 
 ## Tools
 - GitHub operations: use `gh` CLI - do not use GitHub MCP
+- `gh pr create` for this repo requires an explicit token: `GITHUB_TOKEN=$(gh auth token --user tyson-solara6 2>/dev/null) gh pr create --repo Solara6/agentic-engineering` (SSH-alias remote not recognized by default gh auth)
+- `rm -rf` is blocked by Claude Code permissions in this repo; remove files individually: `rm <file>` then `rmdir <dir>`
 
 ## Deploy
 - Docs site: see `docs/technical/deploy.md`. Always verify the linked project ID before running `vercel --prod`.

--- a/content/commands/brief.md
+++ b/content/commands/brief.md
@@ -314,7 +314,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
   "status": "<see enum>",
   "topic": "<intent statement>",
   "slug": "<kebab-case-feature-name>",
-  "worktree_path": "<absolute or repo-relative path to feature worktree>",
+  "worktree_path": null,
   "brief_path": "<docs/planning/<slug>.md or null>",
   "brief_source": "<operator | conductor>",
   "created_at": "<ISO8601>",
@@ -356,7 +356,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 ### Field notes
 
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
-  algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
+  algorithm in Section 3 - Slug derivation. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
 - `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection

--- a/content/commands/brief.md
+++ b/content/commands/brief.md
@@ -127,19 +127,6 @@ Example: intent "I want to build an interactive planning command" -> slug `build
 
 The same slug derivation algorithm applies in `implement-ticket.md` Phase 0b (when deriving slug from ticket title, the ticket-ID prefix is also stripped). For `/brief`, no ticket prefix exists - derive directly from intent.
 
-### Worktree setup (after intent captured, before gray-area menu)
-
-```bash
-cd <repo-root>
-git fetch origin
-# Resolve base branch per conventions.md: develop -> development -> create from main
-git worktree add ../<repo-name>-<slug> -b feature/<slug> origin/<base-branch>
-```
-
-The worktree at `../<repo-name>-<slug>` stays active for the entire architect+engineer
-flow. Brief commit, architect plan commits, and engineer commits all land on
-`feature/<slug>` in this worktree.
-
 ### Turn 2 - Gray area menu
 
 Conductor reads the intent and generates 4-8 SCOPE-SPECIFIC gray areas inline (no
@@ -195,24 +182,20 @@ Write `status: iterating` during revision rounds.
 
 ### Turn N+k - Write and hand-off
 
-1. Conductor writes Brief to `<worktree>/docs/planning/<slug>.md` per the template.
+1. Conductor writes Brief to `docs/planning/<slug>.md` per the template.
 2. Sets `brief-session.json` `status: complete`, `brief_path`, `brief_source: operator`.
 3. Commit:
    ```bash
-   git -C ../<repo-name>-<slug> add docs/planning/<slug>.md
-   git -C ../<repo-name>-<slug> commit -m "docs(brief): add <slug> brief"
+   git add docs/planning/<slug>.md
+   git commit -m "docs(brief): add <slug> brief"
    ```
 4. Surface-and-proceed:
-   > "Brief written to docs/planning/<slug>.md and committed to feature/<slug>. Spawning
-   > architect with brief_path - reply STOP to halt or refine the Brief first."
-5. If no STOP in one turn: spawn architect with `brief_path` in execution contract,
-   targeting the active `feature/<slug>` worktree.
+   > "Brief written to docs/planning/<slug>.md and committed. Spawning architect with
+   > brief_path - reply STOP to halt or refine the Brief first."
+5. If no STOP in one turn: spawn architect with `brief_path` in execution contract.
 6. After architect returns: spawn Skeptic using the operator-confirmed variant (Section 6).
 7. PR opens at the end of the full engineer flow (after Skeptic sign-off on engineer
    output), NOT after Brief commit.
-
-The worktree remains active for the entire architect+engineer flow. Do not remove until
-the PR is merged.
 
 ---
 
@@ -375,9 +358,7 @@ Gitignored under the existing `.agentic/` rule. No `.gitignore` change needed.
 - `slug`: kebab-case slug derived from the operator's intent statement per the slug-derivation
   algorithm in Section 3 worktree setup. Must match the slug used by `implement-ticket.md`
   Phase 0b for the same intent.
-- `worktree_path`: absolute or repo-relative path to the feature worktree where the Brief
-  and downstream architect/engineer work lives. Used by resume to re-enter the correct
-  working directory.
+- `worktree_path`: reserved for future use; currently null. The conductor works directly on its current branch - no worktree is created by /brief.
 - `gray_areas[].selected: bool` - true if operator chose this area in the menu-selection
   step; false if deferred or skipped. Conductor only walks through areas where
   `selected: true`.

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -303,7 +303,7 @@ Create one worktree per unit, each rooted from `BASE_BRANCH` (loop over all N un
 
 ```bash
 # For each unit (unit_slug from planner JSONL block):
-git -C $REPO worktree add ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} \
+git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} \
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
@@ -364,7 +364,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # Confirm branch matches expected sub-branch before merging:
-# git -C ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
+# git -C ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} rev-parse --abbrev-ref HEAD
 # If the branch name does not match ${FEATURE_BRANCH}-${unit_slug}, abort that unit's merge and escalate.
 ```
 
@@ -374,7 +374,7 @@ git -C $REPO merge --no-ff ${FEATURE_BRANCH}-${unit_slug}
 
 ```bash
 # For each unit:
-git -C $REPO worktree remove ${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug} --force
+git -C $REPO worktree remove ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_slug} --force
 git -C $REPO branch -d ${FEATURE_BRANCH}-${unit_slug}
 git -C $REPO worktree prune
 ```

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -86,7 +86,7 @@ git branch -d <branch-name>
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** After Skeptic sign-off, subagent branches merge back into the conductor's current branch. The conductor's branch (not the individual subagent branch) then opens a PR into `develop`/`development`. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
 **Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -60,7 +60,7 @@ A glossary is optional; not every project needs one. But once introduced, it is 
 
 ## Git Workflow
 
-The main working tree stays on `development` (or `develop`) at all times. All feature work happens in worktrees.
+**Conductor does not create worktrees for itself.** The conductor edits directly on its current branch. Worktrees are exclusively for subagents.
 
 **Base branch resolution** - resolve in this order before any work begins:
 1. Use `develop` if it exists.
@@ -69,23 +69,29 @@ The main working tree stays on `development` (or `develop`) at all times. All fe
 
 **Conductor preflight** - run this checklist before any work begins. Do not skip it when the user issues a direct command; commands are goals, not overrides for workflow hygiene.
 1. What branch is the working tree on? (`git branch --show-current`)
-2. Does this branch already contain unrelated commits? If yes, create a new worktree/branch instead of piling on.
+2. Does this branch already contain unrelated commits? If yes, start fresh from the base branch before proceeding.
 3. Are there uncommitted changes? If so, do they belong to the current task? Stash or commit unrelated work before proceeding.
 4. When was `origin` last fetched? Run `git fetch origin` if it has been more than a few minutes.
-5. Does this task need a new worktree? Any new feature, fix, or chore gets its own worktree branched from the resolved base branch.
 
-**Feature worktrees:** Each task or feature gets one worktree branched from `origin/development` (or `origin/develop`). Run `git fetch origin` before creating any worktree. Edit directly in the worktree - do not create sub-worktrees for individual changes.
+**Subagent worktrees:** Each parallel subagent gets its own worktree, branched from the conductor's current branch. Worktrees are created at `.agentic/worktrees/<branch-name>` under the project root (already gitignored via the `.agentic/` umbrella). The conductor merges each subagent branch back after sign-off and removes the worktree.
 
-**Parallel agent work:** When multiple agents need to work simultaneously on the same task, each parallel agent gets its own sub-worktree branching from the feature branch. Sub-worktrees are the parallelism tool, not the default for every edit.
+```bash
+# Create a subagent worktree:
+git worktree add .agentic/worktrees/<branch-name> -b <branch-name> HEAD
+
+# Remove after merge:
+git worktree remove .agentic/worktrees/<branch-name>
+git branch -d <branch-name>
+```
 
 **Branch naming:** `feature/<name>`, `fix/<name>`, `chore/<name>`.
 
-**Merging:** Always open a PR from the feature branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
+**Merging:** Always open a PR from the subagent branch into `develop`/`development` after Skeptic sign-off. PRs are required regardless of whether other sessions are active - they make in-flight work visible and force explicit conflict resolution.
 
-**Cleanup:** Remove worktrees after the branch is merged (PR merged) or the task is explicitly closed or cancelled without a merge. Do not leave stale worktrees. Between tasks, the main tree should be on `development` with no active worktrees.
+**Cleanup:** Remove worktrees after the subagent branch is merged or the task is explicitly closed. Do not leave stale worktrees. Between tasks there should be no active subagent worktrees.
 
-**Commit each fix immediately during testing.** Never accumulate uncommitted changes on the main working tree (`development`/`develop`) during live testing sessions. After each validated fix: create fix branch, commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes. The cost of a quick PR per fix is low; the cost of untangling a divergent working tree is high.
+**Commit each fix immediately during testing.** Never accumulate uncommitted changes during live testing sessions. After each validated fix: commit, PR, merge, pull - then start the next fix. Do not batch multiple unrelated fixes.
 
-**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session creates its own worktree from `development`. The main tree stays on `development` as neutral ground - never move it to a feature branch.
+**Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -1707,7 +1707,7 @@
       <ul>
         <li>Auto-triggered by the conductor when it detects exploratory framing ("I want to build...", "thinking about...", "let's design...") using the surface-and-proceed pattern</li>
         <li>Multi-turn dialogue: intent capture, scope-specific gray-area menu, per-area Q&amp;A, Brief draft, iteration, write and hand-off to architect</li>
-        <li>Produces <code>docs/planning/&lt;slug&gt;.md</code> committed to the feature worktree before architect is spawned</li>
+        <li>Produces <code>docs/planning/&lt;slug&gt;.md</code> committed directly on the conductor's current branch before architect is spawned</li>
         <li>Sets <code>brief_source: operator</code> in <code>.agentic/brief-session.json</code> so downstream Skeptic uses a completeness-only review (framing is already operator-confirmed)</li>
         <li>PRD express-path: <code>/brief --from &lt;path&gt;</code> extracts Brief fields from an existing document; Verification field always requires operator input before writing</li>
         <li>Scope-creep guardrail defers new dimensions to a <code>deferred</code> list; whole-pivot detection offers a restart or "continue with both" option</li>
@@ -1846,7 +1846,7 @@
       <div class="rel-card">
         <h4>Core Rules</h4>
         <ul>
-          <li><strong>Main tree stays on development</strong> (or <code>develop</code>) at all times. Never move it to a feature branch. It is neutral ground for all sessions.</li>
+          <li><strong>Conductor works directly on its current branch.</strong> The main working tree stays on the conductor's current branch. No conductor-level feature worktrees are created; worktrees are a subagent-only construct.</li>
           <li><strong>Protected branches:</strong> never commit directly to <code>main</code>, <code>master</code>, <code>develop</code>, or <code>development</code>. Exception: <code>~/agentic-engineering</code> may commit and push directly to <code>main</code>.</li>
           <li><strong>Base branch resolution:</strong> use <code>develop</code> if it exists, fall back to <code>development</code>, otherwise create <code>develop</code> from <code>main</code>.</li>
           <li><strong>Branch naming:</strong> <code>feature/&lt;name&gt;</code>, <code>fix/&lt;name&gt;</code>, <code>chore/&lt;name&gt;</code>.</li>

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -1858,9 +1858,9 @@
       <div class="rel-card">
         <h4>Worktree Types</h4>
         <ul>
-          <li><strong>Feature worktrees</strong> (<code>feature/*</code>, <code>fix/*</code>) - one per task, branched from <code>origin/development</code>. Removed after PR is merged via <code>gh pr merge --squash --delete-branch</code>.</li>
-          <li><strong>Isolation worktrees</strong> (<code>worktree-agent-*</code>) - created by the Agent tool when <code>isolation: "worktree"</code> is set. Each parallel agent gets its own copy of the repo. Removed immediately after the conductor has opened a PR or confirmed no PR is needed.</li>
-          <li><strong>Multi-session support:</strong> multiple Claude Code sessions can work on different features simultaneously. Each creates its own worktree from development. No coordination needed - worktrees are independent filesystem copies.</li>
+          <li><strong>Subagent worktrees</strong> (<code>feature/*</code>, <code>fix/*</code>) - one per parallel subagent, branched from the conductor's current branch, created at <code>.agentic/worktrees/&lt;branch-name&gt;</code>. The conductor merges and removes them after sign-off.</li>
+          <li><strong>Isolation worktrees</strong> (<code>worktree-agent-*</code>) - created by the Agent tool when <code>isolation: "worktree"</code> is set. Removed after the conductor confirms no PR is needed.</li>
+          <li><strong>Conductor works directly on its branch.</strong> No conductor-level feature worktrees. The main working tree stays on the conductor's current branch; worktrees are a subagent-only construct.</li>
         </ul>
       </div>
     </div>

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -1831,11 +1831,13 @@
   <div class="flow" style="margin-top: 0;">
     <div class="flow-title">Standard Feature Branch Flow</div>
     <div class="flow-row">
-      <span class="flow-box" style="background: rgba(26,90,122,0.07); color:#1a5a7a; border:1px solid rgba(26,90,122,0.25);">development (main tree)</span>
+      <span class="flow-box" style="background: rgba(26,90,122,0.07); color:#1a5a7a; border:1px solid rgba(26,90,122,0.25);">conductor's feature branch</span>
       <span class="flow-arrow">&rarr;</span>
-      <span class="flow-box" style="background: rgba(45,90,61,0.08); color:#2d5a3d; border:1px solid rgba(45,90,61,0.25);">feature/* worktree</span>
+      <span class="flow-box" style="background: rgba(45,90,61,0.08); color:#2d5a3d; border:1px solid rgba(45,90,61,0.25);">subagent worktree (branches from conductor)</span>
       <span class="flow-arrow">&rarr;</span>
-      <span class="flow-box" style="background: rgba(90,61,138,0.08); color:#5a3d8a; border:1px solid rgba(90,61,138,0.3);">PR to develop</span>
+      <span class="flow-box" style="background: rgba(45,90,61,0.08); color:#2d5a3d; border:1px solid rgba(45,90,61,0.25);">merge back to conductor's branch</span>
+      <span class="flow-arrow">&rarr;</span>
+      <span class="flow-box" style="background: rgba(90,61,138,0.08); color:#5a3d8a; border:1px solid rgba(90,61,138,0.3);">PR to develop/development</span>
       <span class="flow-arrow">&rarr;</span>
       <span class="flow-box" style="background: rgba(26,90,122,0.07); color:#1a5a7a; border:1px solid rgba(26,90,122,0.25);">merge + cleanup</span>
     </div>


### PR DESCRIPTION
## Summary

- Conductor never creates worktrees for itself - edits directly on its current branch
- Worktrees are exclusively for subagents, at `.agentic/worktrees/<branch-name>`, branching from the conductor's current branch
- Subagent branches merge back into the conductor's current branch; the conductor's branch opens the PR to develop/development
- `/brief` no longer creates a worktree - conductor commits the brief artifact directly on its current branch

## Files changed

- `content/rules/conventions.md` - Git Workflow section rewritten with new conductor-vs-subagent model
- `content/commands/implement-ticket.md` - worktree paths updated to `.agentic/worktrees/`
- `content/commands/brief.md` - worktree setup block removed; `worktree_path` field marked null/reserved
- `docs/agentic-engineering.html` - Standard Feature Branch Flow diagram and surrounding copy updated
- All adapter builds regenerated (`.claude/`, `.codex/`, `.cursor/`, `.gemini/`, `.kimi/`)
- `scripts/.methodology-baseline.sha256` regenerated

## Test plan

- [ ] Skeptic signed off: 0 Critical, 0 Major after 3 rounds
- [ ] All adapter builds pass
- [ ] Methodology baseline sha256 matches build output