### PR TITLE
fix(eval-harness): correctness_method aggregation reads dimensions.correctness

### DIFF
--- a/evals/icl_vs_orchestration/runner.py
+++ b/evals/icl_vs_orchestration/runner.py
@@ -222,7 +222,8 @@ def _build_report(
     for ticket_id, cid_scores in ticket_scores.items():
         for cid_score in cid_scores.values():
             if isinstance(cid_score, dict):
-                correctness = cid_score.get("correctness", {})
+                # Score result shape: cid_score["dimensions"]["correctness"]["diagnostic"]["method"]
+                correctness = cid_score.get("dimensions", {}).get("correctness", {})
                 method = (
                     correctness.get("diagnostic", {}).get("method")
                     if isinstance(correctness, dict)

--- a/evals/icl_vs_orchestration/tests/test_runner.py
+++ b/evals/icl_vs_orchestration/tests/test_runner.py
@@ -583,14 +583,17 @@ class TestCorrectnessMethodLabel:
     """[Path-C] _build_report computes correctness_method correctly from per-ticket methods."""
 
     def _make_score_with_method(self, method: str) -> dict:
+        # Match production cid_score shape: dimensions.correctness.diagnostic.method
         return {
             "primary": 0.8,
             "status": "ok",
-            "correctness": {
-                "score": 1.0,
-                "diagnostic": {"method": method},
-                "scorer_version": "v1",
-                "status": "scored",
+            "dimensions": {
+                "correctness": {
+                    "score": 1.0,
+                    "diagnostic": {"method": method},
+                    "scorer_version": "v1",
+                    "status": "scored",
+                },
             },
         }
 


### PR DESCRIPTION
## Summary

The Path C smoke (run `415824f0a793`) surfaced a wrong correctness_method label at the report top level: shown as `ac-keyword` when actual mix was 1 ticket using `test-pass-real` and 4 using `ac-keyword`, so the correct label is `mixed`.

Cause: the aggregation in `_build_report()` accessed `cid_score.get('correctness')` directly, but the actual cid_score shape is `cid_score['dimensions']['correctness']['diagnostic']['method']`. Test fixtures had the shallow shape so tests passed without exercising production behavior.

Fix: traverse via `dimensions` wrapper in runner.py; update test fixture so tests reflect production.

## Smoke headline (cosmetic-bug result; signal valid)

AE 0.5801 vs ICL 0.4351 (AVG delta +0.1451, vs Path A's +0.0011). r-brief-tier-whole-file ran real pytest under AE, got correctness=1.0 with 23 tests passing.

## Test plan

- [x] 196 tests pass
- [x] TestCorrectnessMethodLabel exercises the production shape