### PR TITLE
feat(skill-comparison): aggregator + config_discovery for 8-condition matrix

### DIFF
--- a/evals/skill-comparison/aggregate.py
+++ b/evals/skill-comparison/aggregate.py
@@ -1,0 +1,193 @@
+"""
+Purpose: N-condition rollup for the skill-comparison eval matrix. Produces
+         per-condition medians, per-condition delta-vs-baseline, and a
+         baseline noise envelope derived from baseline-vs-baseline replicate
+         stdev. Handles missing cells (NaN/None) without crashing.
+
+Public API:
+    aggregate_conditions(
+        runs: dict[str, list[float | None]],
+        baseline_key: str = "baseline",
+    ) -> list[ConditionRow]
+
+    ConditionRow (dataclass):
+        condition: str
+        n: int
+        median: float | None
+        stdev: float | None
+        delta_vs_baseline: float | None   # None for baseline itself
+        envelope: float | None            # populated only on baseline row
+
+Upstream deps: stdlib statistics, dataclasses, math.
+
+Downstream consumers: evals/skill-comparison/runner.py (calls aggregate_conditions
+                      then writes rows to the TSV via evals/runner/tsv_writer).
+
+Failure modes: all-None cell yields median=None, stdev=None. Baseline cell with
+               n<2 yields envelope=None (stdev undefined; documented). Does not
+               raise on empty runs or fully-missing conditions - degrades
+               gracefully to None fields so the caller can decide how to surface
+               the gap.
+
+Performance: O(total runs); pure in-memory arithmetic. Negligible overhead.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass, field
+from typing import Optional
+
+# The canonical condition order for display. aggregate_conditions respects this
+# order when it appears in the input; unknown conditions are appended after it.
+CANONICAL_CONDITION_ORDER: list[str] = [
+    "baseline",
+    "ae-rules-injected",
+    "engineer-direct",
+    "architect-direct",
+    "investigator-direct",
+    "debugger-direct",
+    "skeptic-direct",
+    "qa-engineer-direct",
+]
+
+
+@dataclass
+class ConditionRow:
+    """Aggregated stats for one condition across all its runs."""
+
+    condition: str
+    n: int  # number of non-None runs included in the aggregation
+    median: Optional[float]  # None if no non-None runs
+    stdev: Optional[float]   # None if n < 2 or no non-None runs
+    delta_vs_baseline: Optional[float]  # None for baseline or if baseline median unavailable
+    envelope: Optional[float]  # baseline noise stdev; populated only on the baseline row
+    raw_scores: list[Optional[float]] = field(default_factory=list, repr=False)
+
+
+def _safe_median(values: list[float]) -> Optional[float]:
+    """Return median of values, or None if values is empty."""
+    if not values:
+        return None
+    return statistics.median(values)
+
+
+def _safe_stdev(values: list[float]) -> Optional[float]:
+    """Return sample stdev (N-1) of values, or None if len < 2."""
+    if len(values) < 2:
+        return None
+    return statistics.stdev(values)
+
+
+def _non_none(scores: list[Optional[float]]) -> list[float]:
+    """Filter out None/NaN entries from a score list."""
+    result: list[float] = []
+    for s in scores:
+        if s is None:
+            continue
+        try:
+            if not math.isnan(float(s)):
+                result.append(float(s))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def aggregate_conditions(
+    runs: dict[str, list[Optional[float]]],
+    baseline_key: str = "baseline",
+) -> list[ConditionRow]:
+    """Aggregate N conditions into ConditionRow entries.
+
+    Args:
+        runs: mapping of condition_name -> list of per-run scores. Scores may
+              be float, int (coerced), None, or float('nan') - all non-numeric
+              entries are treated as missing and excluded from aggregation.
+        baseline_key: name of the baseline condition used for delta computation
+                      and envelope derivation. Defaults to "baseline".
+
+    Returns:
+        List of ConditionRow, one per condition, in CANONICAL_CONDITION_ORDER
+        first then any remaining conditions in dict insertion order.
+    """
+    if not runs:
+        return []
+
+    # Sort conditions: canonical order first, then anything else in insertion order.
+    canonical_set = {c: i for i, c in enumerate(CANONICAL_CONDITION_ORDER)}
+    extra: list[str] = [c for c in runs if c not in canonical_set]
+    ordered_conditions: list[str] = [
+        c for c in CANONICAL_CONDITION_ORDER if c in runs
+    ] + extra
+
+    # Compute baseline stats first so we can subtract them.
+    baseline_scores = _non_none(runs.get(baseline_key, []))
+    baseline_median = _safe_median(baseline_scores)
+    baseline_envelope = _safe_stdev(baseline_scores)  # noise envelope from replicates
+
+    rows: list[ConditionRow] = []
+    for condition in ordered_conditions:
+        raw = runs[condition]
+        valid = _non_none(raw)
+        med = _safe_median(valid)
+        std = _safe_stdev(valid)
+
+        if condition == baseline_key:
+            delta = None
+            envelope = baseline_envelope
+        else:
+            # delta = condition_median - baseline_median; None if either is missing.
+            if med is not None and baseline_median is not None:
+                delta = med - baseline_median
+            else:
+                delta = None
+            envelope = None
+
+        rows.append(
+            ConditionRow(
+                condition=condition,
+                n=len(valid),
+                median=round(med, 6) if med is not None else None,
+                stdev=round(std, 6) if std is not None else None,
+                delta_vs_baseline=round(delta, 6) if delta is not None else None,
+                envelope=round(envelope, 6) if envelope is not None else None,
+                raw_scores=raw,
+            )
+        )
+
+    return rows
+
+
+def rows_to_tsv(rows: list[ConditionRow], task_id: str = "") -> str:
+    """Render ConditionRow list as a TSV string (header + data rows).
+
+    Primarily for smoke-checking and manual inspection. The runner writes to
+    the shared TSV via evals/runner/tsv_writer; this helper is for standalone
+    use and testing.
+
+    Args:
+        rows: output of aggregate_conditions.
+        task_id: optional task identifier prepended as the first column.
+
+    Returns:
+        TSV string with header line followed by one data line per condition.
+    """
+    header_cols = ["condition", "n", "median", "stdev", "delta_vs_baseline", "envelope"]
+    if task_id:
+        header_cols = ["task_id"] + header_cols
+
+    lines = ["\t".join(header_cols)]
+    for row in rows:
+        data = [
+            row.condition,
+            str(row.n),
+            "" if row.median is None else str(row.median),
+            "" if row.stdev is None else str(row.stdev),
+            "" if row.delta_vs_baseline is None else str(row.delta_vs_baseline),
+            "" if row.envelope is None else str(row.envelope),
+        ]
+        if task_id:
+            data = [task_id] + data
+        lines.append("\t".join(data))
+
+    return "\n".join(lines)

--- a/evals/skill-comparison/config_discovery.py
+++ b/evals/skill-comparison/config_discovery.py
@@ -1,0 +1,153 @@
+"""
+Purpose: Discover condition configs from evals/skill-comparison/specs/*.yaml and
+         return structured metadata suitable for driving the 8-condition matrix
+         runner. Mirrors the aggregate_benchmark dynamic-discovery pattern from
+         evals/skill-comparison's reference implementation.
+
+Public API:
+    discover_configs(specs_dir: Path | None = None) -> list[ConditionConfig]
+
+    ConditionConfig (dataclass):
+        name: str           # condition name (e.g. "baseline", "ae-rules-injected")
+        spec_path: Path     # absolute path to the YAML spec file
+        raw: dict           # parsed YAML contents (full spec, unvalidated)
+        content_glob: list[str]   # from spec's content_glob field (empty list if absent)
+        description: str    # from spec's description field (empty string if absent)
+
+Upstream deps: stdlib pathlib, importlib.util; pyyaml (project-standard dep).
+
+Downstream consumers: evals/skill-comparison/runner.py.
+
+Failure modes: returns empty list if specs_dir does not exist or contains no
+               *.yaml files (caller decides whether to abort or warn). Per-file
+               parse errors are logged as warnings and that file is skipped so
+               one bad spec does not block the rest. yaml.YAMLError is caught
+               per-file; other OSError bubbles up from open() as it indicates
+               a filesystem issue broader than a single spec.
+
+Performance: O(number of spec files); dominated by YAML parse. Negligible for
+             the expected 8-10 spec files.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# yaml is project-standard (pyyaml in requirements.txt).
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "pyyaml is required for config_discovery; install it with: pip install pyyaml"
+    ) from exc
+
+_LOG = logging.getLogger(__name__)
+
+# Default specs dir: same directory as this file, under "specs/".
+_DEFAULT_SPECS_DIR = Path(__file__).parent / "specs"
+
+# Canonical 8-condition list. Discovery returns conditions in this order when
+# possible; unknown conditions are appended after in filesystem order.
+CANONICAL_CONDITIONS: list[str] = [
+    "baseline",
+    "ae-rules-injected",
+    "engineer-direct",
+    "architect-direct",
+    "investigator-direct",
+    "debugger-direct",
+    "skeptic-direct",
+    "qa-engineer-direct",
+]
+
+
+@dataclass
+class ConditionConfig:
+    """Parsed metadata for one condition spec YAML."""
+
+    name: str
+    spec_path: Path
+    raw: dict = field(default_factory=dict, repr=False)
+    content_glob: list[str] = field(default_factory=list)
+    description: str = ""
+
+
+def discover_configs(specs_dir: Path | None = None) -> list[ConditionConfig]:
+    """Discover and parse condition configs from specs_dir/*.yaml.
+
+    Args:
+        specs_dir: directory to scan for *.yaml files. Defaults to
+                   evals/skill-comparison/specs/ (relative to this file).
+
+    Returns:
+        List of ConditionConfig, sorted in CANONICAL_CONDITIONS order first,
+        then any remaining specs in lexicographic order.
+    """
+    target_dir = Path(specs_dir) if specs_dir is not None else _DEFAULT_SPECS_DIR
+
+    if not target_dir.exists():
+        _LOG.warning(
+            "config_discovery: specs_dir %s does not exist; returning empty list.",
+            target_dir,
+        )
+        return []
+
+    yaml_files = sorted(target_dir.glob("*.yaml"))
+    if not yaml_files:
+        _LOG.warning(
+            "config_discovery: no *.yaml files found in %s; returning empty list.",
+            target_dir,
+        )
+        return []
+
+    raw_configs: list[ConditionConfig] = []
+    for spec_path in yaml_files:
+        try:
+            with open(spec_path, encoding="utf-8") as fh:
+                raw: Any = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            _LOG.warning(
+                "config_discovery: skipping %s - YAML parse error: %s",
+                spec_path.name,
+                exc,
+            )
+            continue
+
+        if not isinstance(raw, dict):
+            _LOG.warning(
+                "config_discovery: skipping %s - top-level YAML must be a mapping.",
+                spec_path.name,
+            )
+            continue
+
+        # Derive condition name from the YAML's "condition" key, falling back
+        # to the stem of the filename (e.g. "baseline.yaml" -> "baseline").
+        condition_name: str = raw.get("condition") or spec_path.stem
+
+        content_glob_raw = raw.get("content_glob", [])
+        if isinstance(content_glob_raw, str):
+            content_glob_raw = [content_glob_raw]
+        content_glob: list[str] = list(content_glob_raw) if content_glob_raw else []
+
+        description: str = raw.get("description", "") or ""
+
+        raw_configs.append(
+            ConditionConfig(
+                name=condition_name,
+                spec_path=spec_path.resolve(),
+                raw=raw,
+                content_glob=content_glob,
+                description=description,
+            )
+        )
+
+    # Sort: canonical order first, then lexicographic for unknowns.
+    canonical_index: dict[str, int] = {c: i for i, c in enumerate(CANONICAL_CONDITIONS)}
+    n_canonical = len(CANONICAL_CONDITIONS)
+
+    def _sort_key(cfg: ConditionConfig) -> tuple[int, str]:
+        return canonical_index.get(cfg.name, n_canonical), cfg.name
+
+    return sorted(raw_configs, key=_sort_key)

--- a/evals/skill-comparison/tests/test_aggregate.py
+++ b/evals/skill-comparison/tests/test_aggregate.py
@@ -1,0 +1,336 @@
+"""
+Tests for evals/skill-comparison/aggregate.py.
+
+Coverage:
+- N-condition rollup (>2 conditions in one pass)
+- Delta-vs-baseline math for all 7 non-baseline conditions
+- Envelope derived from baseline-vs-baseline stdev (n=5 replicates)
+- Missing cells (None/NaN) handled without crash
+- Canonical condition ordering
+- rows_to_tsv smoke check
+"""
+from __future__ import annotations
+
+import math
+import statistics
+from typing import Optional
+
+import pytest
+
+# conftest.py inserts the skill-comparison/ dir into sys.path.
+from aggregate import (
+    CANONICAL_CONDITION_ORDER,
+    ConditionRow,
+    aggregate_conditions,
+    rows_to_tsv,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / hand-computed reference data
+# ---------------------------------------------------------------------------
+
+# Baseline replicates: 5 runs, hand-picked for simple arithmetic.
+# median([0.6, 0.6, 0.8, 0.8, 1.0]) = 0.8
+# stdev([0.6, 0.6, 0.8, 0.8, 1.0]) = stdev with N-1 divisor
+_BASELINE_SCORES: list[float] = [0.6, 0.6, 0.8, 0.8, 1.0]
+_BASELINE_MEDIAN: float = statistics.median(_BASELINE_SCORES)
+_BASELINE_STDEV: float = statistics.stdev(_BASELINE_SCORES)
+
+# Per-condition scores, n=3 each. Hand-computed expected medians.
+# ae-rules-injected: [0.8, 1.0, 1.0] -> median=1.0
+# engineer-direct:   [0.6, 0.8, 1.0] -> median=0.8
+# architect-direct:  [0.4, 0.6, 0.8] -> median=0.6
+# investigator-direct: [0.0, 0.4, 0.4] -> median=0.4
+# debugger-direct:   [1.0, 1.0, 1.0] -> median=1.0
+# skeptic-direct:    [0.0, 0.0, 0.2] -> median=0.0
+# qa-engineer-direct: [0.6, 0.6, 1.0] -> median=0.6
+
+_ALL_RUNS: dict[str, list[Optional[float]]] = {
+    "baseline": _BASELINE_SCORES,
+    "ae-rules-injected": [0.8, 1.0, 1.0],
+    "engineer-direct": [0.6, 0.8, 1.0],
+    "architect-direct": [0.4, 0.6, 0.8],
+    "investigator-direct": [0.0, 0.4, 0.4],
+    "debugger-direct": [1.0, 1.0, 1.0],
+    "skeptic-direct": [0.0, 0.0, 0.2],
+    "qa-engineer-direct": [0.6, 0.6, 1.0],
+}
+
+# Expected medians (hand-computed).
+_EXPECTED_MEDIANS: dict[str, float] = {
+    "baseline": 0.8,
+    "ae-rules-injected": 1.0,
+    "engineer-direct": 0.8,
+    "architect-direct": 0.6,
+    "investigator-direct": 0.4,
+    "debugger-direct": 1.0,
+    "skeptic-direct": 0.0,
+    "qa-engineer-direct": 0.6,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _row(rows: list[ConditionRow], condition: str) -> ConditionRow:
+    for r in rows:
+        if r.condition == condition:
+            return r
+    raise KeyError(f"condition {condition!r} not found in rows")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNConditionRollup:
+    """aggregate_conditions processes N conditions in a single pass."""
+
+    def test_returns_one_row_per_condition(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        assert len(rows) == len(_ALL_RUNS)
+
+    def test_all_8_conditions_present(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        names = {r.condition for r in rows}
+        assert names == set(_ALL_RUNS.keys())
+
+    def test_canonical_ordering_respected(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        names = [r.condition for r in rows]
+        # First 8 entries must match CANONICAL_CONDITION_ORDER (all are present).
+        assert names == CANONICAL_CONDITION_ORDER
+
+    def test_n_counts_are_correct(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        for r in rows:
+            expected_n = len(_ALL_RUNS[r.condition])
+            assert r.n == expected_n, f"n mismatch for {r.condition}"
+
+
+class TestMedianMath:
+    """Median values match hand-computed expectations."""
+
+    def test_baseline_median(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        row = _row(rows, "baseline")
+        assert row.median == pytest.approx(_BASELINE_MEDIAN, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        "condition,expected",
+        [
+            ("ae-rules-injected", 1.0),
+            ("engineer-direct", 0.8),
+            ("architect-direct", 0.6),
+            ("investigator-direct", 0.4),
+            ("debugger-direct", 1.0),
+            ("skeptic-direct", 0.0),
+            ("qa-engineer-direct", 0.6),
+        ],
+    )
+    def test_non_baseline_medians(self, condition: str, expected: float) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        row = _row(rows, condition)
+        assert row.median == pytest.approx(expected, abs=1e-6), (
+            f"median mismatch for {condition}: got {row.median}, expected {expected}"
+        )
+
+
+class TestDeltaVsBaseline:
+    """Delta-vs-baseline math for all 7 non-baseline conditions."""
+
+    def test_baseline_has_no_delta(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        row = _row(rows, "baseline")
+        assert row.delta_vs_baseline is None
+
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            "ae-rules-injected",
+            "engineer-direct",
+            "architect-direct",
+            "investigator-direct",
+            "debugger-direct",
+            "skeptic-direct",
+            "qa-engineer-direct",
+        ],
+    )
+    def test_delta_equals_median_minus_baseline(self, condition: str) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        baseline_row = _row(rows, "baseline")
+        cond_row = _row(rows, condition)
+        expected_delta = _EXPECTED_MEDIANS[condition] - _EXPECTED_MEDIANS["baseline"]
+        assert cond_row.delta_vs_baseline == pytest.approx(expected_delta, abs=1e-6), (
+            f"delta mismatch for {condition}: "
+            f"got {cond_row.delta_vs_baseline}, expected {expected_delta}"
+        )
+
+    def test_all_7_non_baseline_conditions_have_delta(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        non_baseline = [r for r in rows if r.condition != "baseline"]
+        assert len(non_baseline) == 7
+        for r in non_baseline:
+            assert r.delta_vs_baseline is not None, (
+                f"expected delta for {r.condition} but got None"
+            )
+
+
+class TestEnvelopeFromBaselineStdev:
+    """Envelope column derived from baseline-vs-baseline replicate stdev."""
+
+    def test_baseline_row_has_envelope(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        row = _row(rows, "baseline")
+        assert row.envelope is not None
+
+    def test_envelope_equals_baseline_stdev(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        row = _row(rows, "baseline")
+        assert row.envelope == pytest.approx(_BASELINE_STDEV, abs=1e-6), (
+            f"envelope mismatch: got {row.envelope}, expected {_BASELINE_STDEV}"
+        )
+
+    def test_non_baseline_rows_have_no_envelope(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        for r in rows:
+            if r.condition != "baseline":
+                assert r.envelope is None, (
+                    f"expected envelope=None for {r.condition}, got {r.envelope}"
+                )
+
+    def test_envelope_n5_produces_real_stdev(self) -> None:
+        """n=5 baseline replicates must yield a real (non-zero, non-None) stdev."""
+        # Scores have variance so stdev must be > 0.
+        runs = {"baseline": [0.6, 0.6, 0.8, 0.8, 1.0]}
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "baseline")
+        assert row.envelope is not None
+        assert row.envelope > 0.0
+
+    def test_envelope_n1_baseline_is_none(self) -> None:
+        """With only 1 baseline run, stdev is undefined; envelope must be None."""
+        runs = {"baseline": [0.8], "engineer-direct": [0.6, 0.8, 1.0]}
+        rows = aggregate_conditions(runs)
+        baseline_row = _row(rows, "baseline")
+        assert baseline_row.envelope is None
+
+
+class TestMissingCells:
+    """None/NaN entries are handled without crash; n reflects valid-only count."""
+
+    def test_all_none_cell_does_not_crash(self) -> None:
+        runs = {
+            "baseline": [0.6, 0.8, 1.0],
+            "engineer-direct": [None, None, None],
+        }
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "engineer-direct")
+        assert row.median is None
+        assert row.stdev is None
+        assert row.n == 0
+
+    def test_partial_none_cell_uses_valid_scores(self) -> None:
+        runs = {
+            "baseline": [0.6, 0.8, 1.0],
+            "engineer-direct": [None, 0.6, 1.0],
+        }
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "engineer-direct")
+        # Valid scores: [0.6, 1.0]; median = 0.8
+        assert row.n == 2
+        assert row.median == pytest.approx(0.8, abs=1e-6)
+
+    def test_nan_scores_excluded(self) -> None:
+        runs = {
+            "baseline": [0.6, 0.8, 1.0],
+            "engineer-direct": [float("nan"), 0.8, 1.0],
+        }
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "engineer-direct")
+        assert row.n == 2
+        assert row.median == pytest.approx(0.9, abs=1e-6)
+
+    def test_delta_none_when_condition_missing(self) -> None:
+        """Delta is None when condition cell is all-None (no valid scores)."""
+        runs = {
+            "baseline": [0.6, 0.8, 1.0],
+            "engineer-direct": [None, None, None],
+        }
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "engineer-direct")
+        assert row.delta_vs_baseline is None
+
+    def test_delta_none_when_baseline_missing(self) -> None:
+        """Delta is None when baseline itself has no valid scores."""
+        runs = {
+            "baseline": [None, None],
+            "engineer-direct": [0.6, 0.8, 1.0],
+        }
+        rows = aggregate_conditions(runs)
+        row = _row(rows, "engineer-direct")
+        assert row.delta_vs_baseline is None
+
+    def test_empty_runs_dict_returns_empty_list(self) -> None:
+        rows = aggregate_conditions({})
+        assert rows == []
+
+    def test_single_condition_no_delta(self) -> None:
+        """Only baseline present: delta=None (it IS the baseline)."""
+        runs = {"baseline": [0.6, 0.8, 1.0]}
+        rows = aggregate_conditions(runs)
+        assert len(rows) == 1
+        assert rows[0].delta_vs_baseline is None
+
+
+class TestNonDefaultBaselineKey:
+    """Caller can nominate a different condition as the baseline."""
+
+    def test_custom_baseline_key(self) -> None:
+        runs = {
+            "control": [0.6, 0.8, 1.0],
+            "treatment": [0.8, 1.0, 1.0],
+        }
+        rows = aggregate_conditions(runs, baseline_key="control")
+        control_row = next(r for r in rows if r.condition == "control")
+        treatment_row = next(r for r in rows if r.condition == "treatment")
+        assert control_row.delta_vs_baseline is None
+        assert control_row.envelope is not None
+        assert treatment_row.delta_vs_baseline is not None
+
+
+class TestRowsToTsv:
+    """rows_to_tsv renders valid TSV."""
+
+    def test_header_and_rows_count(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        tsv = rows_to_tsv(rows)
+        lines = tsv.strip().split("\n")
+        # 1 header + 8 data rows
+        assert len(lines) == 9
+
+    def test_header_contains_expected_columns(self) -> None:
+        rows = aggregate_conditions(_ALL_RUNS)
+        tsv = rows_to_tsv(rows)
+        header = tsv.split("\n")[0]
+        for col in ["condition", "n", "median", "stdev", "delta_vs_baseline", "envelope"]:
+            assert col in header
+
+    def test_task_id_column_when_provided(self) -> None:
+        rows = aggregate_conditions({"baseline": [0.8]})
+        tsv = rows_to_tsv(rows, task_id="task-001")
+        header_cols = tsv.split("\n")[0].split("\t")
+        assert header_cols[0] == "task_id"
+        data_row = tsv.split("\n")[1].split("\t")
+        assert data_row[0] == "task-001"
+
+    def test_missing_median_renders_as_empty_string(self) -> None:
+        rows = aggregate_conditions({"baseline": [None, None]})
+        tsv = rows_to_tsv(rows)
+        data_line = tsv.split("\n")[1]
+        cols = data_line.split("\t")
+        # median column (index 2) should be empty string
+        assert cols[2] == ""


### PR DESCRIPTION
## Summary

- Adds `evals/skill-comparison/aggregate.py`: pure-stdlib (statistics.stdev) n-condition rollup. Handles all 8 conditions in one pass, computes per-condition delta-vs-baseline for 7 non-baseline conditions, derives baseline noise envelope from baseline-vs-baseline replicate stdev. Missing cells (None/NaN) degrade gracefully - no crash.
- Adds `evals/skill-comparison/config_discovery.py`: discovers condition configs from `specs/*.yaml`, returns them sorted in canonical order. Ready for specs that don't yet exist - returns empty list when dir is empty.
- Adds `evals/skill-comparison/tests/test_aggregate.py`: 38 tests covering rollup math, all 7 deltas-vs-baseline, envelope derivation (n=5 produces real stdev, n=1 yields None), and missing-cell handling verified against hand-computed fixtures.

## Condition list (8 total per Brief)

`baseline`, `ae-rules-injected`, `engineer-direct`, `architect-direct`, `investigator-direct`, `debugger-direct`, `skeptic-direct`, `qa-engineer-direct`

## Test plan

- [x] `pytest evals/skill-comparison/tests/test_aggregate.py` - 38/38 pass
- [x] Rollup math verified against hand-computed fixture (median([0.6,0.6,0.8,0.8,1.0])=0.8; stdev computed via statistics.stdev)
- [x] Envelope with n=5 baseline replicates produces real stdev > 0
- [x] config_discovery smoke-checked against empty specs dir - returns [] without crash
- [x] Module manifests present on both non-trivial files