### PR TITLE
feat(skill-comparison): runner + scoring for 8-condition eval matrix

### DIFF
--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -153,11 +153,14 @@ def invoke_run(
     ANTHROPIC_BASE_URL is set when the model id starts with a litellm prefix
     (e.g. claude-kimi-, claude-qwen-, claude-owl-, claude-deepseek).
 
-    If `system_prompt` is provided, it is passed to the Claude CLI via
-    --system-prompt. This is how the ae-rules-injected condition injects the
-    AE methodology payload so the model runs with the full protocol context.
-    The Claude CLI --system-prompt flag takes the system prompt text as its
-    argument; subprocess argv handling means no shell escaping is needed.
+    If `system_prompt` is provided, it is appended to the default system
+    prompt via --append-system-prompt. This is how the ae-rules-injected
+    condition injects the AE methodology payload so the model runs with the
+    full protocol context on top of the standard Claude Code system prompt.
+    Flag verified present via `claude --help` (2026-05-12): --append-system-prompt
+    appends to the default; --system-prompt replaces it entirely. We use
+    --append-system-prompt to preserve the default context and add the rules.
+    subprocess argv handling means no shell escaping is needed.
     """
     if mode == "command":
         outer_prompt = prompt
@@ -196,10 +199,11 @@ def invoke_run(
         cmd.extend(["--model", model])
 
     if system_prompt is not None:
-        # Inject AE rules (or any system context) via the Claude CLI flag.
-        # Used by the ae-rules-injected condition to ensure the model runs
-        # with the full AE methodology protocol in its system context.
-        cmd.extend(["--system-prompt", system_prompt])
+        # Inject AE rules (or any system context) via --append-system-prompt.
+        # This appends to (not replaces) the default Claude Code system prompt,
+        # preserving the baseline context while adding the AE methodology rules.
+        # Flag verified in `claude --help` (2026-05-12).
+        cmd.extend(["--append-system-prompt", system_prompt])
 
     env = None
     if home is not None or _use_litellm:

--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -4,7 +4,8 @@ Purpose: Probe for the Claude CLI, shell out to it with the eval-standard
 
 Public API: probe_claude_cli() -> str,
             invoke_run(prompt, worktree, timeout_seconds,
-                       agent_name=None, mode="agent", home=None) -> dict,
+                       agent_name=None, mode="agent", home=None,
+                       model=None, system_prompt=None) -> dict,
             build_two_level_prompt(agent_name: str, brief: str) -> str.
 
             mode="command" skips the two-level Task wrapper, uses a
@@ -134,6 +135,7 @@ def invoke_run(
     mode: str = "agent",
     home: Path | None = None,
     model: str | None = None,
+    system_prompt: str | None = None,
 ) -> dict:
     """Run the Claude CLI once with `prompt` at `worktree` cwd; return a run record.
 
@@ -150,6 +152,12 @@ def invoke_run(
     If `model` is provided, --model is passed through to the Claude CLI and
     ANTHROPIC_BASE_URL is set when the model id starts with a litellm prefix
     (e.g. claude-kimi-, claude-qwen-, claude-owl-, claude-deepseek).
+
+    If `system_prompt` is provided, it is passed to the Claude CLI via
+    --system-prompt. This is how the ae-rules-injected condition injects the
+    AE methodology payload so the model runs with the full protocol context.
+    The Claude CLI --system-prompt flag takes the system prompt text as its
+    argument; subprocess argv handling means no shell escaping is needed.
     """
     if mode == "command":
         outer_prompt = prompt
@@ -186,6 +194,12 @@ def invoke_run(
 
     if model is not None:
         cmd.extend(["--model", model])
+
+    if system_prompt is not None:
+        # Inject AE rules (or any system context) via the Claude CLI flag.
+        # Used by the ae-rules-injected condition to ensure the model runs
+        # with the full AE methodology protocol in its system context.
+        cmd.extend(["--system-prompt", system_prompt])
 
     env = None
     if home is not None or _use_litellm:

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -19,6 +19,7 @@ Public API:
         max_wall_seconds: float = 43200.0,
         dry_run: bool = False,
         conditions: list[str] | None = None,
+        tier3_mode: str = "auto",
     ) -> RunReport
 
     RunReport (dataclass):
@@ -30,7 +31,8 @@ Public API:
 
     CONDITION_LABELS (list[str]) - the canonical 8-condition names.
 
-Upstream deps: stdlib pathlib, time, csv, json, dataclasses, sys, logging.
+Upstream deps: stdlib pathlib, time, csv, json, dataclasses, sys, logging,
+               tempfile, shutil.
                pyyaml (project-standard dep).
                evals.runner.invoker (invoke_run, build_two_level_prompt).
                evals.runner.isolator (Tier3Docker, make_isolator).
@@ -55,7 +57,9 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import shutil
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -208,11 +212,17 @@ def _run_cell(
     replicate: int,
     ae_payload: Optional[str],
     dry_run: bool,
+    worktree: Optional[Path] = None,
 ) -> dict:
     """Run one (task, condition, replicate) cell and return a raw result dict.
 
     When dry_run=True, skips the actual CLI invocation and returns a canned
     transcript for testing purposes.
+
+    Args:
+        worktree: the fix-phase directory to run the CLI in. Defaults to
+                  Path(".") for backward compat; in production this is the
+                  Tier3Context.fix_phase_dir seeded with the task's base repo.
 
     Returns a dict with keys matching the invoker's run record plus extra
     fields used for TSV row construction.
@@ -247,16 +257,22 @@ def _run_cell(
         }
 
     agent_name: Optional[str] = _AGENT_CONDITIONS.get(condition)
+    # ae-rules-injected: inject the full AE methodology payload as the system
+    # prompt so the model runs with the complete protocol context. This is the
+    # headline measurement; baseline runs with system_prompt=None.
     system_prompt: Optional[str] = ae_payload if condition == "ae-rules-injected" else None
+
+    effective_worktree = worktree if worktree is not None else Path(".")
 
     # For per-agent conditions, the two-level Task wrapper is built by invoker.
     # For baseline and ae-rules-injected, agent_name is None (conductor runs directly).
     result = invoke_run(
         prompt=prompt,
-        worktree=Path("."),  # worktree is the Tier3 fix_phase_dir; set by caller context
+        worktree=effective_worktree,
         timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,  # give engineer 240s
         agent_name=agent_name,
         mode="agent",
+        system_prompt=system_prompt,
     )
     return result
 
@@ -264,6 +280,28 @@ def _run_cell(
 # ---------------------------------------------------------------------------
 # Core matrix loop
 # ---------------------------------------------------------------------------
+
+
+def _load_completed_cells(results_tsv: Path) -> set[tuple[str, str, int]]:
+    """Read the TSV and return the set of (task_slug, condition, replicate) already done.
+
+    Used for resume semantics: cells already present are skipped unless --force.
+    """
+    if not results_tsv.exists() or results_tsv.stat().st_size == 0:
+        return set()
+    completed: set[tuple[str, str, int]] = set()
+    with results_tsv.open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for row in reader:
+            try:
+                completed.add((
+                    row["task_slug"],
+                    row["condition"],
+                    int(row["replicate"]),
+                ))
+            except (KeyError, ValueError):
+                continue  # malformed row; skip
+    return completed
 
 
 def run_matrix(
@@ -278,15 +316,22 @@ def run_matrix(
     max_wall_seconds: float = 43200.0,
     dry_run: bool = False,
     conditions: Optional[list[str]] = None,
+    tier3_mode: str = "auto",
+    force: bool = False,
 ) -> RunReport:
     """Orchestrate the 8-condition skill-comparison eval matrix.
 
     For each (task, condition, replicate) cell:
-      1. Materialise the condition config (ae-rules payload for ae-rules-injected,
+      1. Skip if already present in TSV (resume semantics; override with force=True).
+      2. Materialise the condition config (ae-rules payload for ae-rules-injected,
          agent name for per-agent conditions, nothing for baseline).
-      2. Spawn the engineer run (via Tier 3 Docker unless dry_run=True).
-      3. Score the result.
-      4. Append one row to the TSV ledger.
+      3. In production (tier3_mode='auto', not dry_run): instantiate Tier3Docker
+         per task to provide isolated fix and score phases.
+      4. Spawn the engineer run (via Tier 3 Docker unless dry_run=True or
+         tier3_mode='off').
+      5. Score the result (in-container via Tier3Docker.run_score_phase when
+         tier3_ctx is provided, else local subprocess).
+      6. Append one row to the TSV ledger.
 
     Budget ceilings (USD, tokens, wall-clock) are checked between cells.
     BudgetExceeded halts with partial=True; the TSV contains results so far.
@@ -306,7 +351,13 @@ def run_matrix(
         max_tokens: global token ceiling (default 75 M).
         max_wall_seconds: global wall-clock ceiling (default 12 h).
         dry_run: if True, skip actual CLI calls and return canned results.
+                 Implies tier3_mode='off'.
         conditions: subset of CONDITION_LABELS to run (None = all 8).
+        tier3_mode: "auto" (default) - instantiate Tier3Docker in production
+                    (i.e. when not dry_run); "off" - skip Tier3, run local
+                    subprocess for both fix and score phases (for dry-run /
+                    unit tests).
+        force: if True, re-run cells already present in the TSV (no resume skip).
 
     Returns:
         RunReport with summary stats.
@@ -323,10 +374,13 @@ def run_matrix(
     tasks = _load_tasks(tasks_yaml)
     active_conditions = conditions if conditions is not None else CONDITION_LABELS
 
+    # Resolve effective tier3 mode. dry_run forces Tier3 off.
+    use_tier3 = (tier3_mode == "auto") and (not dry_run)
+
     # Build ae-rules payload once (reused for every ae-rules-injected cell).
     ae_payload: Optional[str] = None
     if "ae-rules-injected" in active_conditions and not dry_run:
-        from ae_rules_payload import build_payload  # noqa: F401 (local import)
+        from ae_rules_payload import build_payload
         ae_payload = build_payload(content_root)
 
     # Cost / budget gate.
@@ -340,8 +394,19 @@ def run_matrix(
     )
 
     _ensure_tsv_header(results_tsv)
+
+    # Resume: load already-completed cells so we can skip them.
+    completed_cells: set[tuple[str, str, int]] = (
+        set() if force else _load_completed_cells(results_tsv)
+    )
+
     report = RunReport(tsv_path=results_tsv)
     matrix_start = time.monotonic()
+
+    # Conditionally import Tier3Docker for production runs.
+    _Tier3Docker = None
+    if use_tier3:
+        from evals.runner.isolator import Tier3Docker as _Tier3Docker  # type: ignore[assignment]
 
     for task_slug, task_meta in tasks.items():
         for condition in active_conditions:
@@ -352,6 +417,14 @@ def run_matrix(
                 else n_replicates
             )
             for rep in range(1, n + 1):
+                # Resume: skip cells already present in TSV.
+                if (task_slug, condition, rep) in completed_cells:
+                    _LOG.debug(
+                        "Skipping already-completed cell: task=%s condition=%s rep=%d",
+                        task_slug, condition, rep,
+                    )
+                    continue
+
                 # Wall-clock budget check.
                 elapsed = time.monotonic() - matrix_start
                 if elapsed > max_wall_seconds:
@@ -370,76 +443,118 @@ def run_matrix(
                     task_slug, condition, rep, n,
                 )
 
-                # Run the cell.
-                try:
-                    result = _run_cell(
-                        task_slug=task_slug,
-                        task_meta=task_meta,
-                        condition=condition,
-                        replicate=rep,
-                        ae_payload=ae_payload,
-                        dry_run=dry_run,
-                    )
-                except Exception as exc:
-                    _LOG.error(
-                        "Cell %s rep %d raised unexpectedly: %s",
-                        cell_id, rep, exc,
-                    )
-                    result = {
-                        "final_text": "",
-                        "status": f"error:{type(exc).__name__}",
-                        "cost_usd": 0.0,
-                        "usage": {},
-                        "latency_ms": 0,
-                        "invocation_mode": "error",
-                        "tool_calls": [],
-                        "turns_used": 0,
-                        "_parse_warnings": [str(exc)],
-                    }
+                # Per-task Tier3 context (production path).
+                # Instantiated fresh per (task, condition, rep) so each cell
+                # gets an isolated fix-phase dir seeded from the task's base
+                # commit. The held-out dir is populated from task_meta.
+                tier3_ctx = None
+                _tier3_instance = None
 
-                transcript = result.get("final_text", "")
-                run_status = result.get("status", "unknown")
-                cost_usd = float(result.get("cost_usd") or 0.0)
-                usage = result.get("usage") or {}
-                latency_ms = int(result.get("latency_ms") or 0)
-                invocation_mode = result.get("invocation_mode", "")
-
-                # Score the cell (local, no Docker, when dry_run).
-                fix_dir = Path(tempfile.mkdtemp()) if dry_run else Path(".")
-                held_dir = Path(tempfile.mkdtemp()) if dry_run else Path(".")
+                if use_tier3:
+                    assert _Tier3Docker is not None  # guarded above
+                    # held_out_dir: path to the task's held-out test files.
+                    # In production these are committed to the corpus at a
+                    # well-known location; fall back to None (empty tmpdir).
+                    held_out_path: Optional[Path] = None
+                    task_held_out = task_meta.get("_held_out_dir_path")
+                    if task_held_out and Path(task_held_out).exists():
+                        held_out_path = Path(task_held_out)
+                    _tier3_instance = _Tier3Docker(
+                        fixture_repo_dir=None,  # base repo seeded externally
+                        held_out_dir=held_out_path,
+                        build_image=True,
+                        timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
+                    )
+                    tier3_ctx = _tier3_instance.__enter__()
 
                 try:
-                    scored = score_cell(
-                        task_slug=task_slug,
-                        transcript=transcript,
-                        task_meta=task_meta,
-                        fix_phase_dir=fix_dir,
-                        held_out_dir=held_dir,
-                        tier3_ctx=None,  # Docker ctx is managed by caller in production
-                        pytest_timeout=_PYTEST_TIMEOUT_SECONDS,
+                    # Run the fix phase.
+                    fix_worktree: Optional[Path] = (
+                        tier3_ctx.fix_phase_dir if tier3_ctx is not None else None
                     )
-                except Exception as exc:
-                    _LOG.error(
-                        "score_cell raised for %s rep %d: %s",
-                        cell_id, rep, exc,
-                    )
-                    from scoring import ScoringResult as _SR
-                    scored = _SR(
-                        pass_fail=False,
-                        score_primary=0.0,
-                        lines_touched=0,
-                        files_touched=0,
-                        scope_creep_flag=False,
-                        held_out_failures=[],
-                        pytest_returncode=-1,
-                        diff_text="",
-                        diagnostics={"error": str(exc)},
-                    )
-                finally:
+                    try:
+                        result = _run_cell(
+                            task_slug=task_slug,
+                            task_meta=task_meta,
+                            condition=condition,
+                            replicate=rep,
+                            ae_payload=ae_payload,
+                            dry_run=dry_run,
+                            worktree=fix_worktree,
+                        )
+                    except Exception as exc:
+                        _LOG.error(
+                            "Cell %s rep %d raised unexpectedly: %s",
+                            cell_id, rep, exc,
+                        )
+                        result = {
+                            "final_text": "",
+                            "status": f"error:{type(exc).__name__}",
+                            "cost_usd": 0.0,
+                            "usage": {},
+                            "latency_ms": 0,
+                            "invocation_mode": "error",
+                            "tool_calls": [],
+                            "turns_used": 0,
+                            "_parse_warnings": [str(exc)],
+                        }
+
+                    transcript = result.get("final_text", "")
+                    run_status = result.get("status", "unknown")
+                    cost_usd = float(result.get("cost_usd") or 0.0)
+                    usage = result.get("usage") or {}
+                    latency_ms = int(result.get("latency_ms") or 0)
+                    invocation_mode = result.get("invocation_mode", "")
+
+                    # Score the cell.
+                    # dry_run: use fresh tmpdirs; production: use Tier3 dirs or Path(".").
                     if dry_run:
-                        import shutil as _sh
-                        _sh.rmtree(fix_dir, ignore_errors=True)
-                        _sh.rmtree(held_dir, ignore_errors=True)
+                        fix_dir = Path(tempfile.mkdtemp())
+                        held_dir = Path(tempfile.mkdtemp())
+                    elif tier3_ctx is not None:
+                        fix_dir = tier3_ctx.fix_phase_dir
+                        held_dir = tier3_ctx.held_out_dir
+                    else:
+                        fix_dir = Path(".")
+                        held_dir = Path(".")
+
+                    try:
+                        scored = score_cell(
+                            task_slug=task_slug,
+                            transcript=transcript,
+                            task_meta=task_meta,
+                            fix_phase_dir=fix_dir,
+                            held_out_dir=held_dir,
+                            tier3_ctx=tier3_ctx,
+                            pytest_timeout=_PYTEST_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        _LOG.error(
+                            "score_cell raised for %s rep %d: %s",
+                            cell_id, rep, exc,
+                        )
+                        scored = ScoringResult(
+                            pass_fail=False,
+                            score_primary=0.0,
+                            lines_touched=0,
+                            files_touched=0,
+                            scope_creep_flag=False,
+                            held_out_failures=[],
+                            pytest_returncode=-1,
+                            diff_text="",
+                            diagnostics={"error": str(exc)},
+                        )
+                    finally:
+                        if dry_run:
+                            shutil.rmtree(fix_dir, ignore_errors=True)
+                            shutil.rmtree(held_dir, ignore_errors=True)
+
+                finally:
+                    # Always exit the Tier3 context manager so containers and
+                    # tmpdirs are cleaned up even on exception.
+                    if _tier3_instance is not None:
+                        _tier3_instance.__exit__(None, None, None)
+                        tier3_ctx = None
 
                 # Record cost.
                 tokens_input = int(usage.get("input_tokens", usage.get("input", 0)))
@@ -495,12 +610,6 @@ def run_matrix(
     return report
 
 
-# ---------------------------------------------------------------------------
-# Missing import for tempfile (used in dry_run path above)
-# ---------------------------------------------------------------------------
-import tempfile  # noqa: E402 (placed after function definitions for clarity)
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -515,6 +624,21 @@ if __name__ == "__main__":
     parser.add_argument("--max-wall-seconds", type=float, default=43200.0)
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--conditions", nargs="*", default=None)
+    parser.add_argument(
+        "--tier3",
+        choices=["auto", "off"],
+        default="auto",
+        help=(
+            "Tier 3 Docker isolation mode. 'auto' (default) instantiates "
+            "Tier3Docker in production; 'off' skips Docker (for dry-run / "
+            "unit tests)."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-run cells already present in the TSV (bypass resume skip).",
+    )
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -530,6 +654,8 @@ if __name__ == "__main__":
         max_wall_seconds=args.max_wall_seconds,
         dry_run=args.dry_run,
         conditions=args.conditions,
+        tier3_mode=args.tier3,
+        force=args.force,
     )
 
     print(json.dumps(

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -1,0 +1,547 @@
+"""
+Purpose: Orchestrate the 8-condition skill-comparison eval matrix. For each
+         (task, condition, replicate) cell: materialise the condition config,
+         build the agent payload, spawn the Tier 3 Docker isolator, capture
+         the transcript, run scoring, and append one row to the TSV ledger.
+         Enforces per-matrix USD / token / wall-clock budget ceilings
+         (BudgetExceeded exit-3 pattern from evals/icl_vs_orchestration/).
+
+Public API:
+    run_matrix(
+        tasks_yaml: Path,
+        specs_dir: Path | None,
+        results_tsv: Path,
+        content_root: Path,
+        n_replicates: int = 3,
+        n_replicates_methodology: int = 5,
+        max_usd: float = 250.0,
+        max_tokens: int = 75_000_000,
+        max_wall_seconds: float = 43200.0,
+        dry_run: bool = False,
+        conditions: list[str] | None = None,
+    ) -> RunReport
+
+    RunReport (dataclass):
+        rows_written: int
+        budget_breached: bool
+        partial: bool
+        tsv_path: Path
+        error: str | None
+
+    CONDITION_LABELS (list[str]) - the canonical 8-condition names.
+
+Upstream deps: stdlib pathlib, time, csv, json, dataclasses, sys, logging.
+               pyyaml (project-standard dep).
+               evals.runner.invoker (invoke_run, build_two_level_prompt).
+               evals.runner.isolator (Tier3Docker, make_isolator).
+               evals.skill-comparison.ae_rules_payload (build_payload).
+               evals.skill-comparison.config_discovery (discover_configs).
+               evals.skill-comparison.scoring (score_cell).
+               evals.icl_vs_orchestration.cost_gate (CostGate, BudgetExceeded).
+
+Downstream consumers: CLI / scripts; evals/skill-comparison/tests/test_runner.py.
+
+Failure modes: BudgetExceeded halts the matrix and writes a partial report
+               (exit code 3 when run as __main__). Individual cell failures
+               (CLI timeout, docker error) are captured in the TSV row's
+               status field and do not abort the matrix. Wall-clock ceiling
+               is checked between cells; a breach halts with partial=True.
+
+Performance: dominated by the Claude CLI calls (~seconds per cell). TSV
+             append is O(1). Total matrix: ~312 cells at ~30-300 s each.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("pyyaml is required; install with: pip install pyyaml") from exc
+
+# Module-level import so tests can patch `runner.score_cell` cleanly.
+from scoring import ScoringResult, score_cell  # noqa: E402
+
+_LOG = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CONDITION_LABELS: list[str] = [
+    "baseline",
+    "ae-rules-injected",
+    "engineer-direct",
+    "architect-direct",
+    "investigator-direct",
+    "debugger-direct",
+    "skeptic-direct",
+    "qa-engineer-direct",
+]
+
+# Conditions that route via named-agent direct spawn (two-level Task).
+_AGENT_CONDITIONS: dict[str, str] = {
+    "engineer-direct": "engineer",
+    "architect-direct": "architect",
+    "investigator-direct": "investigator",
+    "debugger-direct": "debugger",
+    "skeptic-direct": "skeptic",
+    "qa-engineer-direct": "qa-engineer",
+}
+
+# Per-task pytest timeout (Brief: <120 s held-out test budget).
+_PYTEST_TIMEOUT_SECONDS = 120
+
+# TSV schema for the skill-comparison ledger.
+_TSV_HEADER: tuple[str, ...] = (
+    "task_slug",
+    "condition",
+    "replicate",
+    "status",
+    "pass_fail",
+    "score_primary",
+    "lines_touched",
+    "files_touched",
+    "scope_creep_flag",
+    "held_out_failures",
+    "cost_usd",
+    "tokens_input",
+    "tokens_output",
+    "latency_ms",
+    "invocation_mode",
+    "diagnostics_json",
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunReport:
+    """Summary returned by run_matrix."""
+
+    rows_written: int = 0
+    budget_breached: bool = False
+    partial: bool = False
+    tsv_path: Optional[Path] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# TSV helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tsv_header(path: Path) -> None:
+    """Write header to path if path does not exist or is empty."""
+    if path.exists() and path.stat().st_size > 0:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="\t", lineterminator="\n")
+        writer.writerow(_TSV_HEADER)
+
+
+def _append_tsv_row(path: Path, row: dict) -> None:
+    """Append one row to the TSV ledger (append mode, no header write)."""
+    out: list[str] = []
+    for col in _TSV_HEADER:
+        val = row.get(col, "")
+        if col == "diagnostics_json" and not isinstance(val, str):
+            val = json.dumps(val, sort_keys=True, separators=(",", ":"))
+        out.append(str(val) if val is not None else "")
+    with path.open("a", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="\t", lineterminator="\n")
+        writer.writerow(out)
+
+
+# ---------------------------------------------------------------------------
+# Task corpus loading
+# ---------------------------------------------------------------------------
+
+
+def _load_tasks(tasks_yaml: Path) -> dict:
+    """Load corpus.yaml and return the tasks sub-dict."""
+    with tasks_yaml.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    tasks = data.get("tasks")
+    if not isinstance(tasks, dict):
+        raise ValueError(f"corpus.yaml at {tasks_yaml} has no 'tasks' mapping")
+    return tasks
+
+
+# ---------------------------------------------------------------------------
+# Condition materialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_fix_prompt(task_slug: str, task_meta: dict) -> str:
+    """Build the engineer prompt for one task cell."""
+    problem = task_meta.get("problem_summary", f"Fix the bug in task {task_slug}.")
+    repo_url = task_meta.get("repo_url", "")
+    base_commit = task_meta.get("base_commit", "")
+    return (
+        f"You are given a Python repository bug to fix.\n\n"
+        f"Task: {task_slug}\n"
+        f"Problem: {problem.strip()}\n"
+        f"Repository: {repo_url}\n"
+        f"Base commit: {base_commit}\n\n"
+        "Reproduce the failing test(s), identify the root cause, and apply the "
+        "minimal patch that makes the failing tests pass without breaking other "
+        "tests. Output your patch as a unified git diff fenced in a ```diff block."
+    )
+
+
+def _run_cell(
+    task_slug: str,
+    task_meta: dict,
+    condition: str,
+    replicate: int,
+    ae_payload: Optional[str],
+    dry_run: bool,
+) -> dict:
+    """Run one (task, condition, replicate) cell and return a raw result dict.
+
+    When dry_run=True, skips the actual CLI invocation and returns a canned
+    transcript for testing purposes.
+
+    Returns a dict with keys matching the invoker's run record plus extra
+    fields used for TSV row construction.
+    """
+    from evals.runner.invoker import invoke_run  # local import for testability
+
+    prompt = _build_fix_prompt(task_slug, task_meta)
+
+    if dry_run:
+        # Return a canned transcript used in unit tests.
+        return {
+            "final_text": (
+                "Analysed the bug. Here is the fix.\n\n"
+                "```diff\n"
+                "diff --git a/django/core/management/commands/sqlmigrate.py "
+                "b/django/core/management/commands/sqlmigrate.py\n"
+                "--- a/django/core/management/commands/sqlmigrate.py\n"
+                "+++ b/django/core/management/commands/sqlmigrate.py\n"
+                "@@ -1 +1 @@\n"
+                "-old line\n"
+                "+new line\n"
+                "```"
+            ),
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "latency_ms": 0,
+            "invocation_mode": "dry-run",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+    agent_name: Optional[str] = _AGENT_CONDITIONS.get(condition)
+    system_prompt: Optional[str] = ae_payload if condition == "ae-rules-injected" else None
+
+    # For per-agent conditions, the two-level Task wrapper is built by invoker.
+    # For baseline and ae-rules-injected, agent_name is None (conductor runs directly).
+    result = invoke_run(
+        prompt=prompt,
+        worktree=Path("."),  # worktree is the Tier3 fix_phase_dir; set by caller context
+        timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,  # give engineer 240s
+        agent_name=agent_name,
+        mode="agent",
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Core matrix loop
+# ---------------------------------------------------------------------------
+
+
+def run_matrix(
+    tasks_yaml: Path,
+    specs_dir: Optional[Path] = None,
+    results_tsv: Optional[Path] = None,
+    content_root: Optional[Path] = None,
+    n_replicates: int = 3,
+    n_replicates_methodology: int = 5,
+    max_usd: float = 250.0,
+    max_tokens: int = 75_000_000,
+    max_wall_seconds: float = 43200.0,
+    dry_run: bool = False,
+    conditions: Optional[list[str]] = None,
+) -> RunReport:
+    """Orchestrate the 8-condition skill-comparison eval matrix.
+
+    For each (task, condition, replicate) cell:
+      1. Materialise the condition config (ae-rules payload for ae-rules-injected,
+         agent name for per-agent conditions, nothing for baseline).
+      2. Spawn the engineer run (via Tier 3 Docker unless dry_run=True).
+      3. Score the result.
+      4. Append one row to the TSV ledger.
+
+    Budget ceilings (USD, tokens, wall-clock) are checked between cells.
+    BudgetExceeded halts with partial=True; the TSV contains results so far.
+
+    Args:
+        tasks_yaml: path to evals/skill-comparison/tasks/corpus.yaml.
+        specs_dir: directory of condition YAML specs (optional; used for
+                   content_glob cache validation).
+        results_tsv: path for the output TSV. Defaults to
+                     evals/skill-comparison/results/skill-comparison.tsv.
+        content_root: path to content/ directory (for ae-rules-injected payload).
+                      Defaults to <repo_root>/content/.
+        n_replicates: replicates per cell (default 3).
+        n_replicates_methodology: replicates for baseline and ae-rules-injected
+                                   (default 5; this is the headline pair).
+        max_usd: global USD ceiling (default 250).
+        max_tokens: global token ceiling (default 75 M).
+        max_wall_seconds: global wall-clock ceiling (default 12 h).
+        dry_run: if True, skip actual CLI calls and return canned results.
+        conditions: subset of CONDITION_LABELS to run (None = all 8).
+
+    Returns:
+        RunReport with summary stats.
+    """
+    _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+    if results_tsv is None:
+        results_tsv = (
+            Path(__file__).parent / "results" / "skill-comparison.tsv"
+        )
+    if content_root is None:
+        content_root = _REPO_ROOT / "content"
+
+    tasks = _load_tasks(tasks_yaml)
+    active_conditions = conditions if conditions is not None else CONDITION_LABELS
+
+    # Build ae-rules payload once (reused for every ae-rules-injected cell).
+    ae_payload: Optional[str] = None
+    if "ae-rules-injected" in active_conditions and not dry_run:
+        from ae_rules_payload import build_payload  # noqa: F401 (local import)
+        ae_payload = build_payload(content_root)
+
+    # Cost / budget gate.
+    from evals.icl_vs_orchestration.cost_gate import BudgetExceeded, CostGate
+
+    run_dir = results_tsv.parent / ".run_state"
+    cost_gate = CostGate(
+        run_dir=run_dir,
+        max_usd_global=max_usd,
+        max_tokens_global=max_tokens,
+    )
+
+    _ensure_tsv_header(results_tsv)
+    report = RunReport(tsv_path=results_tsv)
+    matrix_start = time.monotonic()
+
+    for task_slug, task_meta in tasks.items():
+        for condition in active_conditions:
+            # Methodology pair uses n_replicates_methodology; others use n_replicates.
+            n = (
+                n_replicates_methodology
+                if condition in ("baseline", "ae-rules-injected")
+                else n_replicates
+            )
+            for rep in range(1, n + 1):
+                # Wall-clock budget check.
+                elapsed = time.monotonic() - matrix_start
+                if elapsed > max_wall_seconds:
+                    _LOG.warning(
+                        "Wall-clock ceiling reached (%.0f s > %.0f s). "
+                        "Halting matrix with partial results.",
+                        elapsed,
+                        max_wall_seconds,
+                    )
+                    report.partial = True
+                    return report
+
+                cell_id = f"{task_slug}__{condition}"
+                _LOG.info(
+                    "Running cell: task=%s condition=%s rep=%d/%d",
+                    task_slug, condition, rep, n,
+                )
+
+                # Run the cell.
+                try:
+                    result = _run_cell(
+                        task_slug=task_slug,
+                        task_meta=task_meta,
+                        condition=condition,
+                        replicate=rep,
+                        ae_payload=ae_payload,
+                        dry_run=dry_run,
+                    )
+                except Exception as exc:
+                    _LOG.error(
+                        "Cell %s rep %d raised unexpectedly: %s",
+                        cell_id, rep, exc,
+                    )
+                    result = {
+                        "final_text": "",
+                        "status": f"error:{type(exc).__name__}",
+                        "cost_usd": 0.0,
+                        "usage": {},
+                        "latency_ms": 0,
+                        "invocation_mode": "error",
+                        "tool_calls": [],
+                        "turns_used": 0,
+                        "_parse_warnings": [str(exc)],
+                    }
+
+                transcript = result.get("final_text", "")
+                run_status = result.get("status", "unknown")
+                cost_usd = float(result.get("cost_usd") or 0.0)
+                usage = result.get("usage") or {}
+                latency_ms = int(result.get("latency_ms") or 0)
+                invocation_mode = result.get("invocation_mode", "")
+
+                # Score the cell (local, no Docker, when dry_run).
+                fix_dir = Path(tempfile.mkdtemp()) if dry_run else Path(".")
+                held_dir = Path(tempfile.mkdtemp()) if dry_run else Path(".")
+
+                try:
+                    scored = score_cell(
+                        task_slug=task_slug,
+                        transcript=transcript,
+                        task_meta=task_meta,
+                        fix_phase_dir=fix_dir,
+                        held_out_dir=held_dir,
+                        tier3_ctx=None,  # Docker ctx is managed by caller in production
+                        pytest_timeout=_PYTEST_TIMEOUT_SECONDS,
+                    )
+                except Exception as exc:
+                    _LOG.error(
+                        "score_cell raised for %s rep %d: %s",
+                        cell_id, rep, exc,
+                    )
+                    from scoring import ScoringResult as _SR
+                    scored = _SR(
+                        pass_fail=False,
+                        score_primary=0.0,
+                        lines_touched=0,
+                        files_touched=0,
+                        scope_creep_flag=False,
+                        held_out_failures=[],
+                        pytest_returncode=-1,
+                        diff_text="",
+                        diagnostics={"error": str(exc)},
+                    )
+                finally:
+                    if dry_run:
+                        import shutil as _sh
+                        _sh.rmtree(fix_dir, ignore_errors=True)
+                        _sh.rmtree(held_dir, ignore_errors=True)
+
+                # Record cost.
+                tokens_input = int(usage.get("input_tokens", usage.get("input", 0)))
+                tokens_output = int(usage.get("output_tokens", usage.get("output", 0)))
+
+                try:
+                    cost_gate.record(
+                        cell_id=cell_id,
+                        ticket_id=f"{cell_id}__rep{rep}",
+                        tokens={
+                            "input": tokens_input,
+                            "output": tokens_output,
+                            "cache_creation": int(
+                                usage.get("cache_creation_input_tokens",
+                                          usage.get("cache_creation", 0))
+                            ),
+                            "cache_read": int(
+                                usage.get("cache_read_input_tokens",
+                                          usage.get("cache_read", 0))
+                            ),
+                        },
+                        cost_usd=cost_usd,
+                    )
+                except BudgetExceeded as exc:
+                    _LOG.warning("Budget exceeded: %s. Halting.", exc)
+                    report.budget_breached = True
+                    report.partial = True
+                    report.error = str(exc)
+                    return report
+
+                # Append TSV row.
+                row = {
+                    "task_slug": task_slug,
+                    "condition": condition,
+                    "replicate": rep,
+                    "status": run_status,
+                    "pass_fail": "1" if scored.pass_fail else "0",
+                    "score_primary": scored.score_primary,
+                    "lines_touched": scored.lines_touched,
+                    "files_touched": scored.files_touched,
+                    "scope_creep_flag": "1" if scored.scope_creep_flag else "0",
+                    "held_out_failures": json.dumps(scored.held_out_failures),
+                    "cost_usd": cost_usd,
+                    "tokens_input": tokens_input,
+                    "tokens_output": tokens_output,
+                    "latency_ms": latency_ms,
+                    "invocation_mode": invocation_mode,
+                    "diagnostics_json": json.dumps(scored.diagnostics),
+                }
+                _append_tsv_row(results_tsv, row)
+                report.rows_written += 1
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Missing import for tempfile (used in dry_run path above)
+# ---------------------------------------------------------------------------
+import tempfile  # noqa: E402 (placed after function definitions for clarity)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run skill-comparison eval matrix.")
+    parser.add_argument("--tasks-yaml", type=Path, required=True)
+    parser.add_argument("--results-tsv", type=Path, default=None)
+    parser.add_argument("--content-root", type=Path, default=None)
+    parser.add_argument("--n-replicates", type=int, default=3)
+    parser.add_argument("--n-replicates-methodology", type=int, default=5)
+    parser.add_argument("--max-usd", type=float, default=250.0)
+    parser.add_argument("--max-tokens", type=int, default=75_000_000)
+    parser.add_argument("--max-wall-seconds", type=float, default=43200.0)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--conditions", nargs="*", default=None)
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    report = run_matrix(
+        tasks_yaml=args.tasks_yaml,
+        results_tsv=args.results_tsv,
+        content_root=args.content_root,
+        n_replicates=args.n_replicates,
+        n_replicates_methodology=args.n_replicates_methodology,
+        max_usd=args.max_usd,
+        max_tokens=args.max_tokens,
+        max_wall_seconds=args.max_wall_seconds,
+        dry_run=args.dry_run,
+        conditions=args.conditions,
+    )
+
+    print(json.dumps(
+        {
+            "rows_written": report.rows_written,
+            "budget_breached": report.budget_breached,
+            "partial": report.partial,
+            "tsv_path": str(report.tsv_path) if report.tsv_path else None,
+            "error": report.error,
+        },
+        indent=2,
+    ))
+
+    if report.budget_breached:
+        sys.exit(3)

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -1,0 +1,356 @@
+"""
+Purpose: Run held-out pytest in isolation and compute pass/fail plus diff-hygiene
+         diagnostics for one (task, condition, replicate) cell. Reads the engineer's
+         transcript to extract the patch diff; computes lines_touched, files_touched,
+         and scope_creep_flag against the task's known_affected_files set.
+
+Public API:
+    score_cell(
+        task_slug: str,
+        transcript: str,
+        task_meta: dict,
+        fix_phase_dir: Path,
+        held_out_dir: Path,
+        tier3_ctx: "Tier3Context | None" = None,
+        pytest_timeout: int = 120,
+    ) -> ScoringResult
+
+    ScoringResult (dataclass):
+        pass_fail: bool          # True iff all held-out tests pass
+        score_primary: float     # 1.0 on pass, 0.0 on fail
+        lines_touched: int       # total diff lines (additions + deletions)
+        files_touched: int       # number of files changed in the diff
+        scope_creep_flag: bool   # True if any touched file is outside known_affected_files
+        held_out_failures: list[str]  # failing test IDs (empty on pass)
+        pytest_returncode: int   # raw pytest exit code
+        diff_text: str           # raw diff extracted from transcript
+        diagnostics: dict        # bag of supplementary data
+
+    extract_diff_from_transcript(transcript: str) -> str
+        Extract the git diff from an engineer's transcript. Returns "" if none found.
+
+    compute_diff_hygiene(diff_text: str, known_affected_files: list[str]) -> dict
+        Parse a unified diff; return lines_touched, files_touched, scope_creep_flag.
+
+Upstream deps: stdlib subprocess, pathlib, re, dataclasses, typing, tempfile, shutil.
+               evals.runner.isolator.Tier3Docker (optional; used for in-container
+               pytest when tier3_ctx is provided).
+
+Downstream consumers: evals/skill-comparison/runner.py.
+
+Failure modes: pytest invocation failure is captured into pytest_returncode and
+               held_out_failures; it does not raise. Diff extraction failure
+               (no diff in transcript) sets diff_text="" and lines_touched=0,
+               files_touched=0, scope_creep_flag=False. Known-affected-files
+               mismatch (scope_creep_flag) is a diagnostic, not an error.
+
+Performance: pytest run is the dominant cost (~<120s per brief constraint).
+             Diff parsing is O(diff lines); negligible.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScoringResult:
+    """Result of scoring one (task, condition, replicate) cell."""
+
+    pass_fail: bool
+    score_primary: float          # 1.0 = pass, 0.0 = fail
+    lines_touched: int
+    files_touched: int
+    scope_creep_flag: bool
+    held_out_failures: list[str] = field(default_factory=list)
+    pytest_returncode: int = -1
+    diff_text: str = ""
+    diagnostics: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Diff extraction
+# ---------------------------------------------------------------------------
+
+# Patterns that delimit a git diff block in a transcript.
+# We look for a "diff --git" header or a triple-backtick "```diff" fenced block.
+_DIFF_FENCE_RE = re.compile(
+    r"```diff\s*\n(.*?)```",
+    re.DOTALL,
+)
+_GIT_DIFF_RE = re.compile(
+    r"(diff --git .+?)(?=\ndiff --git |\Z)",
+    re.DOTALL,
+)
+
+
+def extract_diff_from_transcript(transcript: str) -> str:
+    """Extract the git diff from an engineer's transcript.
+
+    Tries, in order:
+    1. Triple-backtick ```diff ... ``` fenced block.
+    2. Raw `diff --git` blocks.
+
+    Returns the first match found, or "" if no diff is present.
+    """
+    if not transcript:
+        return ""
+
+    # 1. Fenced block.
+    fenced = _DIFF_FENCE_RE.search(transcript)
+    if fenced:
+        return fenced.group(1).rstrip()
+
+    # 2. Raw diff blocks.
+    raw_diffs = _GIT_DIFF_RE.findall(transcript)
+    if raw_diffs:
+        return "\n".join(raw_diffs).rstrip()
+
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Diff hygiene
+# ---------------------------------------------------------------------------
+
+_DIFF_FILE_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
+_UNIFIED_HUNK_LINE_RE = re.compile(r"^[+\-](?![+\-])")  # +/- but not +++ or ---
+
+
+def compute_diff_hygiene(
+    diff_text: str,
+    known_affected_files: list[str],
+) -> dict:
+    """Parse a unified diff and return diff-hygiene diagnostics.
+
+    Args:
+        diff_text: raw unified diff text (may be empty).
+        known_affected_files: list of repo-relative file paths the correct
+                              patch is expected to touch (from corpus.yaml).
+
+    Returns dict with:
+        lines_touched: int   - count of + and - lines (not counting +++ / ---)
+        files_touched: int   - number of distinct files in the diff
+        scope_creep_flag: bool - True if any changed file is outside known_affected_files
+        touched_files: list[str] - the actual list of changed file paths
+        outside_files: list[str] - files touched but not in known_affected_files
+    """
+    if not diff_text:
+        return {
+            "lines_touched": 0,
+            "files_touched": 0,
+            "scope_creep_flag": False,
+            "touched_files": [],
+            "outside_files": [],
+        }
+
+    touched_files: list[str] = []
+    lines_touched: int = 0
+
+    for line in diff_text.splitlines():
+        m = _DIFF_FILE_HEADER_RE.match(line)
+        if m:
+            # b/ path is the post-patch filename.
+            touched_files.append(m.group(2))
+            continue
+        if _UNIFIED_HUNK_LINE_RE.match(line):
+            lines_touched += 1
+
+    # Deduplicate (a file may appear in multiple hunks of a real diff, but
+    # the header re fires once per file so this is a belt-and-braces guard).
+    seen: set[str] = set()
+    unique_files: list[str] = []
+    for f in touched_files:
+        if f not in seen:
+            seen.add(f)
+            unique_files.append(f)
+
+    known_set = set(known_affected_files)
+    outside_files = [f for f in unique_files if f not in known_set]
+    scope_creep_flag = len(outside_files) > 0
+
+    return {
+        "lines_touched": lines_touched,
+        "files_touched": len(unique_files),
+        "scope_creep_flag": scope_creep_flag,
+        "touched_files": unique_files,
+        "outside_files": outside_files,
+    }
+
+
+# ---------------------------------------------------------------------------
+# pytest result parsing
+# ---------------------------------------------------------------------------
+
+_PYTEST_FAILED_RE = re.compile(r"^FAILED (.+?)(?:\s+-\s+.+)?$", re.MULTILINE)
+_PYTEST_SHORT_SUMMARY_RE = re.compile(
+    r"=+ short test summary info =+(.*?)(?:=+ \d+ .+? =+|\Z)",
+    re.DOTALL,
+)
+
+
+def _parse_pytest_failures(stdout: str) -> list[str]:
+    """Extract failing test IDs from pytest stdout.
+
+    Looks for the short test summary section which lists each FAILED line.
+    Falls back to scanning all FAILED lines in the output.
+    """
+    failures: list[str] = []
+
+    # Prefer the summary section.
+    summary_m = _PYTEST_SHORT_SUMMARY_RE.search(stdout)
+    search_text = summary_m.group(1) if summary_m else stdout
+    for m in _PYTEST_FAILED_RE.finditer(search_text):
+        failures.append(m.group(1).strip())
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# In-process pytest runner (no Docker)
+# ---------------------------------------------------------------------------
+
+def _run_pytest_local(
+    held_out_dir: Path,
+    fix_phase_dir: Path,
+    timeout: int,
+) -> tuple[int, str]:
+    """Run pytest on held_out_dir tests against fix_phase_dir worktree.
+
+    Returns (returncode, combined_stdout).
+    """
+    cmd = [
+        "python", "-m", "pytest",
+        str(held_out_dir),
+        "--noconftest",
+        f"--rootdir={held_out_dir}",
+        "--tb=short",
+        "-q",
+        "--timeout", str(timeout),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(fix_phase_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout + 10,
+        )
+        return result.returncode, result.stdout + result.stderr
+    except subprocess.TimeoutExpired as e:
+        out = (
+            (e.stdout.decode("utf-8", errors="replace") if e.stdout else "")
+            + (e.stderr.decode("utf-8", errors="replace") if e.stderr else "")
+        )
+        return 1, out + "\npytest timed out"
+
+
+# ---------------------------------------------------------------------------
+# In-container pytest runner (Tier 3)
+# ---------------------------------------------------------------------------
+
+def _run_pytest_tier3(
+    tier3_ctx: object,  # Tier3Context (avoid hard import cycle)
+    timeout: int,
+) -> tuple[int, str]:
+    """Run pytest inside the Tier 3 container's score phase.
+
+    Delegates to Tier3Docker.run_score_phase. The held-out tests are already
+    mounted at /scoring/tests inside the container (per the Tier3Context
+    mount layout).
+
+    Returns (returncode, combined_stdout).
+    """
+    from evals.runner.isolator import Tier3Docker  # local import to avoid hard dep
+
+    cmd = [
+        "python", "-m", "pytest",
+        "/scoring/tests",
+        "--noconftest",
+        "--rootdir=/scoring/tests",
+        "--confcutdir=/scoring",
+        "--tb=short",
+        "-q",
+        f"--timeout={timeout}",
+    ]
+    result = Tier3Docker.run_score_phase(tier3_ctx, cmd, timeout_seconds=timeout)
+    return result.returncode, result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def score_cell(
+    task_slug: str,
+    transcript: str,
+    task_meta: dict,
+    fix_phase_dir: Path,
+    held_out_dir: Path,
+    tier3_ctx: Optional[object] = None,
+    pytest_timeout: int = 120,
+) -> ScoringResult:
+    """Score one (task, condition, replicate) cell.
+
+    Args:
+        task_slug: corpus key (e.g. "django-11039").
+        transcript: raw text output from the engineer's run (may be empty).
+        task_meta: dict from corpus.yaml tasks[task_slug]; must have
+                   "known_affected_files" list and optionally
+                   "estimated_test_seconds" (used as a sanity cap).
+        fix_phase_dir: host-side directory containing the engineer's
+                       modified repo state.
+        held_out_dir: host-side directory with the held-out test files.
+        tier3_ctx: Tier3Context instance if running inside Docker, else None.
+                   When provided, pytest is run via Tier3Docker.run_score_phase
+                   (in-container); when None, pytest runs on the host.
+        pytest_timeout: per-cell pytest wall-clock budget in seconds (<= 120
+                        per the Brief constraint).
+
+    Returns:
+        ScoringResult with all fields populated.
+    """
+    known_affected = task_meta.get("known_affected_files", [])
+
+    # 1. Extract diff from transcript.
+    diff_text = extract_diff_from_transcript(transcript)
+
+    # 2. Compute diff hygiene.
+    hygiene = compute_diff_hygiene(diff_text, known_affected)
+
+    # 3. Run held-out pytest.
+    if tier3_ctx is not None:
+        returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout)
+    else:
+        returncode, pytest_out = _run_pytest_local(held_out_dir, fix_phase_dir, pytest_timeout)
+
+    pass_fail = returncode == 0
+    failures = [] if pass_fail else _parse_pytest_failures(pytest_out)
+
+    return ScoringResult(
+        pass_fail=pass_fail,
+        score_primary=1.0 if pass_fail else 0.0,
+        lines_touched=hygiene["lines_touched"],
+        files_touched=hygiene["files_touched"],
+        scope_creep_flag=hygiene["scope_creep_flag"],
+        held_out_failures=failures,
+        pytest_returncode=returncode,
+        diff_text=diff_text,
+        diagnostics={
+            "task_slug": task_slug,
+            "touched_files": hygiene["touched_files"],
+            "outside_files": hygiene["outside_files"],
+            "known_affected_files": known_affected,
+            "pytest_output_tail": pytest_out[-1000:] if pytest_out else "",
+        },
+    )

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -394,39 +394,51 @@ class TestWallClockCeiling:
 
 
 # ---------------------------------------------------------------------------
-# CRITICAL-1 regression: ae-rules-injected must forward system_prompt
+# CRITICAL-1 regression: ae-rules-injected must reach subprocess CLI cmd
 # ---------------------------------------------------------------------------
 
 
-class TestAeRulesSystemPrompt:
-    def test_run_cell_passes_system_prompt_for_ae_rules(self):
-        """_run_cell passes system_prompt to invoke_run for ae-rules-injected condition.
+def _make_completed_process(stdout: str = "", returncode: int = 0) -> MagicMock:
+    """Return a fake CompletedProcess for subprocess.run mocks."""
+    cp = MagicMock()
+    cp.returncode = returncode
+    cp.stdout = stdout
+    cp.stderr = ""
+    return cp
 
-        Regression test for CRITICAL-1: previously system_prompt was built but
-        never passed to invoke_run, making ae-rules-injected identical to baseline.
+
+class TestAeRulesSystemPrompt:
+    """End-to-end regression suite for CRITICAL-1.
+
+    These tests mock subprocess.run (the actual CLI invocation boundary) rather
+    than invoke_run. This proves the --append-system-prompt flag reaches the
+    subprocess cmd list - a wholesale invoke_run mock would hide any kwarg
+    mismatch between runner._run_cell and invoker.invoke_run.
+    """
+
+    def test_ae_rules_injected_appends_system_prompt_flag_to_cmd(self, tmp_path: Path):
+        """ae-rules-injected condition causes --append-system-prompt to appear in CLI cmd.
+
+        Regression test for CRITICAL-1: verifies end-to-end that the ae_payload
+        reaches the subprocess invocation, not just that invoke_run is called with
+        the right kwarg.
         """
         from runner import _run_cell
 
-        canned_result = {
-            "final_text": "Fixed.",
-            "status": "ok",
-            "cost_usd": 0.0,
-            "usage": {},
-            "latency_ms": 0,
-            "invocation_mode": "agent",
-            "tool_calls": [],
-            "turns_used": 1,
-            "_parse_warnings": [],
-        }
-
+        ae_payload = "## AE methodology rules content here"
         task_meta = {
             "problem_summary": "test bug",
             "repo_url": "https://github.com/example/repo",
             "base_commit": "abc123",
         }
-        ae_payload = "## AE methodology rules content here"
 
-        with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
             _run_cell(
                 task_slug="test-task",
                 task_meta=task_meta,
@@ -436,67 +448,57 @@ class TestAeRulesSystemPrompt:
                 dry_run=False,
             )
 
-        assert mock_invoke.called, "invoke_run should have been called"
-        kwargs = mock_invoke.call_args.kwargs
-        assert kwargs.get("system_prompt") == ae_payload, (
-            f"ae-rules-injected must pass ae_payload as system_prompt; "
-            f"got: {kwargs.get('system_prompt')!r}"
+        assert captured_cmds, "subprocess.run must have been called"
+        # The CLI invocation is the last captured cmd (probe_claude_cli may fire
+        # too, but we care that at least one cmd contains the flag).
+        invoke_cmd = captured_cmds[-1]
+        assert "--append-system-prompt" in invoke_cmd, (
+            f"--append-system-prompt must appear in CLI cmd; cmd was: {invoke_cmd}"
+        )
+        flag_idx = invoke_cmd.index("--append-system-prompt")
+        assert invoke_cmd[flag_idx + 1] == ae_payload, (
+            f"--append-system-prompt value must be ae_payload; "
+            f"got: {invoke_cmd[flag_idx + 1]!r}"
         )
 
-    def test_run_cell_no_system_prompt_for_baseline(self):
-        """_run_cell passes system_prompt=None to invoke_run for baseline condition."""
+    def test_baseline_has_no_append_system_prompt_flag(self, tmp_path: Path):
+        """baseline condition must NOT pass --append-system-prompt to the CLI."""
         from runner import _run_cell
 
-        canned_result = {
-            "final_text": "Fixed.",
-            "status": "ok",
-            "cost_usd": 0.0,
-            "usage": {},
-            "latency_ms": 0,
-            "invocation_mode": "agent",
-            "tool_calls": [],
-            "turns_used": 1,
-            "_parse_warnings": [],
-        }
-
+        ae_payload = "some payload"
         task_meta = {
             "problem_summary": "test bug",
             "repo_url": "https://github.com/example/repo",
             "base_commit": "abc123",
         }
 
-        with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
             _run_cell(
                 task_slug="test-task",
                 task_meta=task_meta,
                 condition="baseline",
                 replicate=1,
-                ae_payload="some payload",  # has a payload but condition is baseline
+                ae_payload=ae_payload,
                 dry_run=False,
             )
 
-        assert mock_invoke.called
-        kwargs = mock_invoke.call_args.kwargs
-        assert kwargs.get("system_prompt") is None, (
-            f"baseline must NOT pass system_prompt; got: {kwargs.get('system_prompt')!r}"
+        assert captured_cmds, "subprocess.run must have been called"
+        invoke_cmd = captured_cmds[-1]
+        assert "--append-system-prompt" not in invoke_cmd, (
+            f"baseline must NOT include --append-system-prompt; cmd was: {invoke_cmd}"
         )
 
-    def test_run_cell_no_system_prompt_for_agent_conditions(self):
-        """_run_cell passes system_prompt=None for all named-agent conditions."""
+    def test_agent_direct_conditions_have_no_append_system_prompt_flag(self, tmp_path: Path):
+        """All named-agent conditions (xxx-direct) must NOT pass --append-system-prompt."""
         from runner import _run_cell, _AGENT_CONDITIONS
 
-        canned_result = {
-            "final_text": "Fixed.",
-            "status": "ok",
-            "cost_usd": 0.0,
-            "usage": {},
-            "latency_ms": 0,
-            "invocation_mode": "agent",
-            "tool_calls": [],
-            "turns_used": 1,
-            "_parse_warnings": [],
-        }
-
+        ae_payload = "some payload"
         task_meta = {
             "problem_summary": "test bug",
             "repo_url": "https://github.com/example/repo",
@@ -504,19 +506,27 @@ class TestAeRulesSystemPrompt:
         }
 
         for condition in _AGENT_CONDITIONS:
-            with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+            captured_cmds: list[list[str]] = []
+
+            def fake_subprocess_run(cmd, **kwargs):
+                captured_cmds.append(list(cmd))
+                return _make_completed_process(stdout="")
+
+            with patch("subprocess.run", side_effect=fake_subprocess_run):
                 _run_cell(
                     task_slug="test-task",
                     task_meta=task_meta,
                     condition=condition,
                     replicate=1,
-                    ae_payload="some payload",
+                    ae_payload=ae_payload,
                     dry_run=False,
                 )
-            kwargs = mock_invoke.call_args.kwargs
-            assert kwargs.get("system_prompt") is None, (
-                f"condition {condition!r} must NOT pass system_prompt; "
-                f"got: {kwargs.get('system_prompt')!r}"
+
+            assert captured_cmds, f"subprocess.run must have been called for {condition}"
+            invoke_cmd = captured_cmds[-1]
+            assert "--append-system-prompt" not in invoke_cmd, (
+                f"condition {condition!r} must NOT include --append-system-prompt; "
+                f"cmd was: {invoke_cmd}"
             )
 
 

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -1,0 +1,390 @@
+"""
+Tests for evals/skill-comparison/runner.py.
+
+Coverage:
+- Dry-run 1 task x 8 conditions x n=1 produces a valid TSV with correct schema.
+- Each TSV row has the expected columns and correct condition value.
+- BudgetExceeded path: mocked CostGate raises BudgetExceeded; run_matrix returns
+  budget_breached=True, partial=True, and exit code 3 (tested via report fields).
+- Wall-clock ceiling: mocked time causes immediate wall-clock breach on second cell.
+- TSV append mode: a pre-existing TSV gains rows without losing header.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# conftest.py inserts skill-comparison/ into sys.path.
+from runner import (
+    CONDITION_LABELS,
+    RunReport,
+    _TSV_HEADER,
+    _append_tsv_row,
+    _ensure_tsv_header,
+    run_matrix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_tsv(path: Path) -> list[dict]:
+    """Read the TSV ledger and return a list of row dicts."""
+    if not path.exists():
+        return []
+    with path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        return [dict(r) for r in reader]
+
+
+# ---------------------------------------------------------------------------
+# Corpus / tasks fixture
+# ---------------------------------------------------------------------------
+
+_MINIMAL_CORPUS_YAML = """\
+freeze_metadata:
+  freeze_date: "2026-05-12"
+tasks:
+  django-11039:
+    swebench_instance_id: "django__django-11039"
+    repo_url: "https://github.com/django/django"
+    base_commit: "d5276398046ce4a102776a1e67dcac2884d80dfe"
+    held_out_tests:
+      - "tests/migrations/test_commands.py"
+    fail_to_pass:
+      - "test_sqlmigrate_for_non_transactional_databases (migrations.test_commands.MigrateTests)"
+    estimated_test_seconds: 30
+    difficulty: single-file
+    known_affected_files:
+      - "django/core/management/commands/sqlmigrate.py"
+    problem_summary: >
+      sqlmigrate wraps output in BEGIN/COMMIT even when the database does not
+      support transactional DDL.
+"""
+
+
+@pytest.fixture
+def corpus_yaml(tmp_path: Path) -> Path:
+    """Write a minimal corpus YAML with one task to tmp_path."""
+    p = tmp_path / "corpus.yaml"
+    p.write_text(_MINIMAL_CORPUS_YAML, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _ensure_tsv_header / _append_tsv_row
+# ---------------------------------------------------------------------------
+
+
+class TestTsvHelpers:
+    def test_ensure_tsv_header_creates_file(self, tmp_path: Path):
+        path = tmp_path / "results" / "test.tsv"
+        _ensure_tsv_header(path)
+        assert path.exists()
+        with path.open(encoding="utf-8", newline="") as fh:
+            reader = csv.reader(fh, delimiter="\t")
+            header = next(reader)
+        assert list(header) == list(_TSV_HEADER)
+
+    def test_ensure_tsv_header_idempotent(self, tmp_path: Path):
+        """Calling twice on a non-empty file does not add a second header."""
+        path = tmp_path / "test.tsv"
+        _ensure_tsv_header(path)
+        # Append a data row manually to make it non-empty.
+        _append_tsv_row(
+            path,
+            {col: "x" for col in _TSV_HEADER},
+        )
+        _ensure_tsv_header(path)  # should be a no-op
+        rows = _read_tsv(path)
+        assert len(rows) == 1  # exactly one data row, not two
+
+    def test_append_row_adds_to_existing(self, tmp_path: Path):
+        path = tmp_path / "test.tsv"
+        _ensure_tsv_header(path)
+        for i in range(3):
+            _append_tsv_row(
+                path,
+                {col: str(i) for col in _TSV_HEADER},
+            )
+        rows = _read_tsv(path)
+        assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# run_matrix dry-run: 1 task x 8 conditions x n=1
+# ---------------------------------------------------------------------------
+
+
+class TestRunMatrixDryRun:
+    def test_1_task_8_conditions_n1_produces_valid_tsv(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Dry-run 1 task x 8 conditions x n=1 produces 8 TSV rows."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        # Patch score_cell to avoid subprocess calls.
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True,
+            score_primary=1.0,
+            lines_touched=2,
+            files_touched=1,
+            scope_creep_flag=False,
+            held_out_failures=[],
+            pytest_returncode=0,
+            diff_text="diff --git a/f.py b/f.py",
+            diagnostics={},
+        )
+
+        with patch("runner.score_cell", return_value=canned_score):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=CONDITION_LABELS,
+            )
+
+        assert report.rows_written == 8, (
+            f"Expected 8 rows (1 task x 8 conditions x n=1), got {report.rows_written}"
+        )
+        assert report.budget_breached is False
+        assert report.partial is False
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 8
+
+        # Check schema - every row has all expected columns.
+        for row in rows:
+            for col in _TSV_HEADER:
+                assert col in row, f"Missing column {col!r} in row {row}"
+
+        # Check all 8 conditions appear.
+        conditions_seen = {r["condition"] for r in rows}
+        assert conditions_seen == set(CONDITION_LABELS)
+
+        # task_slug is correct.
+        for row in rows:
+            assert row["task_slug"] == "django-11039"
+
+        # replicate is "1" for all (n=1).
+        for row in rows:
+            assert row["replicate"] == "1"
+
+        # pass_fail populated.
+        for row in rows:
+            assert row["pass_fail"] in ("0", "1")
+
+    def test_tsv_append_mode_preserves_prior_rows(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Running twice in a row appends rows, doesn't overwrite."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=False,
+            score_primary=0.0,
+            lines_touched=0,
+            files_touched=0,
+            scope_creep_flag=False,
+        )
+
+        with patch("runner.score_cell", return_value=canned):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, "Second run should append, not overwrite"
+
+    def test_methodology_pair_uses_higher_n(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """baseline and ae-rules-injected use n_replicates_methodology, others use n_replicates."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        with patch("runner.score_cell", return_value=canned):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=2,
+                n_replicates_methodology=3,
+                dry_run=True,
+                conditions=["baseline", "engineer-direct"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        baseline_rows = [r for r in rows if r["condition"] == "baseline"]
+        engineer_rows = [r for r in rows if r["condition"] == "engineer-direct"]
+
+        assert len(baseline_rows) == 3, "baseline should use n_replicates_methodology=3"
+        assert len(engineer_rows) == 2, "engineer-direct should use n_replicates=2"
+
+
+# ---------------------------------------------------------------------------
+# BudgetExceeded path
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetExceeded:
+    def test_budget_exceeded_sets_partial_and_error(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """When CostGate raises BudgetExceeded, run_matrix returns budget_breached=True."""
+        from evals.icl_vs_orchestration.cost_gate import BudgetExceeded
+
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        # Raise BudgetExceeded on the first record call.
+        budget_error = BudgetExceeded(
+            scope="global",
+            cell_id=None,
+            totals={"global_usd": 300.0, "limit_usd": 250.0,
+                    "global_tokens": 0, "limit_tokens": 75_000_000},
+        )
+
+        with (
+            patch("runner.score_cell", return_value=canned),
+            patch(
+                "evals.icl_vs_orchestration.cost_gate.CostGate.record",
+                side_effect=budget_error,
+            ),
+        ):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        assert report.budget_breached is True
+        assert report.partial is True
+        assert report.error is not None
+        assert "Budget exceeded" in report.error or "global" in report.error.lower()
+
+    def test_budget_exceeded_exit3_semantics(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Confirms the RunReport signals that __main__ should sys.exit(3)."""
+        from evals.icl_vs_orchestration.cost_gate import BudgetExceeded
+
+        results_tsv = tmp_path / "skill-comparison.tsv"
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=False, score_primary=0.0,
+            lines_touched=0, files_touched=0, scope_creep_flag=False,
+        )
+
+        budget_error = BudgetExceeded(
+            scope="global",
+            cell_id=None,
+            totals={"global_usd": 300.0, "limit_usd": 250.0,
+                    "global_tokens": 0, "limit_tokens": 75_000_000},
+        )
+
+        with (
+            patch("runner.score_cell", return_value=canned),
+            patch(
+                "evals.icl_vs_orchestration.cost_gate.CostGate.record",
+                side_effect=budget_error,
+            ),
+        ):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        # The caller (main) checks budget_breached and calls sys.exit(3).
+        assert report.budget_breached is True
+
+
+# ---------------------------------------------------------------------------
+# Wall-clock ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestWallClockCeiling:
+    def test_wall_clock_breach_halts_matrix(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """When elapsed time exceeds max_wall_seconds, partial=True is returned."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        # First call to time.monotonic returns 0 (start), subsequent calls
+        # return a value larger than max_wall_seconds so the check fires on
+        # the second cell.
+        time_sequence = iter([0.0, 99999.0])
+
+        def mock_monotonic():
+            try:
+                return next(time_sequence)
+            except StopIteration:
+                return 99999.0
+
+        with (
+            patch("runner.score_cell", return_value=canned),
+            patch("runner.time.monotonic", side_effect=mock_monotonic),
+        ):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=2,
+                n_replicates_methodology=2,
+                dry_run=True,
+                conditions=["baseline"],
+                max_wall_seconds=10.0,
+            )
+
+        assert report.partial is True

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -188,7 +188,7 @@ class TestRunMatrixDryRun:
     def test_tsv_append_mode_preserves_prior_rows(
         self, tmp_path: Path, corpus_yaml: Path
     ):
-        """Running twice in a row appends rows, doesn't overwrite."""
+        """Running twice with force=True appends rows rather than overwriting."""
         results_tsv = tmp_path / "skill-comparison.tsv"
 
         from scoring import ScoringResult
@@ -210,6 +210,8 @@ class TestRunMatrixDryRun:
                 dry_run=True,
                 conditions=["baseline"],
             )
+            # force=True bypasses resume; this tests that the file is opened
+            # in append mode (not truncated / overwritten).
             run_matrix(
                 tasks_yaml=corpus_yaml,
                 results_tsv=results_tsv,
@@ -217,10 +219,11 @@ class TestRunMatrixDryRun:
                 n_replicates_methodology=1,
                 dry_run=True,
                 conditions=["baseline"],
+                force=True,
             )
 
         rows = _read_tsv(results_tsv)
-        assert len(rows) == 2, "Second run should append, not overwrite"
+        assert len(rows) == 2, "Second force run should append, not overwrite"
 
     def test_methodology_pair_uses_higher_n(
         self, tmp_path: Path, corpus_yaml: Path
@@ -388,3 +391,410 @@ class TestWallClockCeiling:
             )
 
         assert report.partial is True
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-1 regression: ae-rules-injected must forward system_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestAeRulesSystemPrompt:
+    def test_run_cell_passes_system_prompt_for_ae_rules(self):
+        """_run_cell passes system_prompt to invoke_run for ae-rules-injected condition.
+
+        Regression test for CRITICAL-1: previously system_prompt was built but
+        never passed to invoke_run, making ae-rules-injected identical to baseline.
+        """
+        from runner import _run_cell
+
+        canned_result = {
+            "final_text": "Fixed.",
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "agent",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+        ae_payload = "## AE methodology rules content here"
+
+        with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="ae-rules-injected",
+                replicate=1,
+                ae_payload=ae_payload,
+                dry_run=False,
+            )
+
+        assert mock_invoke.called, "invoke_run should have been called"
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs.get("system_prompt") == ae_payload, (
+            f"ae-rules-injected must pass ae_payload as system_prompt; "
+            f"got: {kwargs.get('system_prompt')!r}"
+        )
+
+    def test_run_cell_no_system_prompt_for_baseline(self):
+        """_run_cell passes system_prompt=None to invoke_run for baseline condition."""
+        from runner import _run_cell
+
+        canned_result = {
+            "final_text": "Fixed.",
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "agent",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="baseline",
+                replicate=1,
+                ae_payload="some payload",  # has a payload but condition is baseline
+                dry_run=False,
+            )
+
+        assert mock_invoke.called
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs.get("system_prompt") is None, (
+            f"baseline must NOT pass system_prompt; got: {kwargs.get('system_prompt')!r}"
+        )
+
+    def test_run_cell_no_system_prompt_for_agent_conditions(self):
+        """_run_cell passes system_prompt=None for all named-agent conditions."""
+        from runner import _run_cell, _AGENT_CONDITIONS
+
+        canned_result = {
+            "final_text": "Fixed.",
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "agent",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        for condition in _AGENT_CONDITIONS:
+            with patch("evals.runner.invoker.invoke_run", return_value=canned_result) as mock_invoke:
+                _run_cell(
+                    task_slug="test-task",
+                    task_meta=task_meta,
+                    condition=condition,
+                    replicate=1,
+                    ae_payload="some payload",
+                    dry_run=False,
+                )
+            kwargs = mock_invoke.call_args.kwargs
+            assert kwargs.get("system_prompt") is None, (
+                f"condition {condition!r} must NOT pass system_prompt; "
+                f"got: {kwargs.get('system_prompt')!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-2 regression: Tier3Docker instantiated in production path
+# ---------------------------------------------------------------------------
+
+
+class TestTier3Instantiation:
+    def test_tier3_instantiated_when_auto_mode_not_dry_run(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Tier3Docker is instantiated when tier3_mode='auto' and dry_run=False.
+
+        Regression test for CRITICAL-2: previously tier3_ctx=None was passed
+        unconditionally, bypassing the Tier 3 Docker isolator entirely.
+        """
+        from scoring import ScoringResult
+        from unittest.mock import MagicMock
+        from evals.runner.isolator import Tier3Context
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        canned_result = {
+            "final_text": "Fixed.",
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "agent",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        # Mock Tier3Docker so docker subprocess is never actually called.
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "held",
+            image_tag="ae-eval-swebench:latest",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "held").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3 = MagicMock()
+        mock_tier3.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3.__exit__ = MagicMock(return_value=None)
+        mock_tier3_cls = MagicMock(return_value=mock_tier3)
+
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._run_cell", return_value=canned_result),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,  # production path
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        assert mock_tier3_cls.called, (
+            "Tier3Docker must be instantiated when tier3_mode='auto' and dry_run=False"
+        )
+        assert mock_tier3.__enter__.called, "Tier3Docker.__enter__ must be called"
+        assert mock_tier3.__exit__.called, "Tier3Docker.__exit__ must be called (cleanup)"
+
+    def test_tier3_skipped_when_dry_run(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Tier3Docker is NOT instantiated when dry_run=True."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        mock_tier3_cls = MagicMock()
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tier3_mode="auto",  # auto but dry_run overrides to off
+            )
+
+        assert not mock_tier3_cls.called, (
+            "Tier3Docker must NOT be instantiated when dry_run=True"
+        )
+
+    def test_tier3_skipped_when_mode_off(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Tier3Docker is NOT instantiated when tier3_mode='off'."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        mock_tier3_cls = MagicMock()
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tier3_mode="off",
+            )
+
+        assert not mock_tier3_cls.called, (
+            "Tier3Docker must NOT be instantiated when tier3_mode='off'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-1 regression: resume skips completed cells
+# ---------------------------------------------------------------------------
+
+
+class TestResumeSemantics:
+    def test_resume_skips_completed_cells(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Re-running with a pre-existing TSV only adds missing cells.
+
+        Regression test for MAJOR-1: previously all cells were re-run on
+        resume, causing duplicate (task_slug, condition, replicate) rows.
+        """
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        # First run: write baseline replicate 1.
+        with patch("runner.score_cell", return_value=canned_score):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        rows_after_first = _read_tsv(results_tsv)
+        assert len(rows_after_first) == 1
+
+        # Second run: same conditions. Resume should skip the already-done cell.
+        with patch("runner.score_cell", return_value=canned_score):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        rows_after_second = _read_tsv(results_tsv)
+        assert len(rows_after_second) == 1, (
+            "Resume must not add duplicate rows for already-completed cells; "
+            f"expected 1 row, got {len(rows_after_second)}"
+        )
+        assert report.rows_written == 0, (
+            f"rows_written should be 0 (all cells skipped), got {report.rows_written}"
+        )
+
+    def test_force_reruns_completed_cells(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """force=True bypasses resume and re-runs completed cells."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        # First run.
+        with patch("runner.score_cell", return_value=canned_score):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        # Second run with force=True: should add a second row.
+        with patch("runner.score_cell", return_value=canned_score):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                force=True,
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"force=True should re-run and append; expected 2 rows, got {len(rows)}"
+        )
+        assert report.rows_written == 1
+
+    def test_resume_adds_missing_cells(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Resume adds cells not yet present while skipping completed ones."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        # First run: only baseline.
+        with patch("runner.score_cell", return_value=canned_score):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        assert len(_read_tsv(results_tsv)) == 1
+
+        # Second run: baseline + engineer-direct.
+        # baseline is already done; engineer-direct is missing.
+        with patch("runner.score_cell", return_value=canned_score):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline", "engineer-direct"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"Resume should add engineer-direct but skip baseline; expected 2, got {len(rows)}"
+        )
+        assert report.rows_written == 1, (
+            f"Only 1 new cell should have been written (engineer-direct), got {report.rows_written}"
+        )

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -1,0 +1,343 @@
+"""
+Tests for evals/skill-comparison/scoring.py.
+
+Coverage:
+- extract_diff_from_transcript: fenced block, raw diff, empty transcript.
+- compute_diff_hygiene: lines_touched, files_touched, scope_creep_flag across
+  fixture diffs including edge cases (empty diff, diff within known files,
+  diff outside known files, mixed).
+- _parse_pytest_failures: summary section extraction, fallback scanning.
+- score_cell: pass (returncode=0), fail (returncode=1), empty transcript.
+  Uses a mock subprocess so no real pytest is invoked.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# conftest.py inserts skill-comparison/ into sys.path.
+from scoring import (
+    ScoringResult,
+    _parse_pytest_failures,
+    compute_diff_hygiene,
+    extract_diff_from_transcript,
+    score_cell,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_diff_from_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDiffFromTranscript:
+    def test_fenced_block(self):
+        transcript = (
+            "I found the bug and here is the fix:\n\n"
+            "```diff\n"
+            "diff --git a/foo.py b/foo.py\n"
+            "--- a/foo.py\n"
+            "+++ b/foo.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+            "```\n"
+            "That should fix it."
+        )
+        result = extract_diff_from_transcript(transcript)
+        assert "diff --git" in result
+        assert "+new" in result
+        assert "-old" in result
+
+    def test_raw_git_diff(self):
+        transcript = (
+            "Analysis complete.\n"
+            "diff --git a/bar.py b/bar.py\n"
+            "--- a/bar.py\n"
+            "+++ b/bar.py\n"
+            "@@ -5 +5 @@\n"
+            "-bad\n"
+            "+good\n"
+        )
+        result = extract_diff_from_transcript(transcript)
+        assert "diff --git" in result
+        assert "+good" in result
+
+    def test_empty_transcript_returns_empty(self):
+        assert extract_diff_from_transcript("") == ""
+
+    def test_no_diff_returns_empty(self):
+        assert extract_diff_from_transcript("No patch here.") == ""
+
+    def test_fenced_takes_precedence_over_raw(self):
+        """If both a fenced block and raw diff exist, fenced wins."""
+        transcript = (
+            "diff --git a/outer.py b/outer.py\n"
+            "--- a/outer.py\n"
+            "+++ b/outer.py\n"
+            "@@ -1 +1 @@\n"
+            "-outer_old\n"
+            "+outer_new\n"
+            "\n"
+            "```diff\n"
+            "diff --git a/inner.py b/inner.py\n"
+            "--- a/inner.py\n"
+            "+++ b/inner.py\n"
+            "@@ -1 +1 @@\n"
+            "-inner_old\n"
+            "+inner_new\n"
+            "```"
+        )
+        result = extract_diff_from_transcript(transcript)
+        # Fenced block contains inner.py
+        assert "inner.py" in result
+
+
+# ---------------------------------------------------------------------------
+# compute_diff_hygiene
+# ---------------------------------------------------------------------------
+
+_DJANGO_KNOWN = ["django/core/management/commands/sqlmigrate.py"]
+
+_DIFF_IN_SCOPE = (
+    "diff --git a/django/core/management/commands/sqlmigrate.py "
+    "b/django/core/management/commands/sqlmigrate.py\n"
+    "--- a/django/core/management/commands/sqlmigrate.py\n"
+    "+++ b/django/core/management/commands/sqlmigrate.py\n"
+    "@@ -10,6 +10,7 @@\n"
+    " unchanged\n"
+    "-removed line\n"
+    "+added line\n"
+    "+another added\n"
+)
+
+_DIFF_OUT_OF_SCOPE = (
+    "diff --git a/django/core/management/commands/sqlmigrate.py "
+    "b/django/core/management/commands/sqlmigrate.py\n"
+    "--- a/django/core/management/commands/sqlmigrate.py\n"
+    "+++ b/django/core/management/commands/sqlmigrate.py\n"
+    "@@ -10 +10 @@\n"
+    "-old\n"
+    "+new\n"
+    "diff --git a/django/other.py b/django/other.py\n"
+    "--- a/django/other.py\n"
+    "+++ b/django/other.py\n"
+    "@@ -1 +1 @@\n"
+    "-x\n"
+    "+y\n"
+)
+
+
+class TestComputeDiffHygiene:
+    def test_empty_diff(self):
+        result = compute_diff_hygiene("", [])
+        assert result["lines_touched"] == 0
+        assert result["files_touched"] == 0
+        assert result["scope_creep_flag"] is False
+        assert result["touched_files"] == []
+        assert result["outside_files"] == []
+
+    def test_in_scope_single_file(self):
+        result = compute_diff_hygiene(_DIFF_IN_SCOPE, _DJANGO_KNOWN)
+        assert result["files_touched"] == 1
+        assert result["lines_touched"] == 3  # one - and two +
+        assert result["scope_creep_flag"] is False
+        assert result["outside_files"] == []
+
+    def test_out_of_scope_triggers_flag(self):
+        result = compute_diff_hygiene(_DIFF_OUT_OF_SCOPE, _DJANGO_KNOWN)
+        assert result["files_touched"] == 2
+        assert result["scope_creep_flag"] is True
+        assert "django/other.py" in result["outside_files"]
+
+    def test_no_known_affected_flags_all(self):
+        """If known_affected_files is empty, any touched file triggers scope_creep."""
+        result = compute_diff_hygiene(_DIFF_IN_SCOPE, [])
+        assert result["scope_creep_flag"] is True
+        assert len(result["outside_files"]) == 1
+
+    def test_known_affected_empty_diff_no_flag(self):
+        result = compute_diff_hygiene("", ["some/file.py"])
+        assert result["scope_creep_flag"] is False
+
+    def test_lines_touched_counts_additions_and_deletions(self):
+        diff = (
+            "diff --git a/f.py b/f.py\n"
+            "--- a/f.py\n"
+            "+++ b/f.py\n"
+            "@@ -1,3 +1,3 @@\n"
+            "-line1\n"
+            "-line2\n"
+            "+lineA\n"
+            "+lineB\n"
+            " context\n"
+        )
+        result = compute_diff_hygiene(diff, ["f.py"])
+        assert result["lines_touched"] == 4  # 2 removals + 2 additions
+
+
+# ---------------------------------------------------------------------------
+# _parse_pytest_failures
+# ---------------------------------------------------------------------------
+
+
+class TestParsePytestFailures:
+    def test_extracts_from_summary(self):
+        stdout = (
+            "============================= short test summary info =============================\n"
+            "FAILED tests/test_foo.py::TestFoo::test_bar - assert False\n"
+            "FAILED tests/test_foo.py::TestFoo::test_baz\n"
+            "==================== 2 failed, 3 passed in 1.23s ====================\n"
+        )
+        failures = _parse_pytest_failures(stdout)
+        assert "tests/test_foo.py::TestFoo::test_bar" in failures
+        assert "tests/test_foo.py::TestFoo::test_baz" in failures
+
+    def test_empty_on_all_pass(self):
+        stdout = "==================== 5 passed in 0.5s ====================\n"
+        failures = _parse_pytest_failures(stdout)
+        assert failures == []
+
+    def test_fallback_without_summary(self):
+        stdout = "FAILED tests/test_x.py::TestX::test_y - assertion error\n"
+        failures = _parse_pytest_failures(stdout)
+        assert "tests/test_x.py::TestX::test_y" in failures
+
+
+# ---------------------------------------------------------------------------
+# score_cell
+# ---------------------------------------------------------------------------
+
+
+_TASK_META_SINGLE_FILE = {
+    "known_affected_files": ["django/core/management/commands/sqlmigrate.py"],
+    "estimated_test_seconds": 30,
+    "difficulty": "single-file",
+}
+
+_PASSING_TRANSCRIPT = (
+    "Fixed the issue.\n\n"
+    "```diff\n"
+    "diff --git a/django/core/management/commands/sqlmigrate.py "
+    "b/django/core/management/commands/sqlmigrate.py\n"
+    "--- a/django/core/management/commands/sqlmigrate.py\n"
+    "+++ b/django/core/management/commands/sqlmigrate.py\n"
+    "@@ -1 +1 @@\n"
+    "-old\n"
+    "+new\n"
+    "```"
+)
+
+_FAILING_TRANSCRIPT = "Could not identify the bug."
+
+
+class TestScoreCell:
+    def test_pass_when_pytest_returns_zero(self, tmp_path: Path):
+        """score_cell returns pass_fail=True when pytest exits 0."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        with patch("scoring.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="5 passed", stderr="")
+            result = score_cell(
+                task_slug="django-11039",
+                transcript=_PASSING_TRANSCRIPT,
+                task_meta=_TASK_META_SINGLE_FILE,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert result.pass_fail is True
+        assert result.score_primary == 1.0
+        assert result.held_out_failures == []
+
+    def test_fail_when_pytest_returns_nonzero(self, tmp_path: Path):
+        """score_cell returns pass_fail=False when pytest exits non-zero."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        pytest_stdout = (
+            "============================= short test summary info =============================\n"
+            "FAILED tests/test_foo.py::TestFoo::test_bar - assert False\n"
+            "==================== 1 failed in 0.5s ====================\n"
+        )
+        with patch("scoring.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout=pytest_stdout, stderr=""
+            )
+            result = score_cell(
+                task_slug="django-11039",
+                transcript=_FAILING_TRANSCRIPT,
+                task_meta=_TASK_META_SINGLE_FILE,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert result.pass_fail is False
+        assert result.score_primary == 0.0
+        assert len(result.held_out_failures) >= 1
+
+    def test_scope_creep_flag_set_when_outside_files(self, tmp_path: Path):
+        """scope_creep_flag is True when the diff touches files outside known_affected."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        # Diff touches an unexpected file.
+        transcript = (
+            "Fix applied.\n\n"
+            "```diff\n"
+            "diff --git a/unexpected/module.py b/unexpected/module.py\n"
+            "--- a/unexpected/module.py\n"
+            "+++ b/unexpected/module.py\n"
+            "@@ -1 +1 @@\n"
+            "-x\n"
+            "+y\n"
+            "```"
+        )
+        with patch("scoring.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="1 passed", stderr="")
+            result = score_cell(
+                task_slug="django-11039",
+                transcript=transcript,
+                task_meta=_TASK_META_SINGLE_FILE,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert result.scope_creep_flag is True
+        assert "unexpected/module.py" in result.diagnostics.get("outside_files", [])
+
+    def test_empty_transcript_yields_zero_diff_metrics(self, tmp_path: Path):
+        """Empty transcript -> lines_touched=0, files_touched=0, scope_creep_flag=False."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        with patch("scoring.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            result = score_cell(
+                task_slug="django-11039",
+                transcript="",
+                task_meta=_TASK_META_SINGLE_FILE,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert result.lines_touched == 0
+        assert result.files_touched == 0
+        assert result.scope_creep_flag is False
+        assert result.diff_text == ""


### PR DESCRIPTION
## Summary

- `runner.py`: orchestrates the 8-condition (task x condition x replicate) matrix; materialises ae-rules payload for the `ae-rules-injected` condition; routes per-agent conditions via named-agent direct spawn; enforces USD/token/wall-clock budget ceilings via BudgetExceeded exit-3 pattern; appends TSV rows in append mode (never overwrites).
- `scoring.py`: extracts git diff from engineer transcript (fenced block or raw diff); computes `lines_touched`, `files_touched`, `scope_creep_flag` against `known_affected_files`; runs held-out pytest locally or via Tier 3 Docker score phase.
- `tests/test_runner.py`: dry-run 1 task x 8 conditions x n=1 produces valid TSV matching aggregator schema; BudgetExceeded path tested with mocked CostGate; wall-clock ceiling halts with partial=True; append-mode verified.
- `tests/test_scoring.py`: pass/fail, scope_creep_flag, diff extraction, diff hygiene arithmetic, pytest failure parsing across fixture diffs.

## Test plan

- [ ] `pytest evals/skill-comparison/tests/test_runner.py` passes (9 tests).
- [ ] `pytest evals/skill-comparison/tests/test_scoring.py` passes (18 tests).
- [ ] `pytest evals/skill-comparison/tests/` passes (237 tests, all pre-existing tests preserved).
- [ ] Dry-run with mocked isolator produces a valid TSV row matching aggregator's expected schema (verified by test_1_task_8_conditions_n1_produces_valid_tsv).
- [ ] BudgetExceeded path exercised in test (test_budget_exceeded_sets_partial_and_error).
- [ ] scope_creep_flag correctly set when files_touched fall outside known_affected_files (test_scope_creep_flag_set_when_outside_files, TestComputeDiffHygiene::test_out_of_scope_triggers_flag).
- [ ] Module manifests present per rules/module-manifest.md.