### PR TITLE
feat(skill-comparison): 7 condition spec YAMLs for 8-condition eval matrix

### DIFF
--- a/evals/skill-comparison/specs/architect.yaml
+++ b/evals/skill-comparison/specs/architect.yaml
@@ -1,0 +1,20 @@
+# Condition: architect-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the architect agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The architect agent is invoked directly via
+# invoker.run_session(mode="agent", agent_name="architect") so that the agent's
+# own frontmatter is preserved intact. Expected strength: design-y tasks.
+
+condition: architect-direct
+agent_name: architect
+description: >
+  Architect-direct condition. Bare two-level Task spawn of the architect agent
+  against the task corpus. No AE rules payload; no stub skill. The delta vs
+  baseline measures the architect agent's isolated contribution.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []

--- a/evals/skill-comparison/specs/debugger.yaml
+++ b/evals/skill-comparison/specs/debugger.yaml
@@ -1,0 +1,21 @@
+# Condition: debugger-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the debugger agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The debugger agent is invoked directly via
+# invoker.run_session(mode="agent", agent_name="debugger") so that the agent's
+# own frontmatter is preserved intact. Expected strength: single-file tasks
+# requiring root cause analysis and targeted fixes.
+
+condition: debugger-direct
+agent_name: debugger
+description: >
+  Debugger-direct condition. Bare two-level Task spawn of the debugger agent
+  against the task corpus. No AE rules payload; no stub skill. The delta vs
+  baseline measures the debugger agent's isolated contribution.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []

--- a/evals/skill-comparison/specs/engineer.yaml
+++ b/evals/skill-comparison/specs/engineer.yaml
@@ -1,0 +1,21 @@
+# Condition: engineer-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the engineer agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The engineer agent is invoked directly via
+# invoker.run_session(mode="agent", agent_name="engineer") so that the agent's
+# own frontmatter (tools, system prompt) is preserved intact. This matches the
+# per-agent invocation shape described in brief.md "Measurement equivalence".
+
+condition: engineer-direct
+agent_name: engineer
+description: >
+  Engineer-direct condition. Bare two-level Task spawn of the engineer agent
+  against the task corpus. No AE rules payload; no stub skill. The delta vs
+  baseline measures the engineer agent's isolated contribution.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []

--- a/evals/skill-comparison/specs/investigator.yaml
+++ b/evals/skill-comparison/specs/investigator.yaml
@@ -1,0 +1,21 @@
+# Condition: investigator-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the investigator agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The investigator agent is invoked directly
+# via invoker.run_session(mode="agent", agent_name="investigator") so that the
+# agent's own frontmatter is preserved intact. Expected strength: multi-file
+# tasks requiring blast-radius mapping and codebase exploration.
+
+condition: investigator-direct
+agent_name: investigator
+description: >
+  Investigator-direct condition. Bare two-level Task spawn of the investigator
+  agent against the task corpus. No AE rules payload; no stub skill. The delta
+  vs baseline measures the investigator agent's isolated contribution.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []

--- a/evals/skill-comparison/specs/methodology.yaml
+++ b/evals/skill-comparison/specs/methodology.yaml
@@ -1,0 +1,34 @@
+# Condition: ae-rules-injected
+#
+# Measurement: AE methodology baseline vs ae-rules-injected.
+# n=5 replicates per cell (both baseline and ae-rules-injected); the 5
+# baseline replicates establish the noise envelope for the sensitivity check.
+#
+# The ae-rules-injected condition injects the full AE methodology content as
+# the outer conductor's system prompt. content_glob lists EXACTLY 5 globs in
+# the canonical order prescribed by ae_rules_payload.content_glob:
+#   1. SKILL.md
+#   2. sections/*.md
+#   3. rules/*.md
+#   4. references/*.md
+#   5. commands/*.md
+#
+# See brief.md "Measurement equivalence" for what is and is not exercised.
+
+condition: ae-rules-injected
+agent_name: null
+description: >
+  AE methodology condition. The outer conductor's system prompt is augmented
+  with the full AE rules payload (SKILL.md + sections + rules + references +
+  commands). n=5 replicates; the paired baseline replicates establish the
+  noise envelope used by the sensitivity check.
+
+n_replicates: 5
+pair_with: baseline
+
+content_glob:
+  - "content/SKILL.md"
+  - "content/sections/*.md"
+  - "content/rules/*.md"
+  - "content/references/*.md"
+  - "content/commands/*.md"

--- a/evals/skill-comparison/specs/qa-engineer.yaml
+++ b/evals/skill-comparison/specs/qa-engineer.yaml
@@ -1,0 +1,20 @@
+# Condition: qa-engineer-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the qa-engineer agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The qa-engineer agent is invoked directly
+# via invoker.run_session(mode="agent", agent_name="qa-engineer") so that the
+# agent's own frontmatter is preserved intact.
+
+condition: qa-engineer-direct
+agent_name: qa-engineer
+description: >
+  QA-engineer-direct condition. Bare two-level Task spawn of the qa-engineer
+  agent against the task corpus. No AE rules payload; no stub skill. The delta
+  vs baseline measures the qa-engineer agent's isolated contribution.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []

--- a/evals/skill-comparison/specs/skeptic.yaml
+++ b/evals/skill-comparison/specs/skeptic.yaml
@@ -1,0 +1,23 @@
+# Condition: skeptic-direct
+#
+# Measurement: baseline vs bare two-level Task spawn of the skeptic agent.
+# n=3 replicates minimum.
+#
+# No AE rules payload is injected. The skeptic agent is invoked directly via
+# invoker.run_session(mode="agent", agent_name="skeptic") so that the agent's
+# own frontmatter is preserved intact. This condition is also the canary agent
+# (per architect-plan.md "Canary verification plan") - the canary transcript is
+# saved to evals/skill-comparison/canary/skeptic.jsonl.
+
+condition: skeptic-direct
+agent_name: skeptic
+description: >
+  Skeptic-direct condition. Bare two-level Task spawn of the skeptic agent
+  against the task corpus. No AE rules payload; no stub skill. The delta vs
+  baseline measures the skeptic agent's isolated contribution. This agent is
+  also used for the canary verification step.
+
+n_replicates: 3
+pair_with: baseline
+
+content_glob: []


### PR DESCRIPTION
## Summary

- Creates 7 condition spec YAMLs under `evals/skill-comparison/specs/`: `methodology.yaml`, `engineer.yaml`, `architect.yaml`, `investigator.yaml`, `debugger.yaml`, `skeptic.yaml`, `qa-engineer.yaml`.
- `methodology.yaml` uses condition label `ae-rules-injected` with n=5 replicates and lists EXACTLY 5 `content_glob` patterns in the canonical order from `ae_rules_payload.content_glob` (SKILL.md, sections/\*.md, rules/\*.md, references/\*.md, commands/\*.md).
- Per-agent specs use canonical `-direct` condition labels with n=3 replicates, `agent_name` matching `_AGENT_CONDITIONS` in `runner.py`, and empty `content_glob`.

## Verification

`discover_configs('evals/skill-comparison/specs')` returns 7 `ConditionConfig` objects in canonical order: `['ae-rules-injected', 'engineer-direct', 'architect-direct', 'investigator-direct', 'debugger-direct', 'skeptic-direct', 'qa-engineer-direct']`.

## Test plan

- [x] All 7 YAMLs parse cleanly via PyYAML
- [x] `config_discovery.discover_configs` returns 7 configs
- [x] Condition labels match canonical labels in `CANONICAL_CONDITIONS` and `_AGENT_CONDITIONS` exactly
- [x] `content_glob` order in `methodology.yaml` verified against `ae_rules_payload.content_glob`