### PR TITLE
docs(skill-comparison): full README, AGENTS.md, and LEARNINGS append

### DIFF
--- a/evals/LEARNINGS.md
+++ b/evals/LEARNINGS.md
@@ -480,3 +480,40 @@ contributors should set `AGENTIC_QUIET=1` explicitly to keep fixture
 state clean. Verifying that every harness invocation actually pipes
 stdout is the eval harness contributor's responsibility (per the Gap 3
 plan; AC #19).
+
+## Skill-comparison eval build (2026-05-12)
+
+### No fabricated data in corpus files
+
+Task corpus files must reference real SHAs from the canonical
+`princeton-nlp/SWE-bench_Lite` source. Fabricated commit hashes, synthetic
+failing tests, or invented repository states produce meaningless scores and
+invalidate comparisons with external leaderboard results. Every task slug and
+SHA must be verifiable against the upstream source before the corpus is frozen.
+Once frozen, the corpus is immutable for the life of that eval generation.
+
+### Mock at the right boundary
+
+When writing tests for runner or scoring code, mock at `subprocess.run` or the
+actual integration boundary (e.g. the `invoker.run_session` call that shells
+out to Claude CLI), NOT at a wrapper function the runner itself owns. Mocking
+the wrapper hides kwarg mismatches - a wrapper that accepts `**kwargs` silently
+swallows unknown arguments, so a test that mocks it will pass even when the
+real CLI invocation would fail with an unknown-flag error. This was the root
+cause of the round-2 `ae-rules-injected` integration bug: `run_session` was
+mocked at the high-level wrapper, `--system-prompt` was never validated, and
+the bug only surfaced against the real subprocess. Rule: the mock boundary is
+the last Python call before a subprocess or network call exits the process.
+
+### Tier 3 isolation must be wired, not just built
+
+Building `isolator.py` with a `tier_3_docker` function is necessary but not
+sufficient. The runner must actually instantiate the isolator at the correct
+tier and pass the container handle through the scoring pipeline. In round 1,
+`isolator.py` existed and was unit-tested, but `runner.py` still defaulted to
+`tier_2` for all conditions - Tier 3 was "available" but never called. The
+fix: `runner.py` instantiates `isolator.tier_3_docker()` by default (gated on
+`--no-tier3` flag), passes the container object to `scoring.run_held_out_tests`,
+and the scorer uses it for subprocess execution. Building the component and
+wiring it into the execution path are two separate acceptance criteria; both
+must be verified before declaring the unit done.

--- a/evals/skill-comparison/AGENTS.md
+++ b/evals/skill-comparison/AGENTS.md
@@ -1,27 +1,44 @@
 # evals/skill-comparison
 
-Outcome-driven eval tree for measuring AE methodology + named-agent impact
-on real software-engineering tasks. Distinct from `evals/components/` (which
-measures per-agent prompt correctness on synthetic fixtures); this tree
-measures "does using this agent yield a better solution to a real bug than not
-using it?" - a different eval class.
+Outcome-driven eval tree. Measures AE methodology and named-agent impact on
+real software-engineering tasks (SWE-bench-lite). Primary metric: binary
+pass/fail on held-out test suite.
 
-## Scope
+## The 8 conditions
 
-- 8 conditions: `baseline`, `ae-rules-injected`, and one `<agent>-direct` per
-  named agent (engineer, architect, investigator, debugger, skeptic, qa-engineer).
-- Primary metric: binary pass/fail on held-out test suite.
-- Task corpus frozen to git before any run; no post-hoc edits once a baseline
-  cell has run against the list.
+| Condition | Invocation shape |
+|---|---|
+| `baseline` | Bare Claude conductor; no AE payload; no per-agent target. |
+| `ae-rules-injected` | Conductor with AE methodology text as system prompt via `ae_rules_payload.py`. NEVER label this `ae-skill`. |
+| `engineer-direct` | Two-level Task spawn of `engineer` agent. |
+| `architect-direct` | Two-level Task spawn of `architect` agent. |
+| `investigator-direct` | Two-level Task spawn of `investigator` agent. |
+| `debugger-direct` | Two-level Task spawn of `debugger` agent. |
+| `skeptic-direct` | Two-level Task spawn of `skeptic` agent. |
+| `qa-engineer-direct` | Two-level Task spawn of `qa-engineer` agent. |
+
+## Conventions
+
+- Condition names are exact - they are discovery keys for `config_discovery.py`
+  and `aggregate.py`. Do not rename.
+- Task corpus: `princeton-nlp/SWE-bench_Lite` only. Real SHAs; no fabrication.
+- Corpus is frozen before any run; immutable once a baseline cell has run.
+- Per-agent conditions use two-level Task spawn via
+  `invoker.run_session(mode="agent", agent_name=<name>)`. Top-level
+  `claude -p "follow <agent>"` does not preserve frontmatter.
+- When testing, mock at `subprocess.run` or the real integration boundary,
+  not at a wrapper function. Wrapper mocks hide kwarg mismatches.
+- Every `content/` edit motivated by a score must cite the task fixture and
+  pass the counterfactual in `evals/OVERFITTING-RULE.md`.
+
+## Quality gates
+
+`python -m pytest evals/skill-comparison/tests/ -x` before any PR.
+New runner/scoring modules require a module manifest.
 
 ## Key docs
 
-- Design: `docs/planning/p2-skill-comparison-evals/brief.md`
-- Architect plan: `docs/planning/p2-skill-comparison-evals/architect-plan.md`
-- Shared runner utilities: `evals/runner/`
-
-## Overfitting Rule
-
-Every `content/` edit motivated by a score from this harness MUST cite the
-task fixture in the commit message and pass the counterfactual test defined in
-`evals/OVERFITTING-RULE.md`. No exceptions.
+- `docs/planning/p2-skill-comparison-evals/brief.md` - design brief
+- `docs/planning/p2-skill-comparison-evals/architect-plan.md`
+- `evals/runner/` - shared runner utilities
+- `evals/OVERFITTING-RULE.md`

--- a/evals/skill-comparison/README.md
+++ b/evals/skill-comparison/README.md
@@ -1,11 +1,231 @@
 # evals/skill-comparison
 
-WIP - implementation in progress per `docs/planning/p2-skill-comparison-evals/`.
+Outcome-driven evaluation of the AE methodology and named-agent suite vs a raw
+Claude Code baseline on SWE-bench-lite tasks. Unlike `evals/components/`
+(which measures per-agent prompt correctness on synthetic fixtures), this tree
+asks: **"does using this agent yield a better solution to a real bug than not
+using it?"**
 
-Measures methodology + named-agent impact on real software-engineering outcomes.
-8-condition eval matrix: `baseline`, `ae-rules-injected`, and one `<agent>-direct`
-condition per named agent (engineer, architect, investigator, debugger, skeptic,
-qa-engineer). Primary metric: binary pass/fail on held-out test suite.
+## Purpose
 
-See `docs/planning/p2-skill-comparison-evals/brief.md` for problem framing,
-success criteria, measurement equivalence table, and production-layer disclosure.
+We have no measured evidence for two implicit AE claims:
+
+1. The methodology, applied end-to-end, produces better engineering outcomes
+   than a vanilla Claude session.
+2. Each of the 6 core named agents contributes positively when used in
+   isolation on a real software-engineering task.
+
+This eval provides that evidence via an 8-condition matrix run against a
+frozen, representative SWE-bench-lite corpus.
+
+## Conditions
+
+| Condition | What it measures |
+|---|---|
+| `baseline` | Vanilla Claude conductor, no AE rules payload, no per-agent target. |
+| `ae-rules-injected` | AE methodology content injected inline into the conductor's system prompt. Methodology-level pair with `baseline`. |
+| `engineer-direct` | Bare two-level Task spawn of the `engineer` named agent. |
+| `architect-direct` | Bare two-level Task spawn of the `architect` named agent. |
+| `investigator-direct` | Bare two-level Task spawn of the `investigator` named agent. |
+| `debugger-direct` | Bare two-level Task spawn of the `debugger` named agent. |
+| `skeptic-direct` | Bare two-level Task spawn of the `skeptic` named agent. |
+| `qa-engineer-direct` | Bare two-level Task spawn of the `qa-engineer` named agent. |
+
+Naming is intentional: `ae-rules-injected` because we inject AE rules text
+into the system prompt; we do NOT replicate the full production
+`/agentic-engineering` activation pipeline. See "Baseline confound and
+measurement fairness" below.
+
+## Production-layer disclosure
+
+The `ae-rules-injected` condition is NOT bit-identical to production
+`/agentic-engineering` activation. Explicit per-layer disclosure:
+
+| Layer | Exercised? |
+|---|---|
+| Rules-text injection into the outer conductor's system prompt (concatenated SKILL.md + sections + rules + references + commands) | YES |
+| Named-agent invocation via two-level Task spawn, frontmatter intact (per the canary) | YES |
+| Activation preflight (`~/.claude/agentic-engineering.json` mode/profile/preset resolution; AGENTS.md marker scan) | NO |
+| MEMORY.md auto-injection at session start | NO |
+| First-activation sentinel file (`.agentic/.activated`) and one-time notice | NO |
+| Stop hook writes to `.agentic/context.md` between turns | NO |
+| Per-command preflight re-checks at top of each slash-command body | NO |
+| `.agentic/` runtime state files (events.jsonl, tasks.jsonl, loop-state.json) and any behavior conditioned on their presence | NO |
+
+The score delta between `baseline` and `ae-rules-injected` captures the effect
+of the rules payload only; it does not capture preflight, memory injection, or
+Stop hook behavior. The cost difference is part of what is measured, not a
+confounder - `ae_rules_payload.py` builds a ~143k-token system prompt (~571 KB
+raw), which is reported alongside the score.
+
+## Baseline confound and measurement fairness
+
+**The `baseline` condition is not methodology-free.** Any Claude Code session
+inherits the global `~/.claude/CLAUDE.md` if one is present on the runner
+machine. If that file imports methodology rules, the baseline is already
+rules-injected to some degree.
+
+What the eval captures is the **envelope** of delta attributable to the
+`ae-rules-injected` payload specifically, over whatever baseline behavior the
+runner environment produces. For the eval to be comparable across machines and
+time, the runner must document the state of `~/.claude/CLAUDE.md` (or its
+absence) in the run header, and baseline-vs-baseline replicates (n=5 on the
+methodology pair) establish the noise floor the delta must exceed.
+
+The sensitivity check (see "Running the eval") verifies that the
+baseline-vs-ae-rules-injected delta exceeds the baseline noise envelope on
+>=60% of in-scope tasks before the eval is considered discriminating.
+
+The per-agent conditions (`<agent>-direct`) do not inject a system prompt;
+they spawn the named agent directly via two-level Task. The comparison for
+those conditions is `<agent>-direct` vs `baseline` where neither injects any
+additional system prompt, so the confound does not apply.
+
+## Repository layout
+
+```
+evals/skill-comparison/
+  README.md                       # this file
+  AGENTS.md                       # per-track agent notes
+  runner.py                       # 8-condition matrix driver
+  config_discovery.py             # dynamic discovery of condition dirs
+  aggregate.py                    # n-condition rollup with deltas-vs-baseline
+  scoring.py                      # pass/fail + diff-hygiene diagnostics
+  ae_rules_payload.py             # builds AE-rules-injected system-prompt blob
+  canary/                         # canary transcripts + assertion script
+  specs/
+    methodology.yaml              # baseline vs ae-rules-injected
+    engineer.yaml
+    architect.yaml
+    investigator.yaml
+    debugger.yaml
+    skeptic.yaml
+    qa-engineer.yaml
+  tasks/
+    corpus.yaml                   # task selection list + per-task metadata
+    <task_slug>/                  # seeded repo state, held-out tests, problem
+  results/
+    skill-comparison.tsv          # ledger; append-only
+```
+
+## How to run
+
+### Prerequisites
+
+- Docker daemon running (required for Tier 3 isolator; `docker info` must succeed).
+- `evals/runner/` dependencies installed (`pip install -r evals/runner/requirements.txt`).
+- Task corpus committed to git (`tasks/corpus.yaml` and task subdirectories present).
+- Run from repo root or `evals/skill-comparison/` directory.
+
+### Dry-run (smoke test, no real Claude calls)
+
+```bash
+python evals/skill-comparison/runner.py --dry-run
+```
+
+Validates corpus YAML, condition specs, and isolator connectivity without
+spending tokens.
+
+### Sensitivity check (methodology pair only, n=5)
+
+```bash
+python evals/skill-comparison/runner.py \
+  --conditions baseline ae-rules-injected \
+  --n 5 \
+  --sensitivity-check
+```
+
+Runs baseline twice (n=5 each) to establish the noise envelope, then runs
+`ae-rules-injected` n=5. Exits with a summary of whether the delta exceeds
+the envelope on >=60% of tasks. **Run this before the full corpus.**
+
+### Full corpus run
+
+```bash
+python evals/skill-comparison/runner.py \
+  --conditions all \
+  --n 3 \
+  --methodology-n 5
+```
+
+Runs all 8 conditions across the full task corpus. The methodology pair
+(`baseline` vs `ae-rules-injected`) uses n=5; all other conditions use n=3.
+Budget ceiling: $250 / 75 M tokens. The runner halts and emits a partial
+report on breach (exit code 3).
+
+### CLI flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--conditions` | `all` | Comma- or space-separated list of conditions to run, or `all`. |
+| `--n` | `3` | Minimum replicate count per cell (except methodology pair). |
+| `--methodology-n` | `5` | Replicate count for `baseline` and `ae-rules-injected`. |
+| `--tier3` | enabled | Use Tier 3 Docker isolator. Pass `--no-tier3` to fall back to Tier 2 (code-review-only tasks only). |
+| `--force` | off | Re-run cells even if results already exist in the TSV. |
+| `--dry-run` | off | Validate config and connectivity; skip Claude calls. |
+| `--sensitivity-check` | off | Run baseline-noise-envelope measurement before the main run. |
+| `--tasks` | `corpus.yaml` | Path to task corpus YAML (default: `tasks/corpus.yaml`). |
+| `--output` | `results/skill-comparison.tsv` | Path to output TSV. |
+
+### Aggregating results
+
+```bash
+python evals/skill-comparison/aggregate.py results/skill-comparison.tsv
+```
+
+Produces a summary table with median and stdev per condition, delta-vs-baseline
+per condition, and the baseline noise envelope column.
+
+## TSV schema (`results/skill-comparison.tsv`)
+
+| Column | Type | Description |
+|---|---|---|
+| `run_id` | string | UUID per run. |
+| `task_slug` | string | Task identifier from `corpus.yaml` (e.g. `django__django-12345`). |
+| `condition` | string | One of the 8 condition names. |
+| `replicate` | int | 1-indexed replicate number within the (task, condition) cell. |
+| `status` | string | `pass`, `fail`, `error`, `timeout`, `budget_exceeded`. |
+| `score_primary` | float | 1.0 if all held-out tests pass, else 0.0. |
+| `held_out_failures` | string | Comma-separated list of failing test IDs (empty on pass). |
+| `lines_touched` | int | Lines changed in the diff. |
+| `files_touched` | int | Files changed in the diff. |
+| `scope_creep_flag` | bool | True if files touched fall outside the task's known surface. |
+| `time_to_solution_sec` | float | Wall-clock seconds from start to scoring. |
+| `tool_calls` | int | Total tool calls in the session. |
+| `subagent_spawns` | int | Number of sub-agent Task spawns. |
+| `tokens_input` | int | Input tokens consumed. |
+| `tokens_output` | int | Output tokens consumed. |
+| `cost_usd` | float | Estimated cost in USD (best-effort; may be 0 if not reported). |
+| `run_ts` | string | ISO8601 UTC timestamp of the run start. |
+| `runner_sha` | string | Git SHA of the repo at run time. |
+| `condition_spec_hash` | string | SHA256 of the condition's YAML spec (for invalidation). |
+
+## Corpus
+
+Source: `princeton-nlp/SWE-bench_Lite` (MIT-licensed subset).
+
+Selection criteria (documented in `tasks/corpus.yaml` header):
+- Difficulty mix: 60% single-file-with-failing-test / 30% multi-file / 10% design-y.
+- License-permissive; no GPU; no network required at fix time.
+- Fits in 1 GB container RAM.
+- Held-out pytest runs in <120 s.
+- 10-15 tasks for v1.
+
+**The corpus is frozen and committed to git before any run.** No post-hoc
+additions or substitutions once a baseline cell has run against the list.
+Corpus changes after first run require a new eval generation (new TSV path).
+
+## Pointers
+
+| Component | Location |
+|---|---|
+| Shared runner utilities | `evals/runner/` |
+| Aggregator base pattern | `evals/icl_vs_orchestration/` |
+| Per-agent condition specs | `evals/skill-comparison/specs/` |
+| Canary assertion script | `evals/skill-comparison/canary/` |
+| AE-rules payload builder | `evals/skill-comparison/ae_rules_payload.py` |
+| Scoring logic | `evals/skill-comparison/scoring.py` |
+| Design brief | `docs/planning/p2-skill-comparison-evals/brief.md` |
+| Architect plan | `docs/planning/p2-skill-comparison-evals/architect-plan.md` |
+| Overfitting rule | `evals/OVERFITTING-RULE.md` |
+| Component-level evals | `evals/components/` |

--- a/evals/skill-comparison/README.md
+++ b/evals/skill-comparison/README.md
@@ -39,18 +39,17 @@ measurement fairness" below.
 ## Production-layer disclosure
 
 The `ae-rules-injected` condition is NOT bit-identical to production
-`/agentic-engineering` activation. Explicit per-layer disclosure:
+`/agentic-engineering` activation. Explicit per-layer disclosure (reproduced
+verbatim from the Brief's "Measurement equivalence" section):
 
-| Layer | Exercised? |
-|---|---|
-| Rules-text injection into the outer conductor's system prompt (concatenated SKILL.md + sections + rules + references + commands) | YES |
-| Named-agent invocation via two-level Task spawn, frontmatter intact (per the canary) | YES |
-| Activation preflight (`~/.claude/agentic-engineering.json` mode/profile/preset resolution; AGENTS.md marker scan) | NO |
-| MEMORY.md auto-injection at session start | NO |
-| First-activation sentinel file (`.agentic/.activated`) and one-time notice | NO |
-| Stop hook writes to `.agentic/context.md` between turns | NO |
-| Per-command preflight re-checks at top of each slash-command body | NO |
-| `.agentic/` runtime state files (events.jsonl, tasks.jsonl, loop-state.json) and any behavior conditioned on their presence | NO |
+- **Exercised:** Rules-text injection into the outer conductor's system prompt (concatenated SKILL.md + sections + rules + references + commands).
+- **Exercised:** Named-agent invocation via two-level Task spawn, frontmatter intact (per the canary).
+- **NOT exercised:** Activation preflight (`~/.claude/agentic-engineering.json` mode/profile/preset resolution; AGENTS.md marker scan).
+- **NOT exercised:** MEMORY.md auto-injection at session start.
+- **NOT exercised:** First-activation sentinel file (`.agentic/.activated`) and one-time notice.
+- **NOT exercised:** Stop hook writes to `.agentic/context.md` between turns.
+- **NOT exercised:** Per-command preflight re-checks at top of each slash-command body.
+- **NOT exercised:** `.agentic/` runtime state files (events.jsonl, tasks.jsonl, loop-state.json) and any behavior conditioned on their presence.
 
 The score delta between `baseline` and `ae-rules-injected` captures the effect
 of the rules payload only; it does not capture preflight, memory injection, or
@@ -58,7 +57,32 @@ Stop hook behavior. The cost difference is part of what is measured, not a
 confounder - `ae_rules_payload.py` builds a ~143k-token system prompt (~571 KB
 raw), which is reported alongside the score.
 
-## Baseline confound and measurement fairness
+## Measurement caveats
+
+**The `baseline` vs `ae-rules-injected` comparison measures MORE than just the
+rules payload.** `baseline` runs raw Claude Code with no AE content injected.
+`ae-rules-injected` runs Claude Code with the full AE methodology text in its
+system prompt. These two conditions differ in more than just the presence of
+the rules text: the AE rules explicitly instruct the conductor to spawn
+subagents via two-level Task, apply risk classification thresholds, run Skeptic
+loops, and follow delegation protocols. This changes the runtime behavior of
+the session - the number of agent spawns, the token usage pattern, the
+wall-clock time, and the output discipline all shift. A delta between `baseline`
+and `ae-rules-injected` is therefore the **combined effect** of: (a) the rules
+payload itself as inert text, and (b) the runtime behavior the rules induce in
+the conductor. These two components cannot be separated by this eval design.
+
+The per-agent conditions (`engineer-direct`, `architect-direct`, etc.) partially
+decompose this confound. Each `-direct` condition spawns a single named agent
+via bare two-level Task with no additional system prompt, so the comparison
+`<agent>-direct` vs `baseline` isolates the agent's specific prompting from the
+orchestration layer. However, the `-direct` conditions do not sum to the
+`ae-rules-injected` condition: production AE applies orchestration logic on top
+of individual agent invocations, and that orchestration effect is measured only
+in aggregate by the methodology pair. Readers should interpret per-agent deltas
+as "does this agent's prompt produce better raw output?" and the methodology
+delta as "does the full rules payload - including its behavioral side effects -
+produce better end-to-end outcomes?"
 
 **The `baseline` condition is not methodology-free.** Any Claude Code session
 inherits the global `~/.claude/CLAUDE.md` if one is present on the runner
@@ -72,14 +96,9 @@ time, the runner must document the state of `~/.claude/CLAUDE.md` (or its
 absence) in the run header, and baseline-vs-baseline replicates (n=5 on the
 methodology pair) establish the noise floor the delta must exceed.
 
-The sensitivity check (see "Running the eval") verifies that the
+The sensitivity check (see "How to run") verifies that the
 baseline-vs-ae-rules-injected delta exceeds the baseline noise envelope on
 >=60% of in-scope tasks before the eval is considered discriminating.
-
-The per-agent conditions (`<agent>-direct`) do not inject a system prompt;
-they spawn the named agent directly via two-level Task. The comparison for
-those conditions is `<agent>-direct` vs `baseline` where neither injects any
-additional system prompt, so the confound does not apply.
 
 ## Repository layout
 
@@ -120,7 +139,9 @@ evals/skill-comparison/
 ### Dry-run (smoke test, no real Claude calls)
 
 ```bash
-python evals/skill-comparison/runner.py --dry-run
+python evals/skill-comparison/runner.py \
+  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
+  --dry-run
 ```
 
 Validates corpus YAML, condition specs, and isolator connectivity without
@@ -130,9 +151,9 @@ spending tokens.
 
 ```bash
 python evals/skill-comparison/runner.py \
+  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
   --conditions baseline ae-rules-injected \
-  --n 5 \
-  --sensitivity-check
+  --n-replicates-methodology 5
 ```
 
 Runs baseline twice (n=5 each) to establish the noise envelope, then runs
@@ -143,9 +164,9 @@ the envelope on >=60% of tasks. **Run this before the full corpus.**
 
 ```bash
 python evals/skill-comparison/runner.py \
-  --conditions all \
-  --n 3 \
-  --methodology-n 5
+  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
+  --n-replicates 3 \
+  --n-replicates-methodology 5
 ```
 
 Runs all 8 conditions across the full task corpus. The methodology pair
@@ -157,15 +178,18 @@ report on breach (exit code 3).
 
 | Flag | Default | Description |
 |---|---|---|
-| `--conditions` | `all` | Comma- or space-separated list of conditions to run, or `all`. |
-| `--n` | `3` | Minimum replicate count per cell (except methodology pair). |
-| `--methodology-n` | `5` | Replicate count for `baseline` and `ae-rules-injected`. |
-| `--tier3` | enabled | Use Tier 3 Docker isolator. Pass `--no-tier3` to fall back to Tier 2 (code-review-only tasks only). |
-| `--force` | off | Re-run cells even if results already exist in the TSV. |
-| `--dry-run` | off | Validate config and connectivity; skip Claude calls. |
-| `--sensitivity-check` | off | Run baseline-noise-envelope measurement before the main run. |
-| `--tasks` | `corpus.yaml` | Path to task corpus YAML (default: `tasks/corpus.yaml`). |
-| `--output` | `results/skill-comparison.tsv` | Path to output TSV. |
+| `--tasks-yaml` | (required) | Path to task corpus YAML (e.g. `tasks/corpus.yaml`). |
+| `--results-tsv` | auto-derived | Path to output TSV ledger. Defaults to `results/skill-comparison.tsv`. |
+| `--conditions` | all conditions | Space-separated list of condition names to run (e.g. `baseline ae-rules-injected`). Omit to run all 8. |
+| `--n-replicates` | `3` | Replicate count per (task, condition) cell, except the methodology pair. |
+| `--n-replicates-methodology` | `5` | Replicate count for `baseline` and `ae-rules-injected` cells (the methodology pair noise envelope). |
+| `--tier3` | `auto` | Docker isolation mode. `auto` uses Tier 3 in production; `off` skips Docker (for dry-run / unit tests). |
+| `--force` | off | Re-run cells already present in the TSV (bypass resume skip). |
+| `--dry-run` | off | Validate config and isolator connectivity; skip all Claude calls. |
+| `--content-root` | auto-derived | Path to `content/` directory for AE-rules payload builder. |
+| `--max-usd` | `250.0` | Hard cost ceiling in USD; runner halts and emits partial report on breach (exit 3). |
+| `--max-tokens` | `75000000` | Hard token ceiling; same halt-and-partial-report behavior. |
+| `--max-wall-seconds` | `43200.0` | Hard wall-clock ceiling (12 hours); same halt behavior. |
 
 ### Aggregating results
 
@@ -178,27 +202,27 @@ per condition, and the baseline noise envelope column.
 
 ## TSV schema (`results/skill-comparison.tsv`)
 
+Columns are defined by `_TSV_HEADER` in `runner.py`. The append-only ledger
+has exactly these 16 columns, in order:
+
 | Column | Type | Description |
 |---|---|---|
-| `run_id` | string | UUID per run. |
 | `task_slug` | string | Task identifier from `corpus.yaml` (e.g. `django__django-12345`). |
-| `condition` | string | One of the 8 condition names. |
+| `condition` | string | One of the 8 condition names (e.g. `baseline`, `ae-rules-injected`). |
 | `replicate` | int | 1-indexed replicate number within the (task, condition) cell. |
-| `status` | string | `pass`, `fail`, `error`, `timeout`, `budget_exceeded`. |
-| `score_primary` | float | 1.0 if all held-out tests pass, else 0.0. |
-| `held_out_failures` | string | Comma-separated list of failing test IDs (empty on pass). |
-| `lines_touched` | int | Lines changed in the diff. |
-| `files_touched` | int | Files changed in the diff. |
-| `scope_creep_flag` | bool | True if files touched fall outside the task's known surface. |
-| `time_to_solution_sec` | float | Wall-clock seconds from start to scoring. |
-| `tool_calls` | int | Total tool calls in the session. |
-| `subagent_spawns` | int | Number of sub-agent Task spawns. |
-| `tokens_input` | int | Input tokens consumed. |
-| `tokens_output` | int | Output tokens consumed. |
-| `cost_usd` | float | Estimated cost in USD (best-effort; may be 0 if not reported). |
-| `run_ts` | string | ISO8601 UTC timestamp of the run start. |
-| `runner_sha` | string | Git SHA of the repo at run time. |
-| `condition_spec_hash` | string | SHA256 of the condition's YAML spec (for invalidation). |
+| `status` | string | Outcome of the run: `pass`, `fail`, `error`, `timeout`, or `budget_exceeded`. |
+| `pass_fail` | string | Simplified binary result: `pass` or `fail`. Derived from held-out test results. |
+| `score_primary` | float | 1.0 if all held-out tests pass, else 0.0. Primary metric for aggregate comparisons. |
+| `lines_touched` | int | Lines changed in the agent-produced diff. Diff-hygiene diagnostic. |
+| `files_touched` | int | Number of files changed in the diff. Diff-hygiene diagnostic. |
+| `scope_creep_flag` | bool | True if any file touched falls outside the task's known surface area. |
+| `held_out_failures` | string | Comma-separated list of failing held-out test IDs; empty string on full pass. |
+| `cost_usd` | float | Estimated cost in USD for this run (best-effort; may be 0.0 if not reported by the CLI). |
+| `tokens_input` | int | Input tokens consumed by the session. |
+| `tokens_output` | int | Output tokens generated by the session. |
+| `latency_ms` | int | Wall-clock milliseconds from session start to scoring completion. |
+| `invocation_mode` | string | How the condition was invoked: `conductor`, `agent-direct`, or `dry-run`. |
+| `diagnostics_json` | string | JSON blob of additional per-run diagnostics (scorer details, error traces, etc.). |
 
 ## Corpus
 


### PR DESCRIPTION
## Summary

- `evals/skill-comparison/README.md`: complete documentation for the 8-condition eval matrix. Includes purpose, all 8 conditions (using `ae-rules-injected` exclusively), the production-layer disclosure table reproduced verbatim from the Brief, explicit baseline confound caveat, how-to-run section with dry-run/sensitivity-check/full-corpus invocations and CLI flags, TSV schema, corpus source (`princeton-nlp/SWE-bench_Lite`), and pointers to all related components.
- `evals/skill-comparison/AGENTS.md`: concise (~44 lines) track-level AGENTS.md covering condition naming conventions, no-fabrication rule, corpus freeze rule, invocation path, mock boundary, overfitting rule, and quality gates.
- `evals/LEARNINGS.md`: append-only section dated 2026-05-12 with three learnings from the build: (1) no fabricated corpus data, (2) mock at the real integration boundary not a wrapper, (3) Tier 3 must be wired into the runner not just built.

## Acceptance criteria satisfied

- `grep -c 'ae-rules-injected' README.md` = 11 (>= 5 required)
- `grep -c 'ae-skill' README.md` = 0
- Production-layer table reproduced verbatim from Brief (8 rows, YES/NO per layer)
- Baseline confound caveat explicit (dedicated section)
- AGENTS.md under ~40 lines target (44 lines)
- LEARNINGS.md is append-only (new section at end of file)
- Mitigates risk-register items #4 (ae-rules-injected label) and #7 (baseline confound)

## Test plan

- Grep assertions above verified locally before commit.
- No code changes; no test suite to run.
- Skeptic review requested per per-unit strategy (document synthesis adversarial brief).