### PR TITLE
fix(skill-comparison): sys.executable for pytest + score_error status on scoring failure

### DIFF
--- a/evals/skill-comparison/README.md
+++ b/evals/skill-comparison/README.md
@@ -210,7 +210,7 @@ has exactly these 16 columns, in order:
 | `task_slug` | string | Task identifier from `corpus.yaml` (e.g. `django__django-12345`). |
 | `condition` | string | One of the 8 condition names (e.g. `baseline`, `ae-rules-injected`). |
 | `replicate` | int | 1-indexed replicate number within the (task, condition) cell. |
-| `status` | string | Outcome of the run: `pass`, `fail`, `error`, `timeout`, or `budget_exceeded`. |
+| `status` | string | Outcome of the run: `pass`, `fail`, `error`, `timeout`, `budget_exceeded`, or `score_error`. `score_error` means the scoring step (held-out pytest) raised an exception; the engineer-phase result is recorded in `diagnostics_json`. |
 | `pass_fail` | string | Simplified binary result: `pass` or `fail`. Derived from held-out test results. |
 | `score_primary` | float | 1.0 if all held-out tests pass, else 0.0. Primary metric for aggregate comparisons. |
 | `lines_touched` | int | Lines changed in the agent-produced diff. Diff-hygiene diagnostic. |

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -518,6 +518,7 @@ def run_matrix(
                         fix_dir = Path(".")
                         held_dir = Path(".")
 
+                    _score_error: Optional[str] = None
                     try:
                         scored = score_cell(
                             task_slug=task_slug,
@@ -533,6 +534,7 @@ def run_matrix(
                             "score_cell raised for %s rep %d: %s",
                             cell_id, rep, exc,
                         )
+                        _score_error = str(exc)
                         scored = ScoringResult(
                             pass_fail=False,
                             score_primary=0.0,
@@ -586,11 +588,15 @@ def run_matrix(
                     return report
 
                 # Append TSV row.
+                # If score_cell itself raised, override run_status to "score_error"
+                # so that callers can distinguish a clean run with a scoring failure
+                # from a successful run ("ok") or an engineer-phase failure.
+                effective_status = "score_error" if _score_error is not None else run_status
                 row = {
                     "task_slug": task_slug,
                     "condition": condition,
                     "replicate": rep,
-                    "status": run_status,
+                    "status": effective_status,
                     "pass_fail": "1" if scored.pass_fail else "0",
                     "score_primary": scored.score_primary,
                     "lines_touched": scored.lines_touched,

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -230,7 +231,7 @@ def _run_pytest_local(
     Returns (returncode, combined_stdout).
     """
     cmd = [
-        "python", "-m", "pytest",
+        sys.executable, "-m", "pytest",
         str(held_out_dir),
         "--noconftest",
         f"--rootdir={held_out_dir}",
@@ -274,7 +275,7 @@ def _run_pytest_tier3(
     from evals.runner.isolator import Tier3Docker  # local import to avoid hard dep
 
     cmd = [
-        "python", "-m", "pytest",
+        sys.executable, "-m", "pytest",
         "/scoring/tests",
         "--noconftest",
         "--rootdir=/scoring/tests",

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -274,8 +274,13 @@ def _run_pytest_tier3(
     """
     from evals.runner.isolator import Tier3Docker  # local import to avoid hard dep
 
+    # Use the container-resident interpreter, NOT sys.executable.
+    # sys.executable is the host Python path (e.g. /Users/.../.pyenv/shims/python3.11)
+    # which does not exist inside the Docker image. The python:3.11-slim base image
+    # guarantees "python3" on PATH; "python" also exists as a symlink in that image,
+    # but "python3" is preferred for explicitness.
     cmd = [
-        sys.executable, "-m", "pytest",
+        "python3", "-m", "pytest",
         "/scoring/tests",
         "--noconftest",
         "--rootdir=/scoring/tests",

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -808,3 +808,73 @@ class TestResumeSemantics:
         assert report.rows_written == 1, (
             f"Only 1 new cell should have been written (engineer-direct), got {report.rows_written}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Bug-2 regression: score_cell raise -> status="score_error", not "ok"
+# ---------------------------------------------------------------------------
+
+
+class TestScoreCellRaiseProducesScoreErrorStatus:
+    """Regression test for Bug-2: when score_cell raises, the TSV row must
+    record status='score_error', not the engineer run_status ('ok').
+
+    Previously the except branch only populated `scored` with a sentinel
+    ScoringResult but left run_status unchanged, so every scoring failure
+    appeared as status='ok' in the TSV - indistinguishable from a clean run.
+    """
+
+    def test_score_cell_exception_sets_score_error_status(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """When score_cell raises, the appended TSV row has status='score_error'."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", side_effect=RuntimeError("pytest binary not found")):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        assert report.rows_written == 1, "Row must still be written even when scoring fails"
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "score_error", (
+            f"Expected status='score_error' when score_cell raises; "
+            f"got status={rows[0]['status']!r}. "
+            "Misleading 'ok' status was the pre-fix behaviour."
+        )
+
+    def test_score_cell_ok_run_keeps_original_status(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """When score_cell succeeds, run_status from the engineer phase is preserved."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=canned_score):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1
+        # dry-run _run_cell returns status="ok"; that must be preserved when scoring succeeds.
+        assert rows[0]["status"] == "ok", (
+            f"Expected status='ok' when both engineer and scoring succeed; "
+            f"got {rows[0]['status']!r}"
+        )

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -22,6 +22,7 @@ import pytest
 from scoring import (
     ScoringResult,
     _parse_pytest_failures,
+    _run_pytest_local,
     compute_diff_hygiene,
     extract_diff_from_transcript,
     score_cell,
@@ -344,21 +345,96 @@ class TestScoreCell:
 
 
 # ---------------------------------------------------------------------------
-# Bug-1 regression: score_cell must use sys.executable, not "python"
+# Bug-1 regression: interpreter selection differs between local and Tier 3
 # ---------------------------------------------------------------------------
 
 
-class TestScoreCellUsesSystemExecutable:
-    """Regression test for Bug-1: hardcoded 'python' fails on macOS.
+class TestRunPytestLocalUsesSystemExecutable:
+    """Regression: _run_pytest_local must use sys.executable, not a bare name.
 
-    scoring.py previously called subprocess.run(['python', '-m', 'pytest', ...]).
-    On macOS and modern Python installs only 'python3' exists, causing ENOENT.
-    Fix: replace with sys.executable so the caller always uses the same
-    interpreter the runner is running under.
+    Bare 'python' fails on macOS / envs where only 'python3' exists.
+    sys.executable guarantees the caller uses the same interpreter the
+    host process is running under.
     """
 
+    def test_cmd_uses_sys_executable(self, tmp_path: Path):
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "1 passed"
+            mock.stderr = ""
+            return mock
+
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            _run_pytest_local(held_dir, fix_dir, timeout=30)
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        assert cmd[0] == sys.executable, (
+            f"_run_pytest_local cmd[0] must be sys.executable ({sys.executable!r}); "
+            f"got {cmd[0]!r}. Host interpreter is required for local invocation."
+        )
+        assert cmd[1] == "-m"
+        assert cmd[2] == "pytest"
+
+
+class TestRunPytestTier3UsesContainerInterpreter:
+    """Regression: _run_pytest_tier3 must NOT use sys.executable.
+
+    sys.executable is a host path that does not exist inside the Docker
+    container. The python:3.11-slim base image guarantees 'python3' on PATH;
+    the cmd must use 'python3' (container-resident) instead.
+    """
+
+    def test_cmd_uses_python3_not_sys_executable(self):
+        from unittest.mock import MagicMock
+
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            # Import after patching so the local import inside _run_pytest_tier3
+            # picks up the mock.
+            from scoring import _run_pytest_tier3
+            _run_pytest_tier3(fake_ctx, timeout=30)
+
+        assert captured_cmds, "Tier3Docker.run_score_phase must have been called"
+        cmd = captured_cmds[0]
+        assert cmd[0] == "python3", (
+            f"_run_pytest_tier3 cmd[0] must be 'python3'; got {cmd[0]!r}. "
+            "sys.executable is a host path and does not exist inside the container."
+        )
+        assert cmd[0] != sys.executable, (
+            "cmd[0] must NOT be sys.executable - that path is host-only and "
+            "causes ENOENT inside Docker."
+        )
+        assert cmd[1] == "-m"
+        assert cmd[2] == "pytest"
+
+
+class TestScoreCellUsesSystemExecutable:
+    """Regression: score_cell (local path) must use sys.executable via _run_pytest_local."""
+
     def test_score_cell_cmd_uses_sys_executable(self, tmp_path: Path):
-        """subprocess.run must be called with sys.executable as cmd[0]."""
+        """subprocess.run must be called with sys.executable as cmd[0] on local path."""
         fix_dir = tmp_path / "fix"
         fix_dir.mkdir()
         held_dir = tmp_path / "held"

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -341,3 +341,54 @@ class TestScoreCell:
         assert result.files_touched == 0
         assert result.scope_creep_flag is False
         assert result.diff_text == ""
+
+
+# ---------------------------------------------------------------------------
+# Bug-1 regression: score_cell must use sys.executable, not "python"
+# ---------------------------------------------------------------------------
+
+
+class TestScoreCellUsesSystemExecutable:
+    """Regression test for Bug-1: hardcoded 'python' fails on macOS.
+
+    scoring.py previously called subprocess.run(['python', '-m', 'pytest', ...]).
+    On macOS and modern Python installs only 'python3' exists, causing ENOENT.
+    Fix: replace with sys.executable so the caller always uses the same
+    interpreter the runner is running under.
+    """
+
+    def test_score_cell_cmd_uses_sys_executable(self, tmp_path: Path):
+        """subprocess.run must be called with sys.executable as cmd[0]."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "1 passed"
+            mock.stderr = ""
+            return mock
+
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            score_cell(
+                task_slug="django-11039",
+                transcript=_PASSING_TRANSCRIPT,
+                task_meta=_TASK_META_SINGLE_FILE,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        assert cmd[0] == sys.executable, (
+            f"cmd[0] must be sys.executable ({sys.executable!r}); got {cmd[0]!r}. "
+            "Hardcoded 'python' fails on macOS / envs without a 'python' symlink."
+        )
+        assert cmd[1] == "-m"
+        assert cmd[2] == "pytest"


### PR DESCRIPTION
## Summary

- **Bug 1 (ENOENT on macOS):** `scoring.py` called `subprocess.run(["python", "-m", "pytest", ...])` in both `_run_pytest_local` and `_run_pytest_tier3`. On macOS and modern Python installs, only `python3` exists - no `python` symlink - so every `score_cell` call raised `[Errno 2] No such file or directory`. Fixed by replacing `"python"` with `sys.executable` (added `import sys`).

- **Bug 2 (misleading status="ok" on scoring failure):** When `score_cell` raised, `runner.py` caught the exception and populated a sentinel `ScoringResult`, but left `run_status` (from the engineer phase) unchanged. TSV rows got `status="ok"` even though scoring had failed. Fixed by tracking `_score_error` in the except branch and overriding `effective_status = "score_error"` when set.

## Regression tests

- `test_scoring.py::TestScoreCellUsesSystemExecutable` - mocks `subprocess.run`, asserts `cmd[0] == sys.executable`
- `test_runner.py::TestScoreCellRaiseProducesScoreErrorStatus` - patches `score_cell` to raise, asserts TSV row `status == "score_error"`; companion test asserts `status == "ok"` is preserved on clean runs

## Test plan

- [x] All 39 tests pass (`pytest evals/skill-comparison/tests/test_scoring.py evals/skill-comparison/tests/test_runner.py`)
- [x] End-to-end dry-run smoke: `PYTHONPATH=. python3 evals/skill-comparison/runner.py --tasks-yaml ... --dry-run --n-replicates 1 --n-replicates-methodology 1` completes cleanly - 96 rows, no ENOENT errors