### PR TITLE
fix(tier3): build Docker image once per run_matrix, not once per cell

### DIFF
--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -6,6 +6,18 @@ Purpose: Provide component-tier isolation for eval runs. Tier 1 = git worktree
          for code-executing components (Worker, Debugger, QA-engineer,
          SWE-bench-style fix tasks).
 
+         NOTE on Tier 3 build-once-reuse contract:
+           Tier3Docker.ensure_image(image_tag, dockerfile, context_dir) builds
+           the image ONCE and caches the resolved digest in a module-level dict
+           keyed by image_tag. Subsequent Tier3Docker.__init__ calls with the
+           same image_tag check the cache first: if a digest is already cached,
+           build_image is forced to False automatically, skipping the build.
+           Callers in run_matrix should call ensure_image ONCE before the cell
+           loop and pass build_image=False to each per-cell Tier3Docker(...)
+           instantiation. The module-level cache (_IMAGE_DIGEST_CACHE) is
+           process-scoped and intentionally not thread-safe (the eval runner is
+           single-threaded).
+
          NOTE on Tier 2 auth preservation: Tier 2 redirects $HOME to a fresh
          tmpdir to keep the developer's real ~/.claude/ uncontaminated. The
          Claude CLI, however, resolves auth relative to $HOME (macOS keychain
@@ -68,6 +80,8 @@ Public API: make_isolator(tier: int, **kwargs) -> Isolator,
             Tier1Worktree (context manager yielding a worktree Path),
             Tier2HomeRedirect (context manager yielding (worktree, fake_home)),
             Tier3Docker (context manager yielding a Tier3Context namedtuple),
+            Tier3Docker.ensure_image(image_tag, dockerfile, context_dir) -> str
+              (class method; build-once, returns cached digest on repeat calls),
             IsolatorBase abstract contract.
 
 Upstream deps: stdlib subprocess, pathlib, tempfile, shutil, uuid, os, sys,
@@ -113,6 +127,14 @@ _log = get_logger("evals.isolator")
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _WORKTREE_BASE = _REPO_ROOT / "evals" / ".worktrees"
+
+# ---------------------------------------------------------------------------
+# Tier 3 image digest cache (build-once-reuse contract)
+# ---------------------------------------------------------------------------
+# Maps image_tag -> resolved sha256 digest string.
+# Populated by Tier3Docker.ensure_image() and checked in Tier3Docker.__init__.
+# Process-scoped; not thread-safe (eval runner is single-threaded).
+_IMAGE_DIGEST_CACHE: dict[str, str] = {}
 
 
 class IsolatorBase(ABC):
@@ -407,8 +429,14 @@ class Tier3Docker(IsolatorBase):
     ) -> None:
         self.fixture_repo_dir = fixture_repo_dir
         self._held_out_dir = held_out_dir
-        self.build_image = build_image
         self.timeout_seconds = timeout_seconds
+
+        # Build-once-reuse: if the image digest is already cached for this tag,
+        # skip the build regardless of the caller-supplied build_image flag.
+        if _DOCKER_IMAGE_TAG in _IMAGE_DIGEST_CACHE:
+            self.build_image = False
+        else:
+            self.build_image = build_image
 
         self._fix_phase_dir: Path | None = None
         self._owned_held_out_dir: Path | None = None  # only set if we created it
@@ -420,9 +448,14 @@ class Tier3Docker(IsolatorBase):
 
     def __enter__(self) -> Tier3Context:
         # 1. Optionally build the image, then resolve the content digest.
-        if self.build_image:
-            self._build_image()
-        image_digest = self._resolve_image_digest()
+        #    Cache hit: skip both build and inspect subprocess (reuse cached digest).
+        if _DOCKER_IMAGE_TAG in _IMAGE_DIGEST_CACHE:
+            image_digest = _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG]
+        else:
+            if self.build_image:
+                self._build_image()
+            image_digest = self._resolve_image_digest()
+            _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = image_digest
 
         # 2. Prepare fix-phase dir (rw copy of the fixture repo).
         fix_phase_dir = Path(tempfile.mkdtemp(prefix="t3-fix-"))
@@ -540,6 +573,77 @@ class Tier3Docker(IsolatorBase):
             )
         digest = result.stdout.strip()
         _log.info("Tier 3: image digest resolved: %s", digest)
+        return digest
+
+    @classmethod
+    def ensure_image(
+        cls,
+        image_tag: str = _DOCKER_IMAGE_TAG,
+        dockerfile: Path = _DOCKERFILE_PATH,
+        context_dir: Path | None = None,
+    ) -> str:
+        """Build the Docker image ONCE and cache the resolved digest.
+
+        Callers in run_matrix should call this ONCE before the cell loop when
+        tier3_mode='auto'. Subsequent Tier3Docker instantiations with the same
+        image_tag will skip the build automatically (cache hit).
+
+        Args:
+            image_tag: local image tag to build/inspect (default: _DOCKER_IMAGE_TAG).
+            dockerfile: path to the Dockerfile (default: _DOCKERFILE_PATH).
+            context_dir: Docker build context directory. Defaults to the
+                         directory containing `dockerfile`.
+
+        Returns:
+            The resolved sha256 image digest string (also stored in the cache).
+
+        Raises:
+            RuntimeError if docker build or docker inspect fails.
+            FileNotFoundError if the Dockerfile is absent.
+        """
+        if image_tag in _IMAGE_DIGEST_CACHE:
+            _log.info("Tier 3: image %s already cached (digest %s)", image_tag, _IMAGE_DIGEST_CACHE[image_tag])
+            return _IMAGE_DIGEST_CACHE[image_tag]
+
+        if not dockerfile.exists():
+            raise RuntimeError(
+                f"Dockerfile not found at {dockerfile}. Cannot build Tier 3 image."
+            )
+
+        effective_context = context_dir if context_dir is not None else dockerfile.parent
+
+        _log.info("Tier 3: building image %s from %s (this will happen once)", image_tag, dockerfile)
+        result = subprocess.run(
+            [
+                "docker", "build",
+                "-t", image_tag,
+                "-f", str(dockerfile),
+                str(effective_context),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker build failed (exit {result.returncode}):\n"
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        _log.info("Tier 3: image built as %s", image_tag)
+
+        # Resolve and cache the content-addressed digest.
+        inspect = subprocess.run(
+            ["docker", "inspect", "--format={{.Id}}", image_tag],
+            capture_output=True,
+            text=True,
+        )
+        if inspect.returncode != 0 or not inspect.stdout.strip():
+            raise RuntimeError(
+                f"docker inspect failed for {image_tag}: "
+                f"{inspect.stderr.strip() or 'image not found locally'}"
+            )
+        digest = inspect.stdout.strip()
+        _IMAGE_DIGEST_CACHE[image_tag] = digest
+        _log.info("Tier 3: image digest cached: %s -> %s", image_tag, digest)
         return digest
 
     # ------------------------------------------------------------------

--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -426,14 +426,16 @@ class Tier3Docker(IsolatorBase):
         held_out_dir: Path | None = None,
         build_image: bool = True,
         timeout_seconds: int = 300,
+        image_tag: str = _DOCKER_IMAGE_TAG,
     ) -> None:
         self.fixture_repo_dir = fixture_repo_dir
         self._held_out_dir = held_out_dir
         self.timeout_seconds = timeout_seconds
+        self.image_tag = image_tag
 
         # Build-once-reuse: if the image digest is already cached for this tag,
         # skip the build regardless of the caller-supplied build_image flag.
-        if _DOCKER_IMAGE_TAG in _IMAGE_DIGEST_CACHE:
+        if self.image_tag in _IMAGE_DIGEST_CACHE:
             self.build_image = False
         else:
             self.build_image = build_image
@@ -449,13 +451,13 @@ class Tier3Docker(IsolatorBase):
     def __enter__(self) -> Tier3Context:
         # 1. Optionally build the image, then resolve the content digest.
         #    Cache hit: skip both build and inspect subprocess (reuse cached digest).
-        if _DOCKER_IMAGE_TAG in _IMAGE_DIGEST_CACHE:
-            image_digest = _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG]
+        if self.image_tag in _IMAGE_DIGEST_CACHE:
+            image_digest = _IMAGE_DIGEST_CACHE[self.image_tag]
         else:
             if self.build_image:
-                self._build_image()
-            image_digest = self._resolve_image_digest()
-            _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = image_digest
+                self._build_image(self.image_tag)
+            image_digest = self._resolve_image_digest(self.image_tag)
+            _IMAGE_DIGEST_CACHE[self.image_tag] = image_digest
 
         # 2. Prepare fix-phase dir (rw copy of the fixture repo).
         fix_phase_dir = Path(tempfile.mkdtemp(prefix="t3-fix-"))
@@ -478,7 +480,7 @@ class Tier3Docker(IsolatorBase):
         return Tier3Context(
             fix_phase_dir=fix_phase_dir,
             held_out_dir=held_out_dir,
-            image_tag=_DOCKER_IMAGE_TAG,
+            image_tag=self.image_tag,
             image_digest=image_digest,
         )
 
@@ -519,7 +521,7 @@ class Tier3Docker(IsolatorBase):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _build_image() -> None:
+    def _build_image(image_tag: str = _DOCKER_IMAGE_TAG) -> None:
         """Build the swebench Docker image from Dockerfile.swebench.
 
         Note: `docker build` requires network to pull the base image and run
@@ -528,6 +530,9 @@ class Tier3Docker(IsolatorBase):
         time (fix and score phases) so that the eval container itself has no
         outbound network during the actual eval execution. The build step is a
         one-time setup; run-time isolation is the security boundary that matters.
+
+        Args:
+            image_tag: local image tag to build (default: _DOCKER_IMAGE_TAG).
         """
         if not _DOCKERFILE_PATH.exists():
             raise RuntimeError(
@@ -537,7 +542,7 @@ class Tier3Docker(IsolatorBase):
         result = subprocess.run(
             [
                 "docker", "build",
-                "-t", _DOCKER_IMAGE_TAG,
+                "-t", image_tag,
                 "-f", str(_DOCKERFILE_PATH),
                 str(_DOCKERFILE_PATH.parent),
             ],
@@ -549,26 +554,29 @@ class Tier3Docker(IsolatorBase):
                 f"docker build failed (exit {result.returncode}):\n"
                 f"{result.stderr.strip() or result.stdout.strip()}"
             )
-        _log.info("Tier 3: image built as %s", _DOCKER_IMAGE_TAG)
+        _log.info("Tier 3: image built as %s", image_tag)
 
     @staticmethod
-    def _resolve_image_digest() -> str:
+    def _resolve_image_digest(image_tag: str = _DOCKER_IMAGE_TAG) -> str:
         """Resolve the local image to its content digest (sha256:<hex>).
 
         Uses `docker inspect` so the returned reference is content-addressed
         and immune to mutable-tag races where a parallel branch overwrites
         the local ae-eval-swebench:latest tag between build and run.
 
+        Args:
+            image_tag: local image tag to inspect (default: _DOCKER_IMAGE_TAG).
+
         Raises RuntimeError if the image is not found locally.
         """
         result = subprocess.run(
-            ["docker", "inspect", "--format={{.Id}}", _DOCKER_IMAGE_TAG],
+            ["docker", "inspect", "--format={{.Id}}", image_tag],
             capture_output=True,
             text=True,
         )
         if result.returncode != 0 or not result.stdout.strip():
             raise RuntimeError(
-                f"docker inspect failed for {_DOCKER_IMAGE_TAG}: "
+                f"docker inspect failed for {image_tag}: "
                 f"{result.stderr.strip() or 'image not found locally'}"
             )
         digest = result.stdout.strip()

--- a/evals/runner/tests/test_isolator_tier3.py
+++ b/evals/runner/tests/test_isolator_tier3.py
@@ -7,7 +7,8 @@ Purpose: Integration tests for evals.runner.isolator.Tier3Docker. Verifies
          flags are applied (--cap-drop=ALL, --security-opt=no-new-privileges,
          --read-only, --pids-limit). Also covers: score-phase conftest/ini
          isolation (C2), timeout leak prevention (M4/M5), mount enumeration
-         (m1), and image digest pinning (M6).
+         (m1), image digest pinning (M6), and build-once-reuse across cells
+         (regression test for tier3-build-once fix).
 
          All tests are skipped if `docker` is unavailable on the test host
          (e.g. CI without Docker) or if Dockerfile.swebench is not present.
@@ -40,11 +41,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import evals.runner.isolator as _isolator_module
 from evals.runner.isolator import (
     Tier3Docker,
     Tier3Context,
     _DOCKERFILE_PATH,
     _DOCKER_IMAGE_TAG,
+    _IMAGE_DIGEST_CACHE,
     _force_remove_cidfile_container,
     make_isolator,
 )
@@ -753,3 +756,150 @@ def test_image_digest_is_content_addressed(built_image, tmp_path):
         assert len(hex_part) == 64, (
             f"sha256 digest hex part must be 64 chars; got {len(hex_part)}: {hex_part!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test 14: build-once-reuse regression (tier3-build-once fix)
+# _build_image must be called AT MOST ONCE across N cell instantiations.
+# ---------------------------------------------------------------------------
+
+
+def test_tier3_build_image_called_once_across_cells():
+    """Regression test: _build_image is called at most once across N simulated
+    cells (tier3-build-once fix).
+
+    Previously, each per-cell Tier3Docker context manager called _build_image()
+    on __enter__, causing N x 24 redundant docker builds for a 24-task matrix.
+    After the fix:
+      - ensure_image() populates _IMAGE_DIGEST_CACHE on first call.
+      - Subsequent Tier3Docker.__init__ detects the cache hit and sets
+        build_image=False, so _build_image is never invoked again.
+
+    This is a pure unit test using mocks; no Docker daemon required.
+    """
+    N_CELLS = 5  # simulate 5 cells that would previously have caused 5 builds
+
+    build_call_count = 0
+    inspect_call_count = 0
+
+    fake_digest = "sha256:" + "a" * 64
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        nonlocal build_call_count, inspect_call_count
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if "build" in cmd:
+            build_call_count += 1
+            result.stdout = "Successfully built abc123"
+        elif "inspect" in cmd:
+            inspect_call_count += 1
+            result.stdout = fake_digest + "\n"
+        return result
+
+    # Clear the module-level cache so we start fresh.
+    _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+            # Simulate what run_matrix does: call ensure_image() ONCE up front.
+            digest = Tier3Docker.ensure_image()
+            assert digest == fake_digest, f"ensure_image returned wrong digest: {digest!r}"
+
+            # Now simulate N cells, each instantiating Tier3Docker(build_image=False).
+            # The cache hit means build_image stays False even if build_image=True is passed.
+            for _ in range(N_CELLS):
+                isolator = Tier3Docker(build_image=True)  # caller passes True; cache overrides
+                assert isolator.build_image is False, (
+                    "Tier3Docker.__init__ must set build_image=False when cache is populated"
+                )
+                # Simulate __enter__ without actually entering (cache path is synchronous).
+                # We verify the cache short-circuit by checking that _build_image was
+                # not incremented further.
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+    # _build_image (docker build) must have been called exactly ONCE (from ensure_image).
+    assert build_call_count == 1, (
+        f"Expected _build_image to be called exactly once across ensure_image + {N_CELLS} cells; "
+        f"got {build_call_count}. The build-once-reuse contract is broken."
+    )
+    # docker inspect must also be called exactly once (from ensure_image).
+    assert inspect_call_count == 1, (
+        f"Expected docker inspect to be called once; got {inspect_call_count}."
+    )
+
+
+def test_tier3_ensure_image_idempotent():
+    """ensure_image() called twice returns the cached digest without rebuilding."""
+    build_call_count = 0
+    inspect_call_count = 0
+    fake_digest = "sha256:" + "b" * 64
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        nonlocal build_call_count, inspect_call_count
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if "build" in cmd:
+            build_call_count += 1
+            result.stdout = "Successfully built"
+        elif "inspect" in cmd:
+            inspect_call_count += 1
+            result.stdout = fake_digest + "\n"
+        return result
+
+    _isolator_module._IMAGE_DIGEST_CACHE.clear()
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+            d1 = Tier3Docker.ensure_image()
+            d2 = Tier3Docker.ensure_image()  # second call - must hit cache
+        assert d1 == fake_digest
+        assert d2 == fake_digest
+        assert build_call_count == 1, (
+            f"ensure_image() should only build once; build_call_count={build_call_count}"
+        )
+        assert inspect_call_count == 1, (
+            f"ensure_image() should only inspect once; inspect_call_count={inspect_call_count}"
+        )
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+
+def test_tier3_enter_uses_cached_digest_without_subprocess():
+    """When the cache is already populated, Tier3Docker.__enter__ must use the
+    cached digest and make zero subprocess calls for build or inspect.
+    """
+    fake_digest = "sha256:" + "c" * 64
+    _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = fake_digest
+
+    subprocess_call_count = 0
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        nonlocal subprocess_call_count
+        subprocess_call_count += 1
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = fake_digest + "\n"
+        return result
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+            isolator = Tier3Docker(build_image=True)  # True is overridden by cache
+            # Manually drive __enter__ logic up to the image-resolution step.
+            # We do NOT enter the full context manager to avoid tmpdir side effects.
+            # Instead, verify __init__ set build_image=False and that if we read
+            # the cache path in __enter__, no subprocess.run is triggered.
+            assert isolator.build_image is False, (
+                "Cache hit must force build_image=False in __init__"
+            )
+            # The cache short-circuit in __enter__ means subprocess is never called
+            # for build or inspect. Verify by checking subprocess_call_count after
+            # the __init__ path (before __enter__ actually executes container setup).
+        # subprocess_call_count may be >0 if __enter__ was called; we only checked __init__.
+        # The real validation is that build_call_count in __init__ itself is 0.
+        # (Full __enter__ flow is exercised by integration tests above.)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()

--- a/evals/runner/tests/test_isolator_tier3.py
+++ b/evals/runner/tests/test_isolator_tier3.py
@@ -871,35 +871,35 @@ def test_tier3_ensure_image_idempotent():
 def test_tier3_enter_uses_cached_digest_without_subprocess():
     """When the cache is already populated, Tier3Docker.__enter__ must use the
     cached digest and make zero subprocess calls for build or inspect.
+
+    Regression test: threads cache lookup through self.image_tag (MAJOR finding fix).
+    The subprocess mock raises on any call so an uncached subprocess would error
+    loudly instead of silently returning a wrong digest.
     """
     fake_digest = "sha256:" + "c" * 64
     _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = fake_digest
 
-    subprocess_call_count = 0
-
-    def _fake_subprocess_run(cmd, **kwargs):
-        nonlocal subprocess_call_count
-        subprocess_call_count += 1
-        result = MagicMock()
-        result.returncode = 0
-        result.stdout = fake_digest + "\n"
-        return result
+    def _noisy_subprocess_run(cmd, **kwargs):
+        raise AssertionError(
+            f"subprocess.run must NOT be called when cache is populated; got cmd={cmd!r}"
+        )
 
     try:
-        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_noisy_subprocess_run):
             isolator = Tier3Docker(build_image=True)  # True is overridden by cache
-            # Manually drive __enter__ logic up to the image-resolution step.
-            # We do NOT enter the full context manager to avoid tmpdir side effects.
-            # Instead, verify __init__ set build_image=False and that if we read
-            # the cache path in __enter__, no subprocess.run is triggered.
             assert isolator.build_image is False, (
                 "Cache hit must force build_image=False in __init__"
             )
-            # The cache short-circuit in __enter__ means subprocess is never called
-            # for build or inspect. Verify by checking subprocess_call_count after
-            # the __init__ path (before __enter__ actually executes container setup).
-        # subprocess_call_count may be >0 if __enter__ was called; we only checked __init__.
-        # The real validation is that build_call_count in __init__ itself is 0.
-        # (Full __enter__ flow is exercised by integration tests above.)
+            # Actually call __enter__ - this is the zero-subprocess claim under test.
+            ctx = isolator.__enter__()
+            try:
+                assert ctx.image_digest == fake_digest, (
+                    f"__enter__ must return the cached digest; got {ctx.image_digest!r}"
+                )
+                assert ctx.image_tag == _DOCKER_IMAGE_TAG, (
+                    f"__enter__ must propagate self.image_tag; got {ctx.image_tag!r}"
+                )
+            finally:
+                isolator.__exit__(None, None, None)
     finally:
         _isolator_module._IMAGE_DIGEST_CACHE.clear()

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -42,6 +42,12 @@ Upstream deps: stdlib pathlib, time, csv, json, dataclasses, sys, logging,
                evals.skill-comparison.seeding (seed_fix_phase, SeedError).
                evals.icl_vs_orchestration.cost_gate (CostGate, BudgetExceeded).
 
+Build-once contract: when tier3_mode='auto' and not dry_run, run_matrix calls
+Tier3Docker.ensure_image() ONCE before the cell loop. Per-cell Tier3Docker(...)
+instantiations pass build_image=False. The module-level _IMAGE_DIGEST_CACHE in
+isolator.py ensures the build subprocess is never invoked more than once per
+process, even if build_image=True were passed accidentally.
+
 Downstream consumers: CLI / scripts; evals/skill-comparison/tests/test_runner.py.
 
 Failure modes: BudgetExceeded halts the matrix and writes a partial report
@@ -411,6 +417,11 @@ def run_matrix(
     _Tier3Docker = None
     if use_tier3:
         from evals.runner.isolator import Tier3Docker as _Tier3Docker  # type: ignore[assignment]
+        # Build-once-reuse: build the Docker image ONCE before the cell loop.
+        # This avoids N*24 redundant docker builds (one per cell). Each per-cell
+        # Tier3Docker(...) call will find the cached digest and skip the build.
+        _LOG.info("Tier 3: ensuring image is built (one-time build before cell loop)")
+        _Tier3Docker.ensure_image()
 
     for task_slug, task_meta in tasks.items():
         for condition in active_conditions:
@@ -467,7 +478,7 @@ def run_matrix(
                     _tier3_instance = _Tier3Docker(
                         fixture_repo_dir=None,  # base repo seeded externally
                         held_out_dir=held_out_path,
-                        build_image=True,
+                        build_image=False,  # image already built once by ensure_image() above
                         timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
                     )
                     tier3_ctx = _tier3_instance.__enter__()


### PR DESCRIPTION
## Summary

- Adds `_IMAGE_DIGEST_CACHE` module-level dict in `isolator.py` - keyed by image tag, stores resolved sha256 digest after first build
- Adds `Tier3Docker.ensure_image()` class method: build + inspect exactly once, return cached digest on subsequent calls
- `run_matrix` in `runner.py` now calls `ensure_image()` ONCE before the cell loop (when `tier3_mode='auto'`), eliminating N×24 redundant docker builds
- Per-cell `Tier3Docker(...)` instantiation now passes `build_image=False`; the cache check in `__init__` also overrides any accidental `build_image=True`

## Root cause

`Tier3Docker.__enter__` called `_build_image()` by default (`build_image=True`). The runner entered this context per cell. For 24 cells × N replicates that means N×24 docker builds back-to-back. In the smoke attempt, the runner hung on the first docker build (buildx process at 0.63s CPU over 7 min).

## Regression tests

Three new unit tests in `evals/runner/tests/test_isolator_tier3.py` (no Docker daemon required):
- `test_tier3_build_image_called_once_across_cells` - mocks subprocess, verifies `docker build` called exactly once across ensure_image + N cell instantiations
- `test_tier3_ensure_image_idempotent` - ensure_image() called twice only builds once
- `test_tier3_enter_uses_cached_digest_without_subprocess` - cache hit in `__init__` forces `build_image=False`

## Test plan
- [x] 592 existing tests pass, 1 pre-existing skip
- [x] 3 new regression tests pass
- [ ] Smoke run: `docker build` should appear exactly once at the start, then cells run