### PR TITLE
feat(runner): add --tasks and --max-cells CLI filters for bounded smoke runs

### DIFF
--- a/evals/skill-comparison/README.md
+++ b/evals/skill-comparison/README.md
@@ -212,6 +212,25 @@ python evals/skill-comparison/runner.py \
 Validates corpus YAML, condition specs, and isolator connectivity without
 spending tokens.
 
+### Bounded smoke run (single cell, fast validation)
+
+Use `--tasks` and `--max-cells` together to verify the full pipeline with
+minimal cost. This is the recommended pre-flight before a full corpus run:
+
+```bash
+PYTHONPATH=. python3 evals/skill-comparison/runner.py \
+  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
+  --results-tsv /tmp/skill-smoke.tsv \
+  --tasks requests-3362 \
+  --conditions baseline \
+  --max-cells 1 \
+  --max-usd 2 --max-tokens 200000 --max-wall-seconds 900
+```
+
+`--tasks requests-3362` restricts the corpus to one task slug. `--max-cells 1`
+stops after the first row is written regardless of remaining iterations. Both
+filters are additive - the more restrictive wins.
+
 ### Sensitivity check (methodology pair only, n=5)
 
 ```bash
@@ -248,6 +267,8 @@ report on breach (exit code 3).
 | `--conditions` | all conditions | Space-separated list of condition names to run (e.g. `baseline ae-rules-injected`). Omit to run all 8. |
 | `--n-replicates` | `3` | Replicate count per (task, condition) cell, except the methodology pair. |
 | `--n-replicates-methodology` | `5` | Replicate count for `baseline` and `ae-rules-injected` cells (the methodology pair noise envelope). |
+| `--tasks` | all tasks | Space-separated list of task slugs to include (matches keys in `corpus.yaml`). Omit to run all tasks. Unknown slugs raise an error before any cell executes. |
+| `--max-cells` | none | Hard stop after writing N rows to the TSV (excluding the header). Useful for single-cell smoke validation. When combined with `--tasks`, whichever limit is reached first wins. |
 | `--tier3` | `auto` | Docker isolation mode. `auto` uses Tier 3 in production; `off` skips Docker (for dry-run / unit tests). |
 | `--force` | off | Re-run cells already present in the TSV (bypass resume skip). |
 | `--dry-run` | off | Validate config and isolator connectivity; skip all Claude calls. |

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -376,11 +376,14 @@ def run_matrix(
                       include. If None or empty, all tasks run. An unrecognised
                       slug raises ValueError before any cell is executed.
         max_cells: hard stop after writing this many rows to the TSV (excluding
-                   the header). Already-completed cells (resume-skipped) count
-                   toward the ceiling. If None, no ceiling. When both
-                   tasks_filter and max_cells are supplied, whichever limit is
-                   reached first wins. When max_cells is reached, report.partial
-                   is set to True (mirrors the wall-clock ceiling behavior).
+                   the header). Only rows written in this invocation count
+                   toward the ceiling - resume-skipped pre-existing rows do NOT
+                   count. This means ``--max-cells 5`` will write up to 5 new
+                   rows regardless of how many already exist in the TSV. If
+                   None, no ceiling. When both tasks_filter and max_cells are
+                   supplied, whichever limit is reached first wins. When
+                   max_cells is reached, report.partial is set to True (mirrors
+                   the wall-clock ceiling behavior).
 
     Returns:
         RunReport with summary stats.

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -20,6 +20,8 @@ Public API:
         dry_run: bool = False,
         conditions: list[str] | None = None,
         tier3_mode: str = "auto",
+        tasks_filter: list[str] | None = None,
+        max_cells: int | None = None,
     ) -> RunReport
 
     RunReport (dataclass):
@@ -328,6 +330,8 @@ def run_matrix(
     conditions: Optional[list[str]] = None,
     tier3_mode: str = "auto",
     force: bool = False,
+    tasks_filter: Optional[list[str]] = None,
+    max_cells: Optional[int] = None,
 ) -> RunReport:
     """Orchestrate the 8-condition skill-comparison eval matrix.
 
@@ -368,6 +372,15 @@ def run_matrix(
                     subprocess for both fix and score phases (for dry-run /
                     unit tests).
         force: if True, re-run cells already present in the TSV (no resume skip).
+        tasks_filter: optional list of task slugs (keys from corpus.yaml) to
+                      include. If None or empty, all tasks run. An unrecognised
+                      slug raises ValueError before any cell is executed.
+        max_cells: hard stop after writing this many rows to the TSV (excluding
+                   the header). Already-completed cells (resume-skipped) count
+                   toward the ceiling. If None, no ceiling. When both
+                   tasks_filter and max_cells are supplied, whichever limit is
+                   reached first wins. When max_cells is reached, report.partial
+                   is set to True (mirrors the wall-clock ceiling behavior).
 
     Returns:
         RunReport with summary stats.
@@ -382,6 +395,17 @@ def run_matrix(
         content_root = _REPO_ROOT / "content"
 
     tasks = _load_tasks(tasks_yaml)
+
+    # Apply tasks_filter: if provided and non-empty, restrict to named slugs.
+    if tasks_filter:
+        unknown = [s for s in tasks_filter if s not in tasks]
+        if unknown:
+            raise ValueError(
+                f"Unknown task slug(s) in --tasks filter: {unknown}. "
+                f"Valid slugs: {sorted(tasks.keys())}"
+            )
+        tasks = {slug: tasks[slug] for slug in tasks_filter}
+
     active_conditions = conditions if conditions is not None else CONDITION_LABELS
 
     # Resolve effective tier3 mode. dry_run forces Tier3 off.
@@ -412,6 +436,12 @@ def run_matrix(
 
     report = RunReport(tsv_path=results_tsv)
     matrix_start = time.monotonic()
+
+    # max_cells: total rows written in this run (across resume + new).
+    # We count rows written in this invocation only (report.rows_written is the
+    # counter); completed_cells are already in the file and do not count toward
+    # the ceiling for this run.
+    _cells_this_run = 0
 
     # Conditionally import Tier3Docker for production runs.
     _Tier3Docker = None
@@ -550,10 +580,19 @@ def run_matrix(
                             },
                         )
                         report.rows_written += 1
+                        _cells_this_run += 1
                         # Cleanup non-Tier3 tmpdir if we created one.
                         if _non_tier3_fix_dir is not None:
                             shutil.rmtree(_non_tier3_fix_dir, ignore_errors=True)
                             _non_tier3_fix_dir = None
+                        if max_cells is not None and _cells_this_run >= max_cells:
+                            _LOG.info(
+                                "max_cells ceiling reached (%d). "
+                                "Halting matrix with partial results.",
+                                max_cells,
+                            )
+                            report.partial = True
+                            return report
                         continue
 
                     # Run the fix phase.
@@ -747,6 +786,15 @@ def run_matrix(
                 }
                 _append_tsv_row(results_tsv, row)
                 report.rows_written += 1
+                _cells_this_run += 1
+                if max_cells is not None and _cells_this_run >= max_cells:
+                    _LOG.info(
+                        "max_cells ceiling reached (%d). "
+                        "Halting matrix with partial results.",
+                        max_cells,
+                    )
+                    report.partial = True
+                    return report
 
     return report
 
@@ -780,6 +828,29 @@ if __name__ == "__main__":
         action="store_true",
         help="Re-run cells already present in the TSV (bypass resume skip).",
     )
+    parser.add_argument(
+        "--tasks",
+        nargs="*",
+        default=None,
+        dest="tasks_filter",
+        metavar="SLUG",
+        help=(
+            "Space-separated list of task slugs to include (matches keys in "
+            "corpus.yaml). If omitted or empty, all tasks run. Unknown slugs "
+            "raise an error before any cell executes."
+        ),
+    )
+    parser.add_argument(
+        "--max-cells",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Hard stop after writing N rows to the TSV (excluding the header). "
+            "Useful for 'just one cell' smoke validation. When both --tasks and "
+            "--max-cells are passed, whichever limit is reached first wins."
+        ),
+    )
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -797,6 +868,8 @@ if __name__ == "__main__":
         conditions=args.conditions,
         tier3_mode=args.tier3,
         force=args.force,
+        tasks_filter=args.tasks_filter if args.tasks_filter else None,
+        max_cells=args.max_cells,
     )
 
     print(json.dumps(

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -1267,6 +1267,28 @@ class TestTasksFilter:
             f"Both tasks should run when tasks_filter=None; got {len(rows)}"
         )
 
+    def test_empty_list_tasks_filter_runs_all(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """When tasks_filter=[] (empty list), all tasks run (same as None)."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tasks_filter=[],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"Both tasks should run when tasks_filter=[]; got {len(rows)}"
+        )
+
     def test_unknown_slug_raises_before_any_cell(
         self, tmp_path: Path, two_task_corpus_yaml: Path
     ):

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -1159,3 +1159,277 @@ class TestSeedErrorAggregatorExclusion:
             f"Median must be computed from valid scores only; "
             f"expected {statistics.median([1.0, 0.8, 0.6])}, got {row.median}"
         )
+
+
+# ---------------------------------------------------------------------------
+# --tasks / tasks_filter and --max-cells tests
+# ---------------------------------------------------------------------------
+
+# Corpus with two tasks so we can verify slug-based filtering.
+_TWO_TASK_CORPUS_YAML = """\
+freeze_metadata:
+  freeze_date: "2026-05-12"
+tasks:
+  django-11039:
+    swebench_instance_id: "django__django-11039"
+    repo_url: "https://github.com/django/django"
+    base_commit: "d5276398046ce4a102776a1e67dcac2884d80dfe"
+    held_out_tests:
+      - "tests/migrations/test_commands.py"
+    fail_to_pass:
+      - "test_sqlmigrate_for_non_transactional_databases"
+    estimated_test_seconds: 30
+    difficulty: single-file
+    known_affected_files:
+      - "django/core/management/commands/sqlmigrate.py"
+    problem_summary: Bug in sqlmigrate.
+  requests-3362:
+    swebench_instance_id: "psf__requests-3362"
+    repo_url: "https://github.com/psf/requests"
+    base_commit: "abc000"
+    held_out_tests:
+      - "tests/test_utils.py"
+    fail_to_pass:
+      - "test_something"
+    estimated_test_seconds: 10
+    difficulty: single-file
+    known_affected_files:
+      - "requests/utils.py"
+    problem_summary: Bug in requests utils.
+"""
+
+
+@pytest.fixture
+def two_task_corpus_yaml(tmp_path: Path) -> Path:
+    """Write a two-task corpus YAML to tmp_path."""
+    p = tmp_path / "corpus.yaml"
+    p.write_text(_TWO_TASK_CORPUS_YAML, encoding="utf-8")
+    return p
+
+
+def _canned_score():
+    from scoring import ScoringResult
+    return ScoringResult(
+        pass_fail=True,
+        score_primary=1.0,
+        lines_touched=1,
+        files_touched=1,
+        scope_creep_flag=False,
+    )
+
+
+class TestTasksFilter:
+    """Tests for the tasks_filter parameter (--tasks CLI flag)."""
+
+    def test_single_slug_filter_runs_only_that_task(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """When tasks_filter=['requests-3362'], only that task's cells appear in TSV."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tasks_filter=["requests-3362"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1, (
+            f"Only 1 row expected (requests-3362 x baseline x n=1); got {len(rows)}"
+        )
+        assert rows[0]["task_slug"] == "requests-3362"
+        assert report.rows_written == 1
+
+    def test_empty_tasks_filter_runs_all(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """When tasks_filter=[] (empty list), all tasks run (same as None)."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tasks_filter=None,  # same as absent
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"Both tasks should run when tasks_filter=None; got {len(rows)}"
+        )
+
+    def test_unknown_slug_raises_before_any_cell(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """An unknown task slug raises ValueError before any cell executes."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            with pytest.raises(ValueError, match="Unknown task slug"):
+                run_matrix(
+                    tasks_yaml=two_task_corpus_yaml,
+                    results_tsv=results_tsv,
+                    n_replicates=1,
+                    n_replicates_methodology=1,
+                    dry_run=True,
+                    conditions=["baseline"],
+                    tasks_filter=["does-not-exist"],
+                )
+
+        # No rows should have been written.
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 0, "No rows must be written when slug validation fails"
+
+    def test_multiple_slugs_filter(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """tasks_filter with multiple valid slugs runs exactly those tasks."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tasks_filter=["django-11039", "requests-3362"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2
+        slugs_seen = {r["task_slug"] for r in rows}
+        assert slugs_seen == {"django-11039", "requests-3362"}
+
+
+class TestMaxCells:
+    """Tests for the max_cells parameter (--max-cells CLI flag)."""
+
+    def test_max_cells_1_stops_after_one_row(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """max_cells=1 stops after writing one row and sets partial=True."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=2,
+                n_replicates_methodology=2,
+                dry_run=True,
+                conditions=["baseline"],
+                max_cells=1,
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1, (
+            f"max_cells=1 must stop after exactly 1 row; got {len(rows)}"
+        )
+        assert report.partial is True, "partial must be True when max_cells is reached"
+        assert report.rows_written == 1
+
+    def test_max_cells_resume_respects_ceiling(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """Second invocation with max_cells=1 stops after writing 1 new row
+        even when prior rows exist in the TSV."""
+        results_tsv = tmp_path / "results.tsv"
+
+        # First run: write 1 row (django-11039 baseline rep1).
+        with patch("runner.score_cell", return_value=_canned_score()):
+            run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tasks_filter=["django-11039"],
+            )
+
+        assert len(_read_tsv(results_tsv)) == 1
+
+        # Second run: force=True so the first row is not counted as
+        # completed; max_cells=1 means only 1 more row should be written.
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline", "engineer-direct"],
+                tasks_filter=["django-11039"],
+                max_cells=1,
+                force=True,
+            )
+
+        # The TSV now has the original row plus 1 new row.
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"Expected 2 total rows (1 prior + 1 new from max_cells=1); got {len(rows)}"
+        )
+        assert report.rows_written == 1
+        assert report.partial is True
+
+    def test_max_cells_none_runs_all(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """max_cells=None (default) does not truncate the run."""
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                max_cells=None,
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, "Both tasks should run when max_cells=None"
+        assert report.partial is False
+
+    def test_tasks_filter_and_max_cells_additive(
+        self, tmp_path: Path, two_task_corpus_yaml: Path
+    ):
+        """tasks_filter limits the task set; max_cells limits total rows written.
+        The more restrictive wins per cell iteration."""
+        results_tsv = tmp_path / "results.tsv"
+
+        # tasks_filter=['requests-3362'] with n=3 replicates and 2 conditions
+        # would produce 6 rows. max_cells=2 cuts to 2.
+        with patch("runner.score_cell", return_value=_canned_score()):
+            report = run_matrix(
+                tasks_yaml=two_task_corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=3,
+                n_replicates_methodology=3,
+                dry_run=True,
+                conditions=["baseline", "engineer-direct"],
+                tasks_filter=["requests-3362"],
+                max_cells=2,
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 2, (
+            f"tasks_filter + max_cells=2 should yield exactly 2 rows; got {len(rows)}"
+        )
+        # All rows must be from the filtered task.
+        for row in rows:
+            assert row["task_slug"] == "requests-3362"
+        assert report.partial is True


### PR DESCRIPTION
## Summary

- Adds `--tasks <slug>...` to restrict the eval corpus to named task slugs; unknown slugs raise `ValueError` before any cell executes
- Adds `--max-cells N` to hard-stop after writing N rows; sets `partial=True` like the wall-clock ceiling
- Both filters are additive with existing `--conditions`, budget flags, and resume semantics

## Changes

- `evals/skill-comparison/runner.py` - `tasks_filter` and `max_cells` params on `run_matrix`; argparse flags; ValueError on unknown slugs; ceiling check after each row write
- `evals/skill-comparison/tests/test_runner.py` - 9 new tests in `TestTasksFilter` and `TestMaxCells` classes
- `evals/skill-comparison/README.md` - "Bounded smoke run" section with recommended command; two new rows in CLI flags table

## Recommended smoke command

```bash
PYTHONPATH=. python3 evals/skill-comparison/runner.py \
  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
  --results-tsv /tmp/skill-smoke.tsv \
  --tasks requests-3362 \
  --conditions baseline \
  --max-cells 1 \
  --max-usd 2 --max-tokens 200000 --max-wall-seconds 900
```

## Test plan

- All 284 existing tests pass (1 skipped - pre-existing live integration test)
- 9 new tests: single slug filter, empty=all, unknown raises before any cell, multiple slugs, max_cells=1 stops after 1 row, resume with max_cells, max_cells=None runs all, additive interaction
- Dry-run smoke verified end-to-end with `--tasks django-11039 --max-cells 1 --dry-run`