### PR TITLE
fix(eval-harness): add pytest-timeout, --rebuild-image flag, and transcript persistence

### DIFF
--- a/evals/runner/Dockerfile.swebench
+++ b/evals/runner/Dockerfile.swebench
@@ -21,13 +21,15 @@ FROM python@sha256:a5b427ace4900267d93db34138e512325c6fa6af84ad5e4ed5f3b36258cc4
 # Metadata
 LABEL org.opencontainers.image.title="ae-eval-swebench" \
       org.opencontainers.image.description="AE eval harness Tier 3 sandbox for SWE-bench fix+score phases" \
-      org.opencontainers.image.source="evals/runner/Dockerfile.swebench"
+      org.opencontainers.image.source="evals/runner/Dockerfile.swebench" \
+      org.opencontainers.image.version="1.1.0"
 
 # Install pytest and a minimal set of test utilities at BUILD time.
 # Network is available here (build time). Network is disabled at run time via
 # `docker run --network none`. No per-task packages are installed at run time;
 # if a task requires additional packages, extend this RUN layer and rebuild.
-RUN pip install --no-cache-dir pytest==8.3.5
+# pytest-timeout: required by scoring.py which passes --timeout=<N> to pytest.
+RUN pip install --no-cache-dir pytest==8.3.5 pytest-timeout==2.4.0
 
 # Create a non-root user for running eval commands.
 RUN groupadd --gid 1001 evaluser && \

--- a/evals/runner/tests/test_isolator_tier3.py
+++ b/evals/runner/tests/test_isolator_tier3.py
@@ -903,3 +903,31 @@ def test_tier3_enter_uses_cached_digest_without_subprocess():
                 isolator.__exit__(None, None, None)
     finally:
         _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Bug-1 regression: pytest-timeout must be installed in the Docker image
+# ---------------------------------------------------------------------------
+
+
+def test_dockerfile_includes_pytest_timeout():
+    """Dockerfile.swebench pip install line must include pytest-timeout.
+
+    Regression test for Bug-1: scoring.py passes --timeout=<N> to pytest
+    inside the container, but the original Dockerfile only installed
+    pytest==8.3.5. Every score phase failed with:
+      'unrecognized arguments: --timeout=120'
+    because pytest-timeout was not present.
+
+    This is a static grep test - no Docker needed. It documents the build-time
+    contract and catches regressions where the Dockerfile is edited and the
+    pytest-timeout dependency is accidentally removed.
+    """
+    dockerfile_text = _DOCKERFILE_PATH.read_text(encoding="utf-8")
+    assert "pytest-timeout" in dockerfile_text, (
+        f"Dockerfile.swebench at {_DOCKERFILE_PATH} must include 'pytest-timeout' "
+        "in its pip install RUN layer. "
+        "Bug-1 regression: scoring.py passes --timeout=<N> to pytest inside the "
+        "container; without pytest-timeout installed, every score phase fails with "
+        "'unrecognized arguments: --timeout=120'."
+    )

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -22,6 +22,7 @@ Public API:
         tier3_mode: str = "auto",
         tasks_filter: list[str] | None = None,
         max_cells: int | None = None,
+        rebuild_image: bool = False,
     ) -> RunReport
 
     RunReport (dataclass):
@@ -49,6 +50,14 @@ Tier3Docker.ensure_image() ONCE before the cell loop. Per-cell Tier3Docker(...)
 instantiations pass build_image=False. The module-level _IMAGE_DIGEST_CACHE in
 isolator.py ensures the build subprocess is never invoked more than once per
 process, even if build_image=True were passed accidentally.
+When rebuild_image=True, the cache entry for the image tag is evicted before
+ensure_image() is called, forcing a fresh docker build on the next invocation.
+
+Transcript persistence: every cell persists the engineer CLI stdout+stderr to
+<results_tsv_dir>/transcripts/<task_slug>__<condition>__rep<N>.log.  On
+cli_exit_* status, the transcript path is logged in diagnostics_json and the
+last 500 chars are printed to stderr for quick post-mortem without opening the
+file.
 
 Downstream consumers: CLI / scripts; evals/skill-comparison/tests/test_runner.py.
 
@@ -332,6 +341,7 @@ def run_matrix(
     force: bool = False,
     tasks_filter: Optional[list[str]] = None,
     max_cells: Optional[int] = None,
+    rebuild_image: bool = False,
 ) -> RunReport:
     """Orchestrate the 8-condition skill-comparison eval matrix.
 
@@ -384,6 +394,11 @@ def run_matrix(
                    supplied, whichever limit is reached first wins. When
                    max_cells is reached, report.partial is set to True (mirrors
                    the wall-clock ceiling behavior).
+        rebuild_image: if True, evict the cached image digest from
+                       _IMAGE_DIGEST_CACHE before calling ensure_image(), forcing
+                       a fresh docker build. Useful when Dockerfile.swebench has
+                       changed and the locally-tagged image is stale. Has no
+                       effect when tier3_mode='off' or dry_run=True.
 
     Returns:
         RunReport with summary stats.
@@ -396,6 +411,11 @@ def run_matrix(
         )
     if content_root is None:
         content_root = _REPO_ROOT / "content"
+
+    # Transcript directory: <results_tsv_dir>/transcripts/
+    # Each cell writes its engineer CLI output here for post-mortem.
+    _transcript_dir = results_tsv.parent / "transcripts"
+    _transcript_dir.mkdir(parents=True, exist_ok=True)
 
     tasks = _load_tasks(tasks_yaml)
 
@@ -449,7 +469,20 @@ def run_matrix(
     # Conditionally import Tier3Docker for production runs.
     _Tier3Docker = None
     if use_tier3:
-        from evals.runner.isolator import Tier3Docker as _Tier3Docker  # type: ignore[assignment]
+        from evals.runner.isolator import (  # type: ignore[assignment]
+            Tier3Docker as _Tier3Docker,
+            _DOCKER_IMAGE_TAG as _T3_IMAGE_TAG,
+            _IMAGE_DIGEST_CACHE as _T3_DIGEST_CACHE,
+        )
+        # rebuild_image=True: evict the cached digest so ensure_image()
+        # forces a fresh docker build. This is explicit operator control -
+        # no surprise rebuilds on normal runs.
+        if rebuild_image and _T3_IMAGE_TAG in _T3_DIGEST_CACHE:
+            _LOG.info(
+                "Tier 3: --rebuild-image requested; evicting cached digest for %s",
+                _T3_IMAGE_TAG,
+            )
+            del _T3_DIGEST_CACHE[_T3_IMAGE_TAG]
         # Build-once-reuse: build the Docker image ONCE before the cell loop.
         # This avoids N*24 redundant docker builds (one per cell). Each per-cell
         # Tier3Docker(...) call will find the cached digest and skip the build.
@@ -672,6 +705,39 @@ def run_matrix(
                     latency_ms = int(result.get("latency_ms") or 0)
                     invocation_mode = result.get("invocation_mode", "")
 
+                    # Persist engineer transcript for post-mortem.
+                    _transcript_slug = f"{task_slug}__{condition}__rep{rep}"
+                    _transcript_path = _transcript_dir / f"{_transcript_slug}.log"
+                    try:
+                        _stderr_tail = result.get("stderr_tail", "") or ""
+                        # Guard: transcript and stderr_tail must be strings.
+                        _transcript_content = transcript if isinstance(transcript, str) else str(transcript)
+                        if _stderr_tail and isinstance(_stderr_tail, str):
+                            _transcript_content = (
+                                _transcript_content
+                                + "\n\n--- stderr ---\n"
+                                + _stderr_tail
+                            )
+                        _transcript_path.write_text(
+                            _transcript_content, encoding="utf-8"
+                        )
+                    except OSError as _t_exc:
+                        _LOG.warning(
+                            "Failed to persist transcript for %s rep %d: %s",
+                            cell_id, rep, _t_exc,
+                        )
+                        _transcript_path = None  # type: ignore[assignment]
+
+                    # On CLI exit failures, print last 500 chars to stderr for
+                    # quick post-mortem without opening the file.
+                    if run_status.startswith("cli_exit_") and transcript:
+                        _tail = transcript[-500:]
+                        print(
+                            f"[cli_exit] {cell_id} rep {rep}: last 500 chars of transcript:\n"
+                            f"{_tail}",
+                            file=sys.stderr,
+                        )
+
                     # Score the cell.
                     # dry_run: use fresh tmpdirs; production: use Tier3 dirs
                     # or the seeded fix_worktree (tier3_mode='off' path).
@@ -769,6 +835,15 @@ def run_matrix(
                 # so that callers can distinguish a clean run with a scoring failure
                 # from a successful run ("ok") or an engineer-phase failure.
                 effective_status = "score_error" if _score_error is not None else run_status
+
+                # Merge transcript path into diagnostics so operators can locate
+                # the log file from the TSV row alone.
+                _diagnostics = dict(scored.diagnostics)
+                if _transcript_path is not None:
+                    _diagnostics["transcript_path"] = str(_transcript_path)
+                if effective_status.startswith("cli_exit_") and _transcript_path is not None:
+                    _diagnostics["cli_exit_transcript"] = str(_transcript_path)
+
                 row = {
                     "task_slug": task_slug,
                     "condition": condition,
@@ -785,7 +860,7 @@ def run_matrix(
                     "tokens_output": tokens_output,
                     "latency_ms": latency_ms,
                     "invocation_mode": invocation_mode,
-                    "diagnostics_json": json.dumps(scored.diagnostics),
+                    "diagnostics_json": json.dumps(_diagnostics),
                 }
                 _append_tsv_row(results_tsv, row)
                 report.rows_written += 1
@@ -854,6 +929,17 @@ if __name__ == "__main__":
             "--max-cells are passed, whichever limit is reached first wins."
         ),
     )
+    parser.add_argument(
+        "--rebuild-image",
+        action="store_true",
+        default=False,
+        help=(
+            "Force a fresh Docker image build by evicting the cached digest "
+            "before calling ensure_image(). Use when Dockerfile.swebench has "
+            "changed and the locally-tagged ae-eval-swebench:latest image is "
+            "stale. Has no effect when --tier3=off or --dry-run."
+        ),
+    )
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -873,6 +959,7 @@ if __name__ == "__main__":
         force=args.force,
         tasks_filter=args.tasks_filter if args.tasks_filter else None,
         max_cells=args.max_cells,
+        rebuild_image=args.rebuild_image,
     )
 
     print(json.dumps(

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -1455,3 +1455,434 @@ class TestMaxCells:
         for row in rows:
             assert row["task_slug"] == "requests-3362"
         assert report.partial is True
+
+
+# ---------------------------------------------------------------------------
+# Bug-1 regression: --rebuild-image invalidates the image digest cache
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildImage:
+    """Regression suite for Bug-1 (--rebuild-image flag).
+
+    Verifies that rebuild_image=True evicts the cached digest from
+    _IMAGE_DIGEST_CACHE before ensure_image() is called, forcing a fresh
+    docker build on the next invocation.
+    """
+
+    def test_rebuild_image_evicts_cache_entry(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """rebuild_image=True removes the cached digest before ensure_image().
+
+        Regression test for Bug-1: previously the cache was never invalidated,
+        so a stale ae-eval-swebench:latest image (missing pytest-timeout) would
+        be reused silently even after Dockerfile.swebench changed.
+        """
+        from evals.runner.isolator import _IMAGE_DIGEST_CACHE, _DOCKER_IMAGE_TAG
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        # Pre-populate the cache with a fake digest to simulate a stale image.
+        _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = "sha256:stale_digest_before_rebuild"
+
+        ensure_image_calls: list[dict] = []
+
+        # Capture whether the cache was empty at ensure_image() call time.
+        original_ensure_image = None
+
+        def fake_ensure_image(image_tag=_DOCKER_IMAGE_TAG, **kwargs):
+            ensure_image_calls.append({
+                "image_tag": image_tag,
+                "cache_had_entry": image_tag in _IMAGE_DIGEST_CACHE,
+            })
+            # Simulate ensure_image caching the new digest.
+            _IMAGE_DIGEST_CACHE[image_tag] = "sha256:fresh_digest_after_rebuild"
+            return "sha256:fresh_digest_after_rebuild"
+
+        mock_tier3_ctx_enter = MagicMock()
+        from evals.runner.isolator import Tier3Context
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "held",
+            image_tag=_DOCKER_IMAGE_TAG,
+            image_digest="sha256:fresh_digest_after_rebuild",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "held").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+        mock_tier3_cls = MagicMock(return_value=mock_tier3_instance)
+        mock_tier3_cls.ensure_image = MagicMock(side_effect=fake_ensure_image)
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=MagicMock(
+            returncode=0,
+            stdout='{"final_text":"ok","status":"ok","cost_usd":0.0,"usage":{},'
+                   '"latency_ms":0,"invocation_mode":"agent","tool_calls":[],'
+                   '"turns_used":1,"_parse_warnings":[]}',
+            stderr="",
+        ))
+
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+                rebuild_image=True,
+            )
+
+        assert len(ensure_image_calls) == 1, (
+            "ensure_image must be called exactly once in production path"
+        )
+        assert not ensure_image_calls[0]["cache_had_entry"], (
+            "rebuild_image=True must evict the cache entry BEFORE ensure_image() "
+            "is called. Cache still had the stale entry when ensure_image() ran - "
+            "Bug-1 regression: stale image would be reused without rebuilding."
+        )
+        # Restore cache to clean state.
+        _IMAGE_DIGEST_CACHE.pop(_DOCKER_IMAGE_TAG, None)
+
+    def test_rebuild_image_false_preserves_cache(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """rebuild_image=False (default) does NOT evict the cache entry."""
+        from evals.runner.isolator import _IMAGE_DIGEST_CACHE, _DOCKER_IMAGE_TAG
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        # Pre-populate the cache.
+        _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = "sha256:existing_digest"
+
+        ensure_image_calls: list[dict] = []
+
+        def fake_ensure_image(image_tag=_DOCKER_IMAGE_TAG, **kwargs):
+            ensure_image_calls.append({
+                "image_tag": image_tag,
+                "cache_had_entry": image_tag in _IMAGE_DIGEST_CACHE,
+            })
+            return _IMAGE_DIGEST_CACHE.get(image_tag, "sha256:existing_digest")
+
+        from evals.runner.isolator import Tier3Context
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "held",
+            image_tag=_DOCKER_IMAGE_TAG,
+            image_digest="sha256:existing_digest",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "held").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+        mock_tier3_cls = MagicMock(return_value=mock_tier3_instance)
+        mock_tier3_cls.ensure_image = MagicMock(side_effect=fake_ensure_image)
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=MagicMock(
+            returncode=0,
+            stdout='{"final_text":"ok","status":"ok","cost_usd":0.0,"usage":{},'
+                   '"latency_ms":0,"invocation_mode":"agent","tool_calls":[],'
+                   '"turns_used":1,"_parse_warnings":[]}',
+            stderr="",
+        ))
+
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+                rebuild_image=False,  # default - do not evict
+            )
+
+        assert len(ensure_image_calls) == 1
+        assert ensure_image_calls[0]["cache_had_entry"], (
+            "rebuild_image=False must NOT evict the cache; the cached entry "
+            "should still be present when ensure_image() is called."
+        )
+        # Restore cache.
+        _IMAGE_DIGEST_CACHE.pop(_DOCKER_IMAGE_TAG, None)
+
+    def test_rebuild_image_no_effect_when_dry_run(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """rebuild_image=True is a no-op when dry_run=True (no Tier3 used)."""
+        from evals.runner.isolator import _IMAGE_DIGEST_CACHE, _DOCKER_IMAGE_TAG
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        _IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = "sha256:should_not_be_evicted"
+
+        mock_tier3_cls = MagicMock()
+        results_tsv = tmp_path / "results.tsv"
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tier3_mode="auto",
+                rebuild_image=True,  # ignored because dry_run=True
+            )
+
+        # Cache entry must not have been evicted (use_tier3 is False for dry_run).
+        assert _IMAGE_DIGEST_CACHE.get(_DOCKER_IMAGE_TAG) == "sha256:should_not_be_evicted", (
+            "rebuild_image=True must have no effect when dry_run=True "
+            "(Tier3 is not used in dry-run mode)."
+        )
+        assert not mock_tier3_cls.called, "Tier3Docker must not be instantiated in dry-run"
+        # Restore.
+        _IMAGE_DIGEST_CACHE.pop(_DOCKER_IMAGE_TAG, None)
+
+
+# ---------------------------------------------------------------------------
+# Bug-2 regression: engineer transcripts persisted on every cell
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptPersistence:
+    """Regression suite for Bug-2 (engineer transcript persistence).
+
+    Verifies that the engineer CLI stdout+stderr is persisted to
+    <results_tsv_dir>/transcripts/<task_slug>__<condition>__rep<N>.log on
+    every cell, and that cli_exit_* status rows include the transcript path
+    in diagnostics_json.
+    """
+
+    def test_transcript_file_created_for_dry_run_cell(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """A transcript file is created for each cell even in dry-run mode."""
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        with patch("runner.score_cell", return_value=canned_score):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        transcript_dir = tmp_path / "transcripts"
+        assert transcript_dir.exists(), "transcripts/ directory must be created"
+        transcript_file = transcript_dir / "django-11039__baseline__rep1.log"
+        assert transcript_file.exists(), (
+            f"Transcript file must be created at {transcript_file}; "
+            "Bug-2 regression: transcript was not persisted."
+        )
+
+    def test_transcript_path_in_diagnostics_on_cli_exit(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """On cli_exit_1, diagnostics_json includes cli_exit_transcript path.
+
+        Regression test for Bug-2: the transcript path was not recorded in
+        diagnostics_json, making post-mortem impossible without knowing the
+        file naming convention.
+        """
+        from scoring import ScoringResult
+        from evals.runner.isolator import Tier3Context
+
+        canned_score = ScoringResult(
+            pass_fail=False, score_primary=0.0,
+            lines_touched=0, files_touched=0, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        # Produce a cli_exit_1 result from run_fix_phase.
+        import json as _json
+        import subprocess as _sp
+
+        canned_invoker_fail = {
+            "final_text": "Error: some CLI failure output",
+            "status": "cli_exit_1",
+            "cost_usd": 0.0,
+            "usage": {"input_tokens": 26, "output_tokens": 0},
+            "latency_ms": 100,
+            "invocation_mode": "tier3",
+            "tool_calls": [],
+            "turns_used": 0,
+            "_parse_warnings": [],
+            "stderr_tail": "fatal: not a git repository",
+        }
+        canned_cp = _sp.CompletedProcess(
+            args=[], returncode=1,
+            stdout=_json.dumps(canned_invoker_fail), stderr="",
+        )
+
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "held",
+            image_tag="ae-eval-swebench:latest",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "held").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+        mock_tier3_cls = MagicMock(return_value=mock_tier3_instance)
+        mock_tier3_cls.ensure_image = MagicMock(return_value="sha256:abc123")
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=canned_cp)
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "cli_exit_1", (
+            f"Expected status='cli_exit_1', got {rows[0]['status']!r}"
+        )
+
+        diagnostics = _json.loads(rows[0]["diagnostics_json"])
+        assert "cli_exit_transcript" in diagnostics, (
+            "diagnostics_json must include 'cli_exit_transcript' key on cli_exit_* rows. "
+            "Bug-2 regression: transcript path was not recorded in diagnostics."
+        )
+        assert "transcript_path" in diagnostics, (
+            "diagnostics_json must include 'transcript_path' for every cell."
+        )
+
+        # The transcript file must actually exist.
+        transcript_path = Path(diagnostics["cli_exit_transcript"])
+        assert transcript_path.exists(), (
+            f"Transcript file {transcript_path} must exist after cli_exit_1. "
+            "Bug-2 regression: transcript was not written to disk."
+        )
+        content = transcript_path.read_text(encoding="utf-8")
+        assert "Error: some CLI failure output" in content, (
+            "Transcript file must contain the engineer's stdout output."
+        )
+        assert "fatal: not a git repository" in content, (
+            "Transcript file must contain the stderr_tail."
+        )
+
+    def test_transcript_stderr_tail_printed_to_stderr_on_cli_exit(
+        self, tmp_path: Path, corpus_yaml: Path, capsys
+    ):
+        """On cli_exit_*, the last 500 chars of transcript are printed to stderr."""
+        from scoring import ScoringResult
+        from evals.runner.isolator import Tier3Context
+
+        canned_score = ScoringResult(
+            pass_fail=False, score_primary=0.0,
+            lines_touched=0, files_touched=0, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        import json as _json, subprocess as _sp
+
+        long_output = "X" * 600
+        canned_invoker_fail = {
+            "final_text": long_output,
+            "status": "cli_exit_1",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "tier3",
+            "tool_calls": [],
+            "turns_used": 0,
+            "_parse_warnings": [],
+        }
+        canned_cp = _sp.CompletedProcess(
+            args=[], returncode=1,
+            stdout=_json.dumps(canned_invoker_fail), stderr="",
+        )
+
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "held",
+            image_tag="ae-eval-swebench:latest",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "held").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+        mock_tier3_cls = MagicMock(return_value=mock_tier3_instance)
+        mock_tier3_cls.ensure_image = MagicMock(return_value="sha256:abc123")
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=canned_cp)
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        captured = capsys.readouterr()
+        assert "[cli_exit]" in captured.err, (
+            "On cli_exit_1, last 500 chars must be printed to stderr for "
+            "quick post-mortem. Bug-2 regression: nothing was printed."
+        )
+        # The tail (last 500 chars of a 600-char string) should appear.
+        assert "X" * 500 in captured.err, (
+            "The last 500 chars of the transcript must appear in stderr output."
+        )


### PR DESCRIPTION
## Summary

- **Bug-1:** `Dockerfile.swebench` only installed `pytest==8.3.5` but `scoring.py` passes `--timeout=120` to pytest inside the container, causing every score phase to fail with `unrecognized arguments: --timeout=120`. Added `pytest-timeout==2.4.0` to the pip install layer. Added `--rebuild-image` CLI flag (option c) to explicitly force a fresh build without surprise rebuilds on normal runs.
- **Bug-2:** Engineer CLI stdout+stderr is now persisted to `<results_tsv_dir>/transcripts/<task_slug>__<condition>__rep<N>.log` on every cell. On `cli_exit_*`, the transcript path is recorded in `diagnostics_json` and the last 500 chars are printed to stderr for quick post-mortem.

## Test plan

- [ ] `test_dockerfile_includes_pytest_timeout` - grep test confirms `pytest-timeout` is in Dockerfile pip install
- [ ] `TestRebuildImage` (3 tests) - cache evicted on `rebuild_image=True`, preserved on `False`, no-op with `dry_run=True`
- [ ] `TestTranscriptPersistence` (3 tests) - transcript file created per cell, path in diagnostics on `cli_exit_1`, last 500 chars printed to stderr
- [ ] All 330 existing tests in `evals/runner/tests/` and `evals/skill-comparison/tests/` pass

## Verification command (smoke, operator runs explicitly)

```bash
PYTHONPATH=. python3 evals/skill-comparison/runner.py \
  --tasks-yaml evals/skill-comparison/tasks/corpus.yaml \
  --results-tsv /tmp/skill-smoke-v4.tsv \
  --tasks requests-3362 \
  --conditions baseline \
  --max-cells 1 \
  --max-usd 5 --max-tokens 2000000 --max-wall-seconds 900 \
  --rebuild-image
```