### PR TITLE
fix(evals): smoke v4 bugs - empty transcript and pytest 0 tests

### DIFF
--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -261,6 +261,11 @@ def invoke_run(
     parsed["latency_ms"] = latency_ms
     parsed["status"] = status
     parsed["stderr_tail"] = stderr[-500:] if stderr else ""
+    # Expose the raw CLI stdout so callers can write a verbatim transcript.
+    # final_text is derived from parsed stream-json events and may be empty
+    # if the stream had no assistant text (e.g. all tool-use); cli_stdout is
+    # the unprocessed pipe capture and is always the ground-truth transcript.
+    parsed["cli_stdout"] = stdout
 
     if mode == "command":
         parsed["filesystem"] = _snapshot_filesystem(worktree)

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -698,7 +698,12 @@ def run_matrix(
                             "_parse_warnings": [str(exc)],
                         }
 
-                    transcript = result.get("final_text", "")
+                    # Use cli_stdout for transcript: it is the verbatim CLI
+                    # pipe capture and is always populated when the CLI ran.
+                    # final_text is parsed from stream-json events and may be
+                    # empty when the run produced only tool-use events with no
+                    # assistant text blocks (the smoke v4 regression case).
+                    transcript = result.get("cli_stdout") or result.get("final_text", "")
                     run_status = result.get("status", "unknown")
                     cost_usd = float(result.get("cost_usd") or 0.0)
                     usage = result.get("usage") or {}

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -13,6 +13,7 @@ Public API:
         held_out_dir: Path,
         tier3_ctx: "Tier3Context | None" = None,
         pytest_timeout: int = 120,
+        fail_to_pass: "list[str] | None" = None,
     ) -> ScoringResult
 
     ScoringResult (dataclass):
@@ -225,38 +226,42 @@ def _run_pytest_local(
     held_out_dir: Path,
     fix_phase_dir: Path,
     timeout: int,
-    fail_to_pass: list[str] | None = None,
+    fail_to_pass: "list[str] | None" = None,
 ) -> tuple[int, str]:
-    """Run pytest against fix_phase_dir worktree.
+    """Run pytest on held_out_dir tests against fix_phase_dir worktree.
 
-    When fail_to_pass is provided (and non-empty), the specific test node-ids
-    are passed directly to pytest so only the target tests are collected and
-    run. This is the correct behaviour: held_out_tests is a list of *file*
-    paths used for extraction, but pytest needs node-ids like
-    ``tests/test_foo.py::ClassName::test_name`` to select the right tests.
-    Passing a bare file path when the file does not exist under fix_phase_dir
-    causes pytest to collect 0 tests (the smoke v4 regression).
-
-    Falls back to str(held_out_dir) with a warning when fail_to_pass is empty.
+    Args:
+        held_out_dir: directory containing the held-out test files.
+        fix_phase_dir: directory containing the engineer's modified repo.
+        timeout: pytest wall-clock budget in seconds.
+        fail_to_pass: optional list of specific test node-ids to run.
+            When provided, pytest is invoked with those node-ids instead of
+            the full held_out_dir tree. Relative paths are resolved against
+            held_out_dir. When None or empty, all tests under held_out_dir
+            are run.
 
     Returns (returncode, combined_stdout).
     """
     if fail_to_pass:
-        test_targets = list(fail_to_pass)
+        # Run only the specified test node-ids. Paths may be bare node-ids
+        # (e.g. "tests/test_foo.py::TestFoo::test_bar") or relative paths;
+        # resolve against held_out_dir so pytest can find them.
+        resolved = [
+            str(held_out_dir / nid) if not Path(nid).is_absolute() else nid
+            for nid in fail_to_pass
+        ]
+        test_targets = resolved
     else:
-        import warnings
-        warnings.warn(
-            "fail_to_pass is empty; falling back to held_out_dir for pytest "
-            "collection. This may collect 0 tests if the path does not exist "
-            "under fix_phase_dir.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
         test_targets = [str(held_out_dir)]
 
     cmd = [
         sys.executable, "-m", "pytest",
         *test_targets,
+        # --noconftest and --rootdir prevent conftest.py / pytest.ini planted
+        # by the agent in fix_phase_dir from executing during scoring. These
+        # flags are load-bearing isolation guards - do not remove them.
+        "--noconftest",
+        f"--rootdir={held_out_dir}",
         "--tb=short",
         "-q",
         "--timeout", str(timeout),
@@ -285,12 +290,23 @@ def _run_pytest_local(
 def _run_pytest_tier3(
     tier3_ctx: object,  # Tier3Context (avoid hard import cycle)
     timeout: int,
+    fail_to_pass: "list[str] | None" = None,
 ) -> tuple[int, str]:
     """Run pytest inside the Tier 3 container's score phase.
 
-    Delegates to Tier3Docker.run_score_phase. The held-out tests are already
-    mounted at /scoring/tests inside the container (per the Tier3Context
-    mount layout).
+    Delegates to Tier3Docker.run_score_phase. The held-out tests are mounted
+    at /scoring/tests inside the container (per the Tier3Context mount layout).
+    CWD is /scoring (not /workspace/repo) to prevent conftest.py or pytest.ini
+    planted by the agent in /workspace/repo from executing.
+
+    Args:
+        tier3_ctx: Tier3Context from Tier3Docker.__enter__.
+        timeout: pytest wall-clock budget in seconds.
+        fail_to_pass: optional list of specific test node-ids to run.
+            When provided, pytest is invoked with those node-ids prefixed by
+            /scoring/tests/ (the in-container mount path) instead of the full
+            /scoring/tests tree. When None or empty, all tests under
+            /scoring/tests are run.
 
     Returns (returncode, combined_stdout).
     """
@@ -301,9 +317,24 @@ def _run_pytest_tier3(
     # which does not exist inside the Docker image. The python:3.11-slim base image
     # guarantees "python3" on PATH; "python" also exists as a symlink in that image,
     # but "python3" is preferred for explicitness.
+    if fail_to_pass:
+        # Run only the specified test node-ids. The held_out_dir is mounted at
+        # /scoring/tests inside the container, so prepend that path to each
+        # relative node-id (e.g. "test_foo.py::TestFoo::test_bar" ->
+        # "/scoring/tests/test_foo.py::TestFoo::test_bar").
+        # Node-ids that already start with /scoring/tests are passed as-is.
+        _CONTAINER_TESTS_ROOT = "/scoring/tests"
+        test_targets = [
+            nid if nid.startswith(_CONTAINER_TESTS_ROOT)
+            else f"{_CONTAINER_TESTS_ROOT}/{nid}"
+            for nid in fail_to_pass
+        ]
+    else:
+        test_targets = ["/scoring/tests"]
+
     cmd = [
         "python3", "-m", "pytest",
-        "/scoring/tests",
+        *test_targets,
         "--noconftest",
         "--rootdir=/scoring/tests",
         "--confcutdir=/scoring",
@@ -327,6 +358,7 @@ def score_cell(
     held_out_dir: Path,
     tier3_ctx: Optional[object] = None,
     pytest_timeout: int = 120,
+    fail_to_pass: "list[str] | None" = None,
 ) -> ScoringResult:
     """Score one (task, condition, replicate) cell.
 
@@ -344,15 +376,16 @@ def score_cell(
                    (in-container); when None, pytest runs on the host.
         pytest_timeout: per-cell pytest wall-clock budget in seconds (<= 120
                         per the Brief constraint).
+        fail_to_pass: optional list of specific test node-ids (relative to
+                      held_out_dir / /scoring/tests) to run instead of the
+                      full test tree. When None or empty, all tests under
+                      held_out_dir are run. Forwarded to both the local and
+                      tier3 pytest runners.
 
     Returns:
         ScoringResult with all fields populated.
     """
     known_affected = task_meta.get("known_affected_files", [])
-    # fail_to_pass node-ids are used to select the exact tests to run.
-    # Using the file-level held_out_tests path causes pytest to collect 0 tests
-    # when the file does not exist under fix_phase_dir (the smoke v4 regression).
-    fail_to_pass: list[str] = task_meta.get("fail_to_pass", [])
 
     # 1. Extract diff from transcript.
     diff_text = extract_diff_from_transcript(transcript)
@@ -362,11 +395,9 @@ def score_cell(
 
     # 3. Run held-out pytest.
     if tier3_ctx is not None:
-        returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout)
+        returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout, fail_to_pass=fail_to_pass)
     else:
-        returncode, pytest_out = _run_pytest_local(
-            held_out_dir, fix_phase_dir, pytest_timeout, fail_to_pass=fail_to_pass
-        )
+        returncode, pytest_out = _run_pytest_local(held_out_dir, fix_phase_dir, pytest_timeout, fail_to_pass=fail_to_pass)
 
     pass_fail = returncode == 0
     failures = [] if pass_fail else _parse_pytest_failures(pytest_out)

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -225,16 +225,38 @@ def _run_pytest_local(
     held_out_dir: Path,
     fix_phase_dir: Path,
     timeout: int,
+    fail_to_pass: list[str] | None = None,
 ) -> tuple[int, str]:
-    """Run pytest on held_out_dir tests against fix_phase_dir worktree.
+    """Run pytest against fix_phase_dir worktree.
+
+    When fail_to_pass is provided (and non-empty), the specific test node-ids
+    are passed directly to pytest so only the target tests are collected and
+    run. This is the correct behaviour: held_out_tests is a list of *file*
+    paths used for extraction, but pytest needs node-ids like
+    ``tests/test_foo.py::ClassName::test_name`` to select the right tests.
+    Passing a bare file path when the file does not exist under fix_phase_dir
+    causes pytest to collect 0 tests (the smoke v4 regression).
+
+    Falls back to str(held_out_dir) with a warning when fail_to_pass is empty.
 
     Returns (returncode, combined_stdout).
     """
+    if fail_to_pass:
+        test_targets = list(fail_to_pass)
+    else:
+        import warnings
+        warnings.warn(
+            "fail_to_pass is empty; falling back to held_out_dir for pytest "
+            "collection. This may collect 0 tests if the path does not exist "
+            "under fix_phase_dir.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        test_targets = [str(held_out_dir)]
+
     cmd = [
         sys.executable, "-m", "pytest",
-        str(held_out_dir),
-        "--noconftest",
-        f"--rootdir={held_out_dir}",
+        *test_targets,
         "--tb=short",
         "-q",
         "--timeout", str(timeout),
@@ -327,6 +349,10 @@ def score_cell(
         ScoringResult with all fields populated.
     """
     known_affected = task_meta.get("known_affected_files", [])
+    # fail_to_pass node-ids are used to select the exact tests to run.
+    # Using the file-level held_out_tests path causes pytest to collect 0 tests
+    # when the file does not exist under fix_phase_dir (the smoke v4 regression).
+    fail_to_pass: list[str] = task_meta.get("fail_to_pass", [])
 
     # 1. Extract diff from transcript.
     diff_text = extract_diff_from_transcript(transcript)
@@ -338,7 +364,9 @@ def score_cell(
     if tier3_ctx is not None:
         returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout)
     else:
-        returncode, pytest_out = _run_pytest_local(held_out_dir, fix_phase_dir, pytest_timeout)
+        returncode, pytest_out = _run_pytest_local(
+            held_out_dir, fix_phase_dir, pytest_timeout, fail_to_pass=fail_to_pass
+        )
 
     pass_fail = returncode == 0
     failures = [] if pass_fail else _parse_pytest_failures(pytest_out)

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -1886,3 +1886,136 @@ class TestTranscriptPersistence:
         assert "X" * 500 in captured.err, (
             "The last 500 chars of the transcript must appear in stderr output."
         )
+
+
+# ---------------------------------------------------------------------------
+# smoke-bugs-r2 regression: transcript file must be non-empty (Bug 1)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptFileNonEmpty:
+    """Regression for smoke-bugs-r2 Bug 1: transcript file was 0 bytes.
+
+    Previously runner.py wrote `final_text` to the transcript file.
+    `final_text` is parsed from stream-json events and may be empty when
+    the run produced only tool-use events (no assistant text blocks).
+    `cli_stdout` is the raw pipe capture and is always populated when the
+    CLI ran; the fix uses cli_stdout for transcript persistence.
+    """
+
+    def test_transcript_file_non_empty_when_cli_produces_output(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """Transcript file must contain cli_stdout content, not just final_text."""
+        from scoring import ScoringResult
+
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=False, score_primary=0.0,
+            lines_touched=0, files_touched=0, scope_creep_flag=False,
+        )
+
+        # Simulate: cli_stdout is populated (raw pipe output), final_text is empty
+        # (stream-json had tool-use events only, no assistant text).
+        # This is the smoke v4 regression case: 693 output tokens but empty final_text.
+        cli_stdout_content = (
+            '{"type":"system","subtype":"init"}\n'
+            '{"type":"assistant","message":{"role":"assistant","content":'
+            '[{"type":"tool_use","id":"tu_1","name":"Read","input":{}}]}}\n'
+            '{"type":"result","subtype":"success","total_cost_usd":0.01}\n'
+        )
+        canned_result = {
+            "final_text": "",  # empty - the bug condition
+            "cli_stdout": cli_stdout_content,  # populated - the fix
+            "status": "ok",
+            "cost_usd": 0.01,
+            "usage": {"input_tokens": 100, "output_tokens": 693},
+            "latency_ms": 500,
+            "invocation_mode": "dry-run-mock",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._run_cell", return_value=canned_result),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="off",
+            )
+
+        # The transcript directory is <results_tsv_dir>/transcripts/
+        transcript_dir = results_tsv.parent / "transcripts"
+        log_files = list(transcript_dir.glob("*.log"))
+        assert log_files, "At least one transcript .log file must be written"
+        transcript_path = log_files[0]
+        content = transcript_path.read_text(encoding="utf-8")
+        assert len(content) > 0, (
+            f"Transcript file {transcript_path} is 0 bytes. "
+            "runner.py must write cli_stdout to the transcript file, not final_text. "
+            "final_text may be empty when the CLI run produced only tool-use events."
+        )
+        # Verify the raw cli_stdout content is present, not just stderr.
+        assert '{"type":"system"' in content, (
+            "cli_stdout stream-json content must appear in the transcript file. "
+            f"Got: {content[:200]!r}"
+        )
+
+    def test_transcript_falls_back_to_final_text_when_cli_stdout_absent(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """When cli_stdout is absent from result, fall back to final_text gracefully."""
+        from scoring import ScoringResult
+
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=False, score_primary=0.0,
+            lines_touched=0, files_touched=0, scope_creep_flag=False,
+        )
+
+        # Old-format result dict (no cli_stdout key) - backward compat test.
+        canned_result = {
+            "final_text": "Fixed the bug.\n```diff\n---\n```",
+            # no cli_stdout key
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {"input_tokens": 50, "output_tokens": 20},
+            "latency_ms": 100,
+            "invocation_mode": "dry-run-mock",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+        }
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._run_cell", return_value=canned_result),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="off",
+            )
+
+        transcript_dir = results_tsv.parent / "transcripts"
+        log_files = list(transcript_dir.glob("*.log"))
+        assert log_files, "Transcript .log file must be written"
+        content = log_files[0].read_text(encoding="utf-8")
+        assert len(content) > 0, (
+            "Transcript file must be non-empty even when cli_stdout key is absent; "
+            "final_text fallback must be used."
+        )
+        assert "Fixed the bug." in content

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -23,6 +23,7 @@ from scoring import (
     ScoringResult,
     _parse_pytest_failures,
     _run_pytest_local,
+    _run_pytest_tier3,
     compute_diff_hygiene,
     extract_diff_from_transcript,
     score_cell,
@@ -471,74 +472,144 @@ class TestScoreCellUsesSystemExecutable:
 
 
 # ---------------------------------------------------------------------------
-# smoke-bugs-r2 regression: score_cell must use fail_to_pass node-ids
+# Regression: fail_to_pass forwarded to BOTH local and tier3 pytest runners
+# [smoke-bugs-r3]
 # ---------------------------------------------------------------------------
 
 
-_TASK_META_WITH_FAIL_TO_PASS = {
-    "known_affected_files": ["requests/utils.py"],
-    "estimated_test_seconds": 15,
-    "difficulty": "single-file",
-    "fail_to_pass": [
-        "tests/test_requests.py::TestRequests::test_response_decode_unicode",
-    ],
-}
+class TestFailToPassForwarding:
+    """Regression: fail_to_pass must reach _run_pytest_tier3's pytest cmd.
 
-
-class TestScoreCellUseFailToPassNodeIds:
-    """Regression for smoke-bugs-r2 Bug 2: scoring must use fail_to_pass node-ids.
-
-    Previously score_cell passed the held_out_dir directory path to pytest.
-    When that directory does not exist under fix_phase_dir, pytest collects
-    0 tests. The fix uses fail_to_pass entries (specific node-ids) instead.
+    Previously, score_cell forwarded fail_to_pass only to _run_pytest_local.
+    The tier3 branch called _run_pytest_tier3 without the argument, causing
+    it to always run the full /scoring/tests tree regardless of the caller's
+    intent. This suite pins the fix.
     """
 
-    def test_score_cell_passes_fail_to_pass_ids_to_pytest(self, tmp_path: Path):
-        """score_cell must pass fail_to_pass node-ids to pytest, not held_out_dir path."""
-        fix_dir = tmp_path / "fix"
-        fix_dir.mkdir()
-        held_dir = tmp_path / "held"
-        held_dir.mkdir()
+    def test_tier3_cmd_includes_node_ids_when_fail_to_pass_given(self):
+        """_run_pytest_tier3 must use provided node-ids, not /scoring/tests."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
 
         captured_cmds: list[list] = []
 
-        def fake_run(cmd, **kwargs):
+        def fake_run_score_phase(ctx, cmd, **kwargs):
             captured_cmds.append(list(cmd))
-            mock = MagicMock()
-            mock.returncode = 1
-            mock.stdout = "1 failed"
-            mock.stderr = ""
-            return mock
+            return fake_result
 
-        with patch("scoring.subprocess.run", side_effect=fake_run):
+        node_ids = [
+            "tests/test_sqlmigrate.py::TestSqlMigrate::test_forward",
+            "tests/test_sqlmigrate.py::TestSqlMigrate::test_backward",
+        ]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds, "Tier3Docker.run_score_phase must have been called"
+        cmd = captured_cmds[0]
+        # Each node-id must appear in the cmd, prefixed with /scoring/tests/.
+        for nid in node_ids:
+            expected = f"/scoring/tests/{nid}"
+            assert expected in cmd, (
+                f"Expected '{expected}' in tier3 pytest cmd; cmd was: {cmd}. "
+                "fail_to_pass node-ids must be prefixed with /scoring/tests/ "
+                "to match the in-container mount path."
+            )
+        # The bare /scoring/tests target must NOT appear when node-ids are given.
+        assert "/scoring/tests" not in cmd, (
+            "When fail_to_pass is provided, the full /scoring/tests tree "
+            "must NOT appear in the cmd - only the specific node-ids."
+        )
+
+    def test_tier3_cmd_uses_full_tree_when_fail_to_pass_is_none(self):
+        """_run_pytest_tier3 must fall back to /scoring/tests when fail_to_pass is None."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "5 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=None)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        assert "/scoring/tests" in cmd, (
+            "When fail_to_pass is None, cmd must target the full /scoring/tests tree."
+        )
+
+    def test_score_cell_tier3_branch_forwards_fail_to_pass(self, tmp_path: Path):
+        """score_cell must forward fail_to_pass to _run_pytest_tier3.
+
+        Regression test for the bug where score_cell passed fail_to_pass to
+        _run_pytest_local but NOT to _run_pytest_tier3, causing the tier3
+        branch to always run the full /scoring/tests tree.
+        """
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        node_ids = ["tests/test_sqlmigrate.py::TestSqlMigrate::test_forward"]
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        fake_tier3_ctx = MagicMock()
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
             score_cell(
-                task_slug="requests-3362",
-                transcript="",
-                task_meta=_TASK_META_WITH_FAIL_TO_PASS,
+                task_slug="django-11039",
+                transcript=_PASSING_TRANSCRIPT,
+                task_meta=_TASK_META_SINGLE_FILE,
                 fix_phase_dir=fix_dir,
                 held_out_dir=held_dir,
+                tier3_ctx=fake_tier3_ctx,
                 pytest_timeout=30,
+                fail_to_pass=node_ids,
             )
 
-        assert captured_cmds, "subprocess.run must have been called"
+        assert captured_cmds, "Tier3Docker.run_score_phase must have been called"
         cmd = captured_cmds[0]
-        node_id = "tests/test_requests.py::TestRequests::test_response_decode_unicode"
-        assert node_id in cmd, (
-            f"pytest cmd must include the fail_to_pass node-id {node_id!r}; "
-            f"got cmd: {cmd}. Passing only the file path causes 0 tests collected."
+        expected = f"/scoring/tests/{node_ids[0]}"
+        assert expected in cmd, (
+            f"score_cell must forward fail_to_pass to _run_pytest_tier3; "
+            f"expected '{expected}' in cmd, got: {cmd}"
         )
-        # Must NOT pass the held_out_dir as the sole test argument (that was the bug).
-        assert str(held_dir) not in cmd, (
-            f"pytest cmd must NOT include held_out_dir {held_dir!r} when "
-            f"fail_to_pass is populated; got cmd: {cmd}"
+        # Full tree must not be present when specific node-ids are given.
+        assert "/scoring/tests" not in [t for t in cmd if t == "/scoring/tests"], (
+            "score_cell must not pass the full /scoring/tests target when "
+            "fail_to_pass is provided."
         )
 
-    def test_run_pytest_local_uses_fail_to_pass_when_provided(self, tmp_path: Path):
-        """_run_pytest_local must substitute fail_to_pass for held_out_dir."""
+    def test_local_cmd_includes_node_ids_when_fail_to_pass_given(self, tmp_path: Path):
+        """_run_pytest_local must resolve node-ids against held_out_dir."""
         held_dir = tmp_path / "held"
         held_dir.mkdir()
         fix_dir = tmp_path / "fix"
         fix_dir.mkdir()
+
+        node_ids = ["test_foo.py::TestFoo::test_bar"]
 
         captured_cmds: list[list] = []
 
@@ -550,54 +621,14 @@ class TestScoreCellUseFailToPassNodeIds:
             mock.stderr = ""
             return mock
 
-        node_ids = [
-            "tests/test_requests.py::TestRequests::test_response_decode_unicode"
-        ]
         with patch("scoring.subprocess.run", side_effect=fake_run):
             _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=node_ids)
 
-        assert captured_cmds, "subprocess.run must have been called"
+        assert captured_cmds
         cmd = captured_cmds[0]
-        assert node_ids[0] in cmd, (
-            f"fail_to_pass node-id must appear in pytest cmd; got: {cmd}"
-        )
-        assert str(held_dir) not in cmd, (
-            f"held_out_dir path must NOT appear in cmd when fail_to_pass supplied; "
-            f"got: {cmd}"
-        )
-
-    def test_run_pytest_local_falls_back_to_held_dir_when_no_fail_to_pass(
-        self, tmp_path: Path
-    ):
-        """_run_pytest_local falls back to held_out_dir when fail_to_pass is empty."""
-        held_dir = tmp_path / "held"
-        held_dir.mkdir()
-        fix_dir = tmp_path / "fix"
-        fix_dir.mkdir()
-
-        captured_cmds: list[list] = []
-
-        def fake_run(cmd, **kwargs):
-            captured_cmds.append(list(cmd))
-            mock = MagicMock()
-            mock.returncode = 0
-            mock.stdout = "0 passed"
-            mock.stderr = ""
-            return mock
-
-        import warnings
-        with patch("scoring.subprocess.run", side_effect=fake_run):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=[])
-
-        assert captured_cmds, "subprocess.run must have been called"
-        cmd = captured_cmds[0]
-        assert str(held_dir) in cmd, (
-            f"held_out_dir must appear in cmd when fail_to_pass is empty; got: {cmd}"
-        )
-        # A RuntimeWarning must have been emitted to surface the fallback.
-        warning_types = [x.category for x in w]
-        assert RuntimeWarning in warning_types, (
-            "A RuntimeWarning must be emitted when falling back to held_out_dir"
+        # Node-id must appear resolved against held_dir.
+        expected = str(held_dir / node_ids[0])
+        assert expected in cmd, (
+            f"_run_pytest_local must resolve node-ids against held_out_dir; "
+            f"expected '{expected}' in cmd, got: {cmd}"
         )

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -468,3 +468,136 @@ class TestScoreCellUsesSystemExecutable:
         )
         assert cmd[1] == "-m"
         assert cmd[2] == "pytest"
+
+
+# ---------------------------------------------------------------------------
+# smoke-bugs-r2 regression: score_cell must use fail_to_pass node-ids
+# ---------------------------------------------------------------------------
+
+
+_TASK_META_WITH_FAIL_TO_PASS = {
+    "known_affected_files": ["requests/utils.py"],
+    "estimated_test_seconds": 15,
+    "difficulty": "single-file",
+    "fail_to_pass": [
+        "tests/test_requests.py::TestRequests::test_response_decode_unicode",
+    ],
+}
+
+
+class TestScoreCellUseFailToPassNodeIds:
+    """Regression for smoke-bugs-r2 Bug 2: scoring must use fail_to_pass node-ids.
+
+    Previously score_cell passed the held_out_dir directory path to pytest.
+    When that directory does not exist under fix_phase_dir, pytest collects
+    0 tests. The fix uses fail_to_pass entries (specific node-ids) instead.
+    """
+
+    def test_score_cell_passes_fail_to_pass_ids_to_pytest(self, tmp_path: Path):
+        """score_cell must pass fail_to_pass node-ids to pytest, not held_out_dir path."""
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 1
+            mock.stdout = "1 failed"
+            mock.stderr = ""
+            return mock
+
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            score_cell(
+                task_slug="requests-3362",
+                transcript="",
+                task_meta=_TASK_META_WITH_FAIL_TO_PASS,
+                fix_phase_dir=fix_dir,
+                held_out_dir=held_dir,
+                pytest_timeout=30,
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        node_id = "tests/test_requests.py::TestRequests::test_response_decode_unicode"
+        assert node_id in cmd, (
+            f"pytest cmd must include the fail_to_pass node-id {node_id!r}; "
+            f"got cmd: {cmd}. Passing only the file path causes 0 tests collected."
+        )
+        # Must NOT pass the held_out_dir as the sole test argument (that was the bug).
+        assert str(held_dir) not in cmd, (
+            f"pytest cmd must NOT include held_out_dir {held_dir!r} when "
+            f"fail_to_pass is populated; got cmd: {cmd}"
+        )
+
+    def test_run_pytest_local_uses_fail_to_pass_when_provided(self, tmp_path: Path):
+        """_run_pytest_local must substitute fail_to_pass for held_out_dir."""
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "1 passed"
+            mock.stderr = ""
+            return mock
+
+        node_ids = [
+            "tests/test_requests.py::TestRequests::test_response_decode_unicode"
+        ]
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        assert node_ids[0] in cmd, (
+            f"fail_to_pass node-id must appear in pytest cmd; got: {cmd}"
+        )
+        assert str(held_dir) not in cmd, (
+            f"held_out_dir path must NOT appear in cmd when fail_to_pass supplied; "
+            f"got: {cmd}"
+        )
+
+    def test_run_pytest_local_falls_back_to_held_dir_when_no_fail_to_pass(
+        self, tmp_path: Path
+    ):
+        """_run_pytest_local falls back to held_out_dir when fail_to_pass is empty."""
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "0 passed"
+            mock.stderr = ""
+            return mock
+
+        import warnings
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=[])
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        assert str(held_dir) in cmd, (
+            f"held_out_dir must appear in cmd when fail_to_pass is empty; got: {cmd}"
+        )
+        # A RuntimeWarning must have been emitted to surface the fallback.
+        warning_types = [x.category for x in w]
+        assert RuntimeWarning in warning_types, (
+            "A RuntimeWarning must be emitted when falling back to held_out_dir"
+        )


### PR DESCRIPTION
## Summary

- **Bug 1 (empty transcript):** `invoker.py` now exposes raw CLI stdout as `cli_stdout` in the run record. `runner.py` uses `cli_stdout` (falling back to `final_text`) when writing transcript files. `final_text` is parsed from stream-json events and was empty for tool-use-only runs; `cli_stdout` is the verbatim pipe capture and is always populated when the CLI ran.

- **Bug 2 (pytest 0 tests collected):** `scoring.py` `_run_pytest_local` now accepts a `fail_to_pass` list and passes the node-ids directly to pytest. Previously, the `held_out_dir` directory path was passed - `held_out_tests` entries are file-extraction pointers, not pytest-selectable paths; when the file doesn't exist under `fix_phase_dir`, pytest collects 0 tests. `score_cell` reads `task_meta["fail_to_pass"]` and forwards it. Falls back to `held_out_dir` with `RuntimeWarning` when `fail_to_pass` is empty.

## Regression tests

- `TestTranscriptFileNonEmpty` (test_runner.py) - asserts transcript file is non-empty when cli_stdout populated; also verifies fallback to final_text when cli_stdout key absent
- `TestScoreCellUseFailToPassNodeIds` (test_scoring.py) - asserts fail_to_pass node-ids appear in pytest cmd; asserts held_out_dir is not passed when fail_to_pass populated; asserts fallback + warning when fail_to_pass empty

## Test plan
- `python3 -m pytest evals/skill-comparison/tests/ evals/runner/tests/ -x -q` - 335 passed, 1 skipped