### PR TITLE
fix(evals): raise max_turns to 40, fix pytest 0-tests-collected in score phase

### DIFF
--- a/evals/runner/cli.py
+++ b/evals/runner/cli.py
@@ -93,6 +93,7 @@ def _run_fixture(
     commit: str,
     content_hash: str,
     scoring,
+    max_turns: int | None = None,
 ) -> dict:
     per_run_scores: list[dict] = []
     invocation_modes: list[str] = []
@@ -164,6 +165,7 @@ def _run_fixture(
                     manifest.timeout_seconds,
                     mode="command",
                     home=fake_home,
+                    max_turns=max_turns,
                 )
                 # Scorer needs the worktree root to read AGENTS.md/.gitignore
                 # line-level content. Stuff it into the record before the
@@ -175,7 +177,8 @@ def _run_fixture(
                 pr_mod.stage_fixture_files(fixture, worktree)
                 prompt_text = pr_mod.build_prompt(manifest.name, fixture)
                 run_record = inv_mod.invoke_run(
-                    prompt_text, worktree, manifest.timeout_seconds, agent_name=agent_name
+                    prompt_text, worktree, manifest.timeout_seconds,
+                    agent_name=agent_name, max_turns=max_turns,
                 )
             score = _score_run(scoring, run_record, fixture)
         per_run_scores.append(score)
@@ -246,7 +249,10 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     rows: list[dict] = []
     for fx in fixtures:
-        row = _run_fixture(manifest, fx, n_runs, commit, content_hash, scoring)
+        row = _run_fixture(
+            manifest, fx, n_runs, commit, content_hash, scoring,
+            max_turns=args.max_turns,
+        )
         rows.append(row)
         _log.info(
             "  -> fixture=%s median=%.4f stdev=%.4f n=%d status=%s",
@@ -294,6 +300,17 @@ def main(argv: list[str] | None = None) -> int:
     p_run.add_argument("component")
     p_run.add_argument("--fixture", default=None, help="Run only this fixture ID.")
     p_run.add_argument("--n", type=int, default=None, help="Override n_runs.")
+    p_run.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        dest="max_turns",
+        help=(
+            "Override --max-turns passed to the Claude CLI for agent-mode runs "
+            f"(default: {inv_mod._MAX_TURNS_DEFAULT}). Raise for SWE-bench fix "
+            "tasks that need many tool iterations."
+        ),
+    )
     p_run.set_defaults(func=cmd_run)
 
     p_list = sub.add_parser("list-components")

--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -56,7 +56,13 @@ _ALLOWED_TOOLS = "Read,Grep,Glob,Task"
 # HOME redirect is what contains the blast radius; the tool list is
 # permissive on purpose.
 _COMMAND_ALLOWED_TOOLS = "Read,Grep,Glob,Task,Write,Edit,Bash"
-_MAX_TURNS = "6"
+# SWE-bench fix tasks need many turns: read files, edit, run tests, iterate.
+# Raised from 6 to 40 (smoke v5 regression: engineer hit max_turns at 6 and
+# exited despite $0.75 spend with no fix applied).
+# The _MAX_TURNS_DEFAULT is the process-level default; invoke_run accepts an
+# optional max_turns kwarg so the runner CLI can override via --max-turns.
+_MAX_TURNS_DEFAULT = 40
+_MAX_TURNS = str(_MAX_TURNS_DEFAULT)
 # Command-mode runs can take many turns (scaffolding /init-project writes
 # ~15 files, runs subprocess calls, and curates content). Give it more
 # headroom than the Tier 1 subagent cap.
@@ -136,6 +142,7 @@ def invoke_run(
     home: Path | None = None,
     model: str | None = None,
     system_prompt: str | None = None,
+    max_turns: int | None = None,
 ) -> dict:
     """Run the Claude CLI once with `prompt` at `worktree` cwd; return a run record.
 
@@ -161,12 +168,16 @@ def invoke_run(
     appends to the default; --system-prompt replaces it entirely. We use
     --append-system-prompt to preserve the default context and add the rules.
     subprocess argv handling means no shell escaping is needed.
+
+    If `max_turns` is provided, it overrides the module-level default for
+    agent mode (_MAX_TURNS_DEFAULT=40) or command mode (_COMMAND_MAX_TURNS=60).
+    Useful for SWE-bench fix tasks that need more tool iterations.
     """
     if mode == "command":
         outer_prompt = prompt
         allowed_tools = _COMMAND_ALLOWED_TOOLS
         permission_mode = "acceptEdits"
-        max_turns = _COMMAND_MAX_TURNS
+        effective_max_turns = str(max_turns) if max_turns is not None else _COMMAND_MAX_TURNS
         expect_subagent = False
     else:
         if agent_name:
@@ -175,7 +186,7 @@ def invoke_run(
             outer_prompt = prompt
         allowed_tools = _ALLOWED_TOOLS
         permission_mode = "default"
-        max_turns = _MAX_TURNS
+        effective_max_turns = str(max_turns) if max_turns is not None else _MAX_TURNS
         expect_subagent = bool(agent_name)
 
     # The Claude CLI accepts the prompt as the argument to -p; subprocess.run
@@ -188,7 +199,7 @@ def invoke_run(
         "--verbose",
         "--allowed-tools", allowed_tools,
         "--permission-mode", permission_mode,
-        "--max-turns", max_turns,
+        "--max-turns", effective_max_turns,
     ]
 
     # Route through litellm when model id uses a non-Anthropic prefix.

--- a/evals/runner/tests/test_invoker.py
+++ b/evals/runner/tests/test_invoker.py
@@ -1,0 +1,150 @@
+"""
+Purpose: Unit tests for evals.runner.invoker. Covers _MAX_TURNS_DEFAULT value
+         and the max_turns override kwarg on invoke_run.
+
+Public API: pytest test module; no public symbols.
+
+Upstream deps: evals.runner.invoker (_MAX_TURNS_DEFAULT, _MAX_TURNS, invoke_run),
+               unittest.mock, subprocess, pathlib.
+
+Downstream consumers: pytest runner (evals/ test suite).
+
+Failure modes: test isolation only; no real Claude CLI calls are made.
+
+Performance: pure unit tests; negligible runtime.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import evals.runner.invoker as invoker_module
+from evals.runner.invoker import _MAX_TURNS, _MAX_TURNS_DEFAULT, invoke_run
+
+
+# ---------------------------------------------------------------------------
+# Regression: _MAX_TURNS raised to 40 (smoke v5 max_turns=6 too low)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTurnsDefault:
+    """Regression: _MAX_TURNS must be >= 40 for SWE-bench fix tasks.
+
+    Previously set to "6" - engineers hit max_turns and exited despite a
+    $0.75 spend with no fix applied (smoke v5 regression). SWE-bench tasks
+    need many tool turns: read files, edit, run tests, iterate.
+    """
+
+    def test_max_turns_default_is_40_or_higher(self):
+        """_MAX_TURNS_DEFAULT must be >= 40 to give engineers enough turns."""
+        assert _MAX_TURNS_DEFAULT >= 40, (
+            f"_MAX_TURNS_DEFAULT must be >= 40 for SWE-bench fix tasks; "
+            f"got {_MAX_TURNS_DEFAULT}. "
+            "Engineers hit max_turns=6 and exited without fixing anything "
+            "(smoke v5 regression)."
+        )
+
+    def test_max_turns_string_matches_default(self):
+        """_MAX_TURNS string must equal str(_MAX_TURNS_DEFAULT)."""
+        assert _MAX_TURNS == str(_MAX_TURNS_DEFAULT), (
+            f"_MAX_TURNS ({_MAX_TURNS!r}) must equal str(_MAX_TURNS_DEFAULT) "
+            f"({str(_MAX_TURNS_DEFAULT)!r}). They diverged."
+        )
+
+    def test_max_turns_not_six(self):
+        """_MAX_TURNS must not be '6' - the pre-regression value."""
+        assert _MAX_TURNS != "6", (
+            "_MAX_TURNS must not be '6'. The original value caused engineers "
+            "to hit max_turns on SWE-bench fix tasks and exit with no fix applied."
+        )
+
+
+# ---------------------------------------------------------------------------
+# invoke_run max_turns kwarg override
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeRunMaxTurnsOverride:
+    """invoke_run must forward max_turns kwarg to the --max-turns CLI flag."""
+
+    def _make_fake_run(self, captured_cmds: list) -> object:
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = '{"type":"result","subtype":"success"}\n'
+            mock.stderr = ""
+            return mock
+
+        return fake_subprocess_run
+
+    def test_default_max_turns_is_applied_in_agent_mode(self, tmp_path: Path):
+        """invoke_run agent mode uses _MAX_TURNS (default 40) when max_turns not given."""
+        captured_cmds: list[list] = []
+
+        with patch("subprocess.run", side_effect=self._make_fake_run(captured_cmds)):
+            with patch.object(invoker_module, "parse_stream_json", return_value={
+                "status": "ok", "final_text": "", "tool_calls": [],
+                "tokens": {}, "turns_used": 1, "_parse_warnings": [],
+                "invocation_mode": "raw-prompt",
+            }):
+                invoke_run("test prompt", tmp_path, timeout_seconds=60)
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        idx = cmd.index("--max-turns")
+        actual_max_turns = cmd[idx + 1]
+        assert actual_max_turns == str(_MAX_TURNS_DEFAULT), (
+            f"Default agent mode must use _MAX_TURNS_DEFAULT={_MAX_TURNS_DEFAULT!r}; "
+            f"got {actual_max_turns!r}. cmd={cmd}"
+        )
+
+    def test_max_turns_kwarg_overrides_default(self, tmp_path: Path):
+        """invoke_run must use the caller-supplied max_turns, not _MAX_TURNS."""
+        captured_cmds: list[list] = []
+
+        with patch("subprocess.run", side_effect=self._make_fake_run(captured_cmds)):
+            with patch.object(invoker_module, "parse_stream_json", return_value={
+                "status": "ok", "final_text": "", "tool_calls": [],
+                "tokens": {}, "turns_used": 1, "_parse_warnings": [],
+                "invocation_mode": "raw-prompt",
+            }):
+                invoke_run("test prompt", tmp_path, timeout_seconds=60, max_turns=99)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        idx = cmd.index("--max-turns")
+        actual = cmd[idx + 1]
+        assert actual == "99", (
+            f"--max-turns must be '99' when max_turns=99 is passed; got {actual!r}. "
+            f"cmd={cmd}"
+        )
+
+    def test_max_turns_kwarg_overrides_in_command_mode(self, tmp_path: Path):
+        """invoke_run command mode must also respect max_turns kwarg."""
+        captured_cmds: list[list] = []
+
+        with patch("subprocess.run", side_effect=self._make_fake_run(captured_cmds)):
+            with patch.object(invoker_module, "parse_stream_json", return_value={
+                "status": "ok", "final_text": "", "tool_calls": [],
+                "tokens": {}, "turns_used": 1, "_parse_warnings": [],
+                "invocation_mode": "raw-prompt",
+                "filesystem": {},
+            }):
+                invoke_run(
+                    "test prompt", tmp_path, timeout_seconds=60,
+                    mode="command", max_turns=15,
+                )
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        idx = cmd.index("--max-turns")
+        actual = cmd[idx + 1]
+        assert actual == "15", (
+            f"--max-turns must be '15' when max_turns=15 is passed in command mode; "
+            f"got {actual!r}. cmd={cmd}"
+        )

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -33,7 +33,8 @@ Public API:
     compute_diff_hygiene(diff_text: str, known_affected_files: list[str]) -> dict
         Parse a unified diff; return lines_touched, files_touched, scope_creep_flag.
 
-Upstream deps: stdlib subprocess, pathlib, re, dataclasses, typing, tempfile, shutil.
+Upstream deps: stdlib subprocess, pathlib, re, dataclasses, typing, tempfile, shutil,
+               logging.
                evals.runner.isolator.Tier3Docker (optional; used for in-container
                pytest when tier3_ctx is provided).
 
@@ -50,6 +51,7 @@ Performance: pytest run is the dominant cost (~<120s per brief constraint).
 """
 from __future__ import annotations
 
+import logging
 import re
 import shutil
 import subprocess
@@ -58,6 +60,8 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
+
+_LOG = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -309,6 +313,21 @@ def _run_pytest_tier3(
             /scoring/tests are run.
 
     Returns (returncode, combined_stdout).
+
+    Isolation contract (score phase):
+        --confcutdir=/scoring prevents pytest from searching above /scoring
+        for conftest.py files, so agent-planted conftest.py at /workspace/repo
+        is never loaded. We do NOT use --noconftest because that blanket-disables
+        ALL conftest.py loading including legitimate conftest.py files in the
+        held-out test tree (/scoring/tests/conftest.py) that SWE-bench tasks
+        require for test collection. Similarly, --rootdir is omitted when
+        specific node-ids are provided because pytest infers the rootdir from
+        the first node-id path, and an explicit --rootdir can cause 0 tests
+        collected when node-id paths don't match the declared rootdir.
+
+        The entrypoint's run-tests command (used by Docker-native test runs in
+        the test suite) retains --noconftest + --rootdir for the full-tree case
+        to preserve backward compatibility with the existing security tests.
     """
     from evals.runner.isolator import Tier3Docker  # local import to avoid hard dep
 
@@ -329,19 +348,45 @@ def _run_pytest_tier3(
             else f"{_CONTAINER_TESTS_ROOT}/{nid}"
             for nid in fail_to_pass
         ]
+        # When specific node-ids are given, omit --rootdir and --noconftest:
+        # - --rootdir conflicts with absolute node-id paths when the dir value
+        #   doesn't match the path prefix, causing 0 tests collected.
+        # - --noconftest blocks legitimate conftest.py in /scoring/tests that
+        #   SWE-bench repo tests need for fixtures/collection.
+        # --confcutdir=/scoring is retained: it stops conftest discovery at
+        # /scoring so agent-planted conftest.py at /workspace/repo is never
+        # loaded regardless of CWD.
+        cmd = [
+            "python3", "-m", "pytest",
+            *test_targets,
+            "--confcutdir=/scoring",
+            "-p", "no:cacheprovider",
+            "--tb=short",
+            "-q",
+            f"--timeout={timeout}",
+        ]
     else:
         test_targets = ["/scoring/tests"]
+        # Full-tree case: use the original security-hardened flags.
+        # --noconftest is safe here because we are running the full tree and
+        # do not depend on conftest.py for targeted collection.
+        cmd = [
+            "python3", "-m", "pytest",
+            *test_targets,
+            "--noconftest",
+            "--rootdir=/scoring/tests",
+            "--confcutdir=/scoring",
+            "-p", "no:cacheprovider",
+            "--tb=short",
+            "-q",
+            f"--timeout={timeout}",
+        ]
 
-    cmd = [
-        "python3", "-m", "pytest",
-        *test_targets,
-        "--noconftest",
-        "--rootdir=/scoring/tests",
-        "--confcutdir=/scoring",
-        "--tb=short",
-        "-q",
-        f"--timeout={timeout}",
-    ]
+    _LOG.info(
+        "_run_pytest_tier3: cmd=%s node_ids=%s",
+        " ".join(cmd),
+        fail_to_pass,
+    )
     result = Tier3Docker.run_score_phase(tier3_ctx, cmd, timeout_seconds=timeout)
     return result.returncode, result.stdout + result.stderr
 

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -632,3 +632,147 @@ class TestFailToPassForwarding:
             f"_run_pytest_local must resolve node-ids against held_out_dir; "
             f"expected '{expected}' in cmd, got: {cmd}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: pytest 0-tests-collected fix [smoke-v5-pytest-collection]
+# --noconftest and --rootdir must NOT appear in the cmd when node-ids are given.
+# These flags prevent pytest from loading conftest.py needed by SWE-bench tests
+# and from finding tests when rootdir does not match the node-id path prefix.
+# ---------------------------------------------------------------------------
+
+
+class TestPytestCollectionFlags:
+    """Regression: _run_pytest_tier3 must not use --noconftest or --rootdir
+    when specific node-ids are provided (smoke v5 0-tests-collected fix).
+
+    --noconftest blanket-disables all conftest.py including legitimate ones
+    in /scoring/tests needed by SWE-bench tests for fixture collection.
+    --rootdir conflicts with absolute node-id paths causing 0 tests collected.
+    --confcutdir=/scoring is retained (prevents agent conftest at /workspace/repo).
+    """
+
+    def test_no_noconftest_flag_when_node_ids_given(self):
+        """`--noconftest` must NOT appear in the cmd when fail_to_pass is given."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        node_ids = ["tests/test_requests.py::TestRequests::test_response_decode_unicode"]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        assert "--noconftest" not in cmd, (
+            "pytest cmd MUST NOT include --noconftest when fail_to_pass is given. "
+            "--noconftest blocks legitimate conftest.py in /scoring/tests that "
+            "SWE-bench tests require for collection. "
+            f"Got cmd: {cmd}"
+        )
+
+    def test_no_rootdir_flag_when_node_ids_given(self):
+        """`--rootdir` must NOT appear in the cmd when fail_to_pass is given."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        node_ids = ["tests/test_requests.py::TestRequests::test_response_decode_unicode"]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        rootdir_flags = [arg for arg in cmd if arg.startswith("--rootdir")]
+        assert not rootdir_flags, (
+            "pytest cmd MUST NOT include --rootdir when fail_to_pass is given. "
+            "--rootdir conflicts with absolute node-id paths and causes "
+            "0 tests collected when rootdir != node-id path prefix. "
+            f"Got cmd: {cmd}"
+        )
+
+    def test_confcutdir_retained_when_node_ids_given(self):
+        """`--confcutdir=/scoring` must appear in the cmd when fail_to_pass is given.
+
+        This is the isolation guard that prevents agent-planted conftest.py at
+        /workspace/repo from loading. It must be retained even when --noconftest
+        and --rootdir are dropped.
+        """
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        node_ids = ["tests/test_requests.py::TestRequests::test_response_decode_unicode"]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        assert "--confcutdir=/scoring" in cmd, (
+            "pytest cmd MUST include --confcutdir=/scoring when fail_to_pass is "
+            "given. This prevents agent-planted conftest.py at /workspace/repo "
+            "from loading during scoring. "
+            f"Got cmd: {cmd}"
+        )
+
+    def test_node_ids_in_cmd_when_fail_to_pass_given(self):
+        """All fail_to_pass node-ids must appear in the cmd prefixed with /scoring/tests/."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "2 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        node_ids = [
+            "tests/test_requests.py::TestRequests::test_response_decode_unicode",
+            "tests/test_requests.py::TestRequests::test_redirect",
+        ]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        for nid in node_ids:
+            expected = f"/scoring/tests/{nid}"
+            assert expected in cmd, (
+                f"Node-id '{nid}' must appear as '{expected}' in the pytest cmd. "
+                f"Got cmd: {cmd}"
+            )


### PR DESCRIPTION
## Summary

- **Bug 1 (max_turns=6 too low):** `_MAX_TURNS` was 6 - engineer hit max_turns on SWE-bench fix tasks and exited with no fix applied despite \$0.75 spend (smoke v5 regression). Raised to 40. Added `max_turns` kwarg to `invoke_run` and `--max-turns N` CLI flag on the `run` subcommand.
- **Bug 2 (pytest 0 tests collected):** `_run_pytest_tier3` used `--noconftest` + `--rootdir=/scoring/tests` when running specific node-ids. `--noconftest` blanket-disables all conftest.py including legitimate ones in `/scoring/tests` that SWE-bench tests require for collection. `--rootdir` conflicts with absolute node-id paths causing 0 collected. Fix: drop both flags for node-id runs; retain `--confcutdir=/scoring` as the isolation guard. Full-tree case retains original security flags. Added INFO-level diagnostic logging of the pytest cmd per call.

## Files changed

- `evals/runner/invoker.py` - `_MAX_TURNS` 6->40; `_MAX_TURNS_DEFAULT` constant; `max_turns` kwarg on `invoke_run`
- `evals/runner/cli.py` - `--max-turns N` argparse flag threaded through `_run_fixture` -> `invoke_run`
- `evals/skill-comparison/scoring.py` - `_run_pytest_tier3` drops `--noconftest`/`--rootdir` for node-id runs; retains `--confcutdir=/scoring`; adds diagnostic logging
- `evals/runner/tests/test_invoker.py` - new; 6 regression tests for max_turns
- `evals/skill-comparison/tests/test_scoring.py` - 4 new regression tests in `TestPytestCollectionFlags`

## Test plan

- [ ] `python3 -m pytest evals/runner/tests/ evals/skill-comparison/tests/ -q` - 346 passed, 1 skipped
- [ ] Regression: `TestMaxTurnsDefault` - _MAX_TURNS >= 40, != "6"
- [ ] Regression: `TestPytestCollectionFlags` - no `--noconftest`/`--rootdir` with node-ids; `--confcutdir=/scoring` retained
- [ ] Smoke: run a single SWE-bench cell and verify engineer gets 40 turns to work