### PR TITLE
fix(evals): forward fail_to_pass to score_cell and use git diff for engineer diffs

### DIFF
--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -560,6 +560,7 @@ def run_matrix(
                     # Seeding: clone repo at base_commit and apply test_patch.
                     # Skipped in dry_run mode (canned transcript path).
                     _seed_status: Optional[str] = None  # None = ok / "seed_error"
+                    _seed_commit: str = ""  # SHA of post-seeding commit; used for engineer diff
                     if not dry_run:
                         # When not using Tier3, create a tempdir for the fix phase.
                         if fix_worktree is None:
@@ -570,12 +571,13 @@ def run_matrix(
 
                         _tasks_root = Path(__file__).parent / "tasks"
                         try:
-                            seed_fix_phase(
+                            _seed_result = seed_fix_phase(
                                 task_slug=task_slug,
                                 task_meta=task_meta,
                                 fix_dir=fix_worktree,
                                 tasks_root=_tasks_root,
                             )
+                            _seed_commit = _seed_result.get("seed_commit", "")
                         except SeedError as seed_exc:
                             _LOG.error(
                                 "Seed failed for %s rep %d (step=%s): %s",
@@ -763,6 +765,7 @@ def run_matrix(
                         held_dir = Path(".")
 
                     _score_error: Optional[str] = None
+                    _fail_to_pass = task_meta.get("fail_to_pass") or []
                     try:
                         scored = score_cell(
                             task_slug=task_slug,
@@ -772,6 +775,8 @@ def run_matrix(
                             held_out_dir=held_dir,
                             tier3_ctx=tier3_ctx,
                             pytest_timeout=_PYTEST_TIMEOUT_SECONDS,
+                            fail_to_pass=_fail_to_pass,
+                            seed_commit=_seed_commit,
                         )
                     except Exception as exc:
                         _LOG.error(

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -1,8 +1,9 @@
 """
 Purpose: Run held-out pytest in isolation and compute pass/fail plus diff-hygiene
-         diagnostics for one (task, condition, replicate) cell. Reads the engineer's
-         transcript to extract the patch diff; computes lines_touched, files_touched,
-         and scope_creep_flag against the task's known_affected_files set.
+         diagnostics for one (task, condition, replicate) cell. Computes the
+         engineer's diff from the working directory (git diff against seed_commit)
+         as the ground-truth source of changes; falls back to transcript parsing
+         only when fix_phase_dir is unavailable (dry-run paths).
 
 Public API:
     score_cell(
@@ -14,6 +15,7 @@ Public API:
         tier3_ctx: "Tier3Context | None" = None,
         pytest_timeout: int = 120,
         fail_to_pass: "list[str] | None" = None,
+        seed_commit: str = "",
     ) -> ScoringResult
 
     ScoringResult (dataclass):
@@ -24,11 +26,16 @@ Public API:
         scope_creep_flag: bool   # True if any touched file is outside known_affected_files
         held_out_failures: list[str]  # failing test IDs (empty on pass)
         pytest_returncode: int   # raw pytest exit code
-        diff_text: str           # raw diff extracted from transcript
+        diff_text: str           # raw diff (from workdir or transcript fallback)
         diagnostics: dict        # bag of supplementary data
+
+    compute_engineer_diff_from_workdir(fix_phase_dir: Path, seed_commit: str) -> str
+        Run `git diff <seed_commit>` in fix_phase_dir to get the engineer's changes
+        relative to the post-seeding state. Returns "" on any git failure.
 
     extract_diff_from_transcript(transcript: str) -> str
         Extract the git diff from an engineer's transcript. Returns "" if none found.
+        Used as a fallback when fix_phase_dir is unavailable (dry-run paths).
 
     compute_diff_hygiene(diff_text: str, known_affected_files: list[str]) -> dict
         Parse a unified diff; return lines_touched, files_touched, scope_creep_flag.
@@ -42,9 +49,10 @@ Downstream consumers: evals/skill-comparison/runner.py.
 
 Failure modes: pytest invocation failure is captured into pytest_returncode and
                held_out_failures; it does not raise. Diff extraction failure
-               (no diff in transcript) sets diff_text="" and lines_touched=0,
-               files_touched=0, scope_creep_flag=False. Known-affected-files
-               mismatch (scope_creep_flag) is a diagnostic, not an error.
+               (workdir unavailable and no diff in transcript) sets diff_text=""
+               and lines_touched=0, files_touched=0, scope_creep_flag=False.
+               Known-affected-files mismatch (scope_creep_flag) is a diagnostic,
+               not an error.
 
 Performance: pytest run is the dominant cost (~<120s per brief constraint).
              Diff parsing is O(diff lines); negligible.
@@ -123,6 +131,71 @@ def extract_diff_from_transcript(transcript: str) -> str:
         return "\n".join(raw_diffs).rstrip()
 
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Workdir-based diff (ground truth)
+# ---------------------------------------------------------------------------
+
+
+def compute_engineer_diff_from_workdir(fix_phase_dir: Path, seed_commit: str) -> str:
+    """Return the engineer's diff relative to seed_commit in fix_phase_dir.
+
+    Runs `git diff <seed_commit>` in fix_phase_dir to capture exactly what the
+    engineer changed after seeding. This is the authoritative diff source for
+    production scoring - it cannot be confused with tool_use payloads or other
+    diff-like text embedded in the CLI transcript.
+
+    Args:
+        fix_phase_dir: host-side directory containing the engineer's working tree.
+        seed_commit: SHA of the post-seeding commit (from seed_fix_phase return value).
+                     When empty, falls back to `git diff HEAD` which compares the
+                     working tree (including unstaged changes) against HEAD.
+
+    Returns:
+        Raw unified diff text, or "" on any git invocation failure.
+    """
+    if not fix_phase_dir or not fix_phase_dir.is_dir():
+        _LOG.debug(
+            "compute_engineer_diff_from_workdir: fix_phase_dir %s unavailable",
+            fix_phase_dir,
+        )
+        return ""
+
+    # When seed_commit is provided, compare the current HEAD (post-engineer commits)
+    # against the seed commit. We use HEAD..seed_commit range to capture all commits
+    # the engineer may have made, plus any unstaged changes.
+    # `git diff <seed_commit>` compares the working tree + index against seed_commit,
+    # which captures both committed and uncommitted engineer changes.
+    base = seed_commit if seed_commit else "HEAD"
+    if not seed_commit:
+        _LOG.debug(
+            "compute_engineer_diff_from_workdir: no seed_commit; using HEAD (unstaged changes only)"
+        )
+        cmd = ["git", "diff", "HEAD"]
+    else:
+        cmd = ["git", "diff", seed_commit]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(fix_phase_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            _LOG.warning(
+                "compute_engineer_diff_from_workdir: git diff %s returned %d: %s",
+                base, result.returncode, result.stderr[:300],
+            )
+            return ""
+        return result.stdout
+    except Exception as exc:
+        _LOG.warning(
+            "compute_engineer_diff_from_workdir: git diff failed: %s", exc
+        )
+        return ""
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +477,7 @@ def score_cell(
     tier3_ctx: Optional[object] = None,
     pytest_timeout: int = 120,
     fail_to_pass: "list[str] | None" = None,
+    seed_commit: str = "",
 ) -> ScoringResult:
     """Score one (task, condition, replicate) cell.
 
@@ -426,14 +500,33 @@ def score_cell(
                       full test tree. When None or empty, all tests under
                       held_out_dir are run. Forwarded to both the local and
                       tier3 pytest runners.
+        seed_commit: git SHA of the post-seeding commit (returned by
+                     seed_fix_phase). When non-empty and fix_phase_dir is a
+                     valid git repo, the engineer diff is computed via
+                     `git diff <seed_commit>` in fix_phase_dir (ground truth).
+                     When empty or unavailable, falls back to transcript
+                     parsing (dry-run path).
 
     Returns:
         ScoringResult with all fields populated.
     """
     known_affected = task_meta.get("known_affected_files", [])
 
-    # 1. Extract diff from transcript.
-    diff_text = extract_diff_from_transcript(transcript)
+    # 1. Compute diff from workdir (ground truth) when available; fall back
+    #    to transcript parsing for dry-run paths where fix_phase_dir is a
+    #    temp dir with no git history.
+    if seed_commit and fix_phase_dir and (fix_phase_dir / ".git").is_dir():
+        diff_text = compute_engineer_diff_from_workdir(fix_phase_dir, seed_commit)
+        _LOG.debug(
+            "score_cell [%s]: using workdir diff (seed_commit=%s, lines=%d)",
+            task_slug, seed_commit[:8], diff_text.count("\n"),
+        )
+    else:
+        diff_text = extract_diff_from_transcript(transcript)
+        _LOG.debug(
+            "score_cell [%s]: using transcript diff fallback (seed_commit=%r)",
+            task_slug, seed_commit or "(empty)",
+        )
 
     # 2. Compute diff hygiene.
     hygiene = compute_diff_hygiene(diff_text, known_affected)

--- a/evals/skill-comparison/seeding.py
+++ b/evals/skill-comparison/seeding.py
@@ -12,8 +12,11 @@ Public API:
         fix_dir: Path,
         tasks_root: Path,
         cache_dir: Path | None = None,
-    ) -> None
+    ) -> dict
         Clones repo at base_commit into fix_dir and applies test_patch.diff.
+        Returns {"seed_commit": "<sha>"} where seed_commit is the git SHA of
+        the post-seeding commit (after test_patch is applied and committed).
+        Callers use seed_commit as the base for computing engineer diffs.
         Raises SeedError on any failure (clone, checkout, or patch failure).
 
     SeedError(RuntimeError):
@@ -147,7 +150,7 @@ def seed_fix_phase(
     fix_dir: Path,
     tasks_root: Path,
     cache_dir: Path | None = None,
-) -> None:
+) -> dict:
     """Clone repo at base_commit into fix_dir and apply test_patch.
 
     Steps:
@@ -156,6 +159,8 @@ def seed_fix_phase(
          If cache hit: use git clone --local from the cache copy.
       3. Copy/clone into fix_dir (always a fresh copy so each cell is isolated).
       4. Apply tasks_root/<slug>/test_patch.diff with git apply.
+      5. Stage and commit the patched state as "seed: test_patch applied".
+         Record the resulting commit SHA for use as the engineer-diff base.
 
     Args:
         task_slug: slug key (e.g. "requests-3362").
@@ -165,6 +170,11 @@ def seed_fix_phase(
         tasks_root: directory containing per-task subdirectories (for locating
                     test_patch.diff).
         cache_dir: override for the cache root; defaults to DEFAULT_CACHE_DIR.
+
+    Returns:
+        dict with key "seed_commit": the git SHA of the post-seeding commit.
+        Callers pass this SHA to scoring so that engineer diffs are computed
+        relative to the post-seeding state, not the upstream base_commit.
 
     Raises:
         SeedError: on clone, checkout, or patch failure.
@@ -284,4 +294,50 @@ def seed_fix_phase(
         shutil.rmtree(fix_dir, ignore_errors=True)
         raise
 
-    _LOG.info("seed_fix_phase complete: %s -> %s", task_slug, fix_dir)
+    # -----------------------------------------------------------------------
+    # Step 4: commit the patched state so scoring can diff against it.
+    # The engineer's changes are then visible via `git diff <seed_commit>`.
+    # Using a dedicated seed identity keeps "git log" clean regardless of the
+    # host's git user config.
+    # -----------------------------------------------------------------------
+    _LOG.info("Committing seed state for %s", task_slug)
+    try:
+        _run(
+            ["git", "add", "-A"],
+            cwd=fix_dir,
+            label=task_slug,
+            step="patch_failed",
+            timeout=30,
+        )
+        _run(
+            [
+                "git",
+                "-c", "user.email=seed@local",
+                "-c", "user.name=seed",
+                "commit",
+                "-m", "seed: test_patch applied",
+            ],
+            cwd=fix_dir,
+            label=task_slug,
+            step="patch_failed",
+            timeout=30,
+        )
+    except SeedError:
+        shutil.rmtree(fix_dir, ignore_errors=True)
+        raise
+
+    # Capture the SHA of the seed commit.
+    rev_result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(fix_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    seed_commit = rev_result.stdout.strip()
+    if not seed_commit:
+        _LOG.warning("seed_fix_phase: could not resolve HEAD SHA for %s", task_slug)
+        seed_commit = ""
+
+    _LOG.info("seed_fix_phase complete: %s -> %s (seed_commit=%s)", task_slug, fix_dir, seed_commit[:8])
+    return {"seed_commit": seed_commit}

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -2019,3 +2019,121 @@ class TestTranscriptFileNonEmpty:
             "final_text fallback must be used."
         )
         assert "Fixed the bug." in content
+
+
+# ---------------------------------------------------------------------------
+# smoke-v6 regression: fail_to_pass forwarded from task_meta to score_cell
+# ---------------------------------------------------------------------------
+
+
+class TestFailToPassForwarded:
+    """Regression test for smoke-v6 bug: runner.run_matrix was not passing
+    fail_to_pass from task_meta to score_cell, so _run_pytest_tier3 received
+    fail_to_pass=None and collected 0 tests from the /scoring/tests directory.
+
+    This test mocks score_cell at the boundary and inspects the captured kwargs
+    to verify fail_to_pass is forwarded correctly.
+    """
+
+    def test_run_matrix_forwards_fail_to_pass_to_score_cell(
+        self, tmp_path: Path, corpus_yaml: Path
+    ):
+        """run_matrix must pass task_meta['fail_to_pass'] to score_cell.
+
+        Regression for smoke-v6: previously score_cell was called without the
+        fail_to_pass kwarg, so pytest ran against the entire /scoring/tests tree
+        and collected 0 tests (the tree had no tests at that path).
+        """
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        results_tsv = tmp_path / "results.tsv"
+
+        captured_kwargs: list[dict] = []
+
+        def capturing_score_cell(**kwargs):
+            captured_kwargs.append(kwargs)
+            return canned_score
+
+        with patch("runner.score_cell", side_effect=capturing_score_cell):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        assert captured_kwargs, "score_cell must have been called"
+        for call_kwargs in captured_kwargs:
+            assert "fail_to_pass" in call_kwargs, (
+                "score_cell must receive fail_to_pass kwarg; "
+                "smoke-v6 showed it was missing, causing 0 tests collected."
+            )
+            # The corpus_yaml fixture has exactly one fail_to_pass entry.
+            ftp = call_kwargs["fail_to_pass"]
+            assert isinstance(ftp, list), (
+                f"fail_to_pass must be a list, got {type(ftp)}"
+            )
+            assert len(ftp) == 1, (
+                f"Expected 1 fail_to_pass entry (from fixture corpus), got {len(ftp)}: {ftp}"
+            )
+
+    def test_run_matrix_forwards_empty_fail_to_pass_when_absent(
+        self, tmp_path: Path
+    ):
+        """When task_meta has no fail_to_pass key, score_cell receives an empty list."""
+        from scoring import ScoringResult
+
+        # Corpus with no fail_to_pass field.
+        corpus_no_ftp = """\
+freeze_metadata:
+  freeze_date: "2026-05-12"
+tasks:
+  django-11039:
+    swebench_instance_id: "django__django-11039"
+    repo_url: "https://github.com/django/django"
+    base_commit: "d5276398046ce4a102776a1e67dcac2884d80dfe"
+    held_out_tests:
+      - "tests/migrations/test_commands.py"
+    estimated_test_seconds: 30
+    difficulty: single-file
+    known_affected_files:
+      - "django/core/management/commands/sqlmigrate.py"
+    problem_summary: test task with no fail_to_pass
+"""
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(corpus_no_ftp, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        captured_kwargs: list[dict] = []
+
+        def capturing_score_cell(**kwargs):
+            captured_kwargs.append(kwargs)
+            return canned_score
+
+        with patch("runner.score_cell", side_effect=capturing_score_cell):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+            )
+
+        assert captured_kwargs, "score_cell must have been called"
+        for call_kwargs in captured_kwargs:
+            ftp = call_kwargs.get("fail_to_pass")
+            assert ftp == [] or ftp is None or ftp == [], (
+                f"fail_to_pass must be [] when absent from task_meta, got {ftp!r}"
+            )

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -6,8 +6,10 @@ Coverage:
 - compute_diff_hygiene: lines_touched, files_touched, scope_creep_flag across
   fixture diffs including edge cases (empty diff, diff within known files,
   diff outside known files, mixed).
+- compute_engineer_diff_from_workdir: absent dir, real git repo diff.
 - _parse_pytest_failures: summary section extraction, fallback scanning.
-- score_cell: pass (returncode=0), fail (returncode=1), empty transcript.
+- score_cell: pass (returncode=0), fail (returncode=1), empty transcript,
+  workdir diff path (seed_commit provided).
   Uses a mock subprocess so no real pytest is invoked.
 """
 from __future__ import annotations
@@ -25,6 +27,7 @@ from scoring import (
     _run_pytest_local,
     _run_pytest_tier3,
     compute_diff_hygiene,
+    compute_engineer_diff_from_workdir,
     extract_diff_from_transcript,
     score_cell,
 )
@@ -776,3 +779,155 @@ class TestPytestCollectionFlags:
                 f"Node-id '{nid}' must appear as '{expected}' in the pytest cmd. "
                 f"Got cmd: {cmd}"
             )
+
+
+# ---------------------------------------------------------------------------
+# smoke-v6 regression: compute_engineer_diff_from_workdir
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEngineerDiffFromWorkdir:
+    """Regression tests for smoke-v6 diff-source fix.
+
+    Previously score_cell called extract_diff_from_transcript which picked up
+    tool_use payloads (test_patch content, diff fragments in stream-json) as the
+    engineer's patch, producing garbage lines_touched values (e.g. 4115 lines)
+    and misleading scope_creep flags even when the engineer made NO changes.
+
+    The fix: use `git diff <seed_commit>` in fix_phase_dir for ground-truth diffs.
+    """
+
+    def test_returns_empty_when_dir_absent(self, tmp_path: Path):
+        """Returns '' when fix_phase_dir does not exist."""
+        from scoring import compute_engineer_diff_from_workdir
+        result = compute_engineer_diff_from_workdir(tmp_path / "nonexistent", "abc123")
+        assert result == "", (
+            "compute_engineer_diff_from_workdir must return '' when dir is absent"
+        )
+
+    def test_returns_diff_from_git_diff_in_temp_repo(self, tmp_path: Path):
+        """Returns the actual diff between seed_commit and current HEAD in a real git repo.
+
+        This test creates a real minimal git repo, makes two commits, and verifies
+        that compute_engineer_diff_from_workdir returns the diff of the second commit.
+        """
+        from scoring import compute_engineer_diff_from_workdir
+        import subprocess as _sp
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args, **kwargs):
+            return _sp.run(
+                ["git"] + list(args),
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+                check=True,
+                **kwargs,
+            )
+
+        # Init a minimal git repo.
+        git("init")
+        git("config", "user.email", "test@test.local")
+        git("config", "user.name", "test")
+
+        # Seed commit: create base file.
+        (repo / "base.py").write_text("x = 1\n")
+        git("add", "-A")
+        git("commit", "-m", "seed: initial")
+        seed_commit_result = _sp.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+        )
+        seed_commit = seed_commit_result.stdout.strip()
+        assert seed_commit, "Must have a valid seed commit SHA"
+
+        # Engineer commit: modify the file.
+        (repo / "base.py").write_text("x = 2\n")
+        git("add", "-A")
+        git("commit", "-m", "fix: change x to 2")
+
+        # compute_engineer_diff_from_workdir should return the change from seed.
+        diff = compute_engineer_diff_from_workdir(repo, seed_commit)
+
+        assert diff, "Diff must be non-empty when engineer changed a file"
+        assert "base.py" in diff, f"base.py must appear in diff; got: {diff[:200]}"
+        assert "+x = 2" in diff, f"Engineer change (+x = 2) must be in diff; got: {diff[:200]}"
+        assert "-x = 1" in diff, f"Seed baseline (-x = 1) must be in diff; got: {diff[:200]}"
+
+    def test_score_cell_uses_workdir_diff_when_seed_commit_provided(self, tmp_path: Path):
+        """score_cell uses git diff <seed_commit> when seed_commit is non-empty and .git exists.
+
+        Regression for smoke-v6: previously score_cell always called
+        extract_diff_from_transcript regardless of whether a workdir was available,
+        causing garbage diff data from stream-json tool_use payloads.
+
+        This test mocks compute_engineer_diff_from_workdir directly to isolate
+        the routing logic without triggering subprocess recursion from the pytest
+        runner path.
+        """
+        import subprocess as _sp
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()  # make it look like a git repo for the routing check
+
+        task_meta = {
+            "known_affected_files": ["fix.py"],
+            "fail_to_pass": [],
+        }
+
+        # The workdir diff we want score_cell to use.
+        workdir_diff = (
+            "diff --git a/fix.py b/fix.py\n"
+            "--- a/fix.py\n"
+            "+++ b/fix.py\n"
+            "@@ -1 +1 @@\n"
+            "-old = True\n"
+            "+old = False\n"
+        )
+
+        # Transcript contains a noisy diff-like fragment (simulates stream-json
+        # tool_use payload) that must NOT be used as the engineer diff.
+        noisy_transcript = (
+            "diff --git a/unrelated.py b/unrelated.py\n"
+            "--- a/unrelated.py\n"
+            "+++ b/unrelated.py\n"
+            "@@ -1 +1 @@\n"
+            "-garbage\n"
+            "+noise\n"
+        )
+
+        seed_sha = "abc123def456abc123def456abc123def456abc1"
+
+        # Mock compute_engineer_diff_from_workdir to return the clean workdir diff,
+        # and mock the pytest subprocess to avoid real test execution.
+        with (
+            patch("scoring.compute_engineer_diff_from_workdir", return_value=workdir_diff),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")),
+        ):
+            result = score_cell(
+                task_slug="test-slug",
+                transcript=noisy_transcript,
+                task_meta=task_meta,
+                fix_phase_dir=repo,
+                held_out_dir=repo,
+                tier3_ctx=None,
+                pytest_timeout=10,
+                fail_to_pass=[],
+                seed_commit=seed_sha,
+            )
+
+        # The diff must come from the workdir (fix.py changed), not the transcript
+        # (unrelated.py garbage).
+        assert "fix.py" in result.diff_text, (
+            f"diff_text must contain fix.py (workdir diff), not transcript noise; "
+            f"diff_text was: {result.diff_text[:400]}"
+        )
+        assert "unrelated.py" not in result.diff_text, (
+            "diff_text must NOT contain unrelated.py (noisy transcript); "
+            "workdir diff should have been used instead"
+        )

--- a/evals/skill-comparison/tests/test_seeding.py
+++ b/evals/skill-comparison/tests/test_seeding.py
@@ -256,6 +256,123 @@ class TestSeedFixPhase:
                 tasks_root=tasks_root,
             )
 
+    def test_returns_seed_commit_sha(self, tmp_path: Path):
+        """seed_fix_phase returns a dict with non-empty 'seed_commit' SHA.
+
+        Regression for smoke-v6 diff-source bug: seed_fix_phase now commits the
+        post-seeding state so scoring can run `git diff <seed_commit>` to get
+        the engineer's changes without parsing the (unreliable) transcript.
+        """
+        tasks_root = tmp_path / "tasks"
+        _write_patch(tasks_root / _TASK_SLUG)
+
+        cache_dir = tmp_path / "cache"
+        key = f"{_TASK_SLUG}-{_TASK_META['base_commit'][:8]}"
+        (cache_dir / key / ".git").mkdir(parents=True, exist_ok=True)
+
+        fix_dir = tmp_path / "fix"
+
+        _FAKE_SHA = "abc123def456abc123def456abc123def456abc1"
+
+        def fake_run(cmd, **kwargs):
+            # rev-parse HEAD returns the fake SHA.
+            if "rev-parse" in cmd:
+                result = _make_subprocess_result(returncode=0, stdout=_FAKE_SHA + "\n")
+                return result
+            return _make_subprocess_result(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = seed_fix_phase(
+                task_slug=_TASK_SLUG,
+                task_meta=_TASK_META,
+                fix_dir=fix_dir,
+                tasks_root=tasks_root,
+                cache_dir=cache_dir,
+            )
+
+        assert isinstance(result, dict), (
+            f"seed_fix_phase must return a dict, got {type(result)}"
+        )
+        assert "seed_commit" in result, (
+            "Return dict must have 'seed_commit' key for engineer diff base"
+        )
+        assert result["seed_commit"] == _FAKE_SHA, (
+            f"seed_commit must equal the HEAD SHA; got {result['seed_commit']!r}"
+        )
+
+    def test_seed_commit_in_returned_dict_after_git_add_commit(self, tmp_path: Path):
+        """seed_fix_phase issues git add -A and git commit after applying the patch.
+
+        Verifies the commit step is present by checking that 'commit' appears in
+        the sequence of git subcommands issued after 'apply'.
+        """
+        tasks_root = tmp_path / "tasks"
+        _write_patch(tasks_root / _TASK_SLUG)
+
+        cache_dir = tmp_path / "cache"
+        key = f"{_TASK_SLUG}-{_TASK_META['base_commit'][:8]}"
+        (cache_dir / key / ".git").mkdir(parents=True, exist_ok=True)
+
+        fix_dir = tmp_path / "fix"
+
+        issued_cmds: list[list[str]] = []
+
+        def recording_run(cmd, **kwargs):
+            issued_cmds.append(list(cmd))
+            if "rev-parse" in cmd:
+                return _make_subprocess_result(returncode=0, stdout="deadbeef" * 5 + "\n")
+            return _make_subprocess_result(returncode=0)
+
+        with patch("subprocess.run", side_effect=recording_run):
+            seed_fix_phase(
+                task_slug=_TASK_SLUG,
+                task_meta=_TASK_META,
+                fix_dir=fix_dir,
+                tasks_root=tasks_root,
+                cache_dir=cache_dir,
+            )
+
+        # Extract git subcommands: handle both `git <subcmd>` and `git -c k=v <subcmd>`.
+        # `-c key=value` option tokens don't start with "-" but ARE option arguments.
+        # Strategy: skip tokens that start with "-" OR are values for "-c" (contain "=").
+        def _git_subcmd(cmd: list) -> str:
+            """Return the git subcommand from a git invocation list.
+
+            Handles: git <subcmd>, git -c k=v <subcmd>, git --flag <subcmd>.
+            The subcommand is the first token after 'git' that is not a flag
+            and not a -c value (which contains '=').
+            """
+            if not cmd or cmd[0] != "git":
+                return ""
+            skip_next = False
+            for token in cmd[1:]:
+                if skip_next:
+                    skip_next = False
+                    continue
+                if token == "-c":
+                    skip_next = True
+                    continue
+                if token.startswith("-"):
+                    continue
+                # A -c value looks like "user.email=seed@local" - contains "=".
+                # But valid subcommands never contain "=".
+                if "=" in token:
+                    continue
+                return token
+            return ""
+
+        git_subcmds = [_git_subcmd(c) for c in issued_cmds if c and c[0] == "git"]
+        assert "apply" in git_subcmds, "git apply must be called"
+        apply_idx = git_subcmds.index("apply")
+        post_apply = git_subcmds[apply_idx + 1:]
+        assert "add" in post_apply, (
+            "git add must be issued after git apply to stage the patch"
+        )
+        assert "commit" in post_apply, (
+            "git commit must be issued after git apply to record the seed state; "
+            "this commit SHA is needed for engineer diff computation in scoring"
+        )
+
 
 # ---------------------------------------------------------------------------
 # seed_corpus tests
@@ -447,6 +564,7 @@ tasks:
 
         def fake_seed(task_slug, task_meta, fix_dir, tasks_root, cache_dir=None):
             seed_calls.append({"task_slug": task_slug, "fix_dir": fix_dir})
+            return {"seed_commit": "fake-sha-for-test"}
 
         with (
             patch("runner.score_cell", return_value=canned_score),


### PR DESCRIPTION
## Summary

- **Bug 1 (smoke-v6):** `runner.run_matrix` was not passing `fail_to_pass` from `task_meta` to `score_cell`, so `_run_pytest_tier3` received `fail_to_pass=None` and collected 0 tests from `/scoring/tests`. Now extracts `fail_to_pass = task_meta.get("fail_to_pass") or []` and passes it to `score_cell`.

- **Bug 2 (smoke-v6):** `extract_diff_from_transcript` was matching `tool_use` payloads in the CLI stream-json output (test_patch content, embedded diff fragments), producing garbage `lines_touched` values (e.g. 4115) even when the engineer made no changes. Replaced with `compute_engineer_diff_from_workdir(fix_phase_dir, seed_commit)` which runs `git diff <seed_commit>` in the fix directory for ground-truth diffs. `seeding.py` now commits the post-seeding state (`seed: test_patch applied`) and returns `{"seed_commit": "<sha>"}` so scoring has a clean base for the diff. Transcript fallback retained for dry-run paths.

## Regression tests

- `test_runner.py::TestFailToPassForwarded` - verifies `fail_to_pass` kwarg reaches `score_cell` from `run_matrix`
- `test_seeding.py::TestSeedFixPhase::test_returns_seed_commit_sha` - verifies `seed_fix_phase` returns a dict with non-empty `seed_commit`
- `test_seeding.py::TestSeedFixPhase::test_seed_commit_in_returned_dict_after_git_add_commit` - verifies `git add` and `git commit` are issued after `git apply`
- `test_scoring.py::TestComputeEngineerDiffFromWorkdir` - verifies the new function returns correct diffs from a real git repo and that `score_cell` routes to it when `seed_commit` is provided

## Test plan
- All 308 tests pass (1 skipped - opt-in live network test)
- No new warnings introduced