### PR TITLE
fix(evals): convert unittest-style fail_to_pass IDs to pytest node-id format

### DIFF
--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -40,6 +40,11 @@ Public API:
     compute_diff_hygiene(diff_text: str, known_affected_files: list[str]) -> dict
         Parse a unified diff; return lines_touched, files_touched, scope_creep_flag.
 
+    _convert_unittest_id_to_pytest(node_id: str) -> str
+        Convert a unittest-style "test_method (module.path.TestClass)" ID to
+        pytest node-id format "module/path.py::TestClass::test_method".
+        Returns the input unchanged if it does not match the unittest pattern.
+
 Upstream deps: stdlib subprocess, pathlib, re, dataclasses, typing, tempfile, shutil,
                logging.
                evals.runner.isolator.Tier3Docker (optional; used for in-container
@@ -296,6 +301,92 @@ def _parse_pytest_failures(stdout: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Unittest-style node-id conversion
+# ---------------------------------------------------------------------------
+
+_UNITTEST_ID_RE = re.compile(r"^(\w[\w.]*)\s+\((\S+)\)$")
+"""Match unittest-style IDs: "test_method (module.path.TestClass)".
+
+Group 1: method name (e.g. "test_foo")
+Group 2: dotted module.TestClass path (e.g. "module.path.TestClass")
+"""
+
+
+def _convert_unittest_id_to_pytest(node_id: str) -> str:
+    """Convert a unittest-style test ID to a pytest node-id.
+
+    unittest format: "test_method (module.path.TestClass)"
+    pytest format:   "module/path.py::TestClass::test_method"
+
+    The module path component (everything before the last dot-segment, which
+    is the class name) is converted from dotted notation to a filesystem path
+    with '.py' appended. Dots inside the class name are not converted.
+
+    Example:
+        "test_foo (myapp.tests.MyTests)" -> "myapp/tests.py::MyTests::test_foo"
+        "test_bar (tests.sub.TheSuite)"  -> "tests/sub.py::TheSuite::test_bar"
+
+    Returns the original string unchanged if it does not match the expected
+    unittest format.
+    """
+    m = _UNITTEST_ID_RE.match(node_id.strip())
+    if not m:
+        return node_id
+
+    method = m.group(1)
+    dotted = m.group(2)  # e.g. "myapp.tests.MyTests"
+
+    parts = dotted.rsplit(".", 1)
+    if len(parts) != 2:
+        # No dot separator - cannot parse; return unchanged.
+        return node_id
+
+    module_path, class_name = parts
+    # Convert dotted module path to filesystem path + .py extension.
+    file_path = module_path.replace(".", "/") + ".py"
+    return f"{file_path}::{class_name}::{method}"
+
+
+def _normalize_fail_to_pass(
+    fail_to_pass: "list[str]",
+    context: str,
+) -> "list[str]":
+    """Normalize a fail_to_pass list, converting unittest-style IDs to pytest format.
+
+    Args:
+        fail_to_pass: raw node-id list from corpus.yaml (may contain unittest IDs).
+        context: log label for warning messages (e.g. "local" or "tier3").
+
+    Returns a new list with all IDs in pytest node-id format.
+    Entries that cannot be parsed log a warning and are dropped (full-tree fallback
+    is the caller's responsibility when the returned list is empty).
+    """
+    result: list[str] = []
+    for nid in fail_to_pass:
+        # Detect unittest-style: contains "(" and ")" but no "::" or ".py"
+        if "(" in nid and ")" in nid and "::" not in nid and ".py" not in nid:
+            converted = _convert_unittest_id_to_pytest(nid)
+            if converted == nid:
+                # Conversion failed (unexpected format).
+                _LOG.warning(
+                    "_normalize_fail_to_pass [%s]: could not convert unittest-style ID %r; "
+                    "dropping it. Full held-out tree will run instead.",
+                    context, nid,
+                )
+                # Signal to caller that we should fall back to full-tree mode.
+                return []
+            _LOG.debug(
+                "_normalize_fail_to_pass [%s]: converted %r -> %r",
+                context, nid, converted,
+            )
+            result.append(converted)
+        else:
+            # Already pytest-style - pass through unchanged.
+            result.append(nid)
+    return result
+
+
+# ---------------------------------------------------------------------------
 # In-process pytest runner (no Docker)
 # ---------------------------------------------------------------------------
 
@@ -320,14 +411,24 @@ def _run_pytest_local(
     Returns (returncode, combined_stdout).
     """
     if fail_to_pass:
-        # Run only the specified test node-ids. Paths may be bare node-ids
-        # (e.g. "tests/test_foo.py::TestFoo::test_bar") or relative paths;
-        # resolve against held_out_dir so pytest can find them.
-        resolved = [
-            str(held_out_dir / nid) if not Path(nid).is_absolute() else nid
-            for nid in fail_to_pass
-        ]
-        test_targets = resolved
+        # Normalize unittest-style IDs to pytest node-id format before resolving.
+        normalized = _normalize_fail_to_pass(fail_to_pass, context="local")
+        if not normalized:
+            # Conversion failed for at least one ID; fall back to full tree.
+            _LOG.warning(
+                "_run_pytest_local: falling back to full held_out_dir due to "
+                "unparseable node-id(s) in fail_to_pass=%r",
+                fail_to_pass,
+            )
+            test_targets = [str(held_out_dir)]
+        else:
+            # Run only the specified test node-ids. Paths may be bare node-ids
+            # (e.g. "tests/test_foo.py::TestFoo::test_bar") or relative paths;
+            # resolve against held_out_dir so pytest can find them.
+            test_targets = [
+                str(held_out_dir / nid) if not Path(nid).is_absolute() else nid
+                for nid in normalized
+            ]
     else:
         test_targets = [str(held_out_dir)]
 
@@ -410,42 +511,63 @@ def _run_pytest_tier3(
     # guarantees "python3" on PATH; "python" also exists as a symlink in that image,
     # but "python3" is preferred for explicitness.
     if fail_to_pass:
-        # Run only the specified test node-ids. The held_out_dir is mounted at
-        # /scoring/tests inside the container, so prepend that path to each
-        # relative node-id (e.g. "test_foo.py::TestFoo::test_bar" ->
-        # "/scoring/tests/test_foo.py::TestFoo::test_bar").
-        # Node-ids that already start with /scoring/tests are passed as-is.
-        _CONTAINER_TESTS_ROOT = "/scoring/tests"
-        test_targets = [
-            nid if nid.startswith(_CONTAINER_TESTS_ROOT)
-            else f"{_CONTAINER_TESTS_ROOT}/{nid}"
-            for nid in fail_to_pass
-        ]
-        # When specific node-ids are given, omit --rootdir and --noconftest:
-        # - --rootdir conflicts with absolute node-id paths when the dir value
-        #   doesn't match the path prefix, causing 0 tests collected.
-        # - --noconftest blocks legitimate conftest.py in /scoring/tests that
-        #   SWE-bench repo tests need for fixtures/collection.
-        # --confcutdir=/scoring is retained: it stops conftest discovery at
-        # /scoring so agent-planted conftest.py at /workspace/repo is never
-        # loaded regardless of CWD.
-        cmd = [
-            "python3", "-m", "pytest",
-            *test_targets,
-            "--confcutdir=/scoring",
-            "-p", "no:cacheprovider",
-            "--tb=short",
-            "-q",
-            f"--timeout={timeout}",
-        ]
+        # Normalize unittest-style IDs to pytest node-id format before resolving.
+        normalized = _normalize_fail_to_pass(fail_to_pass, context="tier3")
+        if not normalized:
+            # Conversion failed for at least one ID; fall back to full tree.
+            _LOG.warning(
+                "_run_pytest_tier3: falling back to full /scoring/tests due to "
+                "unparseable node-id(s) in fail_to_pass=%r",
+                fail_to_pass,
+            )
+            # Fall through to the full-tree path.
+            cmd = [
+                "python3", "-m", "pytest",
+                "/scoring/tests",
+                "--noconftest",
+                "--rootdir=/scoring/tests",
+                "--confcutdir=/scoring",
+                "-p", "no:cacheprovider",
+                "--tb=short",
+                "-q",
+                f"--timeout={timeout}",
+            ]
+        else:
+            # Run only the specified test node-ids. The held_out_dir is mounted at
+            # /scoring/tests inside the container, so prepend that path to each
+            # relative node-id (e.g. "test_foo.py::TestFoo::test_bar" ->
+            # "/scoring/tests/test_foo.py::TestFoo::test_bar").
+            # Node-ids that already start with /scoring/tests are passed as-is.
+            _CONTAINER_TESTS_ROOT = "/scoring/tests"
+            test_targets = [
+                nid if nid.startswith(_CONTAINER_TESTS_ROOT)
+                else f"{_CONTAINER_TESTS_ROOT}/{nid}"
+                for nid in normalized
+            ]
+            # When specific node-ids are given, omit --rootdir and --noconftest:
+            # - --rootdir conflicts with absolute node-id paths when the dir value
+            #   doesn't match the path prefix, causing 0 tests collected.
+            # - --noconftest blocks legitimate conftest.py in /scoring/tests that
+            #   SWE-bench repo tests need for fixtures/collection.
+            # --confcutdir=/scoring is retained: it stops conftest discovery at
+            # /scoring so agent-planted conftest.py at /workspace/repo is never
+            # loaded regardless of CWD.
+            cmd = [
+                "python3", "-m", "pytest",
+                *test_targets,
+                "--confcutdir=/scoring",
+                "-p", "no:cacheprovider",
+                "--tb=short",
+                "-q",
+                f"--timeout={timeout}",
+            ]
     else:
-        test_targets = ["/scoring/tests"]
         # Full-tree case: use the original security-hardened flags.
         # --noconftest is safe here because we are running the full tree and
         # do not depend on conftest.py for targeted collection.
         cmd = [
             "python3", "-m", "pytest",
-            *test_targets,
+            "/scoring/tests",
             "--noconftest",
             "--rootdir=/scoring/tests",
             "--confcutdir=/scoring",

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -23,6 +23,8 @@ import pytest
 # conftest.py inserts skill-comparison/ into sys.path.
 from scoring import (
     ScoringResult,
+    _convert_unittest_id_to_pytest,
+    _normalize_fail_to_pass,
     _parse_pytest_failures,
     _run_pytest_local,
     _run_pytest_tier3,
@@ -930,4 +932,254 @@ class TestComputeEngineerDiffFromWorkdir:
         assert "unrelated.py" not in result.diff_text, (
             "diff_text must NOT contain unrelated.py (noisy transcript); "
             "workdir diff should have been used instead"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: unittest-style fail_to_pass IDs converted to pytest node-id format
+# [unittest-style-fix]
+# ---------------------------------------------------------------------------
+
+
+class TestConvertUnittestIdToPytest:
+    """Unit tests for _convert_unittest_id_to_pytest.
+
+    Regression for django-11039 / django-11049 corpus entries whose
+    fail_to_pass IDs use the unittest format "test_method (module.path.TestClass)".
+    Previously, these IDs were passed as-is to pytest which treated them as
+    paths, producing invalid paths and deterministic FAIL scores.
+    """
+
+    def test_simple_three_part_module(self):
+        """test_foo (myapp.tests.MyTests) -> myapp/tests.py::MyTests::test_foo"""
+        result = _convert_unittest_id_to_pytest("test_foo (myapp.tests.MyTests)")
+        assert result == "myapp/tests.py::MyTests::test_foo"
+
+    def test_two_part_module(self):
+        """test_bar (tests.TheSuite) -> tests.py::TheSuite::test_bar"""
+        result = _convert_unittest_id_to_pytest("test_bar (tests.TheSuite)")
+        assert result == "tests.py::TheSuite::test_bar"
+
+    def test_deep_module_path(self):
+        """test_baz (a.b.c.d.MyClass) -> a/b/c/d.py::MyClass::test_baz"""
+        result = _convert_unittest_id_to_pytest("test_baz (a.b.c.d.MyClass)")
+        assert result == "a/b/c/d.py::MyClass::test_baz"
+
+    def test_django_style_id(self):
+        """Realistic django corpus ID format."""
+        result = _convert_unittest_id_to_pytest(
+            "test_migrate_with_deferred_sql (migrations.test_executor.ExecutorTests)"
+        )
+        assert result == "migrations/test_executor.py::ExecutorTests::test_migrate_with_deferred_sql"
+
+    def test_pytest_style_passthrough(self):
+        """pytest-style IDs with '::' are passed through unchanged."""
+        nid = "tests/test_foo.py::TestFoo::test_bar"
+        assert _convert_unittest_id_to_pytest(nid) == nid
+
+    def test_plain_path_passthrough(self):
+        """Bare file paths without parens are passed through unchanged."""
+        nid = "tests/test_foo.py"
+        assert _convert_unittest_id_to_pytest(nid) == nid
+
+    def test_no_dot_in_parens_returns_unchanged(self):
+        """If parens contain no dot, cannot extract class - return unchanged."""
+        nid = "test_foo (MyTests)"
+        # Single segment - rsplit('.', 1) returns one part, not two.
+        assert _convert_unittest_id_to_pytest(nid) == nid
+
+    def test_strips_whitespace(self):
+        """Leading/trailing whitespace on the ID is stripped before matching."""
+        result = _convert_unittest_id_to_pytest("  test_foo (myapp.tests.MyTests)  ")
+        assert result == "myapp/tests.py::MyTests::test_foo"
+
+
+class TestNormalizeFailToPass:
+    """Unit tests for _normalize_fail_to_pass.
+
+    [unittest-style-fix] Regression: ensure the normalizer handles mixed lists
+    correctly, converts unittest IDs, and falls back on unparseable entries.
+    """
+
+    def test_unittest_ids_converted(self):
+        ids = [
+            "test_foo (myapp.tests.MyTests)",
+            "test_bar (myapp.tests.MyTests)",
+        ]
+        result = _normalize_fail_to_pass(ids, context="test")
+        assert result == [
+            "myapp/tests.py::MyTests::test_foo",
+            "myapp/tests.py::MyTests::test_bar",
+        ]
+
+    def test_pytest_ids_unchanged(self):
+        ids = [
+            "tests/test_foo.py::TestFoo::test_bar",
+            "tests/test_baz.py::TestBaz::test_qux",
+        ]
+        result = _normalize_fail_to_pass(ids, context="test")
+        assert result == ids
+
+    def test_mixed_list_converts_unittest_only(self):
+        ids = [
+            "test_foo (myapp.tests.MyTests)",
+            "tests/test_other.py::TestOther::test_x",
+        ]
+        result = _normalize_fail_to_pass(ids, context="test")
+        assert result == [
+            "myapp/tests.py::MyTests::test_foo",
+            "tests/test_other.py::TestOther::test_x",
+        ]
+
+    def test_unparseable_returns_empty_list(self):
+        """An ID that looks unittest-style but cannot be parsed triggers fallback."""
+        # This has parens but no dot inside - _convert_unittest_id_to_pytest returns it unchanged.
+        ids = ["test_foo (NoClassName)"]
+        result = _normalize_fail_to_pass(ids, context="test")
+        assert result == [], (
+            "Unparseable unittest-style ID must return [] to signal full-tree fallback"
+        )
+
+    def test_empty_list_returns_empty(self):
+        assert _normalize_fail_to_pass([], context="test") == []
+
+
+class TestUnittestStyleIdConvertedToLocalCmd:
+    """Regression [unittest-style-fix]: _run_pytest_local converts unittest IDs.
+
+    test_unittest_style_id_converted_to_pytest_node_id (local path).
+    """
+
+    def test_unittest_style_id_converted_to_pytest_node_id(self, tmp_path: Path):
+        """_run_pytest_local must convert 'test_foo (module.TestClass)' to pytest format."""
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+
+        unittest_ids = ["test_foo (myapp.tests.MyTests)"]
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "1 passed"
+            mock.stderr = ""
+            return mock
+
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=unittest_ids)
+
+        assert captured_cmds, "subprocess.run must have been called"
+        cmd = captured_cmds[0]
+        # The converted pytest node-id must appear, resolved against held_dir.
+        expected_fragment = "myapp/tests.py::MyTests::test_foo"
+        cmd_str = " ".join(cmd)
+        assert expected_fragment in cmd_str, (
+            f"Converted pytest node-id '{expected_fragment}' must appear in cmd; "
+            f"got: {cmd}"
+        )
+        # The raw unittest-style ID must NOT appear.
+        assert "test_foo (myapp.tests.MyTests)" not in cmd_str, (
+            "Raw unittest-style ID must not appear in cmd after conversion"
+        )
+
+    def test_pytest_style_id_passes_through_unchanged(self, tmp_path: Path):
+        """_run_pytest_local must not alter already-valid pytest node-ids."""
+        held_dir = tmp_path / "held"
+        held_dir.mkdir()
+        fix_dir = tmp_path / "fix"
+        fix_dir.mkdir()
+
+        pytest_ids = ["tests/test_foo.py::TestFoo::test_bar"]
+        captured_cmds: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "1 passed"
+            mock.stderr = ""
+            return mock
+
+        with patch("scoring.subprocess.run", side_effect=fake_run):
+            _run_pytest_local(held_dir, fix_dir, timeout=30, fail_to_pass=pytest_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        # The pytest-style ID (resolved against held_dir) must appear.
+        expected = str(held_dir / pytest_ids[0])
+        assert expected in cmd, (
+            f"pytest-style ID must pass through unchanged; expected '{expected}' in cmd; "
+            f"got: {cmd}"
+        )
+
+
+class TestUnittestStyleIdConvertedToTier3Cmd:
+    """Regression [unittest-style-fix]: _run_pytest_tier3 converts unittest IDs.
+
+    test_unittest_style_id_converted_to_pytest_node_id (tier3 path).
+    """
+
+    def test_unittest_style_id_converted_to_pytest_node_id(self):
+        """_run_pytest_tier3 must convert 'test_foo (module.TestClass)' to pytest format."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        unittest_ids = ["test_foo (myapp.tests.MyTests)"]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=unittest_ids)
+
+        assert captured_cmds, "Tier3Docker.run_score_phase must have been called"
+        cmd = captured_cmds[0]
+        # Converted ID must appear prefixed with /scoring/tests/.
+        expected = "/scoring/tests/myapp/tests.py::MyTests::test_foo"
+        assert expected in cmd, (
+            f"Converted pytest node-id '{expected}' must appear in tier3 cmd; "
+            f"got: {cmd}"
+        )
+        # Raw unittest-style ID must not appear.
+        cmd_str = " ".join(cmd)
+        assert "test_foo (myapp.tests.MyTests)" not in cmd_str, (
+            "Raw unittest-style ID must not appear in tier3 cmd after conversion"
+        )
+
+    def test_pytest_style_id_passes_through_unchanged(self):
+        """_run_pytest_tier3 must not alter already-valid pytest node-ids."""
+        fake_ctx = MagicMock()
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        captured_cmds: list[list] = []
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return fake_result
+
+        pytest_ids = ["tests/test_foo.py::TestFoo::test_bar"]
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = fake_run_score_phase
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=pytest_ids)
+
+        assert captured_cmds
+        cmd = captured_cmds[0]
+        expected = f"/scoring/tests/{pytest_ids[0]}"
+        assert expected in cmd, (
+            f"pytest-style ID must appear unchanged (prefixed); "
+            f"expected '{expected}'; got: {cmd}"
         )


### PR DESCRIPTION
## Summary

- Corpus tasks (django-11039, django-11049 and similar) have `fail_to_pass` IDs in unittest format `"test_method (module.path.TestClass)"`. Pytest cannot resolve these as file paths, so it exits non-zero and every such task scores FAIL deterministically.
- Added `_convert_unittest_id_to_pytest` and `_normalize_fail_to_pass` helpers in `scoring.py`. Both `_run_pytest_local` and `_run_pytest_tier3` now normalize IDs before building the pytest command. Falls back to the full held-out tree when an ID cannot be parsed.
- Added 17 regression tests across `TestConvertUnittestIdToPytest`, `TestNormalizeFailToPass`, `TestUnittestStyleIdConvertedToLocalCmd`, and `TestUnittestStyleIdConvertedToTier3Cmd` - all 49 tests pass.

## Test plan

- [x] `python3 -m pytest evals/skill-comparison/tests/test_scoring.py -v` - 49/49 pass
- [x] Conversion: `"test_foo (myapp.tests.MyTests)"` -> `"myapp/tests.py::MyTests::test_foo"`
- [x] Pytest-style IDs (`contains ::`) pass through unchanged
- [x] Unparseable IDs (no dot inside parens) log a warning and fall back to full-tree mode