### PR TITLE
fix(evals): pass held_out_from_fix_dir=True so score phase mounts test files

### DIFF
--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -407,7 +407,14 @@ class Tier3Docker(IsolatorBase):
       held_out_dir:     optional host path for the held-out test tree. If None,
                         a separate empty tmpdir is created (the dir still exists
                         but nothing is in it - the mount still does not appear
-                        inside the fix-phase container).
+                        inside the fix-phase container). Ignored when
+                        held_out_from_fix_dir=True.
+      held_out_from_fix_dir: if True, set held_out_dir = fix_phase_dir at
+                        __enter__ time. Use for SWE-bench tasks where
+                        seed_fix_phase applies test_patch into the fix dir,
+                        so /scoring/tests should mount the same path as
+                        /workspace/repo. Mutually exclusive with held_out_dir
+                        (held_out_from_fix_dir takes precedence).
       build_image:      if True (default), build the Docker image from
                         Dockerfile.swebench before entering. Set to False when
                         the image is known to be pre-built (e.g. in test
@@ -427,9 +434,11 @@ class Tier3Docker(IsolatorBase):
         build_image: bool = True,
         timeout_seconds: int = 300,
         image_tag: str = _DOCKER_IMAGE_TAG,
+        held_out_from_fix_dir: bool = False,
     ) -> None:
         self.fixture_repo_dir = fixture_repo_dir
         self._held_out_dir = held_out_dir
+        self._held_out_from_fix_dir = held_out_from_fix_dir
         self.timeout_seconds = timeout_seconds
         self.image_tag = image_tag
 
@@ -471,7 +480,12 @@ class Tier3Docker(IsolatorBase):
         self._fix_phase_dir = fix_phase_dir
 
         # 3. Prepare held-out dir.
-        if self._held_out_dir is not None:
+        # held_out_from_fix_dir=True: SWE-bench design where test_patch is applied
+        # to the fix-phase dir during seeding. Both /workspace/repo and
+        # /scoring/tests mount the same source path (two ro bind-mounts, same dir).
+        if self._held_out_from_fix_dir:
+            held_out_dir = fix_phase_dir
+        elif self._held_out_dir is not None:
             held_out_dir = self._held_out_dir
         else:
             held_out_dir = Path(tempfile.mkdtemp(prefix="t3-held-"))

--- a/evals/runner/tests/test_isolator_tier3.py
+++ b/evals/runner/tests/test_isolator_tier3.py
@@ -931,3 +931,104 @@ def test_dockerfile_includes_pytest_timeout():
         "container; without pytest-timeout installed, every score phase fails with "
         "'unrecognized arguments: --timeout=120'."
     )
+
+
+# ---------------------------------------------------------------------------
+# held_out_from_fix_dir regression tests (held-out-mount fix)
+# ---------------------------------------------------------------------------
+
+
+def test_held_out_from_fix_dir_sets_held_out_equal_to_fix_phase():
+    """When held_out_from_fix_dir=True, Tier3Context.held_out_dir == fix_phase_dir.
+
+    Regression test for the held-out-mount bug: if no held_out_dir is passed,
+    __enter__ used to create an empty tmpdir for /scoring/tests. pytest inside
+    the score container found no tests and exited with 'file or directory not
+    found'. With held_out_from_fix_dir=True the held-out dir is the same
+    object as the fix-phase dir, where seed_fix_phase places the test files.
+    """
+    fake_digest = "sha256:" + "d" * 64
+    _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = fake_digest
+
+    def _noisy_subprocess_run(cmd, **kwargs):
+        raise AssertionError(
+            f"subprocess.run must NOT be called when cache is populated; got cmd={cmd!r}"
+        )
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_noisy_subprocess_run):
+            isolator = Tier3Docker(held_out_from_fix_dir=True, build_image=False)
+            ctx = isolator.__enter__()
+            try:
+                assert ctx.held_out_dir == ctx.fix_phase_dir, (
+                    f"held_out_from_fix_dir=True must set held_out_dir == fix_phase_dir; "
+                    f"got held_out_dir={ctx.held_out_dir!r}, fix_phase_dir={ctx.fix_phase_dir!r}"
+                )
+            finally:
+                isolator.__exit__(None, None, None)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+
+def test_held_out_from_fix_dir_no_empty_tmpdir_created():
+    """When held_out_from_fix_dir=True, no separate owned tmpdir is created for
+    held-out. _owned_held_out_dir must remain None so __exit__ does not attempt
+    to delete the fix-phase dir a second time.
+    """
+    fake_digest = "sha256:" + "e" * 64
+    _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = fake_digest
+
+    def _noisy_subprocess_run(cmd, **kwargs):
+        raise AssertionError(f"subprocess.run called unexpectedly: {cmd!r}")
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_noisy_subprocess_run):
+            isolator = Tier3Docker(held_out_from_fix_dir=True, build_image=False)
+            ctx = isolator.__enter__()
+            try:
+                assert isolator._owned_held_out_dir is None, (
+                    "_owned_held_out_dir must be None when held_out_from_fix_dir=True "
+                    "(fix-phase dir must not be double-deleted on __exit__)"
+                )
+            finally:
+                isolator.__exit__(None, None, None)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+
+def test_held_out_from_fix_dir_takes_precedence_over_held_out_dir(tmp_path):
+    """When both held_out_from_fix_dir=True and held_out_dir=<path> are passed,
+    held_out_from_fix_dir takes precedence and the result equals fix_phase_dir.
+    """
+    import shutil as _shutil
+
+    fake_digest = "sha256:" + "f" * 64
+    _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = fake_digest
+
+    explicit_held = tmp_path / "explicit-held"
+    explicit_held.mkdir()
+
+    def _noisy_subprocess_run(cmd, **kwargs):
+        raise AssertionError(f"subprocess.run called unexpectedly: {cmd!r}")
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_noisy_subprocess_run):
+            isolator = Tier3Docker(
+                held_out_dir=explicit_held,
+                held_out_from_fix_dir=True,
+                build_image=False,
+            )
+            ctx = isolator.__enter__()
+            try:
+                assert ctx.held_out_dir == ctx.fix_phase_dir, (
+                    "held_out_from_fix_dir=True must override held_out_dir; "
+                    f"expected fix_phase_dir={ctx.fix_phase_dir!r}, "
+                    f"got held_out_dir={ctx.held_out_dir!r}"
+                )
+                assert ctx.held_out_dir != explicit_held, (
+                    "explicit held_out_dir must be ignored when held_out_from_fix_dir=True"
+                )
+            finally:
+                isolator.__exit__(None, None, None)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -541,11 +541,18 @@ def run_matrix(
                     task_held_out = task_meta.get("_held_out_dir_path")
                     if task_held_out and Path(task_held_out).exists():
                         held_out_path = Path(task_held_out)
+                    # held_out_from_fix_dir=True: test_patch is applied to the
+                    # fix-phase dir during seeding, so /scoring/tests must
+                    # mount the same dir as /workspace/repo. When a task also
+                    # provides a held_out_path (pre-seeded corpus files),
+                    # held_out_from_fix_dir takes precedence so the
+                    # post-seeding test files are used for scoring.
                     _tier3_instance = _Tier3Docker(
                         fixture_repo_dir=None,  # base repo seeded externally
                         held_out_dir=held_out_path,
                         build_image=False,  # image already built once by ensure_image() above
                         timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
+                        held_out_from_fix_dir=True,
                     )
                     tier3_ctx = _tier3_instance.__enter__()
 

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -2137,3 +2137,128 @@ tasks:
             assert ftp == [] or ftp is None or ftp == [], (
                 f"fail_to_pass must be [] when absent from task_meta, got {ftp!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# held-out-mount regression: held_out_from_fix_dir=True passed in production
+# ---------------------------------------------------------------------------
+
+
+class TestHeldOutFromFixDir:
+    """Regression test for the held-out-mount bug.
+
+    When no held_out_dir is passed to Tier3Docker, __enter__ used to create an
+    empty tmpdir for /scoring/tests. pytest inside the score container found no
+    tests and exited with 'file or directory not found'.
+
+    Fix: runner passes held_out_from_fix_dir=True so Tier3Docker sets
+    held_out_dir = fix_phase_dir at __enter__ time, where seed_fix_phase has
+    placed the test files.
+    """
+
+    _MINIMAL_CORPUS_YAML = """\
+freeze_metadata:
+  freeze_date: "2026-05-12"
+tasks:
+  django-11039:
+    swebench_instance_id: "django__django-11039"
+    repo_url: "https://github.com/django/django"
+    base_commit: "d5276398046ce4a102776a1e67dcac2884d80dfe"
+    held_out_tests:
+      - "tests/migrations/test_commands.py"
+    fail_to_pass:
+      - "test_sqlmigrate_for_non_transactional_databases"
+    estimated_test_seconds: 30
+    difficulty: single-file
+    known_affected_files:
+      - "django/core/management/commands/sqlmigrate.py"
+    problem_summary: >
+      sqlmigrate wraps output in BEGIN/COMMIT even when the database does not
+      support transactional DDL.
+"""
+
+    def test_runner_passes_held_out_from_fix_dir_true_in_production(
+        self, tmp_path: Path
+    ):
+        """run_matrix passes held_out_from_fix_dir=True when tier3_mode='auto'.
+
+        Regression test for held-out-mount bug: previously Tier3Docker was
+        instantiated without held_out_from_fix_dir, so __enter__ created an
+        empty tmpdir for /scoring/tests - pytest found no tests and exited with
+        'file or directory not found'. This test captures the kwargs passed to
+        Tier3Docker.__init__ and asserts held_out_from_fix_dir=True is present.
+        """
+        from scoring import ScoringResult
+        from evals.runner.isolator import Tier3Context
+        import json as _json, subprocess as _sp
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(self._MINIMAL_CORPUS_YAML, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        canned_invoker = {
+            "final_text": "Fixed.",
+            "status": "ok",
+            "cost_usd": 0.0,
+            "usage": {},
+            "latency_ms": 0,
+            "invocation_mode": "agent",
+            "tool_calls": [],
+            "turns_used": 1,
+            "_parse_warnings": [],
+            "stderr_tail": "",
+        }
+        canned_cp = _sp.CompletedProcess(
+            args=[], returncode=0,
+            stdout=_json.dumps(canned_invoker), stderr="",
+        )
+
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "fix",  # same dir, as held_out_from_fix_dir would set
+            image_tag="ae-eval-swebench:latest",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+
+        captured_init_kwargs: list[dict] = []
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+
+        def capturing_tier3_cls(*args, **kwargs):
+            captured_init_kwargs.append(kwargs)
+            return mock_tier3_instance
+
+        mock_tier3_cls = MagicMock(side_effect=capturing_tier3_cls)
+        mock_tier3_cls.ensure_image = MagicMock(return_value="sha256:abc123")
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=canned_cp)
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        assert captured_init_kwargs, "Tier3Docker must have been instantiated"
+        for kwargs in captured_init_kwargs:
+            assert kwargs.get("held_out_from_fix_dir") is True, (
+                f"Tier3Docker must be instantiated with held_out_from_fix_dir=True; "
+                f"got kwargs={kwargs!r}. "
+                "held-out-mount regression: without this flag, __enter__ creates an "
+                "empty tmpdir for /scoring/tests and pytest finds no test files."
+            )


### PR DESCRIPTION
## Summary

- `Tier3Docker.__init__` gains `held_out_from_fix_dir: bool = False`. When `True`, `__enter__` sets `held_out_dir = fix_phase_dir` instead of creating an empty tmpdir.
- `runner.py` passes `held_out_from_fix_dir=True` per cell in the production (`tier3_mode='auto'`) path.
- Score phase now mounts the same source dir at both `/workspace/repo:ro` and `/scoring/tests:ro` - where `seed_fix_phase` placed the held-out test files via `test_patch`.

## Test plan

- [ ] `evals/runner/tests/test_isolator_tier3.py` - 3 new unit tests: `held_out_dir == fix_phase_dir` when param is True, no owned tmpdir created, precedence over explicit `held_out_dir`
- [ ] `evals/skill-comparison/tests/test_runner.py::TestHeldOutFromFixDir` - verifies runner passes `held_out_from_fix_dir=True` to Tier3Docker
- [ ] All 68 existing tests pass (23 isolator + 45 runner)