### PR TITLE
fix(evals): inject PYTHONPATH=/workspace/repo in score-phase container

### DIFF
--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -582,7 +582,16 @@ def _run_pytest_tier3(
         " ".join(cmd),
         fail_to_pass,
     )
-    result = Tier3Docker.run_score_phase(tier3_ctx, cmd, timeout_seconds=timeout)
+    # Inject PYTHONPATH=/workspace/repo so the repo under test is importable
+    # inside the score-phase container without pip install (network is disabled).
+    # This resolves ImportError when conftest.py or test modules do
+    # `from <repo_package> import ...` (e.g. `from requests.packages import ...`).
+    result = Tier3Docker.run_score_phase(
+        tier3_ctx,
+        cmd,
+        timeout_seconds=timeout,
+        env={"PYTHONPATH": "/workspace/repo"},
+    )
     return result.returncode, result.stdout + result.stderr
 
 

--- a/evals/skill-comparison/tests/test_scoring.py
+++ b/evals/skill-comparison/tests/test_scoring.py
@@ -1183,3 +1183,68 @@ class TestUnittestStyleIdConvertedToTier3Cmd:
             f"pytest-style ID must appear unchanged (prefixed); "
             f"expected '{expected}'; got: {cmd}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: PYTHONPATH=/workspace/repo injected into score-phase container
+# [score-phase-pythonpath]
+# ---------------------------------------------------------------------------
+
+
+class TestRunPytestTier3SetsPythonpath:
+    """Regression: _run_pytest_tier3 must pass PYTHONPATH=/workspace/repo to
+    run_score_phase so that the repo package under test is importable inside
+    the container without pip install (network is disabled during scoring).
+
+    Without this, SWE-bench tasks whose conftest.py or test files do
+    `from <repo_package> import ...` raise ImportError at collection time.
+    """
+
+    def _make_fake_run_score_phase(self, captured_kwargs: list) -> object:
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "1 passed"
+        fake_result.stderr = ""
+
+        def fake_run_score_phase(ctx, cmd, **kwargs):
+            captured_kwargs.append(dict(kwargs))
+            return fake_result
+
+        return fake_run_score_phase
+
+    def test_pythonpath_workspace_repo_in_env(self):
+        """run_score_phase must receive env={"PYTHONPATH": "/workspace/repo"}."""
+        fake_ctx = MagicMock()
+        captured: list[dict] = []
+
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = self._make_fake_run_score_phase(captured)
+            _run_pytest_tier3(fake_ctx, timeout=30)
+
+        assert captured, "Tier3Docker.run_score_phase must have been called"
+        env = captured[0].get("env")
+        assert isinstance(env, dict), (
+            f"_run_pytest_tier3 must pass env dict to run_score_phase; got {env!r}"
+        )
+        assert env.get("PYTHONPATH") == "/workspace/repo", (
+            f"PYTHONPATH must be '/workspace/repo'; got {env.get('PYTHONPATH')!r}. "
+            "Without this, `from <repo_package> import ...` in test conftest raises "
+            "ImportError when --network none prevents pip install."
+        )
+
+    def test_pythonpath_set_with_explicit_fail_to_pass(self):
+        """PYTHONPATH env must be injected regardless of whether fail_to_pass is given."""
+        fake_ctx = MagicMock()
+        captured: list[dict] = []
+
+        node_ids = ["tests/test_foo.py::TestFoo::test_bar"]
+        with patch("evals.runner.isolator.Tier3Docker") as MockDocker:
+            MockDocker.run_score_phase.side_effect = self._make_fake_run_score_phase(captured)
+            _run_pytest_tier3(fake_ctx, timeout=30, fail_to_pass=node_ids)
+
+        assert captured, "Tier3Docker.run_score_phase must have been called"
+        env = captured[0].get("env")
+        assert isinstance(env, dict) and env.get("PYTHONPATH") == "/workspace/repo", (
+            f"PYTHONPATH must be '/workspace/repo' even when fail_to_pass is set; "
+            f"got env={env!r}"
+        )


### PR DESCRIPTION
## Summary

- `_run_pytest_tier3` now passes `env={"PYTHONPATH": "/workspace/repo"}` to `Tier3Docker.run_score_phase`, injecting `-e PYTHONPATH=/workspace/repo` into the score-phase docker run command
- Fixes `ImportError` when `conftest.py` or test files do `from <repo_package> import ...` - `--network none` blocks `pip install`, so `PYTHONPATH` is the only reliable way to make the repo importable
- Two regression tests added: `TestRunPytestTier3SetsPythonpath` pins that `run_score_phase` receives the env dict both with and without `fail_to_pass` node-ids

## Test plan
- [ ] `python3 -m pytest evals/skill-comparison/tests/test_scoring.py -q` - 51 passed
- [ ] `python3 -m pytest evals/skill-comparison/tests/ -q` - 328 passed, 1 skipped
- [ ] New tests: `TestRunPytestTier3SetsPythonpath::test_pythonpath_workspace_repo_in_env` and `test_pythonpath_set_with_explicit_fail_to_pass`