### PR TITLE
fix(eval-harness): add requests deps to Dockerfile.swebench

### DIFF
--- a/evals/runner/Dockerfile.swebench
+++ b/evals/runner/Dockerfile.swebench
@@ -22,14 +22,19 @@ FROM python@sha256:a5b427ace4900267d93db34138e512325c6fa6af84ad5e4ed5f3b36258cc4
 LABEL org.opencontainers.image.title="ae-eval-swebench" \
       org.opencontainers.image.description="AE eval harness Tier 3 sandbox for SWE-bench fix+score phases" \
       org.opencontainers.image.source="evals/runner/Dockerfile.swebench" \
-      org.opencontainers.image.version="1.1.0"
+      org.opencontainers.image.version="1.2.0"
 
 # Install pytest and a minimal set of test utilities at BUILD time.
 # Network is available here (build time). Network is disabled at run time via
 # `docker run --network none`. No per-task packages are installed at run time;
 # if a task requires additional packages, extend this RUN layer and rebuild.
 # pytest-timeout: required by scoring.py which passes --timeout=<N> to pytest.
-RUN pip install --no-cache-dir pytest==8.3.5 pytest-timeout==2.4.0
+#
+# Transitive runtime deps for the 12 SWE-bench-lite corpus tasks:
+#   urllib3 chardet certifi idna - requests stack (requests-3362, etc.)
+RUN pip install --no-cache-dir \
+    pytest==8.3.5 pytest-timeout==2.4.0 \
+    urllib3 chardet certifi idna
 
 # Create a non-root user for running eval commands.
 RUN groupadd --gid 1001 evaluser && \

--- a/evals/runner/tests/test_dockerfile_swebench_deps.py
+++ b/evals/runner/tests/test_dockerfile_swebench_deps.py
@@ -1,0 +1,25 @@
+"""
+Regression test: Dockerfile.swebench must include urllib3 and sibling
+requests-stack packages so that SWE-bench-lite corpus tasks (e.g.
+requests-3362) do not fail with ModuleNotFoundError at score-phase pytest time.
+
+Finding: smoke v9 failed with `ModuleNotFoundError: No module named 'urllib3'`
+because the image only had pytest + pytest-timeout.
+"""
+
+import pathlib
+
+DOCKERFILE = pathlib.Path(__file__).parent.parent / "Dockerfile.swebench"
+
+REQUIRED_PACKAGES = ["urllib3", "chardet", "certifi", "idna"]
+
+
+def test_dockerfile_includes_urllib3_etc():
+    """Dockerfile.swebench must pip-install the requests transitive dep stack."""
+    content = DOCKERFILE.read_text()
+    missing = [pkg for pkg in REQUIRED_PACKAGES if pkg not in content]
+    assert not missing, (
+        f"Dockerfile.swebench is missing these packages: {missing}. "
+        "Add them to the RUN pip install layer so score-phase pytest can "
+        "import them without network access."
+    )


### PR DESCRIPTION
## Summary
- Add `urllib3 chardet certifi idna` to `Dockerfile.swebench` RUN layer - unblocks requests-3362 smoke which failed with `ModuleNotFoundError: No module named 'urllib3'`
- Bump image version label to `1.2.0` to bust the local Docker cache on next `--rebuild-image` run
- Add `evals/runner/tests/test_dockerfile_swebench_deps.py` grep regression test to prevent the gap from reopening silently

## Test plan
- [x] `pytest evals/runner/tests/test_dockerfile_swebench_deps.py` - 1 passed
- [ ] Rebuild image with `--rebuild-image` on next smoke run
- [ ] Confirm requests-3362 smoke passes without `ModuleNotFoundError`