### PR TITLE
fix(eval-harness): force docker rmi before build when --rebuild-image is set

### DIFF
--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -80,8 +80,11 @@ Public API: make_isolator(tier: int, **kwargs) -> Isolator,
             Tier1Worktree (context manager yielding a worktree Path),
             Tier2HomeRedirect (context manager yielding (worktree, fake_home)),
             Tier3Docker (context manager yielding a Tier3Context namedtuple),
-            Tier3Docker.ensure_image(image_tag, dockerfile, context_dir) -> str
-              (class method; build-once, returns cached digest on repeat calls),
+            Tier3Docker.ensure_image(image_tag, dockerfile, context_dir,
+                                      force_rebuild=False) -> str
+              (class method; build-once, returns cached digest on repeat calls;
+               force_rebuild=True runs docker rmi before docker build so cached
+               layers from a stale image are discarded),
             IsolatorBase abstract contract.
 
 Upstream deps: stdlib subprocess, pathlib, tempfile, shutil, uuid, os, sys,
@@ -603,6 +606,7 @@ class Tier3Docker(IsolatorBase):
         image_tag: str = _DOCKER_IMAGE_TAG,
         dockerfile: Path = _DOCKERFILE_PATH,
         context_dir: Path | None = None,
+        force_rebuild: bool = False,
     ) -> str:
         """Build the Docker image ONCE and cache the resolved digest.
 
@@ -615,6 +619,16 @@ class Tier3Docker(IsolatorBase):
             dockerfile: path to the Dockerfile (default: _DOCKERFILE_PATH).
             context_dir: Docker build context directory. Defaults to the
                          directory containing `dockerfile`.
+            force_rebuild: if True, remove the existing locally-tagged image
+                           with `docker rmi -f` before running `docker build`.
+                           This forces Docker to start from a clean slate rather
+                           than reusing cached layers, which is necessary when
+                           FROM or pip install in the Dockerfile have changed but
+                           the local tag still points to a stale image. Errors
+                           from `docker rmi` are swallowed (the image may not
+                           exist yet on the first build). The in-process
+                           _IMAGE_DIGEST_CACHE entry for `image_tag` is also
+                           evicted so the fresh digest is stored after the build.
 
         Returns:
             The resolved sha256 image digest string (also stored in the cache).
@@ -623,7 +637,7 @@ class Tier3Docker(IsolatorBase):
             RuntimeError if docker build or docker inspect fails.
             FileNotFoundError if the Dockerfile is absent.
         """
-        if image_tag in _IMAGE_DIGEST_CACHE:
+        if image_tag in _IMAGE_DIGEST_CACHE and not force_rebuild:
             _log.info("Tier 3: image %s already cached (digest %s)", image_tag, _IMAGE_DIGEST_CACHE[image_tag])
             return _IMAGE_DIGEST_CACHE[image_tag]
 
@@ -633,6 +647,20 @@ class Tier3Docker(IsolatorBase):
             )
 
         effective_context = context_dir if context_dir is not None else dockerfile.parent
+
+        if force_rebuild:
+            # Evict stale in-process cache entry so the fresh digest is stored below.
+            _IMAGE_DIGEST_CACHE.pop(image_tag, None)
+            _log.info(
+                "Tier 3: force_rebuild=True; removing existing image %s before build "
+                "(docker rmi errors are ignored if image is absent)",
+                image_tag,
+            )
+            subprocess.run(
+                ["docker", "rmi", "-f", image_tag],
+                capture_output=True,
+                check=False,  # image may not exist; errors swallowed intentionally
+            )
 
         _log.info("Tier 3: building image %s from %s (this will happen once)", image_tag, dockerfile)
         result = subprocess.run(

--- a/evals/runner/tests/test_isolator_tier3.py
+++ b/evals/runner/tests/test_isolator_tier3.py
@@ -1032,3 +1032,132 @@ def test_held_out_from_fix_dir_takes_precedence_over_held_out_dir(tmp_path):
                 isolator.__exit__(None, None, None)
     finally:
         _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Regression test: force_rebuild=True in ensure_image() runs docker rmi
+# before docker build so Docker layer cache is discarded, not just in-process
+# cache. Prevents stale image reuse when Dockerfile.swebench changes.
+# Bug: --rebuild-image only evicted _IMAGE_DIGEST_CACHE; `docker build` still
+# reused cached layers from the old locally-tagged image.
+# Fix: ensure_image(force_rebuild=True) runs `docker rmi -f <tag>` first.
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_image_force_rebuild_runs_rmi():
+    """ensure_image(force_rebuild=True) invokes `docker rmi -f <image_tag>`
+    before `docker build`, discarding Docker's layer cache for the tagged image.
+
+    Regression test for the --rebuild-image bug: the old code only evicted
+    _IMAGE_DIGEST_CACHE (in-process) but did not remove the locally-tagged
+    Docker image. `docker build` would then reuse cached layers and produce
+    an image that appeared fresh but still used stale layers from the old
+    Dockerfile. force_rebuild=True now calls `docker rmi -f` first.
+    """
+    build_call_count = 0
+    rmi_call_count = 0
+    rmi_calls: list[list[str]] = []
+    inspect_call_count = 0
+    fake_digest = "sha256:" + "9" * 64
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        nonlocal build_call_count, rmi_call_count, inspect_call_count
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        if len(cmd) >= 2 and cmd[1] == "rmi":
+            rmi_call_count += 1
+            rmi_calls.append(list(cmd))
+        elif "build" in cmd:
+            build_call_count += 1
+            result.stdout = "Successfully built"
+        elif "inspect" in cmd:
+            inspect_call_count += 1
+            result.stdout = fake_digest + "\n"
+        return result
+
+    # Seed the cache as if ensure_image() had previously been called.
+    _isolator_module._IMAGE_DIGEST_CACHE[_DOCKER_IMAGE_TAG] = "sha256:" + "0" * 64
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+            digest = Tier3Docker.ensure_image(force_rebuild=True)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+    # docker rmi must have been called with -f and the image tag.
+    assert rmi_call_count == 1, (
+        f"Expected docker rmi to be called exactly once; got {rmi_call_count}. "
+        "force_rebuild=True must remove the old image before building."
+    )
+    assert "-f" in rmi_calls[0], (
+        f"docker rmi call must include -f (force); got: {rmi_calls[0]!r}"
+    )
+    assert _DOCKER_IMAGE_TAG in rmi_calls[0], (
+        f"docker rmi must target the image tag {_DOCKER_IMAGE_TAG!r}; "
+        f"got: {rmi_calls[0]!r}"
+    )
+
+    # docker build must still have been called (force_rebuild doesn't skip build).
+    assert build_call_count == 1, (
+        f"Expected docker build to be called exactly once; got {build_call_count}."
+    )
+
+    # The fresh digest must be returned (not the old stale one).
+    assert digest == fake_digest, (
+        f"ensure_image(force_rebuild=True) must return the freshly resolved digest; "
+        f"got {digest!r}"
+    )
+
+    # Cache must now hold the fresh digest, not the old one.
+    assert _isolator_module._IMAGE_DIGEST_CACHE.get(_DOCKER_IMAGE_TAG) is None, (
+        "Cache must have been cleared by the finally block in this test "
+        "(confirming force_rebuild evicted the stale entry)"
+    )
+
+
+def test_ensure_image_force_rebuild_rmi_errors_are_swallowed():
+    """ensure_image(force_rebuild=True) does not raise when docker rmi fails
+    (e.g. image does not exist yet on the first build).
+
+    The rmi step is best-effort: errors must be swallowed so that
+    `--rebuild-image` on a fresh machine (no prior image) does not abort.
+    """
+    rmi_returncode = 1  # simulate "No such image"
+    build_call_count = 0
+    fake_digest = "sha256:" + "a" * 64
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        nonlocal rmi_returncode, build_call_count
+        result = MagicMock()
+        result.stdout = ""
+        result.stderr = ""
+        if len(cmd) >= 2 and cmd[1] == "rmi":
+            result.returncode = rmi_returncode  # rmi fails
+        elif "build" in cmd:
+            build_call_count += 1
+            result.returncode = 0
+            result.stdout = "Successfully built"
+        elif "inspect" in cmd:
+            result.returncode = 0
+            result.stdout = fake_digest + "\n"
+        else:
+            result.returncode = 0
+        return result
+
+    _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+    try:
+        with patch("evals.runner.isolator.subprocess.run", side_effect=_fake_subprocess_run):
+            # Must not raise even though docker rmi returned non-zero.
+            digest = Tier3Docker.ensure_image(force_rebuild=True)
+    finally:
+        _isolator_module._IMAGE_DIGEST_CACHE.clear()
+
+    assert digest == fake_digest, (
+        f"Expected fresh digest after force_rebuild despite rmi failure; got {digest!r}"
+    )
+    assert build_call_count == 1, (
+        f"docker build must still run after a failed rmi; got {build_call_count} builds."
+    )

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -50,8 +50,11 @@ Tier3Docker.ensure_image() ONCE before the cell loop. Per-cell Tier3Docker(...)
 instantiations pass build_image=False. The module-level _IMAGE_DIGEST_CACHE in
 isolator.py ensures the build subprocess is never invoked more than once per
 process, even if build_image=True were passed accidentally.
-When rebuild_image=True, the cache entry for the image tag is evicted before
-ensure_image() is called, forcing a fresh docker build on the next invocation.
+When rebuild_image=True, ensure_image(force_rebuild=True) is called, which runs
+`docker rmi -f` before `docker build` to discard Docker's layer cache and force
+a fully clean rebuild. This is necessary when Dockerfile.swebench has changed
+but the locally-tagged image is stale - evicting only the in-process digest
+cache was insufficient because `docker build` would still reuse cached layers.
 
 Transcript persistence: every cell persists the engineer CLI stdout+stderr to
 <results_tsv_dir>/transcripts/<task_slug>__<condition>__rep<N>.log.  On
@@ -471,23 +474,21 @@ def run_matrix(
     if use_tier3:
         from evals.runner.isolator import (  # type: ignore[assignment]
             Tier3Docker as _Tier3Docker,
-            _DOCKER_IMAGE_TAG as _T3_IMAGE_TAG,
-            _IMAGE_DIGEST_CACHE as _T3_DIGEST_CACHE,
         )
-        # rebuild_image=True: evict the cached digest so ensure_image()
-        # forces a fresh docker build. This is explicit operator control -
-        # no surprise rebuilds on normal runs.
-        if rebuild_image and _T3_IMAGE_TAG in _T3_DIGEST_CACHE:
-            _LOG.info(
-                "Tier 3: --rebuild-image requested; evicting cached digest for %s",
-                _T3_IMAGE_TAG,
-            )
-            del _T3_DIGEST_CACHE[_T3_IMAGE_TAG]
         # Build-once-reuse: build the Docker image ONCE before the cell loop.
         # This avoids N*24 redundant docker builds (one per cell). Each per-cell
         # Tier3Docker(...) call will find the cached digest and skip the build.
+        #
+        # rebuild_image=True: pass force_rebuild=True to ensure_image() so it
+        # runs `docker rmi -f` before `docker build`. This discards Docker's
+        # layer cache for the locally-tagged image (not just the in-process
+        # digest cache), which is necessary when Dockerfile.swebench has changed
+        # and the tag still points to a stale image built from the old file.
+        # Evicting only _IMAGE_DIGEST_CACHE (the old approach) was insufficient
+        # because `docker build` would still reuse cached layers and produce an
+        # image that appeared fresh but was not.
         _LOG.info("Tier 3: ensuring image is built (one-time build before cell loop)")
-        _Tier3Docker.ensure_image()
+        _Tier3Docker.ensure_image(force_rebuild=rebuild_image)
 
     for task_slug, task_meta in tasks.items():
         for condition in active_conditions:


### PR DESCRIPTION
## Summary

- `--rebuild-image` previously only evicted the in-process `_IMAGE_DIGEST_CACHE`. Docker still reused cached layers from the locally-tagged image, so Dockerfile changes (FROM, pip install) were silently ignored.
- `ensure_image()` gains a `force_rebuild: bool = False` parameter. When `True`, it runs `docker rmi -f <image_tag>` (errors swallowed - image may not exist yet) before `docker build`, forcing Docker to start from a clean slate.
- `runner.py` passes `force_rebuild=rebuild_image` to `ensure_image()` and drops the now-redundant manual `_IMAGE_DIGEST_CACHE` eviction block.

## Test plan

- `test_ensure_image_force_rebuild_runs_rmi` - asserts `docker rmi -f <tag>` is called before `docker build`, fresh digest is returned, and stale cache entry is replaced
- `test_ensure_image_force_rebuild_rmi_errors_are_swallowed` - asserts a non-zero `docker rmi` exit (e.g. "No such image" on first build) does not abort the operation
- All 11 existing unit tests (mock-based, no Docker required) still pass