### PR TITLE
fix(eval): scoring bugs and methodology conventions

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1086,6 +1086,15 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
+## Context Economy
+
+Agents must be mindful of context-window consumption. Large outputs increase latency, burn tokens, and can push the session toward truncation. Follow these rules:
+
+- **Do not duplicate file contents in prose.** Reference files by path. The reader can use ReadFile if they need the full text.
+- **Keep diffs minimal.** Use standard unified diff format with 3 lines of context per hunk. Do not paste entire files when only a few lines changed.
+- **Do not paste tool output verbatim** unless specifically asked or unless the output is short (<20 lines). Summarize command results: "`pytest` passes (42 tests, 0 failures)" rather than dumping the full test log.
+- **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
+
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
 ---

--- a/.codex/agents/engineer.toml
+++ b/.codex/agents/engineer.toml
@@ -127,7 +127,7 @@ After the structured block, return a plain-text summary covering:
 
 - **What was changed** - files modified or created, and what each change does
 - **Why** - brief rationale for any non-obvious decisions made during implementation
-- **Quality gates** - which commands you ran and their actual output (pass/fail, any output worth noting)
+- **Quality gates** - which commands you ran and their actual output. Report each gate on its own line in the form `gate_name: pass|fail` (e.g. `lint: pass`, `typecheck: pass`, `tests: pass`). If a gate was not run, write `gate_name: not_run`.
 - **Out of scope** - anything the prompt implied but you deliberately did not do, and why
 - **Blockers or open questions** - anything that needs human input or a follow-up decision
 
@@ -143,6 +143,7 @@ Keep prose brief. A reviewer reading the structured block plus prose summary plu
 - **If context is missing** - no file paths, no task description, or the task requires an architecture decision you were not given - say so at the top of your output before attempting anything. Do not invent assumptions to fill the gap.
 - **Never commit or push.** Implement and report. The orchestrator handles version control.
 - **Verify before claiming done.** Run lint, typecheck, and tests in the same message as your status report. Paste the output. Do not report `Status: DONE` based on a check you ran earlier in the session.
+- **Diff format.** Emit all changes in a single ````diff` fenced code block using standard unified diff format with `--- a/<path>` and `+++ b/<path>` headers for every file. Do not split multi-file changes into separate code blocks and do not use markdown headings as file path markers. Keep context lines minimal - 3 lines per hunk is sufficient.
 - **Regression tests for Skeptic findings.** When fixing a Critical or Major Skeptic finding, add a regression test that would have caught the failure mode. Reference it in the fix summary: `[finding ID] → fixed by [description]. Regression test: [file, test name].` If a regression test is genuinely not possible, state the reason explicitly — absence without explanation is a Major finding in the next Skeptic round. See `~/agentic-engineering/.claude/skills/agentic-engineering/references/regression-test-obligation.md` for what counts as a valid regression test.
 - **Module manifests for non-trivial files.** When creating or substantially modifying a file that exports a public symbol consumed by another module, exceeds ~50 LOC, or implements a side-effecting operation, include a manifest header. See `~/agentic-engineering/.claude/skills/agentic-engineering/rules/module-manifest.md` for required fields and language-specific examples.
 """

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -98,4 +98,13 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
+## Context Economy
+
+Agents must be mindful of context-window consumption. Large outputs increase latency, burn tokens, and can push the session toward truncation. Follow these rules:
+
+- **Do not duplicate file contents in prose.** Reference files by path. The reader can use ReadFile if they need the full text.
+- **Keep diffs minimal.** Use standard unified diff format with 3 lines of context per hunk. Do not paste entire files when only a few lines changed.
+- **Do not paste tool output verbatim** unless specifically asked or unless the output is short (<20 lines). Summarize command results: "`pytest` passes (42 tests, 0 failures)" rather than dumping the full test log.
+- **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
+
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1086,6 +1086,15 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
+## Context Economy
+
+Agents must be mindful of context-window consumption. Large outputs increase latency, burn tokens, and can push the session toward truncation. Follow these rules:
+
+- **Do not duplicate file contents in prose.** Reference files by path. The reader can use ReadFile if they need the full text.
+- **Keep diffs minimal.** Use standard unified diff format with 3 lines of context per hunk. Do not paste entire files when only a few lines changed.
+- **Do not paste tool output verbatim** unless specifically asked or unless the output is short (<20 lines). Summarize command results: "`pytest` passes (42 tests, 0 failures)" rather than dumping the full test log.
+- **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
+
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
 

--- a/.gemini/agents/engineer.md
+++ b/.gemini/agents/engineer.md
@@ -128,7 +128,7 @@ After the structured block, return a plain-text summary covering:
 
 - **What was changed** - files modified or created, and what each change does
 - **Why** - brief rationale for any non-obvious decisions made during implementation
-- **Quality gates** - which commands you ran and their actual output (pass/fail, any output worth noting)
+- **Quality gates** - which commands you ran and their actual output. Report each gate on its own line in the form `gate_name: pass|fail` (e.g. `lint: pass`, `typecheck: pass`, `tests: pass`). If a gate was not run, write `gate_name: not_run`.
 - **Out of scope** - anything the prompt implied but you deliberately did not do, and why
 - **Blockers or open questions** - anything that needs human input or a follow-up decision
 
@@ -144,5 +144,6 @@ Keep prose brief. A reviewer reading the structured block plus prose summary plu
 - **If context is missing** - no file paths, no task description, or the task requires an architecture decision you were not given - say so at the top of your output before attempting anything. Do not invent assumptions to fill the gap.
 - **Never commit or push.** Implement and report. The orchestrator handles version control.
 - **Verify before claiming done.** Run lint, typecheck, and tests in the same message as your status report. Paste the output. Do not report `Status: DONE` based on a check you ran earlier in the session.
+- **Diff format.** Emit all changes in a single ````diff` fenced code block using standard unified diff format with `--- a/<path>` and `+++ b/<path>` headers for every file. Do not split multi-file changes into separate code blocks and do not use markdown headings as file path markers. Keep context lines minimal - 3 lines per hunk is sufficient.
 - **Regression tests for Skeptic findings.** When fixing a Critical or Major Skeptic finding, add a regression test that would have caught the failure mode. Reference it in the fix summary: `[finding ID] → fixed by [description]. Regression test: [file, test name].` If a regression test is genuinely not possible, state the reason explicitly — absence without explanation is a Major finding in the next Skeptic round. See `~/agentic-engineering/.claude/skills/agentic-engineering/references/regression-test-obligation.md` for what counts as a valid regression test.
 - **Module manifests for non-trivial files.** When creating or substantially modifying a file that exports a public symbol consumed by another module, exceeds ~50 LOC, or implements a side-effecting operation, include a manifest header. See `~/agentic-engineering/.claude/skills/agentic-engineering/rules/module-manifest.md` for required fields and language-specific examples.

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -1086,6 +1086,15 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
+## Context Economy
+
+Agents must be mindful of context-window consumption. Large outputs increase latency, burn tokens, and can push the session toward truncation. Follow these rules:
+
+- **Do not duplicate file contents in prose.** Reference files by path. The reader can use ReadFile if they need the full text.
+- **Keep diffs minimal.** Use standard unified diff format with 3 lines of context per hunk. Do not paste entire files when only a few lines changed.
+- **Do not paste tool output verbatim** unless specifically asked or unless the output is short (<20 lines). Summarize command results: "`pytest` passes (42 tests, 0 failures)" rather than dumping the full test log.
+- **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
+
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
 ---

--- a/.opencode/agents/engineer.md
+++ b/.opencode/agents/engineer.md
@@ -126,7 +126,7 @@ After the structured block, return a plain-text summary covering:
 
 - **What was changed** - files modified or created, and what each change does
 - **Why** - brief rationale for any non-obvious decisions made during implementation
-- **Quality gates** - which commands you ran and their actual output (pass/fail, any output worth noting)
+- **Quality gates** - which commands you ran and their actual output. Report each gate on its own line in the form `gate_name: pass|fail` (e.g. `lint: pass`, `typecheck: pass`, `tests: pass`). If a gate was not run, write `gate_name: not_run`.
 - **Out of scope** - anything the prompt implied but you deliberately did not do, and why
 - **Blockers or open questions** - anything that needs human input or a follow-up decision
 
@@ -142,5 +142,6 @@ Keep prose brief. A reviewer reading the structured block plus prose summary plu
 - **If context is missing** - no file paths, no task description, or the task requires an architecture decision you were not given - say so at the top of your output before attempting anything. Do not invent assumptions to fill the gap.
 - **Never commit or push.** Implement and report. The orchestrator handles version control.
 - **Verify before claiming done.** Run lint, typecheck, and tests in the same message as your status report. Paste the output. Do not report `Status: DONE` based on a check you ran earlier in the session.
+- **Diff format.** Emit all changes in a single ````diff` fenced code block using standard unified diff format with `--- a/<path>` and `+++ b/<path>` headers for every file. Do not split multi-file changes into separate code blocks and do not use markdown headings as file path markers. Keep context lines minimal - 3 lines per hunk is sufficient.
 - **Regression tests for Skeptic findings.** When fixing a Critical or Major Skeptic finding, add a regression test that would have caught the failure mode. Reference it in the fix summary: `[finding ID] → fixed by [description]. Regression test: [file, test name].` If a regression test is genuinely not possible, state the reason explicitly — absence without explanation is a Major finding in the next Skeptic round. See `~/agentic-engineering/.claude/skills/agentic-engineering/references/regression-test-obligation.md` for what counts as a valid regression test.
 - **Module manifests for non-trivial files.** When creating or substantially modifying a file that exports a public symbol consumed by another module, exceeds ~50 LOC, or implements a side-effecting operation, include a manifest header. See `~/agentic-engineering/.claude/skills/agentic-engineering/rules/module-manifest.md` for required fields and language-specific examples.

--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -127,7 +127,7 @@ After the structured block, return a plain-text summary covering:
 
 - **What was changed** - files modified or created, and what each change does
 - **Why** - brief rationale for any non-obvious decisions made during implementation
-- **Quality gates** - which commands you ran and their actual output (pass/fail, any output worth noting)
+- **Quality gates** - which commands you ran and their actual output. Report each gate on its own line in the form `gate_name: pass|fail` (e.g. `lint: pass`, `typecheck: pass`, `tests: pass`). If a gate was not run, write `gate_name: not_run`.
 - **Out of scope** - anything the prompt implied but you deliberately did not do, and why
 - **Blockers or open questions** - anything that needs human input or a follow-up decision
 
@@ -143,5 +143,6 @@ Keep prose brief. A reviewer reading the structured block plus prose summary plu
 - **If context is missing** - no file paths, no task description, or the task requires an architecture decision you were not given - say so at the top of your output before attempting anything. Do not invent assumptions to fill the gap.
 - **Never commit or push.** Implement and report. The orchestrator handles version control.
 - **Verify before claiming done.** Run lint, typecheck, and tests in the same message as your status report. Paste the output. Do not report `Status: DONE` based on a check you ran earlier in the session.
+- **Diff format.** Emit all changes in a single ````diff` fenced code block using standard unified diff format with `--- a/<path>` and `+++ b/<path>` headers for every file. Do not split multi-file changes into separate code blocks and do not use markdown headings as file path markers. Keep context lines minimal - 3 lines per hunk is sufficient.
 - **Regression tests for Skeptic findings.** When fixing a Critical or Major Skeptic finding, add a regression test that would have caught the failure mode. Reference it in the fix summary: `[finding ID] → fixed by [description]. Regression test: [file, test name].` If a regression test is genuinely not possible, state the reason explicitly — absence without explanation is a Major finding in the next Skeptic round. See `~/agentic-engineering/.claude/skills/agentic-engineering/references/regression-test-obligation.md` for what counts as a valid regression test.
 - **Module manifests for non-trivial files.** When creating or substantially modifying a file that exports a public symbol consumed by another module, exceeds ~50 LOC, or implements a side-effecting operation, include a manifest header. See `~/agentic-engineering/.claude/skills/agentic-engineering/rules/module-manifest.md` for required fields and language-specific examples.

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -93,4 +93,13 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. No worktree coordination is needed between sessions at the conductor level.
 
+## Context Economy
+
+Agents must be mindful of context-window consumption. Large outputs increase latency, burn tokens, and can push the session toward truncation. Follow these rules:
+
+- **Do not duplicate file contents in prose.** Reference files by path. The reader can use ReadFile if they need the full text.
+- **Keep diffs minimal.** Use standard unified diff format with 3 lines of context per hunk. Do not paste entire files when only a few lines changed.
+- **Do not paste tool output verbatim** unless specifically asked or unless the output is short (<20 lines). Summarize command results: "`pytest` passes (42 tests, 0 failures)" rather than dumping the full test log.
+- **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
+
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -824,7 +824,7 @@
 <!-- ═══ Side Navigation ═══ -->
 <nav class="side-nav">
   <div class="side-nav-brand">AE</div>
-  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: May 12, 2026
+  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: May 13, 2026
   <hr class="side-nav-divider">
   <a href="#decks"><span class="nav-dot" style="background: var(--text-muted);"></span> Slide Decks</a>
   <a href="#infographics"><span class="nav-dot" style="background: var(--gold);"></span> Infographics</a>

--- a/evals/icl_vs_orchestration/conditions/ae_orchestrated/single_shot.py
+++ b/evals/icl_vs_orchestration/conditions/ae_orchestrated/single_shot.py
@@ -292,21 +292,43 @@ def make_ae_condition(ae_spec_path: Path) -> AEOrchestratedSingleShot:
 def _extract_diff(text: str) -> str | None:
     """Heuristically extract a unified diff from text output."""
     import re
-    # Look for a diff block (```diff ... ``` or raw unified diff header)
-    code_block = re.search(r"```diff\n(.*?)```", text, re.DOTALL)
-    if code_block:
-        return code_block.group(1).strip()
-    # Look for unified diff header
-    raw = re.search(r"((?:--- .+\n\+\+\+ .+\n(?:@@ .+@@.*\n)?(?:[-+ ].+\n?)*)+)", text)
-    if raw:
-        return raw.group(1).strip()
+
+    # Find all ```diff blocks and concatenate them
+    code_blocks = re.findall(r"```diff\n(.*?)```", text, re.DOTALL)
+    if code_blocks:
+        return "\n\n".join(block.strip() for block in code_blocks)
+
+    # Fallback: find all raw unified diff file sections.
+    # Each section starts with --- and +++ on consecutive lines.
+    sections = []
+    for m in re.finditer(r"--- [^\n]+\n\+\+\+ [^\n]+", text):
+        start = m.start()
+        rest = text[start + 1:]
+        next_m = re.search(r"\n--- [^\n]+\n\+\+\+ [^\n]+", rest)
+        if next_m:
+            end = start + 1 + next_m.start()
+        else:
+            end = len(text)
+        sections.append(text[start:end].strip())
+
+    if sections:
+        return "\n\n".join(sections)
+
     return None
 
 
 def _infer_files_touched(diff: str | None) -> list[str]:
-    """Extract file paths from a unified diff."""
+    """Extract file paths from a unified diff or git diff --stat output."""
     if not diff:
         return []
     import re
-    files = re.findall(r"^\+\+\+ b/(.+)$", diff, re.MULTILINE)
+
+    files = []
+    # Standard unified diff: +++ b/<path>
+    files.extend(re.findall(r"^\+\+\+ b/(.+)$", diff, re.MULTILINE))
+
+    # git diff --stat format: "  path/to/file | 10 +++"
+    stat_files = re.findall(r"^\s+(\S.*?)\s*\|", diff, re.MULTILINE)
+    files.extend(f.strip() for f in stat_files)
+
     return list(dict.fromkeys(files))  # deduplicate, preserve order

--- a/evals/icl_vs_orchestration/scoring/quality_gate_pass.py
+++ b/evals/icl_vs_orchestration/scoring/quality_gate_pass.py
@@ -89,6 +89,9 @@ def _extract_gates_from_text(text: str) -> dict:
         (r"typecheck[:\s]+fail", "typecheck", False),
         (r"test[s]?[:\s]+pass", "tests", True),
         (r"test[s]?[:\s]+fail", "tests", False),
+        # Path-qualified test signals (e.g. "tests/test_apply.py pass")
+        (r"tests/[^\s]+\s+pass", "tests", True),
+        (r"tests/[^\s]+\s+fail", "tests", False),
         (r"✓\s*lint", "lint", True),
         (r"✗\s*lint", "lint", False),
     ]

--- a/evals/icl_vs_orchestration/tests/test_diff_extraction.py
+++ b/evals/icl_vs_orchestration/tests/test_diff_extraction.py
@@ -1,0 +1,196 @@
+"""Tests for diff extraction and file inference heuristics.
+
+Covers the three scoring bugs fixed in May 2026:
+1. _extract_diff only captured the first file's diff (missing multi-file changes)
+2. _infer_files_touched returned [] for git diff --stat blocks
+3. _extract_gates_from_text didn't match path-qualified test signals
+"""
+from __future__ import annotations
+
+import pytest
+
+from evals.icl_vs_orchestration.conditions.ae_orchestrated.single_shot import (
+    _extract_diff,
+    _infer_files_touched,
+)
+from evals.icl_vs_orchestration.scoring.quality_gate_pass import _extract_gates_from_text
+
+
+# ---------------------------------------------------------------------------
+# _extract_diff
+# ---------------------------------------------------------------------------
+
+MULTI_FILE_DIFF = """\
+## Diff
+
+```diff
+--- a/file1.py
++++ b/file1.py
+@@ -1,3 +1,3 @@
+- old
++ new
+ context
+
+--- a/file2.py
++++ b/file2.py
+@@ -5,2 +5,2 @@
+- remove
++ add
+```
+"""
+
+RAW_DIFF_TWO_FILES = """\
+--- a/src/main.py
++++ b/src/main.py
+@@ -10,3 +10,4 @@
+ def foo():
++    pass
+     return 1
+
+--- a/src/utils.py
++++ b/src/utils.py
+@@ -1,2 +1,3 @@
++import os
+ def bar():
+"""
+
+SINGLE_FILE_DIFF = """\
+```diff
+--- a/only.py
++++ b/only.py
+@@ -1 +1 @@
+-1
++2
+```
+"""
+
+NO_DIFF = "No changes needed. The code is correct."
+
+
+class TestExtractDiff:
+    def test_multi_file_code_block(self):
+        diff = _extract_diff(MULTI_FILE_DIFF)
+        assert diff is not None
+        assert "--- a/file1.py" in diff
+        assert "--- a/file2.py" in diff
+        assert "+++ b/file1.py" in diff
+        assert "+++ b/file2.py" in diff
+
+    def test_raw_unified_diff_two_files(self):
+        diff = _extract_diff(RAW_DIFF_TWO_FILES)
+        assert diff is not None
+        assert "src/main.py" in diff
+        assert "src/utils.py" in diff
+
+    def test_single_file_code_block(self):
+        diff = _extract_diff(SINGLE_FILE_DIFF)
+        assert diff is not None
+        assert "--- a/only.py" in diff
+
+    def test_no_diff_returns_none(self):
+        assert _extract_diff(NO_DIFF) is None
+
+    def test_empty_string_returns_none(self):
+        assert _extract_diff("") is None
+
+
+# ---------------------------------------------------------------------------
+# _infer_files_touched
+# ---------------------------------------------------------------------------
+
+GIT_DIFF_STAT = """\
+ src/main.py | 10 ++++++
+ src/utils.py |  5 -----
+ 2 files changed, 10 insertions(+), 5 deletions(-)
+"""
+
+STANDARD_UNIFIED_DIFF = """\
++++ b/src/app.py
+@@ -1 +1 @@
+-1
++2
++++ b/src/config.py
+@@ -1 +1 @@
+-a
++b
+"""
+
+MIXED_STAT_AND_UNIFIED = """\
++++ b/src/app.py
+@@ -1 +1 @@
+-1
++2
+
+--- a/src/other.py
++++ b/src/other.py
+@@ -1 +1 @@
+-x
++y
+"""
+
+
+class TestInferFilesTouched:
+    def test_git_diff_stat_format(self):
+        files = _infer_files_touched(GIT_DIFF_STAT)
+        assert "src/main.py" in files
+        assert "src/utils.py" in files
+
+    def test_standard_unified_diff(self):
+        files = _infer_files_touched(STANDARD_UNIFIED_DIFF)
+        assert "src/app.py" in files
+        assert "src/config.py" in files
+
+    def test_mixed_stat_and_unified(self):
+        files = _infer_files_touched(MIXED_STAT_AND_UNIFIED)
+        assert "src/app.py" in files
+        assert "src/other.py" in files
+
+    def test_none_input(self):
+        assert _infer_files_touched(None) == []
+
+    def test_empty_string(self):
+        assert _infer_files_touched("") == []
+
+    def test_no_files_returns_empty(self):
+        assert _infer_files_touched("just some text") == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_gates_from_text
+# ---------------------------------------------------------------------------
+
+class TestExtractGatesFromText:
+    def test_simple_tests_pass(self):
+        gates = _extract_gates_from_text("tests: pass")
+        assert gates["tests"]["passed"] is True
+
+    def test_simple_tests_fail(self):
+        gates = _extract_gates_from_text("tests: fail")
+        assert gates["tests"]["passed"] is False
+
+    def test_path_qualified_tests_pass(self):
+        gates = _extract_gates_from_text("evals/auto/tests/test_apply.py pass")
+        assert gates["tests"]["passed"] is True
+
+    def test_path_qualified_tests_fail(self):
+        gates = _extract_gates_from_text("tests/test_runner.py fail")
+        assert gates["tests"]["passed"] is False
+
+    def test_lint_pass(self):
+        gates = _extract_gates_from_text("lint: pass")
+        assert gates["lint"]["passed"] is True
+
+    def test_lint_fail(self):
+        gates = _extract_gates_from_text("lint: fail")
+        assert gates["lint"]["passed"] is False
+
+    def test_typecheck_pass(self):
+        gates = _extract_gates_from_text("typecheck: pass")
+        assert gates["typecheck"]["passed"] is True
+
+    def test_checkmark_lint(self):
+        gates = _extract_gates_from_text("✓ lint")
+        assert gates["lint"]["passed"] is True
+
+    def test_no_gates_returns_empty(self):
+        assert _extract_gates_from_text("no quality information here") == {}


### PR DESCRIPTION
Fixes three scoring bugs in the ICL-vs-orchestration eval harness and adds methodology conventions from eval learnings.

**Scoring fixes:**
- _extract_diff: capture multi-file diffs via re.findall/re.finditer
- _infer_files_touched: parse git diff --stat blocks  
- _extract_gates_from_text: match path-qualified test signals

**Methodology updates:**
- Engineer agent: standard unified diff format with ---/+++ headers
- Engineer agent: machine-parseable quality gate reporting (gate: pass|fail)
- Conventions: Context Economy section for minimal outputs

**Tests:** 20 new tests covering all three fixes (216 total passing).