### PR TITLE
docs(protocol): conductor context budget (Gap 1)

### DIFF
--- a/.codex/commands/brief.md
+++ b/.codex/commands/brief.md
@@ -35,6 +35,8 @@ Interactive planning dialogue. Produces a Brief at `docs/planning/<slug>.md` via
 structured multi-turn conversation, then hands off to the architect and engineer with
 `brief_path` pre-populated in the execution contract.
 
+**Context budget note:** Brief sessions are structured multi-turn conversations that track state in `brief-session.json`. Each gray-area resolution consumes conductor turns. Complex Briefs with many gray areas can push the conductor toward its context limit. The conductor SHOULD recommend `/wrap` after resolving 10+ gray areas in a single session, or if the total conductor turn count approaches the soft limit (15–20 turns). See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Section 1 - Trigger model

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1021,6 +1021,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Limitation:** Cross-iteration semantic-dup within the same ticket where the Skeptic re-words the finding may produce different `pattern_hash` values and result in duplicate entries. Acknowledged.
 
+**Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.codex/references/design-goals.md
+++ b/.codex/references/design-goals.md
@@ -87,6 +87,8 @@ The "Decisions & Context" section of `~/.claude/CLAUDE.md` operationalizes this 
 
 The trigger-pointer pattern in `~/.claude/CLAUDE.md` operationalizes this goal. Risk signals and the delegation decision table are inline; protocol procedural details are pointers to canonical specs read on trigger.
 
+Runtime context management complements structural delegation: the conductor defines context budgets, exchange log compression, and memory retrieval to manage its own context window. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Non-Goals

--- a/.codex/references/subagent-protocol.md
+++ b/.codex/references/subagent-protocol.md
@@ -428,3 +428,44 @@ This document is the canonical source for The Subagent Protocol. **When this doc
 When this document changes:
 1. If the change affects the risk signal list or delegation decision table, update `~/.claude/CLAUDE.md` to match. Procedural changes (worktree rules, check-in behavior, parallel spawning details) are picked up automatically via pointers.
 2. Check `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md` for sections that may be affected by changes to orchestration rules (particularly Sections 2, 5, 9, and 10).
+
+## 13. Conductor context budget
+
+The conductor's own context window is a finite resource. Long-running sessions degrade reasoning quality, increase the risk of context-window exhaustion, and make recovery expensive. The Subagent Protocol therefore defines context-budget rules for the main conductor session.
+
+### 13.1 Soft limit (recommended: 15–20 conductor turns)
+
+When the conductor reaches the soft limit, it MUST:
+1. Warn the user that the session is approaching its recommended context budget.
+2. Recommend `/wrap` to preserve state and restart with a fresh context window.
+3. Summarize what has been accomplished and what remains.
+4. Offer to continue ONLY if the user explicitly confirms.
+
+The soft limit is a signal, not a stop. The user may choose to continue, but they do so with informed consent.
+
+### 13.2 Hard limit (recommended: 25–30 conductor turns)
+
+When the conductor reaches the hard limit, it MUST:
+1. Refuse further implementation work, Skeptic rounds, or subagent spawns.
+2. Invoke `/wrap` automatically (or instruct the user to do so).
+3. Preserve all state via `context.md` and `MEMORY.md` updates.
+4. Explain that the hard limit exists to protect output quality and that a fresh session is required.
+
+The hard limit is absolute. No exception, no override.
+
+### 13.3 Rationale
+
+AE's structural delegation (subagents, worktrees) offloads most implementation work from the conductor. The conductor's role is coordination, synthesis, and decision-making. These tasks require high-fidelity context. A conductor that has been running for 30+ turns is operating with degraded context, increasing the risk of:
+- Missing critical details from earlier turns
+- Re-introducing bugs that were already fixed
+- Making inconsistent decisions
+- Hitting the underlying model's context-window ceiling
+
+The `/wrap` + restart flow already handles session handoff. The context budget simply makes the handoff proactive rather than reactive.
+
+### 13.4 Exceptions
+
+The context budget applies to **implementation work** and **multi-turn planning**. It does NOT apply to:
+- Single-turn Q&A or information retrieval
+- Brief sessions that resolve quickly (fewer than 5 gray areas)
+- Diagnostic-only work (reading logs, explaining errors)

--- a/.cursor/commands/brief.md
+++ b/.cursor/commands/brief.md
@@ -35,6 +35,8 @@ Interactive planning dialogue. Produces a Brief at `docs/planning/<slug>.md` via
 structured multi-turn conversation, then hands off to the architect and engineer with
 `brief_path` pre-populated in the execution contract.
 
+**Context budget note:** Brief sessions are structured multi-turn conversations that track state in `brief-session.json`. Each gray-area resolution consumes conductor turns. Complex Briefs with many gray areas can push the conductor toward its context limit. The conductor SHOULD recommend `/wrap` after resolving 10+ gray areas in a single session, or if the total conductor turn count approaches the soft limit (15–20 turns). See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Section 1 - Trigger model

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1021,6 +1021,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Limitation:** Cross-iteration semantic-dup within the same ticket where the Skeptic re-words the finding may produce different `pattern_hash` values and result in duplicate entries. Acknowledged.
 
+**Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.cursor/rules/references/design-goals.md
+++ b/.cursor/rules/references/design-goals.md
@@ -87,6 +87,8 @@ The "Decisions & Context" section of `~/.claude/CLAUDE.md` operationalizes this 
 
 The trigger-pointer pattern in `~/.claude/CLAUDE.md` operationalizes this goal. Risk signals and the delegation decision table are inline; protocol procedural details are pointers to canonical specs read on trigger.
 
+Runtime context management complements structural delegation: the conductor defines context budgets, exchange log compression, and memory retrieval to manage its own context window. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Non-Goals

--- a/.cursor/rules/references/subagent-protocol.md
+++ b/.cursor/rules/references/subagent-protocol.md
@@ -428,3 +428,44 @@ This document is the canonical source for The Subagent Protocol. **When this doc
 When this document changes:
 1. If the change affects the risk signal list or delegation decision table, update `~/.claude/CLAUDE.md` to match. Procedural changes (worktree rules, check-in behavior, parallel spawning details) are picked up automatically via pointers.
 2. Check `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md` for sections that may be affected by changes to orchestration rules (particularly Sections 2, 5, 9, and 10).
+
+## 13. Conductor context budget
+
+The conductor's own context window is a finite resource. Long-running sessions degrade reasoning quality, increase the risk of context-window exhaustion, and make recovery expensive. The Subagent Protocol therefore defines context-budget rules for the main conductor session.
+
+### 13.1 Soft limit (recommended: 15–20 conductor turns)
+
+When the conductor reaches the soft limit, it MUST:
+1. Warn the user that the session is approaching its recommended context budget.
+2. Recommend `/wrap` to preserve state and restart with a fresh context window.
+3. Summarize what has been accomplished and what remains.
+4. Offer to continue ONLY if the user explicitly confirms.
+
+The soft limit is a signal, not a stop. The user may choose to continue, but they do so with informed consent.
+
+### 13.2 Hard limit (recommended: 25–30 conductor turns)
+
+When the conductor reaches the hard limit, it MUST:
+1. Refuse further implementation work, Skeptic rounds, or subagent spawns.
+2. Invoke `/wrap` automatically (or instruct the user to do so).
+3. Preserve all state via `context.md` and `MEMORY.md` updates.
+4. Explain that the hard limit exists to protect output quality and that a fresh session is required.
+
+The hard limit is absolute. No exception, no override.
+
+### 13.3 Rationale
+
+AE's structural delegation (subagents, worktrees) offloads most implementation work from the conductor. The conductor's role is coordination, synthesis, and decision-making. These tasks require high-fidelity context. A conductor that has been running for 30+ turns is operating with degraded context, increasing the risk of:
+- Missing critical details from earlier turns
+- Re-introducing bugs that were already fixed
+- Making inconsistent decisions
+- Hitting the underlying model's context-window ceiling
+
+The `/wrap` + restart flow already handles session handoff. The context budget simply makes the handoff proactive rather than reactive.
+
+### 13.4 Exceptions
+
+The context budget applies to **implementation work** and **multi-turn planning**. It does NOT apply to:
+- Single-turn Q&A or information retrieval
+- Brief sessions that resolve quickly (fewer than 5 gray areas)
+- Diagnostic-only work (reading logs, explaining errors)

--- a/.gemini/commands/brief.toml
+++ b/.gemini/commands/brief.toml
@@ -41,6 +41,8 @@ Interactive planning dialogue. Produces a Brief at `docs/planning/<slug>.md` via
 structured multi-turn conversation, then hands off to the architect and engineer with
 `brief_path` pre-populated in the execution contract.
 
+**Context budget note:** Brief sessions are structured multi-turn conversations that track state in `brief-session.json`. Each gray-area resolution consumes conductor turns. Complex Briefs with many gray areas can push the conductor toward its context limit. The conductor SHOULD recommend `/wrap` after resolving 10+ gray areas in a single session, or if the total conductor turn count approaches the soft limit (15–20 turns). See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Section 1 - Trigger model

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -1027,6 +1027,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Limitation:** Cross-iteration semantic-dup within the same ticket where the Skeptic re-words the finding may produce different `pattern_hash` values and result in duplicate entries. Acknowledged.
 
+**Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.gemini/references/design-goals.md
+++ b/.gemini/references/design-goals.md
@@ -87,6 +87,8 @@ The "Decisions & Context" section of `~/.claude/CLAUDE.md` operationalizes this 
 
 The trigger-pointer pattern in `~/.claude/CLAUDE.md` operationalizes this goal. Risk signals and the delegation decision table are inline; protocol procedural details are pointers to canonical specs read on trigger.
 
+Runtime context management complements structural delegation: the conductor defines context budgets, exchange log compression, and memory retrieval to manage its own context window. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Non-Goals

--- a/.gemini/references/subagent-protocol.md
+++ b/.gemini/references/subagent-protocol.md
@@ -428,3 +428,44 @@ This document is the canonical source for The Subagent Protocol. **When this doc
 When this document changes:
 1. If the change affects the risk signal list or delegation decision table, update `~/.claude/CLAUDE.md` to match. Procedural changes (worktree rules, check-in behavior, parallel spawning details) are picked up automatically via pointers.
 2. Check `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md` for sections that may be affected by changes to orchestration rules (particularly Sections 2, 5, 9, and 10).
+
+## 13. Conductor context budget
+
+The conductor's own context window is a finite resource. Long-running sessions degrade reasoning quality, increase the risk of context-window exhaustion, and make recovery expensive. The Subagent Protocol therefore defines context-budget rules for the main conductor session.
+
+### 13.1 Soft limit (recommended: 15–20 conductor turns)
+
+When the conductor reaches the soft limit, it MUST:
+1. Warn the user that the session is approaching its recommended context budget.
+2. Recommend `/wrap` to preserve state and restart with a fresh context window.
+3. Summarize what has been accomplished and what remains.
+4. Offer to continue ONLY if the user explicitly confirms.
+
+The soft limit is a signal, not a stop. The user may choose to continue, but they do so with informed consent.
+
+### 13.2 Hard limit (recommended: 25–30 conductor turns)
+
+When the conductor reaches the hard limit, it MUST:
+1. Refuse further implementation work, Skeptic rounds, or subagent spawns.
+2. Invoke `/wrap` automatically (or instruct the user to do so).
+3. Preserve all state via `context.md` and `MEMORY.md` updates.
+4. Explain that the hard limit exists to protect output quality and that a fresh session is required.
+
+The hard limit is absolute. No exception, no override.
+
+### 13.3 Rationale
+
+AE's structural delegation (subagents, worktrees) offloads most implementation work from the conductor. The conductor's role is coordination, synthesis, and decision-making. These tasks require high-fidelity context. A conductor that has been running for 30+ turns is operating with degraded context, increasing the risk of:
+- Missing critical details from earlier turns
+- Re-introducing bugs that were already fixed
+- Making inconsistent decisions
+- Hitting the underlying model's context-window ceiling
+
+The `/wrap` + restart flow already handles session handoff. The context budget simply makes the handoff proactive rather than reactive.
+
+### 13.4 Exceptions
+
+The context budget applies to **implementation work** and **multi-turn planning**. It does NOT apply to:
+- Single-turn Q&A or information retrieval
+- Brief sessions that resolve quickly (fewer than 5 gray areas)
+- Diagnostic-only work (reading logs, explaining errors)

--- a/content/commands/brief.md
+++ b/content/commands/brief.md
@@ -35,6 +35,8 @@ Interactive planning dialogue. Produces a Brief at `docs/planning/<slug>.md` via
 structured multi-turn conversation, then hands off to the architect and engineer with
 `brief_path` pre-populated in the execution contract.
 
+**Context budget note:** Brief sessions are structured multi-turn conversations that track state in `brief-session.json`. Each gray-area resolution consumes conductor turns. Complex Briefs with many gray areas can push the conductor toward its context limit. The conductor SHOULD recommend `/wrap` after resolving 10+ gray areas in a single session, or if the total conductor turn count approaches the soft limit (15–20 turns). See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Section 1 - Trigger model

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1021,6 +1021,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Limitation:** Cross-iteration semantic-dup within the same ticket where the Skeptic re-words the finding may produce different `pattern_hash` values and result in duplicate entries. Acknowledged.
 
+**Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/content/references/design-goals.md
+++ b/content/references/design-goals.md
@@ -87,6 +87,8 @@ The "Decisions & Context" section of `~/.claude/CLAUDE.md` operationalizes this 
 
 The trigger-pointer pattern in `~/.claude/CLAUDE.md` operationalizes this goal. Risk signals and the delegation decision table are inline; protocol procedural details are pointers to canonical specs read on trigger.
 
+Runtime context management complements structural delegation: the conductor defines context budgets, exchange log compression, and memory retrieval to manage its own context window. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Non-Goals

--- a/content/references/subagent-protocol.md
+++ b/content/references/subagent-protocol.md
@@ -428,3 +428,44 @@ This document is the canonical source for The Subagent Protocol. **When this doc
 When this document changes:
 1. If the change affects the risk signal list or delegation decision table, update `~/.claude/CLAUDE.md` to match. Procedural changes (worktree rules, check-in behavior, parallel spawning details) are picked up automatically via pointers.
 2. Check `~/agentic-engineering/.claude/skills/agentic-engineering/references/skeptic-protocol.md` for sections that may be affected by changes to orchestration rules (particularly Sections 2, 5, 9, and 10).
+
+## 13. Conductor context budget
+
+The conductor's own context window is a finite resource. Long-running sessions degrade reasoning quality, increase the risk of context-window exhaustion, and make recovery expensive. The Subagent Protocol therefore defines context-budget rules for the main conductor session.
+
+### 13.1 Soft limit (recommended: 15–20 conductor turns)
+
+When the conductor reaches the soft limit, it MUST:
+1. Warn the user that the session is approaching its recommended context budget.
+2. Recommend `/wrap` to preserve state and restart with a fresh context window.
+3. Summarize what has been accomplished and what remains.
+4. Offer to continue ONLY if the user explicitly confirms.
+
+The soft limit is a signal, not a stop. The user may choose to continue, but they do so with informed consent.
+
+### 13.2 Hard limit (recommended: 25–30 conductor turns)
+
+When the conductor reaches the hard limit, it MUST:
+1. Refuse further implementation work, Skeptic rounds, or subagent spawns.
+2. Invoke `/wrap` automatically (or instruct the user to do so).
+3. Preserve all state via `context.md` and `MEMORY.md` updates.
+4. Explain that the hard limit exists to protect output quality and that a fresh session is required.
+
+The hard limit is absolute. No exception, no override.
+
+### 13.3 Rationale
+
+AE's structural delegation (subagents, worktrees) offloads most implementation work from the conductor. The conductor's role is coordination, synthesis, and decision-making. These tasks require high-fidelity context. A conductor that has been running for 30+ turns is operating with degraded context, increasing the risk of:
+- Missing critical details from earlier turns
+- Re-introducing bugs that were already fixed
+- Making inconsistent decisions
+- Hitting the underlying model's context-window ceiling
+
+The `/wrap` + restart flow already handles session handoff. The context budget simply makes the handoff proactive rather than reactive.
+
+### 13.4 Exceptions
+
+The context budget applies to **implementation work** and **multi-turn planning**. It does NOT apply to:
+- Single-turn Q&A or information retrieval
+- Brief sessions that resolve quickly (fewer than 5 gray areas)
+- Diagnostic-only work (reading logs, explaining errors)


### PR DESCRIPTION
## Summary

Implements **Gap 1: Conductor Context Budget** from the runtime context management planning doc.

### Changes
- **`content/references/subagent-protocol.md`** — Adds new Section 13 with:
  - 13.1 Soft limit (15–20 turns): warn, recommend `/wrap`, summarize, offer to continue with consent
  - 13.2 Hard limit (25–30 turns): refuse work, auto-`/wrap`, preserve state, explain
  - 13.3 Rationale: why conductor context degrades and why proactive handoff matters
  - 13.4 Exceptions: single-turn Q&A, quick Briefs, diagnostic work
- **`content/commands/brief.md`** — Adds context-budget note recommending `/wrap` after 10+ gray areas
- **`content/commands/implement-ticket.md`** — Adds context-budget check in Phase 6 after Round 2 sign-off
- **`content/references/design-goals.md`** — Goal 4 now references runtime context management
- Regenerated all adapter artifacts

### Acceptance criteria
- [x] Reader can state soft and hard limits without guessing
- [x] `/brief` and `/implement-ticket` reference the budget
- [x] Limits consistent with AE focused-sessions principle

Related: `docs/planning/gap-runtime-context-management.md`