### PR TITLE
docs(protocol): exchange log compression rules (Gap 2)

### DIFF
--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1023,6 +1023,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
 
+**Exchange log compression:** After Round 2 sign-off, if the conductor detects the exchange log is growing large (>500 tokens), apply the compressed format for subsequent rounds. Always preserve Round 1 and the most recent round in full. See `content/references/skeptic-protocol.md` Section 3 "Exchange log compression".
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.codex/references/skeptic-protocol.md
+++ b/.codex/references/skeptic-protocol.md
@@ -194,6 +194,35 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 
 **Worker output management:** For implementations producing large outputs, Workers should write results to files and return file paths rather than inline content. This keeps spawn prompts manageable and prevents context degradation from accumulating full implementation text in the exchange log.
 
+### Exchange log compression
+
+The conductor maintains an exchange log across Skeptic rounds to enforce the 2-re-route escalation limit. In long-running sessions, this log can grow large. The conductor MAY compress the exchange log to preserve context space, provided the compressed format retains all metadata required for escalation correctness.
+
+**Compression rules:**
+
+1. **Always preserve in full:**
+   - Round 1 (original plan + first Skeptic findings)
+   - The most recent round
+   - Any round containing a Critical finding that remains open
+
+2. **Compress middle rounds** (rounds 2 through N-1, where N is the most recent round) into a single summary block:
+   ```
+   Rounds 2–{N-1} (compressed):
+   - Rounds skipped: {count}
+   - Findings raised and resolved: [{finding_id}, {finding_id}, ...]
+   - Findings deferred: [{finding_id}: {rationale}, ...]
+   - Round outcomes: [Round 2: sign-off, Round 3: findings remained, ...]
+   ```
+
+3. **Escalation metadata retention:** The compressed log MUST retain:
+   - Every finding ID ever raised, its classification (Critical/Major/Minor), and its final resolution status
+   - For each finding that was escalated or re-routed, the round number(s) in which it appeared
+   - The total re-route count for each finding
+
+4. **When to compress:** The conductor SHOULD apply compression after Round 3 sign-off, or earlier if the exchange log exceeds ~500 tokens.
+
+5. **Fresh Skeptic invariant:** Compression affects ONLY the conductor's internal exchange log. The Skeptic remains a fresh invocation for every round. The Skeptic never sees the compressed log — it receives only the current round's adversarial brief, preflight list, and artifact.
+
 ---
 
 ## 4. The Resolved Issues Preflight List
@@ -511,6 +540,24 @@ Round 2:
 Round 3:
   Skeptic findings: none
   Sign-off granted.
+```
+
+#### Example: compressed 4-round exchange log
+
+```
+Round 1:
+  Skeptic findings: [C1: missing input validation, M1: inconsistent error handling, Minor: typo in comment]
+  Worker actions: [C1 fixed by adding validate_input(), M1 fixed by unifying error format, Minor: deferred]
+
+Rounds 2–3 (compressed):
+  - Rounds skipped: 2
+  - Findings raised and resolved: [M2: missing docstring on validate_input]
+  - Findings deferred: []
+  - Round outcomes: [Round 2: findings remained, Round 3: sign-off]
+
+Round 4 (most recent):
+  Skeptic findings: [M3: test coverage gap in edge case]
+  Worker actions: [M3 fixed by adding test_validate_input_empty_string]
 ```
 
 ### Sign-off validation

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1023,6 +1023,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
 
+**Exchange log compression:** After Round 2 sign-off, if the conductor detects the exchange log is growing large (>500 tokens), apply the compressed format for subsequent rounds. Always preserve Round 1 and the most recent round in full. See `content/references/skeptic-protocol.md` Section 3 "Exchange log compression".
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.cursor/rules/references/skeptic-protocol.md
+++ b/.cursor/rules/references/skeptic-protocol.md
@@ -194,6 +194,35 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 
 **Worker output management:** For implementations producing large outputs, Workers should write results to files and return file paths rather than inline content. This keeps spawn prompts manageable and prevents context degradation from accumulating full implementation text in the exchange log.
 
+### Exchange log compression
+
+The conductor maintains an exchange log across Skeptic rounds to enforce the 2-re-route escalation limit. In long-running sessions, this log can grow large. The conductor MAY compress the exchange log to preserve context space, provided the compressed format retains all metadata required for escalation correctness.
+
+**Compression rules:**
+
+1. **Always preserve in full:**
+   - Round 1 (original plan + first Skeptic findings)
+   - The most recent round
+   - Any round containing a Critical finding that remains open
+
+2. **Compress middle rounds** (rounds 2 through N-1, where N is the most recent round) into a single summary block:
+   ```
+   Rounds 2–{N-1} (compressed):
+   - Rounds skipped: {count}
+   - Findings raised and resolved: [{finding_id}, {finding_id}, ...]
+   - Findings deferred: [{finding_id}: {rationale}, ...]
+   - Round outcomes: [Round 2: sign-off, Round 3: findings remained, ...]
+   ```
+
+3. **Escalation metadata retention:** The compressed log MUST retain:
+   - Every finding ID ever raised, its classification (Critical/Major/Minor), and its final resolution status
+   - For each finding that was escalated or re-routed, the round number(s) in which it appeared
+   - The total re-route count for each finding
+
+4. **When to compress:** The conductor SHOULD apply compression after Round 3 sign-off, or earlier if the exchange log exceeds ~500 tokens.
+
+5. **Fresh Skeptic invariant:** Compression affects ONLY the conductor's internal exchange log. The Skeptic remains a fresh invocation for every round. The Skeptic never sees the compressed log — it receives only the current round's adversarial brief, preflight list, and artifact.
+
 ---
 
 ## 4. The Resolved Issues Preflight List
@@ -511,6 +540,24 @@ Round 2:
 Round 3:
   Skeptic findings: none
   Sign-off granted.
+```
+
+#### Example: compressed 4-round exchange log
+
+```
+Round 1:
+  Skeptic findings: [C1: missing input validation, M1: inconsistent error handling, Minor: typo in comment]
+  Worker actions: [C1 fixed by adding validate_input(), M1 fixed by unifying error format, Minor: deferred]
+
+Rounds 2–3 (compressed):
+  - Rounds skipped: 2
+  - Findings raised and resolved: [M2: missing docstring on validate_input]
+  - Findings deferred: []
+  - Round outcomes: [Round 2: findings remained, Round 3: sign-off]
+
+Round 4 (most recent):
+  Skeptic findings: [M3: test coverage gap in edge case]
+  Worker actions: [M3 fixed by adding test_validate_input_empty_string]
 ```
 
 ### Sign-off validation

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -1029,6 +1029,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
 
+**Exchange log compression:** After Round 2 sign-off, if the conductor detects the exchange log is growing large (>500 tokens), apply the compressed format for subsequent rounds. Always preserve Round 1 and the most recent round in full. See `content/references/skeptic-protocol.md` Section 3 "Exchange log compression".
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -194,6 +194,35 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 
 **Worker output management:** For implementations producing large outputs, Workers should write results to files and return file paths rather than inline content. This keeps spawn prompts manageable and prevents context degradation from accumulating full implementation text in the exchange log.
 
+### Exchange log compression
+
+The conductor maintains an exchange log across Skeptic rounds to enforce the 2-re-route escalation limit. In long-running sessions, this log can grow large. The conductor MAY compress the exchange log to preserve context space, provided the compressed format retains all metadata required for escalation correctness.
+
+**Compression rules:**
+
+1. **Always preserve in full:**
+   - Round 1 (original plan + first Skeptic findings)
+   - The most recent round
+   - Any round containing a Critical finding that remains open
+
+2. **Compress middle rounds** (rounds 2 through N-1, where N is the most recent round) into a single summary block:
+   ```
+   Rounds 2–{N-1} (compressed):
+   - Rounds skipped: {count}
+   - Findings raised and resolved: [{finding_id}, {finding_id}, ...]
+   - Findings deferred: [{finding_id}: {rationale}, ...]
+   - Round outcomes: [Round 2: sign-off, Round 3: findings remained, ...]
+   ```
+
+3. **Escalation metadata retention:** The compressed log MUST retain:
+   - Every finding ID ever raised, its classification (Critical/Major/Minor), and its final resolution status
+   - For each finding that was escalated or re-routed, the round number(s) in which it appeared
+   - The total re-route count for each finding
+
+4. **When to compress:** The conductor SHOULD apply compression after Round 3 sign-off, or earlier if the exchange log exceeds ~500 tokens.
+
+5. **Fresh Skeptic invariant:** Compression affects ONLY the conductor's internal exchange log. The Skeptic remains a fresh invocation for every round. The Skeptic never sees the compressed log — it receives only the current round's adversarial brief, preflight list, and artifact.
+
 ---
 
 ## 4. The Resolved Issues Preflight List
@@ -511,6 +540,24 @@ Round 2:
 Round 3:
   Skeptic findings: none
   Sign-off granted.
+```
+
+#### Example: compressed 4-round exchange log
+
+```
+Round 1:
+  Skeptic findings: [C1: missing input validation, M1: inconsistent error handling, Minor: typo in comment]
+  Worker actions: [C1 fixed by adding validate_input(), M1 fixed by unifying error format, Minor: deferred]
+
+Rounds 2–3 (compressed):
+  - Rounds skipped: 2
+  - Findings raised and resolved: [M2: missing docstring on validate_input]
+  - Findings deferred: []
+  - Round outcomes: [Round 2: findings remained, Round 3: sign-off]
+
+Round 4 (most recent):
+  Skeptic findings: [M3: test coverage gap in edge case]
+  Worker actions: [M3 fixed by adding test_validate_input_empty_string]
 ```
 
 ### Sign-off validation

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1023,6 +1023,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
 
+**Exchange log compression:** After Round 2 sign-off, if the conductor detects the exchange log is growing large (>500 tokens), apply the compressed format for subsequent rounds. Always preserve Round 1 and the most recent round in full. See `content/references/skeptic-protocol.md` Section 3 "Exchange log compression".
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -194,6 +194,35 @@ This pattern is applicable to any multi-agent system capable of invoking subagen
 
 **Worker output management:** For implementations producing large outputs, Workers should write results to files and return file paths rather than inline content. This keeps spawn prompts manageable and prevents context degradation from accumulating full implementation text in the exchange log.
 
+### Exchange log compression
+
+The conductor maintains an exchange log across Skeptic rounds to enforce the 2-re-route escalation limit. In long-running sessions, this log can grow large. The conductor MAY compress the exchange log to preserve context space, provided the compressed format retains all metadata required for escalation correctness.
+
+**Compression rules:**
+
+1. **Always preserve in full:**
+   - Round 1 (original plan + first Skeptic findings)
+   - The most recent round
+   - Any round containing a Critical finding that remains open
+
+2. **Compress middle rounds** (rounds 2 through N-1, where N is the most recent round) into a single summary block:
+   ```
+   Rounds 2–{N-1} (compressed):
+   - Rounds skipped: {count}
+   - Findings raised and resolved: [{finding_id}, {finding_id}, ...]
+   - Findings deferred: [{finding_id}: {rationale}, ...]
+   - Round outcomes: [Round 2: sign-off, Round 3: findings remained, ...]
+   ```
+
+3. **Escalation metadata retention:** The compressed log MUST retain:
+   - Every finding ID ever raised, its classification (Critical/Major/Minor), and its final resolution status
+   - For each finding that was escalated or re-routed, the round number(s) in which it appeared
+   - The total re-route count for each finding
+
+4. **When to compress:** The conductor SHOULD apply compression after Round 3 sign-off, or earlier if the exchange log exceeds ~500 tokens.
+
+5. **Fresh Skeptic invariant:** Compression affects ONLY the conductor's internal exchange log. The Skeptic remains a fresh invocation for every round. The Skeptic never sees the compressed log — it receives only the current round's adversarial brief, preflight list, and artifact.
+
 ---
 
 ## 4. The Resolved Issues Preflight List
@@ -511,6 +540,24 @@ Round 2:
 Round 3:
   Skeptic findings: none
   Sign-off granted.
+```
+
+#### Example: compressed 4-round exchange log
+
+```
+Round 1:
+  Skeptic findings: [C1: missing input validation, M1: inconsistent error handling, Minor: typo in comment]
+  Worker actions: [C1 fixed by adding validate_input(), M1 fixed by unifying error format, Minor: deferred]
+
+Rounds 2–3 (compressed):
+  - Rounds skipped: 2
+  - Findings raised and resolved: [M2: missing docstring on validate_input]
+  - Findings deferred: []
+  - Round outcomes: [Round 2: findings remained, Round 3: sign-off]
+
+Round 4 (most recent):
+  Skeptic findings: [M3: test coverage gap in edge case]
+  Worker actions: [M3 fixed by adding test_validate_input_empty_string]
 ```
 
 ### Sign-off validation


### PR DESCRIPTION
## Summary

Implements **Gap 2: Smart Truncation for the Exchange Log** from the runtime context management planning doc.

### Changes
- **`content/references/skeptic-protocol.md`** — Adds Section 3 subsection "Exchange log compression" with 5 rules:
  1. Always preserve Round 1 and most recent round in full
  2. Compress middle rounds into structured summary block
  3. Retain all escalation metadata (finding IDs, classifications, resolution status, re-route counts)
  4. Compress after Round 3 or when log exceeds ~500 tokens
  5. Fresh Skeptic invariant (compression is conductor-only)
- **`content/references/skeptic-protocol.md`** — Adds concrete 4-round compressed exchange log example in Section 11
- **`content/commands/implement-ticket.md`** — Adds exchange log compression step in Phase 6 after Round 2 sign-off
- Regenerated all adapter artifacts

### Acceptance criteria
- [x] Conductor can enforce 2-re-route escalation with compressed log
- [x] Compressed format documented with concrete example
- [x] Format preserves all finding IDs, classifications, and resolution status

Related: `docs/planning/gap-runtime-context-management.md`