### PR TITLE
feat(tools): agentic-memory retrieval CLI (Gap 3)

### DIFF
--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -37,6 +37,8 @@ Interactive planning dialogue. Produces a Brief at `docs/planning/<slug>.md` via
 structured multi-turn conversation, then hands off to the architect and engineer with
 `brief_path` pre-populated in the execution contract.
 
+**Context budget note:** Brief sessions are structured multi-turn conversations that track state in `brief-session.json`. Each gray-area resolution consumes conductor turns. Complex Briefs with many gray areas can push the conductor toward its context limit. The conductor SHOULD recommend `/wrap` after resolving 10+ gray areas in a single session, or if the total conductor turn count approaches the soft limit (15–20 turns). See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Section 1 - Trigger model

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -1023,6 +1023,8 @@ Fires exactly once per ticket per `/implement-ticket` invocation.
 
 **Limitation:** Cross-iteration semantic-dup within the same ticket where the Skeptic re-words the finding may produce different `pattern_hash` values and result in duplicate entries. Acknowledged.
 
+**Context budget check:** After Round 2 sign-off, if the conductor turn count is approaching the soft limit (15–20 turns), the conductor MUST recommend `/wrap` and preserve state before continuing. Do not initiate Round 3 or beyond if the hard limit (25–30 turns) is within reach. See `content/references/subagent-protocol.md` Section 13.
+
 ---
 
 ## Phase 6b: QA Gate (conditional)

--- a/.claude/commands/memory-update.md
+++ b/.claude/commands/memory-update.md
@@ -69,3 +69,20 @@ Do not commit - committing is the user's responsibility. Return confirmation whe
 If the Worker returned "No-op" or "Abort": complete silently. No further action.
 
 Otherwise: complete silently - do NOT report back to the user.
+
+## Memory retrieval
+
+To query existing memory without rewriting it, use `bin/agentic-memory`:
+
+```bash
+# Find recent Skeptic spawns
+agentic-memory query --type spawn_complete --agent skeptic --last 5
+
+# Find decisions about a topic
+agentic-memory query --source MEMORY.md --topic "context budget"
+
+# Show recent turns
+agentic-memory turns --last 5
+```
+
+This is a permitted direct action — the conductor may run it inline without spawning a subagent.

--- a/.codex/commands/memory-update.md
+++ b/.codex/commands/memory-update.md
@@ -67,3 +67,20 @@ Do not commit - committing is the user's responsibility. Return confirmation whe
 If the Worker returned "No-op" or "Abort": complete silently. No further action.
 
 Otherwise: complete silently - do NOT report back to the user.
+
+## Memory retrieval
+
+To query existing memory without rewriting it, use `bin/agentic-memory`:
+
+```bash
+# Find recent Skeptic spawns
+agentic-memory query --type spawn_complete --agent skeptic --last 5
+
+# Find decisions about a topic
+agentic-memory query --source MEMORY.md --topic "context budget"
+
+# Show recent turns
+agentic-memory turns --last 5
+```
+
+This is a permitted direct action — the conductor may run it inline without spawning a subagent.

--- a/.codex/references/subagent-protocol.md
+++ b/.codex/references/subagent-protocol.md
@@ -150,6 +150,7 @@ These transitions apply to fix-pass Engineer spawns inside `/implement-ticket` P
 - Reading a single specific file when the path is already known
 - Answering a question directly from context already in memory
 - `git status`, `git log`, `git diff` — read-only, instant
+- `agentic-memory query` / `agentic-memory turns` — read-only, instant; lightweight memory retrieval
 - Taking a screenshot or browser snapshot
 - Synthesizing and explaining results that subagents have already returned
 - A one or two-line edit to a single file, where the correct output is immediately apparent without reading any other file, **and no Elevated risk signals are present**

--- a/.cursor/commands/memory-update.md
+++ b/.cursor/commands/memory-update.md
@@ -67,3 +67,20 @@ Do not commit - committing is the user's responsibility. Return confirmation whe
 If the Worker returned "No-op" or "Abort": complete silently. No further action.
 
 Otherwise: complete silently - do NOT report back to the user.
+
+## Memory retrieval
+
+To query existing memory without rewriting it, use `bin/agentic-memory`:
+
+```bash
+# Find recent Skeptic spawns
+agentic-memory query --type spawn_complete --agent skeptic --last 5
+
+# Find decisions about a topic
+agentic-memory query --source MEMORY.md --topic "context budget"
+
+# Show recent turns
+agentic-memory turns --last 5
+```
+
+This is a permitted direct action — the conductor may run it inline without spawning a subagent.

--- a/.cursor/rules/references/subagent-protocol.md
+++ b/.cursor/rules/references/subagent-protocol.md
@@ -150,6 +150,7 @@ These transitions apply to fix-pass Engineer spawns inside `/implement-ticket` P
 - Reading a single specific file when the path is already known
 - Answering a question directly from context already in memory
 - `git status`, `git log`, `git diff` — read-only, instant
+- `agentic-memory query` / `agentic-memory turns` — read-only, instant; lightweight memory retrieval
 - Taking a screenshot or browser snapshot
 - Synthesizing and explaining results that subagents have already returned
 - A one or two-line edit to a single file, where the correct output is immediately apparent without reading any other file, **and no Elevated risk signals are present**

--- a/.gemini/commands/memory-update.toml
+++ b/.gemini/commands/memory-update.toml
@@ -73,4 +73,21 @@ Do not commit - committing is the user's responsibility. Return confirmation whe
 If the Worker returned "No-op" or "Abort": complete silently. No further action.
 
 Otherwise: complete silently - do NOT report back to the user.
+
+## Memory retrieval
+
+To query existing memory without rewriting it, use `bin/agentic-memory`:
+
+```bash
+# Find recent Skeptic spawns
+agentic-memory query --type spawn_complete --agent skeptic --last 5
+
+# Find decisions about a topic
+agentic-memory query --source MEMORY.md --topic "context budget"
+
+# Show recent turns
+agentic-memory turns --last 5
+```
+
+This is a permitted direct action — the conductor may run it inline without spawning a subagent.
 """

--- a/.gemini/references/subagent-protocol.md
+++ b/.gemini/references/subagent-protocol.md
@@ -150,6 +150,7 @@ These transitions apply to fix-pass Engineer spawns inside `/implement-ticket` P
 - Reading a single specific file when the path is already known
 - Answering a question directly from context already in memory
 - `git status`, `git log`, `git diff` — read-only, instant
+- `agentic-memory query` / `agentic-memory turns` — read-only, instant; lightweight memory retrieval
 - Taking a screenshot or browser snapshot
 - Synthesizing and explaining results that subagents have already returned
 - A one or two-line edit to a single file, where the correct output is immediately apparent without reading any other file, **and no Elevated risk signals are present**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 - GitHub operations: use `gh` CLI - do not use GitHub MCP
 - `gh pr create` for this repo requires an explicit token: `GITHUB_TOKEN=$(gh auth token --user tyson-solara6 2>/dev/null) gh pr create --repo Solara6/agentic-engineering` (SSH-alias remote not recognized by default gh auth)
 - `rm -rf` is blocked by Claude Code permissions in this repo; remove files individually: `rm <file>` then `rmdir <dir>`
+- `bin/agentic-memory` — lightweight memory retrieval tool for querying `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md` on demand.
 
 ## Deploy
 - Docs site: see `docs/technical/deploy.md`. Always verify the linked project ID before running `vercel --prod`.

--- a/bin/agentic-memory
+++ b/bin/agentic-memory
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Purpose: Lightweight memory-retrieval CLI for querying AE's existing data
+         stores and returning a compact Markdown summary suitable for
+         pasting into a prompt.
+
+Public API: agentic-memory query [keyword] [--since YYYY-MM-DD]
+                      [--until YYYY-MM-DD] [--type event_type]
+                      [--agent agent_name] [--last N]
+                      [--source MEMORY.md|events.jsonl|context.md]
+                      [--topic topic]
+            agentic-memory turns --last N
+
+Upstream deps: Python 3 stdlib only (argparse, datetime, json, re, sys,
+               pathlib). No external dependencies.
+
+Downstream consumers: content/commands/memory-update.md (command spec);
+                      conductors running inline memory retrieval.
+
+Failure modes: missing source files -> warning to stderr, skipped;
+               malformed JSONL -> line skipped, warning to stderr;
+               no matches -> "No results found" to stdout, exit 0.
+               Never raises to the caller.
+
+Performance: O(file size). Linear scan of each source file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+EVENTS_PATH = Path(".agentic/events.jsonl")
+MEMORY_PATHS = [Path("MEMORY.md"), Path(".agentic/memory.md")]
+CONTEXT_PATH = Path(".agentic/context.md")
+
+
+def _parse_iso_date(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def _event_to_date(ts: str) -> date | None:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _read_events_jsonl(
+    path: Path,
+    *,
+    keyword: str | None = None,
+    since: date | None = None,
+    until: date | None = None,
+    event_type: str | None = None,
+    agent: str | None = None,
+    last: int | None = None,
+) -> tuple[list[dict] | None, str | None]:
+    if not path.exists():
+        return None, f"Warning: {path} not found"
+
+    results: list[dict] = []
+    bad_lines = 0
+
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                bad_lines += 1
+                continue
+
+            ts = event.get("ts", "")
+            if since or until:
+                event_date = _event_to_date(ts)
+                if event_date is None:
+                    continue
+                if since and event_date < since:
+                    continue
+                if until and event_date > until:
+                    continue
+
+            if event_type and event.get("event") != event_type:
+                continue
+            if agent and event.get("agent") != agent:
+                continue
+
+            if keyword:
+                data = event.get("data", {})
+                data_str = json.dumps(data, separators=(",", ":")) if isinstance(data, (dict, list)) else str(data)
+                haystack = f"{event.get('event', '')} {event.get('agent', '')} {event.get('task_id', '')} {data_str}"
+                if keyword.lower() not in haystack.lower():
+                    continue
+
+            results.append(event)
+
+    if bad_lines:
+        print(f"Warning: {bad_lines} malformed JSONL line(s) skipped in {path}", file=sys.stderr)
+
+    results.sort(key=lambda e: e.get("ts", ""))
+    if last is not None and last > 0:
+        results = results[-last:]
+    return results, None
+
+
+def _read_memory(
+    paths: list[Path],
+    *,
+    keyword: str | None = None,
+    topic: str | None = None,
+) -> tuple[list[dict] | None, str | None]:
+    chosen: Path | None = None
+    for p in paths:
+        if p.exists():
+            chosen = p
+            break
+    if chosen is None:
+        return None, f"Warning: none of {', '.join(str(p) for p in paths)} found"
+
+    text = chosen.read_text(encoding="utf-8", errors="replace")
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_body: list[str] = []
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections.append((current_heading, "\n".join(current_body)))
+            current_heading = line[3:].strip()
+            current_body = []
+        else:
+            current_body.append(line)
+    if current_heading is not None:
+        sections.append((current_heading, "\n".join(current_body)))
+
+    results: list[dict] = []
+    for heading, body in sections:
+        if topic:
+            if topic.lower() not in heading.lower():
+                continue
+            excerpt = body.strip().replace("\n", " ")[:200]
+            results.append({"heading": heading, "excerpt": excerpt})
+            continue
+
+        if keyword:
+            haystack = f"{heading}\n{body}"
+            if keyword.lower() not in haystack.lower():
+                continue
+            excerpt = body.strip().replace("\n", " ")[:200]
+            results.append({"heading": heading, "excerpt": excerpt})
+
+    return results, None
+
+
+def _split_turns(text: str) -> list[tuple[str, str]]:
+    """Split context.md into turns using a cascading heuristic."""
+    lines = text.splitlines()
+
+    # Heuristic 1: explicit "## Turn" markers
+    if any(re.match(r"^##\s+Turn\b", line, re.IGNORECASE) for line in lines):
+        turns: list[tuple[str, str]] = []
+        current_heading = "Start"
+        current_body: list[str] = []
+        for line in lines:
+            m = re.match(r"^##\s+(Turn.*)", line, re.IGNORECASE)
+            if m:
+                if current_body or current_heading != "Start":
+                    turns.append((current_heading, "\n".join(current_body)))
+                current_heading = m.group(1).strip()
+                current_body = []
+            else:
+                current_body.append(line)
+        turns.append((current_heading, "\n".join(current_body)))
+        return turns
+
+    # Heuristic 2: "---" separators (3+ dashes, alone on line)
+    if any(re.match(r"^---+$", line) for line in lines):
+        turns = []
+        current_body: list[str] = []
+        for line in lines:
+            if re.match(r"^---+$", line):
+                if current_body:
+                    turns.append((f"Turn {len(turns) + 1}", "\n".join(current_body)))
+                    current_body = []
+            else:
+                current_body.append(line)
+        if current_body:
+            turns.append((f"Turn {len(turns) + 1}", "\n".join(current_body)))
+        return turns
+
+    # Heuristic 3: "## " headings as turn boundaries
+    if any(line.startswith("## ") for line in lines):
+        turns = []
+        current_heading = "Start"
+        current_body: list[str] = []
+        for line in lines:
+            if line.startswith("## "):
+                if current_body or current_heading != "Start":
+                    turns.append((current_heading, "\n".join(current_body)))
+                current_heading = line[3:].strip()
+                current_body = []
+            else:
+                current_body.append(line)
+        turns.append((current_heading, "\n".join(current_body)))
+        return turns
+
+    # Heuristic 4: blank-line separators
+    turns = []
+    current_body: list[str] = []
+    for line in lines:
+        if line.strip() == "":
+            if current_body:
+                turns.append((f"Turn {len(turns) + 1}", "\n".join(current_body)))
+                current_body = []
+        else:
+            current_body.append(line)
+    if current_body:
+        turns.append((f"Turn {len(turns) + 1}", "\n".join(current_body)))
+    return turns
+
+
+def _read_context(
+    path: Path,
+    *,
+    keyword: str | None = None,
+    last: int | None = None,
+) -> tuple[list[tuple[str, str]] | None, str | None]:
+    if not path.exists():
+        return None, f"Warning: {path} not found"
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    turns = _split_turns(text)
+
+    if keyword:
+        turns = [(h, b) for h, b in turns if keyword.lower() in (h + "\n" + b).lower()]
+
+    if last is not None and last > 0:
+        turns = turns[-last:]
+
+    return turns, None
+
+
+def _format_events(results: list[dict]) -> str:
+    label = "match" if len(results) == 1 else "matches"
+    lines = [f"## Results from events.jsonl ({len(results)} {label})"]
+    for r in results:
+        ts = r.get("ts", "unknown")
+        evt = r.get("event", "unknown")
+        ag = r.get("agent") or "none"
+        tid = r.get("task_id") or "none"
+        lines.append(f"- {ts} | {evt} | agent={ag} | task_id={tid}")
+    return "\n".join(lines)
+
+
+def _format_memory(results: list[dict]) -> str:
+    label = "match" if len(results) == 1 else "matches"
+    lines = [f"## Results from MEMORY.md ({len(results)} {label})"]
+    for r in results:
+        lines.append(f'- Section: "{r["heading"]}"')
+        excerpt = r.get("excerpt", "")
+        if excerpt:
+            lines.append(f'- Excerpt: "{excerpt}..."')
+    return "\n".join(lines)
+
+
+def _format_context(turns: list[tuple[str, str]]) -> str:
+    label = "match" if len(turns) == 1 else "matches"
+    lines = [f"## Results from context.md ({len(turns)} {label})"]
+    for i, (heading, body) in enumerate(turns, 1):
+        excerpt = body.strip().replace("\n", " ")[:150]
+        lines.append(f"- Turn {i} ({heading}): {excerpt}...")
+    return "\n".join(lines)
+
+
+def _format_turns(turns: list[tuple[str, str]]) -> str:
+    label = "turn" if len(turns) == 1 else "turns"
+    lines = [f"## Last {len(turns)} {label} from context.md\n"]
+    for i, (heading, body) in enumerate(turns, 1):
+        lines.append(f"### Turn {i}: {heading}\n")
+        lines.append(body.strip())
+        lines.append("")
+    return "\n".join(lines)
+
+
+def cmd_query(args: argparse.Namespace) -> int:
+    keyword: str | None = args.keyword
+    since = _parse_iso_date(args.since) if args.since else None
+    until = _parse_iso_date(args.until) if args.until else None
+    event_type: str | None = args.type
+    agent: str | None = args.agent
+    last: int | None = args.last
+    source: str | None = args.source
+    topic: str | None = args.topic
+
+    outputs: list[str] = []
+    has_error = False
+
+    sources = []
+    if source is None or source == "events.jsonl":
+        sources.append("events.jsonl")
+    if source is None or source in ("MEMORY.md", "memory.md"):
+        sources.append("memory")
+    if source is None or source == "context.md":
+        sources.append("context")
+
+    if "events.jsonl" in sources:
+        results, err = _read_events_jsonl(
+            EVENTS_PATH,
+            keyword=keyword,
+            since=since,
+            until=until,
+            event_type=event_type,
+            agent=agent,
+            last=last,
+        )
+        if err:
+            print(err, file=sys.stderr)
+            has_error = True
+        elif results:
+            outputs.append(_format_events(results))
+
+    if "memory" in sources:
+        results, err = _read_memory(MEMORY_PATHS, keyword=keyword, topic=topic)
+        if err:
+            print(err, file=sys.stderr)
+            has_error = True
+        elif results:
+            outputs.append(_format_memory(results))
+
+    if "context" in sources:
+        results, err = _read_context(CONTEXT_PATH, keyword=keyword, last=last)
+        if err:
+            print(err, file=sys.stderr)
+            has_error = True
+        elif results:
+            outputs.append(_format_context(results))
+
+    if not outputs:
+        print("No results found")
+        return 0
+
+    print("\n\n".join(outputs))
+    return 0
+
+
+def cmd_turns(args: argparse.Namespace) -> int:
+    last: int = args.last
+    turns, err = _read_context(CONTEXT_PATH, last=last)
+    if err:
+        print(err, file=sys.stderr)
+        print("No results found")
+        return 0
+
+    if not turns:
+        print("No results found")
+        return 0
+
+    print(_format_turns(turns))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agentic-memory",
+        description="Lightweight memory retrieval tool for querying .agentic/events.jsonl, MEMORY.md, and .agentic/context.md",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    query_parser = subparsers.add_parser("query", help="Query memory sources")
+    query_parser.add_argument("keyword", nargs="?", help="Keyword to search for")
+    query_parser.add_argument("--since", help="Date filter YYYY-MM-DD")
+    query_parser.add_argument("--until", help="Date filter YYYY-MM-DD")
+    query_parser.add_argument("--type", help="Event type filter")
+    query_parser.add_argument("--agent", help="Agent name filter")
+    query_parser.add_argument("--last", type=int, help="Limit to last N results")
+    query_parser.add_argument(
+        "--source",
+        choices=["events.jsonl", "MEMORY.md", "context.md"],
+        help="Source to query",
+    )
+    query_parser.add_argument(
+        "--topic", help="Topic filter for MEMORY.md section headings"
+    )
+
+    turns_parser = subparsers.add_parser("turns", help="Show recent turns from context.md")
+    turns_parser.add_argument(
+        "--last", type=int, default=5, help="Number of recent turns to show"
+    )
+
+    args = parser.parse_args(argv[1:])
+    if args.command == "query":
+        return cmd_query(args)
+    if args.command == "turns":
+        return cmd_turns(args)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/content/commands/memory-update.md
+++ b/content/commands/memory-update.md
@@ -67,3 +67,20 @@ Do not commit - committing is the user's responsibility. Return confirmation whe
 If the Worker returned "No-op" or "Abort": complete silently. No further action.
 
 Otherwise: complete silently - do NOT report back to the user.
+
+## Memory retrieval
+
+To query existing memory without rewriting it, use `bin/agentic-memory`:
+
+```bash
+# Find recent Skeptic spawns
+agentic-memory query --type spawn_complete --agent skeptic --last 5
+
+# Find decisions about a topic
+agentic-memory query --source MEMORY.md --topic "context budget"
+
+# Show recent turns
+agentic-memory turns --last 5
+```
+
+This is a permitted direct action — the conductor may run it inline without spawning a subagent.

--- a/content/references/subagent-protocol.md
+++ b/content/references/subagent-protocol.md
@@ -150,6 +150,7 @@ These transitions apply to fix-pass Engineer spawns inside `/implement-ticket` P
 - Reading a single specific file when the path is already known
 - Answering a question directly from context already in memory
 - `git status`, `git log`, `git diff` — read-only, instant
+- `agentic-memory query` / `agentic-memory turns` — read-only, instant; lightweight memory retrieval
 - Taking a screenshot or browser snapshot
 - Synthesizing and explaining results that subagents have already returned
 - A one or two-line edit to a single file, where the correct output is immediately apparent without reading any other file, **and no Elevated risk signals are present**


### PR DESCRIPTION
## Summary

Implements **Gap 3: On-Demand Memory Retrieval Tool** from the runtime context management planning doc.

### Changes
- **`bin/agentic-memory`** — New Python CLI tool (stdlib only) with:
  - `query` subcommand: searches `.agentic/events.jsonl`, `MEMORY.md`/`.agentic/memory.md`, and `.agentic/context.md` by keyword, event type, agent name, date range, or topic
  - `turns` subcommand: returns last N turns from `.agentic/context.md`
  - Graceful handling of missing files and malformed JSONL
  - Compact markdown output suitable for spawn prompts
- **`content/commands/memory-update.md`** — Adds "Memory retrieval" section documenting the tool
- **`content/references/subagent-protocol.md`** — Lists `agentic-memory` as a permitted direct action
- **`AGENTS.md`** — Notes the new tool in the Decisions section
- Regenerated all adapter artifacts (includes catching up `.claude/` adapters for previously-merged Gaps 1–2)

### Acceptance criteria
- [x] `agentic-memory query` returns relevant results from existing files
- [x] Output is compact enough to fit in a spawn prompt
- [x] Tool handles missing files gracefully
- [x] Tool is documented in at least one methodology document

**Skeptic note:** `.kimi/skills/agentic-engineering/commands` and `references` are directory symlinks to `content/`, so no separate `.kimi/` file changes are needed.

Related: `docs/planning/gap-runtime-context-management.md`