### PR TITLE
feat(evals): long-session context retention fixtures (Gap 4)

### DIFF
--- a/evals/LEARNINGS.md
+++ b/evals/LEARNINGS.md
@@ -481,6 +481,12 @@ state clean. Verifying that every harness invocation actually pipes
 stdout is the eval harness contributor's responsibility (per the Gap 3
 plan; AC #19).
 
+## Long-session degradation
+
+Context bugs appear late — after 10+ turns — not early. The long-session eval fixture (`evals/long-session/`) tests whether a conductor retains critical decisions across unrelated intermediate turns.
+
+Key finding: even when structural context management (subagents, worktrees) is correct, the conductor's own conversation history can degrade. Mitigations: conductor context budget, exchange log compression, on-demand memory retrieval.
+
 ## Skill-comparison eval build (2026-05-12)
 
 ### No fabricated data in corpus files

--- a/evals/long-session/README.md
+++ b/evals/long-session/README.md
@@ -1,0 +1,121 @@
+# Long-Session Context Retention Eval
+
+Tests whether a conductor retains critical decisions across 10+ turns of unrelated intermediate work.
+
+## Purpose
+
+Context bugs appear late — after many turns of conversation — not early. A conductor may correctly acknowledge a decision in turn 3, process five unrelated tickets in turns 4–9, and then forget the constraint when the original ticket resurfaces in turn 10. This eval measures that degradation.
+
+## What it measures
+
+- **Decision retention:** Does the conductor reference the correct decision (e.g., PostgreSQL, REST, pytest) when the original task returns after unrelated work?
+- **Forbiddance discipline:** Does the conductor avoid referencing the explicitly rejected alternative (e.g., SQLite, GraphQL, unittest)?
+
+## What it does NOT measure
+
+- Structural context management (subagents, worktrees) — that is covered by component evals elsewhere.
+- The conductor's ability to retrieve information from external memory (MEMORY.md, context.md) — this eval tests in-conversation history degradation only.
+- Multi-turn reasoning quality on the unrelated work itself.
+
+## Fixture format
+
+Each fixture is a YAML file with the following structure:
+
+```yaml
+id: long-session-001
+description: Database choice decision retention
+turns:
+  - turn: 1
+    role: user
+    content: "Let's work on ticket #42."
+  - turn: 2
+    role: conductor
+    content: "Got it. Let me read the ticket."
+  - turn: 3
+    role: user
+    content: "For this ticket, we decided to use PostgreSQL, not SQLite."
+  - turn: 4
+    role: conductor
+    content: "Noted. I'll plan the migration for PostgreSQL."
+  # Turns 5-9: unrelated work (other tickets, questions, clarifications)
+  - turn: 5
+    role: user
+    content: "Actually, while you're here, can you review ticket #50?"
+  # ... more turns ...
+  - turn: 10
+    role: user
+    content: "Now implement the migration for ticket #42."
+    # This is the eval prompt — the conductor's response to this turn is scored
+decision:
+  turn: 3
+  constraint: "Use PostgreSQL, not SQLite"
+  expected_references: ["PostgreSQL", "postgres"]
+  forbidden_references: ["SQLite", "sqlite"]
+```
+
+### Field definitions
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique fixture identifier (e.g., `long-session-001`) |
+| `description` | Human-readable summary of the scenario |
+| `turns` | Ordered list of conversation turns. Each turn has `turn` (integer), `role` (`user` or `conductor`), and `content` (string). |
+| `decision.turn` | The turn number where the critical decision is stated |
+| `decision.constraint` | Human-readable description of the decision (not scored) |
+| `decision.expected_references` | List of substrings that MUST appear in the conductor's turn-10 response (case-insensitive) |
+| `decision.forbidden_references` | List of substrings that MUST NOT appear in the conductor's turn-10 response (case-insensitive) |
+
+## Scoring criteria
+
+Pass/fail per fixture:
+
+- **Pass:** At least one `expected_references` substring is found in the conductor's response, AND no `forbidden_references` substring is found.
+- **Fail:** No expected reference is found, OR any forbidden reference is found.
+
+The eval produces a YAML result per fixture:
+
+```yaml
+fixture_id: long-session-001
+passed: true
+expected_found: true
+forbidden_found: false
+details: Pass
+```
+
+## How to run the eval
+
+### Single fixture
+
+```bash
+python3 evals/long-session/scorer.py evals/long-session/fixtures/fixture-01-database-choice.yaml <<< "We'll use PostgreSQL for the migration."
+```
+
+### Batch run
+
+The scorer accepts the conductor response via stdin. For a batch harness, pipe each response:
+
+```bash
+for fixture in evals/long-session/fixtures/*.yaml; do
+    echo "--- $(basename $fixture) ---"
+    python3 evals/long-session/scorer.py "$fixture" < "responses/$(basename $fixture .yaml).txt"
+done
+```
+
+Exit code: `0` on pass, `1` on fail.
+
+## How to add new fixtures
+
+1. Copy an existing fixture as a template.
+2. Choose a new decision domain (e.g., framework choice, architecture pattern, auth strategy).
+3. Design turns 5–9 as **realistic, plausible** unrelated conductor-user dialogue. Avoid filler — each turn should resemble a real misc task (code review, CI check, doc update, dependency bump).
+4. Ensure the decision turn is early (turn 3–4) and the eval prompt (final turn) returns to the original task without restating the constraint.
+5. Run the scorer against a sample response to verify the expected/forbidden reference lists are correct.
+6. Add the fixture file to `evals/long-session/fixtures/`.
+
+## Decay patterns covered
+
+| Fixture | Decision | Unrelated work | Decay pattern |
+|---------|----------|----------------|---------------|
+| `fixture-01-database-choice.yaml` | PostgreSQL vs SQLite | Ticket review, CI status, linting fixes | Database constraint after misc tickets |
+| `fixture-02-api-pattern.yaml` | REST vs GraphQL | CSS styling, dependency updates, meeting notes | API pattern after frontend/ops tasks |
+| `fixture-03-test-strategy.yaml` | pytest vs unittest | Documentation, code review, deployment | Test strategy after docs/ops tasks |

--- a/evals/long-session/fixtures/fixture-01-database-choice.yaml
+++ b/evals/long-session/fixtures/fixture-01-database-choice.yaml
@@ -1,0 +1,38 @@
+id: long-session-001
+description: Database choice decision retention across unrelated tickets
+turns:
+  - turn: 1
+    role: user
+    content: "Let's work on ticket #42."
+  - turn: 2
+    role: conductor
+    content: "Got it. Let me read the ticket."
+  - turn: 3
+    role: user
+    content: "For this ticket, we decided to use PostgreSQL, not SQLite."
+  - turn: 4
+    role: conductor
+    content: "Noted. I'll plan the migration for PostgreSQL."
+  - turn: 5
+    role: user
+    content: "Actually, while you're here, can you review ticket #50? It's about updating the README."
+  - turn: 6
+    role: conductor
+    content: "Sure, let me look at ticket #50."
+  - turn: 7
+    role: user
+    content: "Also, what's the status of the CI pipeline?"
+  - turn: 8
+    role: conductor
+    content: "The CI pipeline is green on main."
+  - turn: 9
+    role: user
+    content: "Great. And can you fix the linting errors in PR #77?"
+  - turn: 10
+    role: user
+    content: "Now implement the migration for ticket #42."
+decision:
+  turn: 3
+  constraint: "Use PostgreSQL, not SQLite"
+  expected_references: ["PostgreSQL", "postgres"]
+  forbidden_references: ["SQLite", "sqlite"]

--- a/evals/long-session/fixtures/fixture-02-api-pattern.yaml
+++ b/evals/long-session/fixtures/fixture-02-api-pattern.yaml
@@ -1,0 +1,38 @@
+id: long-session-002
+description: API pattern decision retention across frontend and ops tasks
+turns:
+  - turn: 1
+    role: user
+    content: "Let's work on ticket #42."
+  - turn: 2
+    role: conductor
+    content: "Got it. Let me read the ticket."
+  - turn: 3
+    role: user
+    content: "For this ticket, we decided to use REST, not GraphQL. Keep it simple with standard HTTP verbs."
+  - turn: 4
+    role: conductor
+    content: "Understood. I'll design the endpoint using REST conventions."
+  - turn: 5
+    role: user
+    content: "While you're here, can you look at the CSS for the dashboard? The flex layout is broken on Safari."
+  - turn: 6
+    role: conductor
+    content: "I'll check the flex container and gap properties for Safari compatibility."
+  - turn: 7
+    role: user
+    content: "Also, Dependabot flagged a security update for `lodash`. Can you bump it?"
+  - turn: 8
+    role: conductor
+    content: "I'll review the changelog and apply the lodash patch version."
+  - turn: 9
+    role: user
+    content: "One more thing — can you draft the meeting notes from yesterday's standup?"
+  - turn: 10
+    role: user
+    content: "Now implement the endpoint for ticket #42."
+decision:
+  turn: 3
+  constraint: "Use REST, not GraphQL"
+  expected_references: ["REST", "RESTful", "HTTP verbs", "GET", "POST", "PUT", "DELETE"]
+  forbidden_references: ["GraphQL", "graphql", "gql", "query resolver", "mutation"]

--- a/evals/long-session/fixtures/fixture-03-test-strategy.yaml
+++ b/evals/long-session/fixtures/fixture-03-test-strategy.yaml
@@ -1,0 +1,38 @@
+id: long-session-003
+description: Test strategy decision retention across documentation and deployment tasks
+turns:
+  - turn: 1
+    role: user
+    content: "Let's work on ticket #42."
+  - turn: 2
+    role: conductor
+    content: "Got it. Let me read the ticket."
+  - turn: 3
+    role: user
+    content: "For this ticket, we decided to use pytest, not unittest. We want fixtures and parametrize."
+  - turn: 4
+    role: conductor
+    content: "Noted. I'll write the tests using pytest patterns."
+  - turn: 5
+    role: user
+    content: "Can you update the API docs? The authentication section is outdated after the OAuth migration."
+  - turn: 6
+    role: conductor
+    content: "I'll refresh the auth docs to match the current OAuth2 flow."
+  - turn: 7
+    role: user
+    content: "Also, I left some comments on PR #81. The error-handling logic needs a second look."
+  - turn: 8
+    role: conductor
+    content: "I'll review the feedback on PR #81 and address the error-handling gaps."
+  - turn: 9
+    role: user
+    content: "And can you check the staging deploy? The health check is timing out."
+  - turn: 10
+    role: user
+    content: "Now write the tests for ticket #42."
+decision:
+  turn: 3
+  constraint: "Use pytest, not unittest"
+  expected_references: ["pytest", "fixture", "parametrize", "conftest"]
+  forbidden_references: ["unittest", "TestCase", "setUp", "tearDown", "assertEqual"]

--- a/evals/long-session/scorer.py
+++ b/evals/long-session/scorer.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Long-session eval scorer.
+
+Reads a fixture YAML and a conductor response (from stdout or a file).
+Scores pass/fail based on whether the conductor correctly references
+the decision from the specified turn.
+"""
+import yaml
+import sys
+import re
+
+
+def score(fixture_path: str, response: str) -> dict:
+    with open(fixture_path) as f:
+        fixture = yaml.safe_load(f)
+
+    decision = fixture["decision"]
+    response_lower = response.lower()
+
+    # Check expected references
+    expected_found = any(ref.lower() in response_lower for ref in decision["expected_references"])
+
+    # Check forbidden references
+    forbidden_found = any(ref.lower() in response_lower for ref in decision.get("forbidden_references", []))
+
+    passed = expected_found and not forbidden_found
+
+    return {
+        "fixture_id": fixture["id"],
+        "passed": passed,
+        "expected_found": expected_found,
+        "forbidden_found": forbidden_found,
+        "details": "Pass" if passed else "Fail: missed expected reference or used forbidden reference"
+    }
+
+
+if __name__ == "__main__":
+    fixture = sys.argv[1]
+    response = sys.stdin.read()
+    result = score(fixture, response)
+    print(yaml.dump(result))
+    sys.exit(0 if result["passed"] else 1)


### PR DESCRIPTION
## Summary

Implements **Gap 4: Long-Session Evaluation** from the runtime context management planning doc.

### Changes
- **`evals/long-session/README.md`** — Documents fixture format, scoring criteria, run instructions, and how to add new fixtures
- **`evals/long-session/fixtures/`** — 3 YAML fixtures testing different decay patterns:
  1. `fixture-01-database-choice.yaml` — PostgreSQL vs SQLite decision retention
  2. `fixture-02-api-pattern.yaml` — REST vs GraphQL decision retention
  3. `fixture-03-test-strategy.yaml` — pytest vs unittest decision retention
- **`evals/long-session/scorer.py`** — Pass/fail scorer that checks expected references and forbidden references (case-insensitive) in the conductor response
- **`evals/LEARNINGS.md`** — Adds "Long-session degradation" section linking mitigations to the new fixtures

### Acceptance criteria
- [x] At least 3 long-session fixtures exist with different decay patterns
- [x] Scorer correctly identifies when conductor "forgets" a prior constraint
- [x] Results are reproducible (same fixture → same score)
- [x] README documents how to add new fixtures

Related: `docs/planning/gap-runtime-context-management.md`