### PR TITLE
feat(evals): add per-task dockerfile routing and py310 image

### DIFF
--- a/evals/runner/Dockerfile.swebench-py310
+++ b/evals/runner/Dockerfile.swebench-py310
@@ -1,0 +1,95 @@
+# Dockerfile.swebench-py310
+#
+# Purpose: Python 3.10 variant of the Tier 3 sandbox for SWE-bench-style evals.
+#          Used by tasks that require Python 3.10+ (astropy-12907, sphinx-7686,
+#          sklearn-10297).
+#
+# Security model: identical to Dockerfile.swebench — all deps installed at BUILD
+# time; containers run with --network none and --read-only rootfs.
+#
+# Base image: python:3.10-slim.
+FROM python:3.10-slim
+
+# Metadata
+LABEL org.opencontainers.image.title="ae-eval-swebench-py310" \
+      org.opencontainers.image.description="AE eval harness Tier 3 sandbox for Python 3.10+ tasks" \
+      org.opencontainers.image.source="evals/runner/Dockerfile.swebench-py310" \
+      org.opencontainers.image.version="1.1.0"
+
+# Install system build tools required for C-extension compilation
+# (astropy, scikit-learn, scipy).  Kept in the image because post_seed
+# `pip install -e .` / `python setup.py build_ext --inplace` may run
+# inside the container after seeding.
+# git is required by setuptools-scm for astropy version resolution.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ make git \
+    libopenblas-dev gfortran liblapack-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# GCC 14+ treats incompatible pointer types as errors.  The C extensions in
+# astropy and scikit-learn were generated for older GCC/numpy and need this
+# workaround until they are regenerated with modern Cython.
+ENV CFLAGS="-Wno-error=incompatible-pointer-types"
+
+# Install pytest, test utilities, and task-specific runtime dependencies.
+# Network is available at BUILD time only.
+#
+# Core test stack (same as Dockerfile.swebench):
+#   pytest==8.3.5 pytest-timeout==2.4.0
+#   urllib3 chardet certifi idna - requests stack
+#
+# Python 3.10+ task dependencies:
+#   docutils           - sphinx-7686 conftest import
+#   pytest-doctestplus - astropy setup.cfg passes --doctest-rst to pytest
+#   setuptools-scm     - astropy version resolution at build time
+#   cython==0.29.22    - matches astropy pyproject.toml pin
+#   extension-helpers  - astropy build helper
+#   setuptools<58      - astropy build requires old setuptools.dep_util
+#   numpy==1.26.4      - numpy 2.x breaks astropy C extensions at this commit
+#   scipy              - runtime deps for scikit-learn
+#   hypothesis         - astropy conftest import
+#   pyerfa PyYAML      - astropy runtime deps
+#   pygments           - sphinx runtime deps
+#   Jinja2<3.1         - sphinx 3.x needs old Jinja2 (environmentfilter removed in 3.1)
+#   sphinxcontrib-*    - sphinx runtime deps
+#   babel alabaster    - sphinx runtime deps
+#   snowballstemmer    - sphinx runtime deps
+#   imagesize packaging - sphinx runtime deps
+# Install numpy FIRST so scipy is built against the pinned version.
+RUN pip install --no-cache-dir \
+    pytest==8.3.5 pytest-timeout==2.4.0 \
+    urllib3 chardet certifi idna requests \
+    docutils pytest-doctestplus setuptools-scm \
+    "setuptools<58" wheel extension-helpers "cython==0.29.22" \
+    "numpy==1.26.4"
+
+RUN pip install --no-cache-dir \
+    scipy hypothesis pyerfa PyYAML \
+    pygments "Jinja2<3.1" snowballstemmer babel "alabaster==0.7.12" imagesize packaging \
+    "sphinxcontrib-applehelp<1.0.3" "sphinxcontrib-devhelp<1.0.3" \
+    "sphinxcontrib-htmlhelp<1.0.3" "sphinxcontrib-jsmath<1.0.2" \
+    "sphinxcontrib-serializinghtml<1.1.6" "sphinxcontrib-qthelp<1.0.4" \
+    roman
+
+# Create a non-root user for running eval commands.
+RUN groupadd --gid 1001 evaluser && \
+    useradd --uid 1001 --gid evaluser --shell /bin/bash --create-home evaluser
+
+# Mount points (populated at docker run time, not at build time):
+#   /workspace/repo   - fix-phase rw mount (or ro during scoring phase)
+#   /scoring/tests    - held-out test tree, ro, scoring phase only
+#   /scoring          - CWD for score phase
+RUN mkdir -p /workspace/repo /scoring/tests && \
+    chown evaluser:evaluser /workspace /workspace/repo /scoring /scoring/tests
+
+# Copy the entrypoint script.
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Switch to non-root user.
+USER evaluser
+
+# Default working directory; docker run -w overrides this per phase.
+WORKDIR /workspace/repo
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/evals/skill-comparison/preflight.py
+++ b/evals/skill-comparison/preflight.py
@@ -157,17 +157,41 @@ def check_task(
     tier3_ctx = None
     non_tier3_fix_dir: Optional[Path] = None
 
+    # Derive image tag from per-task dockerfile (same logic as runner.py).
+    # Resolve tasks_root so the path computation works regardless of whether
+    # tasks_root is relative (e.g. "tasks/" -> "." parent) or absolute.
+    _dockerfile_dir = tasks_root.resolve().parent.parent / "runner"
+    _default_image_tag = "ae-eval-swebench:latest"
+
+    def _derive_image_tag(dockerfile_name: str) -> str:
+        if dockerfile_name == "Dockerfile.swebench":
+            return _default_image_tag
+        prefix = "Dockerfile.swebench-"
+        if dockerfile_name.startswith(prefix):
+            suffix = dockerfile_name[len(prefix):]
+            return f"ae-eval-swebench:{suffix}"
+        return f"ae-eval-swebench:{dockerfile_name.replace('.', '-')}"
+
+    dockerfile_name = task_meta.get("dockerfile", "Dockerfile.swebench")
+    image_tag = _derive_image_tag(dockerfile_name)
+
     try:
         if tier3:
             from evals.runner.isolator import Tier3Docker
 
-            Tier3Docker.ensure_image(force_rebuild=rebuild_image)
+            dockerfile_path = _dockerfile_dir / dockerfile_name
+            Tier3Docker.ensure_image(
+                image_tag=image_tag,
+                dockerfile=dockerfile_path,
+                force_rebuild=rebuild_image,
+            )
             tier3_instance = Tier3Docker(
                 fixture_repo_dir=None,
                 held_out_dir=None,
                 build_image=False,
                 timeout_seconds=timeout * 2,
                 held_out_from_fix_dir=True,
+                image_tag=image_tag,
             )
             tier3_ctx = tier3_instance.__enter__()
             fix_dir = tier3_ctx.fix_phase_dir
@@ -200,6 +224,44 @@ def check_task(
                 seed_error=str(exc),
                 diagnostics={"error_type": type(exc).__name__},
             )
+
+        # Post-seed commands (e.g. C-extension builds).
+        # In Tier3 mode, commands run inside the container so cross-platform
+        # builds work; in non-Tier3 mode they run on the host.
+        _post_seed_cmds = task_meta.get("post_seed_commands")
+        if _post_seed_cmds:
+            for _cmd in _post_seed_cmds:
+                _LOG.info("Preflight post-seed command for %s: %s", task_slug, _cmd)
+                if tier3_ctx is not None:
+                    _ps_result = Tier3Docker.run_fix_phase(
+                        ctx=tier3_ctx,
+                        command=["sh", "-c", _cmd],
+                        timeout_seconds=300,
+                    )
+                else:
+                    _ps_result = subprocess.run(
+                        _cmd,
+                        shell=True,
+                        cwd=fix_dir,
+                        capture_output=True,
+                        text=True,
+                        timeout=300,
+                    )
+                if _ps_result.returncode != 0:
+                    _LOG.error(
+                        "Preflight post-seed command failed for %s: %s\nstderr: %s",
+                        task_slug, _cmd, _ps_result.stderr,
+                    )
+                    return PreflightResult(
+                        task_slug=task_slug,
+                        status="seed_error",
+                        seed_error=f"post_seed_command failed: {_cmd}",
+                        diagnostics={
+                            "cmd": _cmd,
+                            "stderr": _ps_result.stderr[:500],
+                            "returncode": _ps_result.returncode,
+                        },
+                    )
 
         # Run held-out pytest against the unmodified base commit.
         fail_to_pass = task_meta.get("fail_to_pass") or []
@@ -355,7 +417,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     corpus = yaml.safe_load(args.tasks_yaml.read_text(encoding="utf-8"))
     tasks = corpus.get("tasks", {})
-    tasks_root = args.tasks_yaml.parent
+    tasks_root = args.tasks_yaml.parent.resolve()
 
     task_slugs = args.tasks if args.tasks else list(tasks.keys())
 

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -79,6 +79,7 @@ import csv
 import json
 import logging
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -475,20 +476,47 @@ def run_matrix(
         from evals.runner.isolator import (  # type: ignore[assignment]
             Tier3Docker as _Tier3Docker,
         )
-        # Build-once-reuse: build the Docker image ONCE before the cell loop.
-        # This avoids N*24 redundant docker builds (one per cell). Each per-cell
-        # Tier3Docker(...) call will find the cached digest and skip the build.
-        #
-        # rebuild_image=True: pass force_rebuild=True to ensure_image() so it
-        # runs `docker rmi -f` before `docker build`. This discards Docker's
-        # layer cache for the locally-tagged image (not just the in-process
-        # digest cache), which is necessary when Dockerfile.swebench has changed
-        # and the tag still points to a stale image built from the old file.
-        # Evicting only _IMAGE_DIGEST_CACHE (the old approach) was insufficient
-        # because `docker build` would still reuse cached layers and produce an
-        # image that appeared fresh but was not.
-        _LOG.info("Tier 3: ensuring image is built (one-time build before cell loop)")
-        _Tier3Docker.ensure_image(force_rebuild=rebuild_image)
+
+    # Per-task dockerfile routing.
+    # Collect unique dockerfiles from active tasks and ensure each image is
+    # built once before the cell loop.  Default dockerfile uses the standard
+    # tag; custom dockerfiles derive their tag from the filename.
+    _dockerfile_dir = Path(__file__).resolve().parent.parent.parent / "evals" / "runner"
+    _default_image_tag = "ae-eval-swebench:latest"
+
+    def _derive_image_tag(dockerfile_name: str) -> str:
+        """Map Dockerfile.swebench-<suffix> -> ae-eval-swebench:<suffix>."""
+        if dockerfile_name == "Dockerfile.swebench":
+            return _default_image_tag
+        prefix = "Dockerfile.swebench-"
+        if dockerfile_name.startswith(prefix):
+            suffix = dockerfile_name[len(prefix):]
+            return f"ae-eval-swebench:{suffix}"
+        # Fallback for unexpected filenames.
+        return f"ae-eval-swebench:{dockerfile_name.replace('.', '-')}"
+
+    _task_image_tags: dict[str, str] = {}  # task_slug -> image_tag
+    if use_tier3:
+        assert _Tier3Docker is not None
+        unique_dockerfiles: dict[str, str] = {}  # dockerfile_name -> image_tag
+        for task_slug, task_meta in tasks.items():
+            dockerfile_name = task_meta.get("dockerfile", "Dockerfile.swebench")
+            image_tag = _derive_image_tag(dockerfile_name)
+            _task_image_tags[task_slug] = image_tag
+            unique_dockerfiles[dockerfile_name] = image_tag
+
+        for dockerfile_name, image_tag in unique_dockerfiles.items():
+            dockerfile_path = _dockerfile_dir / dockerfile_name
+            _LOG.info(
+                "Tier 3: ensuring image %s from %s (one-time build before cell loop)",
+                image_tag,
+                dockerfile_path,
+            )
+            _Tier3Docker.ensure_image(
+                image_tag=image_tag,
+                dockerfile=dockerfile_path,
+                force_rebuild=rebuild_image,
+            )
 
     for task_slug, task_meta in tasks.items():
         for condition in active_conditions:
@@ -548,12 +576,16 @@ def run_matrix(
                     # provides a held_out_path (pre-seeded corpus files),
                     # held_out_from_fix_dir takes precedence so the
                     # post-seeding test files are used for scoring.
+                    _cell_image_tag = _task_image_tags.get(
+                        task_slug, _default_image_tag
+                    )
                     _tier3_instance = _Tier3Docker(
                         fixture_repo_dir=None,  # base repo seeded externally
                         held_out_dir=held_out_path,
                         build_image=False,  # image already built once by ensure_image() above
                         timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
                         held_out_from_fix_dir=True,
+                        image_tag=_cell_image_tag,
                     )
                     tier3_ctx = _tier3_instance.__enter__()
 
@@ -598,6 +630,48 @@ def run_matrix(
                                 cell_id, rep, seed_exc,
                             )
                             _seed_status = "seed_error"
+
+                    # Post-seed commands: run after successful seeding and before
+                    # the engineer spawn.  If any command fails, treat it as a
+                    # seed_error so the cell is skipped.
+                    #
+                    # When Tier3 is active, commands run INSIDE the container
+                    # (via run_fix_phase command path) so C-extension builds
+                    # produce Linux-compatible binaries even when the host is
+                    # macOS.  The container mounts fix_worktree rw, so in-place
+                    # builds write .so files back to the host directory.
+                    # When Tier3 is off, commands run directly on the host.
+                    if _seed_status is None and not dry_run:
+                        _post_seed_cmds = task_meta.get("post_seed_commands")
+                        if _post_seed_cmds and fix_worktree is not None:
+                            for _cmd in _post_seed_cmds:
+                                _LOG.info(
+                                    "Running post-seed command for %s: %s",
+                                    cell_id, _cmd,
+                                )
+                                if tier3_ctx is not None and _Tier3Docker is not None:
+                                    _ps_result = _Tier3Docker.run_fix_phase(
+                                        ctx=tier3_ctx,
+                                        command=["sh", "-c", _cmd],
+                                        timeout_seconds=300,
+                                    )
+                                else:
+                                    _ps_result = subprocess.run(
+                                        _cmd,
+                                        shell=True,
+                                        cwd=fix_worktree,
+                                        capture_output=True,
+                                        text=True,
+                                        timeout=300,
+                                    )
+                                if _ps_result.returncode != 0:
+                                    _LOG.error(
+                                        "Post-seed command failed for %s rep %d: %s\nstderr: %s",
+                                        cell_id, rep, _cmd,
+                                        _ps_result.stderr,
+                                    )
+                                    _seed_status = "seed_error"
+                                    break
 
                     # If seeding failed, record seed_error row and skip engineer.
                     if _seed_status == "seed_error":

--- a/evals/skill-comparison/tasks/corpus.yaml
+++ b/evals/skill-comparison/tasks/corpus.yaml
@@ -204,6 +204,9 @@ tasks:
     problem_summary: >
       separability_matrix computes incorrect results for nested CompoundModels;
       the _cstack helper assigns 1 instead of the right submatrix block.
+    dockerfile: "Dockerfile.swebench-py310"
+    post_seed_commands:
+      - "python setup.py build_ext --inplace"
 
   pylint-7080:
     swebench_instance_id: "pylint-dev__pylint-7080"
@@ -281,6 +284,7 @@ tasks:
       autosummary includes imported members in the members template variable
       even when autosummary_imported_members is False, polluting generated
       API docs with symbols from re-exported modules.
+    dockerfile: "Dockerfile.swebench-py310"
 
   sklearn-10297:
     swebench_instance_id: "scikit-learn__scikit-learn-10297"
@@ -298,6 +302,9 @@ tasks:
       RidgeClassifierCV raises an error when store_cv_values=True is passed
       because the parameter exists in the docstring but is not implemented
       in the underlying fit logic.
+    dockerfile: "Dockerfile.swebench-py310"
+    post_seed_commands:
+      - "python setup.py build_ext --inplace"
 
   # -----------------------------------------------------------------------
   # DESIGN-Y tasks (1 task, ~8%)

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -2262,3 +2262,356 @@ tasks:
                 "held-out-mount regression: without this flag, __enter__ creates an "
                 "empty tmpdir for /scoring/tests and pytest finds no test files."
             )
+
+
+# ---------------------------------------------------------------------------
+# Per-task dockerfile routing
+# ---------------------------------------------------------------------------
+
+
+_CORPUS_WITH_CUSTOM_DOCKERFILE = """\
+freeze_metadata:
+  freeze_date: "2026-05-12"
+tasks:
+  django-11039:
+    swebench_instance_id: "django__django-11039"
+    repo_url: "https://github.com/django/django"
+    base_commit: "d5276398046ce4a102776a1e67dcac2884d80dfe"
+    held_out_tests:
+      - "tests/migrations/test_commands.py"
+    fail_to_pass:
+      - "test_sqlmigrate_for_non_transactional_databases"
+    estimated_test_seconds: 30
+    difficulty: single-file
+    known_affected_files:
+      - "django/core/management/commands/sqlmigrate.py"
+    problem_summary: Bug in sqlmigrate.
+  astropy-12907:
+    swebench_instance_id: "astropy__astropy-12907"
+    repo_url: "https://github.com/astropy/astropy"
+    base_commit: "d16bfe05a744909de4b27f5875fe0d4ed41ce607"
+    held_out_tests:
+      - "astropy/modeling/tests/test_separable.py"
+    fail_to_pass:
+      - "test_separable"
+    estimated_test_seconds: 25
+    difficulty: single-file
+    known_affected_files:
+      - "astropy/modeling/separable.py"
+    problem_summary: Bug in separability.
+    dockerfile: "Dockerfile.swebench-py310"
+"""
+
+
+class TestPerTaskDockerfileRouting:
+    """Tests for per-task dockerfile selection and image_tag derivation."""
+
+    def test_ensure_image_called_with_custom_dockerfile(self, tmp_path: Path):
+        """Tasks with a custom dockerfile trigger ensure_image with the right params."""
+        from scoring import ScoringResult
+        from evals.runner.isolator import Tier3Context
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(_CORPUS_WITH_CUSTOM_DOCKERFILE, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        canned_cp = _make_completed_process(stdout="")
+
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "fix",
+            image_tag="ae-eval-swebench:py310",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+
+        ensure_image_calls: list[dict] = []
+
+        def fake_ensure_image(*, image_tag, dockerfile, force_rebuild=False):
+            ensure_image_calls.append({
+                "image_tag": image_tag,
+                "dockerfile_name": dockerfile.name,
+                "force_rebuild": force_rebuild,
+            })
+            return "sha256:abc123"
+
+        mock_tier3_cls = MagicMock(return_value=mock_tier3_instance)
+        mock_tier3_cls.ensure_image = MagicMock(side_effect=fake_ensure_image)
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=canned_cp)
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        # Two unique dockerfiles in the corpus -> two ensure_image calls.
+        assert len(ensure_image_calls) == 2, (
+            f"Expected 2 ensure_image calls (one per unique dockerfile), got {ensure_image_calls}"
+        )
+
+        tags = {c["image_tag"] for c in ensure_image_calls}
+        assert tags == {"ae-eval-swebench:latest", "ae-eval-swebench:py310"}, (
+            f"Expected both default and py310 tags; got {tags}"
+        )
+
+        # Verify the custom dockerfile call used the correct filename.
+        py310_calls = [c for c in ensure_image_calls if c["image_tag"] == "ae-eval-swebench:py310"]
+        assert len(py310_calls) == 1
+        assert py310_calls[0]["dockerfile_name"] == "Dockerfile.swebench-py310"
+
+    def test_tier3_init_uses_derived_image_tag(self, tmp_path: Path):
+        """Per-cell Tier3Docker is instantiated with the task's derived image_tag."""
+        from scoring import ScoringResult
+        from evals.runner.isolator import Tier3Context
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(_CORPUS_WITH_CUSTOM_DOCKERFILE, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+        canned_cp = _make_completed_process(stdout="")
+
+        mock_ctx = Tier3Context(
+            fix_phase_dir=tmp_path / "fix",
+            held_out_dir=tmp_path / "fix",
+            image_tag="ae-eval-swebench:py310",
+            image_digest="sha256:abc123",
+        )
+        (tmp_path / "fix").mkdir(parents=True, exist_ok=True)
+
+        captured_init_kwargs: list[dict] = []
+
+        mock_tier3_instance = MagicMock()
+        mock_tier3_instance.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_tier3_instance.__exit__ = MagicMock(return_value=None)
+
+        def capturing_tier3_cls(*args, **kwargs):
+            captured_init_kwargs.append(kwargs)
+            return mock_tier3_instance
+
+        mock_tier3_cls = MagicMock(side_effect=capturing_tier3_cls)
+        mock_tier3_cls.ensure_image = MagicMock(return_value="sha256:abc123")
+        mock_tier3_cls.run_fix_phase = MagicMock(return_value=canned_cp)
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner.seed_fix_phase"),
+            patch("evals.runner.isolator.Tier3Docker", mock_tier3_cls),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="auto",
+                tasks_filter=["astropy-12907"],
+            )
+
+        assert len(captured_init_kwargs) == 1, (
+            f"Expected 1 Tier3Docker init, got {len(captured_init_kwargs)}"
+        )
+        assert captured_init_kwargs[0].get("image_tag") == "ae-eval-swebench:py310", (
+            f"astropy-12907 must use py310 image tag; got {captured_init_kwargs[0]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Post-seed command execution
+# ---------------------------------------------------------------------------
+
+
+class TestPostSeedCommands:
+    """Tests for post_seed_commands execution and failure handling."""
+
+    def test_post_seed_command_runs_after_seeding(self, tmp_path: Path):
+        """post_seed_commands are executed after seed_fix_phase succeeds."""
+        from scoring import ScoringResult
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(_MINIMAL_CORPUS_YAML, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        # Inject a post_seed_commands into the task meta by patching _load_tasks
+        modified_tasks = {
+            "django-11039": {
+                "swebench_instance_id": "django__django-11039",
+                "repo_url": "https://github.com/django/django",
+                "base_commit": "d5276398046ce4a102776a1e67dcac2884d80dfe",
+                "held_out_tests": ["tests/migrations/test_commands.py"],
+                "fail_to_pass": ["test_sqlmigrate_for_non_transactional_databases"],
+                "estimated_test_seconds": 30,
+                "difficulty": "single-file",
+                "known_affected_files": ["django/core/management/commands/sqlmigrate.py"],
+                "problem_summary": "Bug in sqlmigrate.",
+                "post_seed_commands": ["echo 'post-seed-ok'"],
+            }
+        }
+
+        run_commands: list[str] = []
+
+        def fake_subprocess_run(cmd, *, shell=False, cwd=None, **kwargs):
+            if shell and cmd == "echo 'post-seed-ok'":
+                run_commands.append(cmd)
+                return _make_completed_process(stdout="post-seed-ok\n")
+            return _make_completed_process(stdout="")
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._load_tasks", return_value=modified_tasks),
+            patch("subprocess.run", side_effect=fake_subprocess_run),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="off",
+            )
+
+        assert run_commands == ["echo 'post-seed-ok'"], (
+            f"post_seed_command must run after seeding; got {run_commands}"
+        )
+
+    def test_post_seed_command_failure_becomes_seed_error(self, tmp_path: Path):
+        """If a post_seed_command fails, the cell records status='seed_error'."""
+        from scoring import ScoringResult
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(_MINIMAL_CORPUS_YAML, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        modified_tasks = {
+            "django-11039": {
+                "swebench_instance_id": "django__django-11039",
+                "repo_url": "https://github.com/django/django",
+                "base_commit": "d5276398046ce4a102776a1e67dcac2884d80dfe",
+                "held_out_tests": ["tests/migrations/test_commands.py"],
+                "fail_to_pass": ["test_sqlmigrate_for_non_transactional_databases"],
+                "estimated_test_seconds": 30,
+                "difficulty": "single-file",
+                "known_affected_files": ["django/core/management/commands/sqlmigrate.py"],
+                "problem_summary": "Bug in sqlmigrate.",
+                "post_seed_commands": ["exit 1"],
+            }
+        }
+
+        def fake_subprocess_run(cmd, *, shell=False, cwd=None, **kwargs):
+            if shell and cmd == "exit 1":
+                cp = _make_completed_process(stdout="")
+                cp.returncode = 1
+                cp.stderr = "intentional failure"
+                return cp
+            return _make_completed_process(stdout="")
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._load_tasks", return_value=modified_tasks),
+            patch("subprocess.run", side_effect=fake_subprocess_run),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=False,
+                conditions=["baseline"],
+                tier3_mode="off",
+            )
+
+        rows = _read_tsv(results_tsv)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "seed_error", (
+            f"Expected status='seed_error' when post_seed_command fails; got {rows[0]['status']!r}"
+        )
+        assert rows[0]["score_primary"] == "", (
+            "seed_error rows must have empty score_primary"
+        )
+
+    def test_post_seed_commands_not_run_on_dry_run(self, tmp_path: Path):
+        """post_seed_commands are skipped in dry_run mode."""
+        from scoring import ScoringResult
+
+        corpus_yaml = tmp_path / "corpus.yaml"
+        corpus_yaml.write_text(_MINIMAL_CORPUS_YAML, encoding="utf-8")
+        results_tsv = tmp_path / "results.tsv"
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        modified_tasks = {
+            "django-11039": {
+                "swebench_instance_id": "django__django-11039",
+                "repo_url": "https://github.com/django/django",
+                "base_commit": "d5276398046ce4a102776a1e67dcac2884d80dfe",
+                "held_out_tests": ["tests/migrations/test_commands.py"],
+                "fail_to_pass": ["test_sqlmigrate_for_non_transactional_databases"],
+                "estimated_test_seconds": 30,
+                "difficulty": "single-file",
+                "known_affected_files": ["django/core/management/commands/sqlmigrate.py"],
+                "problem_summary": "Bug in sqlmigrate.",
+                "post_seed_commands": ["echo 'should-not-run'"],
+            }
+        }
+
+        run_commands: list[str] = []
+
+        def fake_subprocess_run(cmd, *, shell=False, cwd=None, **kwargs):
+            if shell:
+                run_commands.append(cmd)
+            return _make_completed_process(stdout="")
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("runner._load_tasks", return_value=modified_tasks),
+            patch("subprocess.run", side_effect=fake_subprocess_run),
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                conditions=["baseline"],
+                tier3_mode="auto",
+            )
+
+        assert run_commands == [], (
+            f"post_seed_commands must NOT run in dry_run mode; got {run_commands}"
+        )


### PR DESCRIPTION
## Problem

The skill-comparison eval runner hardcoded `Dockerfile.swebench` (python:3.9-slim). Tasks needing Python 3.10+ failed with environment errors:
- astropy-12907: C extensions not built, `--doctest-rst` pytest conflict
- sphinx-7686: docutils missing
- sklearn-10297: would hit similar C extension issues

The py310 eval burned 28M tokens for guaranteed 0.0 scores before discovering these issues.

## Solution

### 1. Per-task dockerfile routing (`runner.py`)

- Tasks in `corpus.yaml` can specify `dockerfile: Dockerfile.swebench-py310`
- Runner collects unique dockerfiles before the cell loop, builds each image once
- Derives image tag from filename: `Dockerfile.swebench-py310` -> `ae-eval-swebench:py310`
- Passes correct `image_tag` to each per-cell `Tier3Docker()` instantiation

### 2. Post-seed commands (`runner.py`)

- Tasks can specify `post_seed_commands` (list of shell commands)
- Commands run after `seed_fix_phase()` and before the engineer spawn
- Tier3 path: runs inside the container via `Tier3Docker.run_fix_phase(command=...)`
- Non-Tier3 path: runs via `subprocess.run(shell=True, cwd=fix_worktree)`
- Failure produces a `seed_error` row and skips the cell

### 3. `Dockerfile.swebench-py310`

- Python 3.10-slim base
- System build tools: gcc, g++, make, gfortran, libopenblas-dev, liblapack-dev
- `CFLAGS="-Wno-error=incompatible-pointer-types"` for GCC 14 compatibility
- Pinned numpy==1.26.4 (numpy 2.x breaks astropy/sklearn at these commits)
- Sphinx deps: docutils, Jinja2<3.1, alabaster, sphinxcontrib-*, roman
- Astropy build deps: setuptools<58, extension-helpers, cython==0.29.22
- Test utilities: pytest-doctestplus, hypothesis

### 4. Corpus updates (`corpus.yaml`)

- astropy-12907: `dockerfile: Dockerfile.swebench-py310`, `post_seed_commands: ["python setup.py build_ext --inplace"]`
- sphinx-7686: `dockerfile: Dockerfile.swebench-py310`
- sklearn-10297: `dockerfile: Dockerfile.swebench-py310`, `post_seed_commands: ["python setup.py build_ext --inplace"]`

### 5. Preflight integration

Preflight mirrors the runner's per-task dockerfile routing so it validates the same code path.

## Validation

Preflight against py310 tasks (with `--rebuild-image`):
- **astropy-12907 = ok** ✅
- **sphinx-7686 = ok** ✅

Both show expected test failures on base commit, confirming infrastructure is working.

## Tests

- 5 new tests for per-task dockerfile routing and post-seed commands
- Full suite: 374 passed, 1 skipped, 1 failed (pre-existing Bug-1 regression unrelated to this PR)

## Files changed

- `evals/runner/Dockerfile.swebench-py310` (new)
- `evals/skill-comparison/runner.py`
- `evals/skill-comparison/preflight.py`
- `evals/skill-comparison/tasks/corpus.yaml`
- `evals/skill-comparison/tests/test_runner.py`
