### PR TITLE
feat(evals): add Kimi CLI backend support to skill-comparison harness

### DIFF
--- a/.kimi/skills/agentic-engineering/SKILL.md
+++ b/.kimi/skills/agentic-engineering/SKILL.md
@@ -1,1 +1,1 @@
-/Users/tyson.hummel/Documents/tools/agentic-engineering/.kimi/skills/agentic-engineering/SKILL.md
+../../../content/SKILL.md

--- a/evals/runner/cli.py
+++ b/evals/runner/cli.py
@@ -94,6 +94,7 @@ def _run_fixture(
     content_hash: str,
     scoring,
     max_turns: int | None = None,
+    backend: str = "claude",
 ) -> dict:
     per_run_scores: list[dict] = []
     invocation_modes: list[str] = []
@@ -166,6 +167,7 @@ def _run_fixture(
                     mode="command",
                     home=fake_home,
                     max_turns=max_turns,
+                    backend=backend,
                 )
                 # Scorer needs the worktree root to read AGENTS.md/.gitignore
                 # line-level content. Stuff it into the record before the
@@ -179,6 +181,7 @@ def _run_fixture(
                 run_record = inv_mod.invoke_run(
                     prompt_text, worktree, manifest.timeout_seconds,
                     agent_name=agent_name, max_turns=max_turns,
+                    backend=backend,
                 )
             score = _score_run(scoring, run_record, fixture)
         per_run_scores.append(score)
@@ -213,7 +216,7 @@ def _run_fixture(
 
 
 def cmd_run(args: argparse.Namespace) -> int:
-    inv_mod.probe_claude_cli()
+    inv_mod.probe_cli(args.backend)
     manifest = ld.load_component(args.component)
     content_hash = ld.compute_component_content_hash(manifest)
     commit = _git_head_commit()
@@ -252,6 +255,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         row = _run_fixture(
             manifest, fx, n_runs, commit, content_hash, scoring,
             max_turns=args.max_turns,
+            backend=args.backend,
         )
         rows.append(row)
         _log.info(
@@ -309,6 +313,15 @@ def main(argv: list[str] | None = None) -> int:
             "Override --max-turns passed to the Claude CLI for agent-mode runs "
             f"(default: {inv_mod._MAX_TURNS_DEFAULT}). Raise for SWE-bench fix "
             "tasks that need many tool iterations."
+        ),
+    )
+    p_run.add_argument(
+        "--backend",
+        choices=["claude", "kimi"],
+        default="claude",
+        help=(
+            "CLI backend to use for eval runs. 'claude' (default) uses Claude Code; "
+            "'kimi' uses the Kimi CLI."
         ),
     )
     p_run.set_defaults(func=cmd_run)

--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -2,11 +2,11 @@
 Purpose: Probe for the Claude CLI, shell out to it with the eval-standard
          non-interactive flags, and return a normalized per-run record.
 
-Public API: probe_claude_cli() -> str,
+Public API: probe_cli(backend) -> str,
             invoke_run(prompt, worktree, timeout_seconds,
                        agent_name=None, mode="agent", home=None,
-                       model=None, system_prompt=None) -> dict,
-            build_two_level_prompt(agent_name: str, brief: str) -> str.
+                       model=None, system_prompt=None, backend="claude") -> dict,
+            build_two_level_prompt(agent_name: str, brief: str, backend="claude") -> str.
 
             mode="command" skips the two-level Task wrapper, uses a
             permissive tool list + acceptEdits permission mode, and returns
@@ -17,25 +17,26 @@ Upstream deps: stdlib subprocess, time, tempfile, shutil; evals.runner.normalize
 
 Downstream consumers: evals.runner.cli.
 
-Failure modes: probe_claude_cli raises RuntimeError with remediation text if the
-               `claude` binary is not on PATH. invoke_run captures timeouts and
+Failure modes: probe_cli raises RuntimeError with remediation text if the
+               requested binary is not on PATH. invoke_run captures timeouts and
                non-zero exits into the returned record's status field rather than
                raising; the scoring module decides how to score invalid runs.
 
-               Two-level spawn: when agent_name is provided, the outer Claude
+               Two-level spawn: when agent_name is provided, the outer CLI
                session is instructed to spawn the named subagent via the Task
-               tool and return its response verbatim. The normalizer extracts
-               the subagent's text from the tool_result event. If no
-               tool_result is present (e.g. the outer session refused to
-               spawn), invocation_mode is reported as "raw-prompt" as a
+               tool (Claude) or Agent tool (Kimi) and return its response verbatim.
+               The normalizer extracts the subagent's text from the tool_result
+               event. If no tool_result is present (e.g. the outer session refused
+               to spawn), invocation_mode is reported as "raw-prompt" as a
                diagnostic fallback, and the outer assistant text is used.
 
-Performance: dominated by the Claude CLI call itself (seconds). Runner overhead
+Performance: dominated by the CLI call itself (seconds). Runner overhead
              is a single subprocess.run per run.
 """
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import shutil
 import subprocess
@@ -45,6 +46,17 @@ from pathlib import Path
 from .normalizer import parse_stream_json
 
 CLAUDE_BIN = "claude"
+KIMI_BIN = "kimi"
+
+_LOG = logging.getLogger(__name__)
+
+
+class Backend:
+    """Backend identifiers for the eval runner."""
+
+    CLAUDE = "claude"
+    KIMI = "kimi"
+
 
 # Tier 1 is read-only. The Skeptic (and any future Tier 1 component) reads
 # diffs and worker output - it does not execute shell commands and does not
@@ -70,39 +82,68 @@ _COMMAND_MAX_TURNS = "60"
 
 
 def probe_claude_cli() -> str:
-    if shutil.which(CLAUDE_BIN) is None:
+    """Legacy alias for probe_cli(Backend.CLAUDE). Kept for backward compat."""
+    return probe_cli(Backend.CLAUDE)
+
+
+def probe_cli(backend: str = Backend.CLAUDE) -> str:
+    """Check that the requested CLI binary is on PATH and returns its version."""
+    if backend == Backend.KIMI:
+        bin_name = KIMI_BIN
+        install_hint = (
+            "Install Kimi CLI (https://docs.moonshot.cn/kimi-cli) and ensure "
+            "`kimi --version` runs before using the evals runner."
+        )
+    else:
+        bin_name = CLAUDE_BIN
+        install_hint = (
+            "Install Claude Code (https://docs.claude.com/claude-code) and ensure "
+            "`claude --version` runs before using the evals runner."
+        )
+
+    if shutil.which(bin_name) is None:
         raise RuntimeError(
-            "The `claude` CLI was not found on PATH. Install Claude Code "
-            "(https://docs.claude.com/claude-code) and ensure `claude --version` "
-            "runs before using the evals runner."
+            f"The `{bin_name}` CLI was not found on PATH. {install_hint}"
         )
     result = subprocess.run(
-        [CLAUDE_BIN, "--version"],
+        [bin_name, "--version"],
         capture_output=True,
         text=True,
         timeout=15,
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"`claude --version` exited {result.returncode}: {result.stderr.strip()}"
+            f"`{bin_name} --version` exited {result.returncode}: {result.stderr.strip()}"
         )
     return result.stdout.strip()
 
 
-def build_two_level_prompt(agent_name: str, brief: str) -> str:
+def build_two_level_prompt(agent_name: str, brief: str, backend: str = Backend.CLAUDE) -> str:
     """Wrap a subagent brief in the outer-session spawner instruction.
 
-    The outer claude -p session's job is to spawn the named subagent via the
-    Task tool, pass the brief through unchanged, and return the subagent's
-    response verbatim. The outer session must not add commentary, and must
-    not re-interpret or re-format the brief.
+    The outer CLI session's job is to spawn the named subagent via the
+    Task tool (Claude) or Agent tool (Kimi), pass the brief through unchanged,
+    and return the subagent's response verbatim. The outer session must not add
+    commentary, and must not re-interpret or re-format the brief.
     """
+    if backend == Backend.KIMI:
+        tool_name = "Agent"
+        instruction = (
+            f"Use the {tool_name} tool exactly once with subagent_type='{agent_name}' "
+            "and the prompt below. Return the subagent's response verbatim, with "
+            "no added commentary or formatting.\n\n"
+        )
+    else:
+        tool_name = "Task"
+        instruction = (
+            f"Invoke the {tool_name} tool exactly once with subagent_type='{agent_name}' "
+            "and the prompt below. Return the subagent's response verbatim, with "
+            "no added commentary or formatting.\n\n"
+        )
     return (
-        f"Invoke the Task tool exactly once with subagent_type='{agent_name}' "
-        "and the prompt below. Return the subagent's response verbatim, with "
-        "no added commentary or formatting.\n\n"
-        "---\n\n"
-        f"{brief.rstrip()}\n"
+        instruction
+        + "---\n\n"
+        + f"{brief.rstrip()}\n"
     )
 
 
@@ -112,7 +153,7 @@ def _snapshot_filesystem(root: Path) -> dict[str, str]:
     Used by Tier 2 command-mode runs to capture the resulting worktree state
     so the scorer can check file existence, sizes, and content. Skips
     symlinks (shouldn't occur in a scaffolding run) and anything under
-    `.git/` (none in Tier 2 worktrees today, but belt-and-braces).
+    `.git/` (none in Tier 2 worktrees today, but belt-and-suspenders).
     """
     out: dict[str, str] = {}
     if not root.exists():
@@ -143,35 +184,31 @@ def invoke_run(
     model: str | None = None,
     system_prompt: str | None = None,
     max_turns: int | None = None,
+    backend: str = Backend.CLAUDE,
 ) -> dict:
-    """Run the Claude CLI once with `prompt` at `worktree` cwd; return a run record.
+    """Run the CLI once with `prompt` at `worktree` cwd; return a run record.
 
     Modes:
-      "agent"   (default): wrap prompt in a two-level Task spawn of the named
+      "agent"   (default): wrap prompt in a two-level Task/Agent spawn of the named
                 subagent; use the Tier 1 read-only tool list.
-      "command": pass the prompt through verbatim (no Task wrapper), use the
+      "command": pass the prompt through verbatim (no Task/Agent wrapper), use the
                 command tool list with acceptEdits, and capture a filesystem
                 snapshot of the worktree on exit under the key "filesystem".
 
     If `home` is provided, the subprocess inherits the current environment
     except HOME is overridden to `home` (Tier 2 HOME redirect).
 
-    If `model` is provided, --model is passed through to the Claude CLI and
-    ANTHROPIC_BASE_URL is set when the model id starts with a litellm prefix
-    (e.g. claude-kimi-, claude-qwen-, claude-owl-, claude-deepseek).
+    If `model` is provided, --model is passed through to the CLI.
 
     If `system_prompt` is provided, it is appended to the default system
-    prompt via --append-system-prompt. This is how the ae-rules-injected
-    condition injects the AE methodology payload so the model runs with the
-    full protocol context on top of the standard Claude Code system prompt.
-    Flag verified present via `claude --help` (2026-05-12): --append-system-prompt
-    appends to the default; --system-prompt replaces it entirely. We use
-    --append-system-prompt to preserve the default context and add the rules.
-    subprocess argv handling means no shell escaping is needed.
+    prompt via --append-system-prompt (Claude only). For Kimi, this parameter
+    is ignored with a warning because Kimi has no equivalent flag.
 
     If `max_turns` is provided, it overrides the module-level default for
     agent mode (_MAX_TURNS_DEFAULT=40) or command mode (_COMMAND_MAX_TURNS=60).
     Useful for SWE-bench fix tasks that need more tool iterations.
+
+    `backend` selects the CLI to invoke: "claude" (default) or "kimi".
     """
     if mode == "command":
         outer_prompt = prompt
@@ -181,7 +218,7 @@ def invoke_run(
         expect_subagent = False
     else:
         if agent_name:
-            outer_prompt = build_two_level_prompt(agent_name, prompt)
+            outer_prompt = build_two_level_prompt(agent_name, prompt, backend=backend)
         else:
             outer_prompt = prompt
         allowed_tools = _ALLOWED_TOOLS
@@ -189,32 +226,52 @@ def invoke_run(
         effective_max_turns = str(max_turns) if max_turns is not None else _MAX_TURNS
         expect_subagent = bool(agent_name)
 
-    # The Claude CLI accepts the prompt as the argument to -p; subprocess.run
-    # passes it through argv without shell parsing, so no escaping is needed.
-    cmd = [
-        CLAUDE_BIN,
-        "-p",
-        outer_prompt,
-        "--output-format", "stream-json",
-        "--verbose",
-        "--allowed-tools", allowed_tools,
-        "--permission-mode", permission_mode,
-        "--max-turns", effective_max_turns,
-    ]
+    if backend == Backend.KIMI:
+        cmd = [
+            KIMI_BIN,
+            "-p",
+            outer_prompt,
+            "--print",
+            "--yolo",
+            "--output-format", "stream-json",
+            "--work-dir", str(worktree),
+            "--max-steps-per-turn", effective_max_turns,
+        ]
+        if model is not None:
+            cmd.extend(["--model", model])
+        if system_prompt is not None:
+            _LOG.warning(
+                "Kimi backend does not support --append-system-prompt; "
+                "system_prompt parameter is ignored."
+            )
+        # Kimi uses --work-dir instead of subprocess cwd.
+        subprocess_cwd = None
+    else:
+        # Claude CLI accepts the prompt as the argument to -p; subprocess.run
+        # passes it through argv without shell parsing, so no escaping is needed.
+        cmd = [
+            CLAUDE_BIN,
+            "-p",
+            outer_prompt,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--allowed-tools", allowed_tools,
+            "--permission-mode", permission_mode,
+            "--max-turns", effective_max_turns,
+        ]
+        if model is not None:
+            cmd.extend(["--model", model])
+        if system_prompt is not None:
+            # Inject AE rules (or any system context) via --append-system-prompt.
+            # This appends to (not replaces) the default Claude Code system prompt,
+            # preserving the baseline context while adding the AE methodology rules.
+            # Flag verified in `claude --help` (2026-05-12).
+            cmd.extend(["--append-system-prompt", system_prompt])
+        subprocess_cwd = str(worktree)
 
     # Route through litellm when model id uses a non-Anthropic prefix.
     _litellm_prefixes = ("claude-kimi-", "claude-qwen-", "claude-owl-", "claude-deepseek")
     _use_litellm = model is not None and any(model.startswith(p) for p in _litellm_prefixes)
-
-    if model is not None:
-        cmd.extend(["--model", model])
-
-    if system_prompt is not None:
-        # Inject AE rules (or any system context) via --append-system-prompt.
-        # This appends to (not replaces) the default Claude Code system prompt,
-        # preserving the baseline context while adding the AE methodology rules.
-        # Flag verified in `claude --help` (2026-05-12).
-        cmd.extend(["--append-system-prompt", system_prompt])
 
     env = None
     if home is not None or _use_litellm:
@@ -252,7 +309,7 @@ def invoke_run(
     try:
         result = subprocess.run(
             cmd,
-            cwd=str(worktree),
+            cwd=subprocess_cwd,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,

--- a/evals/runner/isolator.py
+++ b/evals/runner/isolator.py
@@ -710,16 +710,17 @@ class Tier3Docker(IsolatorBase):
         agent_name: str | None = None,
         system_prompt: str | None = None,
         model: str | None = None,
+        backend: str = "claude",
     ) -> subprocess.CompletedProcess[str]:
-        """Run the engineer fix phase, either via Claude CLI (prompt mode) or
+        """Run the engineer fix phase, either via CLI (prompt mode) or
         an arbitrary command (command mode).
 
-        When `prompt` is provided the method invokes the Claude CLI on the
+        When `prompt` is provided the method invokes the CLI on the
         HOST (not inside the container) with cwd=ctx.fix_phase_dir so that
         the agent's file writes land in the host-side directory that is
         later mounted at /workspace/repo:rw inside the score-phase container.
-        The container is NOT started for the claude CLI invocation because the
-        CLI requires outbound network to reach the Anthropic API; an
+        The container is NOT started for the CLI invocation because the
+        CLI requires outbound network to reach the API; an
         in-container invocation under --network none would break auth.
 
         When `command` is provided (and `prompt` is None) the command is
@@ -737,16 +738,17 @@ class Tier3Docker(IsolatorBase):
             ctx: Tier3Context from __enter__.
             command: command to run INSIDE the container (command path).
             timeout_seconds: wall-clock limit.
-            env: additional env vars for the claude CLI subprocess (prompt path)
+            env: additional env vars for the CLI subprocess (prompt path)
                  or injected into the docker run command (command path).
-            prompt: engineer prompt for the Claude CLI. When set, the CLI is
+            prompt: engineer prompt for the CLI. When set, the CLI is
                     invoked on the HOST at cwd=ctx.fix_phase_dir.
-            agent_name: optional named-agent spawned via two-level Task wrapper
+            agent_name: optional named-agent spawned via two-level Task/Agent wrapper
                         (prompt path only). None = conductor runs directly.
             system_prompt: optional system prompt appended via
-                           --append-system-prompt (prompt path only; used for
+                           --append-system-prompt (Claude prompt path only; used for
                            ae-rules-injected condition).
-            model: optional --model flag for the Claude CLI (prompt path only).
+            model: optional --model flag for the CLI (prompt path only).
+            backend: "claude" (default) or "kimi".
 
         Returns a CompletedProcess. For the prompt path, returncode is 0 when
         the invoker returns status='ok' and 1 otherwise; stdout contains the
@@ -765,13 +767,13 @@ class Tier3Docker(IsolatorBase):
             )
 
         if prompt is not None:
-            # Claude CLI requires network (Anthropic API) so the fix-phase CLI
+            # CLI requires network (Anthropic/Moonshot API) so the fix-phase CLI
             # invocation runs on the host at cwd=fix_phase_dir. Filesystem isolation
             # is provided by routing all engineer edits through fix_phase_dir; held-out
             # tests are not present in fix_phase_dir. See risk-register item #6 and
             # architect-plan "Implementation deviation" note.
-            # Prompt path: run the Claude CLI on the HOST so it can reach the
-            # Anthropic API.  The agent's file writes go into ctx.fix_phase_dir,
+            # Prompt path: run the CLI on the HOST so it can reach the
+            # API.  The agent's file writes go into ctx.fix_phase_dir,
             # which is the host-side copy of the repo mounted at /workspace/repo:rw
             # for the score phase.
             import json as _json
@@ -784,6 +786,7 @@ class Tier3Docker(IsolatorBase):
                 mode="agent",
                 system_prompt=system_prompt,
                 model=model,
+                backend=backend,
             )
             returncode = 0 if result.get("status") == "ok" else 1
             stdout_json = _json.dumps(result, default=str)

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -104,7 +104,7 @@ _LOG = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-CONDITION_LABELS: list[str] = [
+CONDITION_LABELS_CLAUDE: list[str] = [
     "baseline",
     "ae-rules-injected",
     "engineer-direct",
@@ -115,8 +115,19 @@ CONDITION_LABELS: list[str] = [
     "qa-engineer-direct",
 ]
 
-# Conditions that route via named-agent direct spawn (two-level Task).
-_AGENT_CONDITIONS: dict[str, str] = {
+CONDITION_LABELS_KIMI: list[str] = [
+    "baseline",
+    "ae-skill",
+    "coder-direct",
+    "explore-direct",
+    "plan-direct",
+]
+
+# Backward compat: default to Claude conditions.
+CONDITION_LABELS: list[str] = CONDITION_LABELS_CLAUDE
+
+# Conditions that route via named-agent direct spawn (two-level Task/Agent).
+_AGENT_CONDITIONS_CLAUDE: dict[str, str] = {
     "engineer-direct": "engineer",
     "architect-direct": "architect",
     "investigator-direct": "investigator",
@@ -124,6 +135,33 @@ _AGENT_CONDITIONS: dict[str, str] = {
     "skeptic-direct": "skeptic",
     "qa-engineer-direct": "qa-engineer",
 }
+
+_AGENT_CONDITIONS_KIMI: dict[str, str] = {
+    "coder-direct": "coder",
+    "explore-direct": "explore",
+    "plan-direct": "plan",
+}
+
+# Backward compat: default to Claude agent mapping.
+_AGENT_CONDITIONS: dict[str, str] = _AGENT_CONDITIONS_CLAUDE
+
+
+def _agent_conditions_for_backend(backend: str) -> dict[str, str]:
+    if backend == "kimi":
+        return _AGENT_CONDITIONS_KIMI
+    return _AGENT_CONDITIONS_CLAUDE
+
+
+def _condition_labels_for_backend(backend: str) -> list[str]:
+    if backend == "kimi":
+        return CONDITION_LABELS_KIMI
+    return CONDITION_LABELS_CLAUDE
+
+
+def _methodology_pair_for_backend(backend: str) -> tuple[str, ...]:
+    if backend == "kimi":
+        return ("baseline", "ae-skill")
+    return ("baseline", "ae-rules-injected")
 
 # Per-task pytest timeout (Brief: <120 s held-out test budget).
 _PYTEST_TIMEOUT_SECONDS = 120
@@ -238,6 +276,7 @@ def _run_cell(
     ae_payload: Optional[str],
     dry_run: bool,
     worktree: Optional[Path] = None,
+    backend: str = "claude",
 ) -> dict:
     """Run one (task, condition, replicate) cell and return a raw result dict.
 
@@ -248,6 +287,7 @@ def _run_cell(
         worktree: the fix-phase directory to run the CLI in. Defaults to
                   Path(".") for backward compat; in production this is the
                   Tier3Context.fix_phase_dir seeded with the task's base repo.
+        backend: "claude" (default) or "kimi".
 
     Returns a dict with keys matching the invoker's run record plus extra
     fields used for TSV row construction.
@@ -281,16 +321,20 @@ def _run_cell(
             "_parse_warnings": [],
         }
 
-    agent_name: Optional[str] = _AGENT_CONDITIONS.get(condition)
-    # ae-rules-injected: inject the full AE methodology payload as the system
-    # prompt so the model runs with the complete protocol context. This is the
-    # headline measurement; baseline runs with system_prompt=None.
-    system_prompt: Optional[str] = ae_payload if condition == "ae-rules-injected" else None
+    agent_conditions = _agent_conditions_for_backend(backend)
+    agent_name: Optional[str] = agent_conditions.get(condition)
+    # ae-rules-injected (Claude): inject the full AE methodology payload as the
+    # system prompt so the model runs with the complete protocol context.
+    # Kimi has no --append-system-prompt equivalent, so system_prompt is None.
+    if backend == "kimi":
+        system_prompt: Optional[str] = None
+    else:
+        system_prompt = ae_payload if condition == "ae-rules-injected" else None
 
     effective_worktree = worktree if worktree is not None else Path(".")
 
-    # For per-agent conditions, the two-level Task wrapper is built by invoker.
-    # For baseline and ae-rules-injected, agent_name is None (conductor runs directly).
+    # For per-agent conditions, the two-level Task/Agent wrapper is built by invoker.
+    # For baseline and methodology conditions, agent_name is None (conductor runs directly).
     result = invoke_run(
         prompt=prompt,
         worktree=effective_worktree,
@@ -298,6 +342,7 @@ def _run_cell(
         agent_name=agent_name,
         mode="agent",
         system_prompt=system_prompt,
+        backend=backend,
     )
     return result
 
@@ -346,8 +391,9 @@ def run_matrix(
     tasks_filter: Optional[list[str]] = None,
     max_cells: Optional[int] = None,
     rebuild_image: bool = False,
+    backend: str = "claude",
 ) -> RunReport:
-    """Orchestrate the 8-condition skill-comparison eval matrix.
+    """Orchestrate the skill-comparison eval matrix.
 
     For each (task, condition, replicate) cell:
       1. Skip if already present in TSV (resume semantics; override with force=True).
@@ -373,14 +419,14 @@ def run_matrix(
         content_root: path to content/ directory (for ae-rules-injected payload).
                       Defaults to <repo_root>/content/.
         n_replicates: replicates per cell (default 3).
-        n_replicates_methodology: replicates for baseline and ae-rules-injected
+        n_replicates_methodology: replicates for the methodology pair
                                    (default 5; this is the headline pair).
         max_usd: global USD ceiling (default 250).
         max_tokens: global token ceiling (default 75 M).
         max_wall_seconds: global wall-clock ceiling (default 12 h).
         dry_run: if True, skip actual CLI calls and return canned results.
                  Implies tier3_mode='off'.
-        conditions: subset of CONDITION_LABELS to run (None = all 8).
+        conditions: subset of condition labels to run (None = all for backend).
         tier3_mode: "auto" (default) - instantiate Tier3Docker in production
                     (i.e. when not dry_run); "off" - skip Tier3, run local
                     subprocess for both fix and score phases (for dry-run /
@@ -403,6 +449,8 @@ def run_matrix(
                        a fresh docker build. Useful when Dockerfile.swebench has
                        changed and the locally-tagged image is stale. Has no
                        effect when tier3_mode='off' or dry_run=True.
+        backend: "claude" (default) or "kimi". Selects the CLI backend and
+                 condition matrix.
 
     Returns:
         RunReport with summary stats.
@@ -433,14 +481,17 @@ def run_matrix(
             )
         tasks = {slug: tasks[slug] for slug in tasks_filter}
 
-    active_conditions = conditions if conditions is not None else CONDITION_LABELS
+    default_conditions = _condition_labels_for_backend(backend)
+    active_conditions = conditions if conditions is not None else default_conditions
 
     # Resolve effective tier3 mode. dry_run forces Tier3 off.
     use_tier3 = (tier3_mode == "auto") and (not dry_run)
 
     # Build ae-rules payload once (reused for every ae-rules-injected cell).
+    # Kimi backend has no --append-system-prompt equivalent, so skip payload build.
     ae_payload: Optional[str] = None
-    if "ae-rules-injected" in active_conditions and not dry_run:
+    methodology_pair = _methodology_pair_for_backend(backend)
+    if backend != "kimi" and "ae-rules-injected" in active_conditions and not dry_run:
         from ae_rules_payload import build_payload
         ae_payload = build_payload(content_root)
 
@@ -507,6 +558,10 @@ def run_matrix(
 
         for dockerfile_name, image_tag in unique_dockerfiles.items():
             dockerfile_path = _dockerfile_dir / dockerfile_name
+            if rebuild_image:
+                # Evict cached digest so ensure_image() rebuilds from scratch.
+                from evals.runner.isolator import _IMAGE_DIGEST_CACHE
+                _IMAGE_DIGEST_CACHE.pop(image_tag, None)
             _LOG.info(
                 "Tier 3: ensuring image %s from %s (one-time build before cell loop)",
                 image_tag,
@@ -728,16 +783,21 @@ def run_matrix(
                             # Score-phase enforces container isolation - see run_score_phase.
                             # Build prompt and invoke via the isolator.
                             _fix_prompt = _build_fix_prompt(task_slug, task_meta)
-                            _agent_name: Optional[str] = _AGENT_CONDITIONS.get(condition)
-                            _system_prompt: Optional[str] = (
-                                ae_payload if condition == "ae-rules-injected" else None
-                            )
+                            _agent_conditions = _agent_conditions_for_backend(backend)
+                            _agent_name: Optional[str] = _agent_conditions.get(condition)
+                            if backend == "kimi":
+                                _system_prompt: Optional[str] = None
+                            else:
+                                _system_prompt = (
+                                    ae_payload if condition == "ae-rules-injected" else None
+                                )
                             cp = _Tier3Docker.run_fix_phase(
                                 ctx=tier3_ctx,
                                 prompt=_fix_prompt,
                                 timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
                                 agent_name=_agent_name,
                                 system_prompt=_system_prompt,
+                                backend=backend,
                             )
                             # run_fix_phase (prompt path) encodes the invoker
                             # dict as JSON in cp.stdout.
@@ -764,6 +824,7 @@ def run_matrix(
                                 ae_payload=ae_payload,
                                 dry_run=dry_run,
                                 worktree=fix_worktree,
+                                backend=backend,
                             )
                     except Exception as exc:
                         _LOG.error(
@@ -1032,6 +1093,15 @@ if __name__ == "__main__":
             "stale. Has no effect when --tier3=off or --dry-run."
         ),
     )
+    parser.add_argument(
+        "--backend",
+        choices=["claude", "kimi"],
+        default="claude",
+        help=(
+            "CLI backend to use for the eval runs. 'claude' (default) uses the "
+            "Claude Code CLI; 'kimi' uses the Kimi CLI."
+        ),
+    )
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -1052,6 +1122,7 @@ if __name__ == "__main__":
         tasks_filter=args.tasks_filter if args.tasks_filter else None,
         max_cells=args.max_cells,
         rebuild_image=args.rebuild_image,
+        backend=args.backend,
     )
 
     print(json.dumps(

--- a/evals/skill-comparison/tests/test_runner.py
+++ b/evals/skill-comparison/tests/test_runner.py
@@ -2615,3 +2615,263 @@ class TestPostSeedCommands:
         assert run_commands == [], (
             f"post_seed_commands must NOT run in dry_run mode; got {run_commands}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Kimi backend tests
+# ---------------------------------------------------------------------------
+
+
+class TestKimiBackendFlagGeneration:
+    """Tests for Kimi backend CLI flag generation in _run_cell."""
+
+    def test_kimi_backend_uses_kimi_binary(self, tmp_path: Path):
+        """Kimi backend invokes the `kimi` binary, not `claude`."""
+        from runner import _run_cell
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="baseline",
+                replicate=1,
+                ae_payload=None,
+                dry_run=False,
+                backend="kimi",
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        invoke_cmd = captured_cmds[-1]
+        assert invoke_cmd[0] == "kimi", (
+            f"Kimi backend must use 'kimi' binary; got {invoke_cmd[0]!r}"
+        )
+
+    def test_kimi_backend_has_correct_flags(self, tmp_path: Path):
+        """Kimi backend generates --print --yolo --work-dir --max-steps-per-turn."""
+        from runner import _run_cell
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="baseline",
+                replicate=1,
+                ae_payload=None,
+                dry_run=False,
+                backend="kimi",
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        invoke_cmd = captured_cmds[-1]
+        assert "--print" in invoke_cmd, "Kimi backend must include --print"
+        assert "--yolo" in invoke_cmd, "Kimi backend must include --yolo"
+        assert "--work-dir" in invoke_cmd, "Kimi backend must include --work-dir"
+        assert "--max-steps-per-turn" in invoke_cmd, (
+            "Kimi backend must include --max-steps-per-turn"
+        )
+        # Kimi must NOT have Claude-specific flags.
+        assert "--allowed-tools" not in invoke_cmd, (
+            "Kimi backend must NOT include --allowed-tools"
+        )
+        assert "--permission-mode" not in invoke_cmd, (
+            "Kimi backend must NOT include --permission-mode"
+        )
+        assert "--verbose" not in invoke_cmd, (
+            "Kimi backend must NOT include --verbose"
+        )
+
+    def test_kimi_backend_no_append_system_prompt_for_ae_skill(self, tmp_path: Path):
+        """Kimi ae-skill condition must NOT pass --append-system-prompt."""
+        from runner import _run_cell
+
+        ae_payload = "## AE methodology rules content here"
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="ae-skill",
+                replicate=1,
+                ae_payload=ae_payload,
+                dry_run=False,
+                backend="kimi",
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        invoke_cmd = captured_cmds[-1]
+        assert "--append-system-prompt" not in invoke_cmd, (
+            f"Kimi ae-skill must NOT include --append-system-prompt; cmd was: {invoke_cmd}"
+        )
+
+    def test_kimi_backend_uses_agent_tool_wording(self, tmp_path: Path):
+        """Kimi two-level prompt references 'Agent tool', not 'Task tool'."""
+        from runner import _run_cell
+
+        task_meta = {
+            "problem_summary": "test bug",
+            "repo_url": "https://github.com/example/repo",
+            "base_commit": "abc123",
+        }
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return _make_completed_process(stdout="")
+
+        with patch("subprocess.run", side_effect=fake_subprocess_run):
+            _run_cell(
+                task_slug="test-task",
+                task_meta=task_meta,
+                condition="coder-direct",
+                replicate=1,
+                ae_payload=None,
+                dry_run=False,
+                backend="kimi",
+            )
+
+        assert captured_cmds, "subprocess.run must have been called"
+        # The prompt is passed as the -p argument (index 2 for kimi).
+        prompt_arg = captured_cmds[-1][2]
+        assert "Agent tool" in prompt_arg, (
+            "Kimi two-level prompt must reference 'Agent tool'"
+        )
+        assert "Task tool" not in prompt_arg, (
+            "Kimi two-level prompt must NOT reference 'Task tool'"
+        )
+        assert "subagent_type='coder'" in prompt_arg, (
+            "Kimi coder-direct must map to subagent_type='coder'"
+        )
+
+
+class TestKimiBackendRunMatrix:
+    """Tests for run_matrix with backend='kimi'."""
+
+    def test_kimi_backend_uses_kimi_conditions(self, tmp_path: Path, corpus_yaml: Path):
+        """run_matrix with backend='kimi' uses the 5-condition Kimi matrix."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        with patch("runner.score_cell", return_value=canned_score):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                backend="kimi",
+            )
+
+        rows = _read_tsv(results_tsv)
+        conditions_seen = {r["condition"] for r in rows}
+        expected = {
+            "baseline",
+            "ae-skill",
+            "coder-direct",
+            "explore-direct",
+            "plan-direct",
+        }
+        assert conditions_seen == expected, (
+            f"Kimi backend must use Kimi condition set; expected {expected}, got {conditions_seen}"
+        )
+        assert report.rows_written == 5, (
+            f"Expected 5 rows (1 task x 5 conditions x n=1), got {report.rows_written}"
+        )
+
+    def test_kimi_backend_does_not_build_ae_payload(self, tmp_path: Path, corpus_yaml: Path):
+        """Kimi backend skips ae_rules_payload.build_payload since it cannot inject rules."""
+        results_tsv = tmp_path / "results.tsv"
+
+        from scoring import ScoringResult
+
+        canned_score = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        with (
+            patch("runner.score_cell", return_value=canned_score),
+            patch("ae_rules_payload.build_payload") as mock_build_payload,
+        ):
+            run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=1,
+                n_replicates_methodology=1,
+                dry_run=True,
+                backend="kimi",
+            )
+
+        mock_build_payload.assert_not_called(), (
+            "Kimi backend must NOT call build_payload (no --append-system-prompt support)"
+        )
+
+    def test_kimi_methodology_pair_uses_higher_n(self, tmp_path: Path, corpus_yaml: Path):
+        """baseline and ae-skill use n_replicates_methodology on Kimi backend."""
+        results_tsv = tmp_path / "skill-comparison.tsv"
+
+        from scoring import ScoringResult
+
+        canned = ScoringResult(
+            pass_fail=True, score_primary=1.0,
+            lines_touched=1, files_touched=1, scope_creep_flag=False,
+        )
+
+        with patch("runner.score_cell", return_value=canned):
+            report = run_matrix(
+                tasks_yaml=corpus_yaml,
+                results_tsv=results_tsv,
+                n_replicates=2,
+                n_replicates_methodology=3,
+                dry_run=True,
+                backend="kimi",
+                conditions=["baseline", "coder-direct"],
+            )
+
+        rows = _read_tsv(results_tsv)
+        baseline_rows = [r for r in rows if r["condition"] == "baseline"]
+        coder_rows = [r for r in rows if r["condition"] == "coder-direct"]
+
+        assert len(baseline_rows) == 3, "baseline should use n_replicates_methodology=3"
+        assert len(coder_rows) == 2, "coder-direct should use n_replicates=2"


### PR DESCRIPTION
## Summary

Ports the skill-comparison eval harness from Claude CLI to support Kimi CLI as an alternative backend.

## Changes

- **Backend-agnostic invoker** ():
  - Added  enum (, ╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   ▐█▛█▛█▌  Welcome to Kimi Code CLI!                                         │
│   ▐█████▌  Send /help for help information.                                  │
│                                                                              │
│  Directory: ~/Documents/Development/ai-tools/agentic-engineering/.agentic/w  │
│  orktrees/feature-kimi-backend-support                                       │
│  Session: 3984d2eb-609b-4b04-b825-88140ef65971                               │
│  API Key: ****** (from KIMI_API_KEY)                                         │
│  Model: Kimi-k2.6                                                            │
│                                                                              │
│  Tip: Spot a bug or have feedback? Type /feedback right in this session — e  │
│  very report makes Kimi better.                                              │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
⠼ MCP Servers: 0/2 connected, 0 tools
• context-mode (pending)
• openai-image-generation (pending)

── input ──────────────────────────────────────────────────────────────────────                                                                               ─
 




 
───────────────────────────────────────────────────────────────────────────────                                                                               ─
yolo  agent (Kimi-k2.6 ●)  …/feature-kimi-backend-support  ctrl-j: newline
                                                    connecting to mcp servers..                                                                               . Bye!
Error: OPENAI_API_KEY is not set.
Context Mode MCP server v1.0.103 running on stdio
Detected runtimes:
  JavaScript: bun (1.3.10) ⚡
  TypeScript: bun (1.3.10)
  Python:     python3 (Python 3.9.6)
  Shell:      bash (GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin25.1.0))
  Ruby:       ruby (ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin24])
  Go:         go (go version go1.26.2 darwin/arm64)
  Rust:       rustc (rustc 1.95.0 (59807616e 2026-04-14))
  Perl:       perl (This is perl 5, version 34, subversion 1 (v5.34.1) built for darwin-thread-multi-2level))
  -  probes for the appropriate binary
  - Kimi CLI invocation: 
  - Preserves exact existing Claude behavior (default backend)

- **Kimi condition matrix** ():
  - , , , , 
  - Maps Kimi subagent types: , , 
  - Claude 8-condition matrix preserved unchanged

- **Isolator + CLI** (, ):
  - Pass  parameter through the stack
  - Added  CLI flag

- **Tests** ():
  - Added Kimi backend tests (flag generation, condition matrix, agent mapping)
  - All existing Claude tests preserved

## Test Results



## Notes

- Kimi backend does not support ; the  condition relies on natural skill discovery from 
- Default backend is  for backward compatibility