### PR TITLE
fix(evals): Kimi backend normalizer, timeout, and MCP fixes

### DIFF
--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -244,6 +244,9 @@ def invoke_run(
                 "Kimi backend does not support --append-system-prompt; "
                 "system_prompt parameter is ignored."
             )
+        # Disable MCP servers for eval runs to avoid connection errors from
+        # misconfigured or unavailable MCP servers interfering with the harness.
+        cmd.extend(["--mcp-config-file", "/tmp/empty-mcp.json"])
         # Kimi uses --work-dir instead of subprocess cwd.
         subprocess_cwd = None
     else:

--- a/evals/runner/normalizer.py
+++ b/evals/runner/normalizer.py
@@ -1,5 +1,5 @@
 """
-Purpose: Parse Claude CLI stream-json stdout into a normalized per-run trace
+Purpose: Parse Claude or Kimi CLI stream-json stdout into a normalized per-run trace
          capturing final text, tool calls, turn count, and latency.
 
 Public API: parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict,
@@ -23,7 +23,7 @@ Failure modes: malformed JSON lines are skipped with a note in the trace's
                CLI versions, error exits), usage is {} and no exception is raised.
 
                Two-level spawn: when expect_subagent=True, the parser prefers
-               the text returned inside the Task tool's tool_result event (the
+               the text returned inside the Task/Agent tool's tool_result event (the
                subagent's final output) over the outer session's assistant
                text. If no tool_result is found, invocation_mode is set to
                "raw-prompt" and final_text falls back to the outer session's
@@ -35,6 +35,10 @@ from __future__ import annotations
 
 import json
 
+
+# ---------------------------------------------------------------------------
+# Claude format helpers
+# ---------------------------------------------------------------------------
 
 def _is_outer_task_result(obj: dict) -> bool:
     """True if this user event is the outer-level result of a Task subagent call.
@@ -89,14 +93,78 @@ def _extract_tool_result_text(obj: dict) -> str | None:
     return None
 
 
-def parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict:
-    """Parse a single Claude CLI run's stream-json stdout into a normalized run record.
+# ---------------------------------------------------------------------------
+# Kimi format helpers
+# ---------------------------------------------------------------------------
 
-    The stream-json format emits one JSON object per line with a "type" discriminator.
-    We care about assistant messages (final text concatenation), tool use blocks
-    (count), tool_result events carrying subagent output (Task tool), and the
-    final result event (total turns, cost).
+def _extract_kimi_assistant_text(obj: dict) -> str:
+    """Extract text from a Kimi assistant message's content array.
+
+    Ignores think blocks; concatenates text blocks.
     """
+    content = obj.get("content", [])
+    if not isinstance(content, list):
+        return ""
+    texts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            texts.append(block.get("text", ""))
+    return "".join(texts)
+
+
+def _extract_kimi_subagent_text(tool_content: str) -> str | None:
+    """Extract the subagent's meaningful output from a Kimi tool response.
+
+    Kimi tool responses have a structured header (agent_id, status, etc.)
+    followed by a [summary] section. We want the summary content.
+    """
+    if not tool_content:
+        return None
+    # Look for [summary] marker and take everything after it.
+    marker = "[summary]\n"
+    idx = tool_content.find(marker)
+    if idx != -1:
+        text = tool_content[idx + len(marker):].strip()
+        if text:
+            return text
+    # Fallback: if no marker, return the whole thing if it looks like a diff or code.
+    stripped = tool_content.strip()
+    if stripped:
+        return stripped
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main parser
+# ---------------------------------------------------------------------------
+
+def parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict:
+    """Parse a Claude or Kimi CLI run's stream-json stdout into a normalized run record.
+
+    Auto-detects the backend format: Claude uses a "type" discriminator per line,
+    Kimi uses a "role" field. Empty streams fall back to Claude defaults.
+    """
+    # Detect format from first non-empty parseable line.
+    backend = "claude"
+    for line in raw_stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "role" in obj:
+            backend = "kimi"
+        break
+
+    if backend == "kimi":
+        return _parse_stream_json_kimi(raw_stdout, expect_subagent)
+    return _parse_stream_json_claude(raw_stdout, expect_subagent)
+
+
+def _parse_stream_json_claude(raw_stdout: str, expect_subagent: bool) -> dict:
+    """Claude-specific parser (original logic, preserved exactly)."""
     final_text_parts: list[str] = []
     tool_calls: list[dict] = []
     turns_used: int = 0
@@ -137,17 +205,11 @@ def parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict:
                     last_assistant_text = "".join(txt_chunks)
                     final_text_parts.append(last_assistant_text)
         elif t == "user":
-            # The outer Task tool_result arrives as a `user` message with
-            # parent_tool_use_id=None and tool_use_result.agentType set.
-            # Nested tool_results from the subagent's own Read/Grep calls
-            # have parent_tool_use_id set to the Task tool_use id; we skip
-            # those explicitly so we never score the text of a Read result.
             if expect_subagent and subagent_text is None and _is_outer_task_result(obj):
                 extracted = _extract_tool_result_text(obj)
                 if extracted:
                     subagent_text = extracted
         elif t == "result":
-            # Final event; carries num_turns, total_cost_usd, and usage in current CLI.
             turns_used = int(obj.get("num_turns", obj.get("turns", 0)) or 0)
             if "total_cost_usd" in obj:
                 cost_usd = float(obj["total_cost_usd"])
@@ -156,7 +218,6 @@ def parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict:
             if isinstance(obj.get("usage"), dict):
                 result_usage = obj["usage"]
 
-    # Determine final_text and invocation_mode.
     if expect_subagent:
         if subagent_text:
             final_text = subagent_text
@@ -179,6 +240,82 @@ def parse_stream_json(raw_stdout: str, expect_subagent: bool = False) -> dict:
         "cost_usd": cost_usd,
         "invocation_mode": invocation_mode,
         "usage": result_usage,
+        "_parse_warnings": warnings,
+    }
+
+
+def _parse_stream_json_kimi(raw_stdout: str, expect_subagent: bool) -> dict:
+    """Kimi-specific parser for role-based stream-json format."""
+    final_text_parts: list[str] = []
+    tool_calls: list[dict] = []
+    warnings: list[str] = []
+    last_assistant_text: str = ""
+    subagent_text: str | None = None
+    outer_result_text: str = ""
+
+    # Track the outer Agent tool call id for subagent extraction.
+    outer_agent_call_id: str | None = None
+
+    for line in raw_stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as e:
+            warnings.append(f"json_decode_error: {e}")
+            continue
+
+        role = obj.get("role")
+        if role == "assistant":
+            txt = _extract_kimi_assistant_text(obj)
+            if txt:
+                last_assistant_text = txt
+                final_text_parts.append(txt)
+            # Collect tool calls.
+            for tc in obj.get("tool_calls", []):
+                if isinstance(tc, dict):
+                    func = tc.get("function", {})
+                    tool_calls.append({
+                        "name": func.get("name") if isinstance(func, dict) else None,
+                        "id": tc.get("id"),
+                    })
+                    # Track the outer Agent call for subagent extraction.
+                    if expect_subagent and outer_agent_call_id is None:
+                        if isinstance(func, dict) and func.get("name") == "Agent":
+                            outer_agent_call_id = tc.get("id")
+        elif role == "tool":
+            if expect_subagent and subagent_text is None:
+                if outer_agent_call_id is not None and obj.get("tool_call_id") == outer_agent_call_id:
+                    content = obj.get("content")
+                    if isinstance(content, str):
+                        extracted = _extract_kimi_subagent_text(content)
+                        if extracted:
+                            subagent_text = extracted
+
+    # Kimi does not emit a result event; usage/cost are unavailable in stream-json.
+    if expect_subagent:
+        if subagent_text:
+            final_text = subagent_text
+            invocation_mode = "two-level"
+        else:
+            final_text = last_assistant_text or outer_result_text or "\n\n".join(final_text_parts)
+            invocation_mode = "raw-prompt"
+            warnings.append(
+                "two-level spawn requested but no Agent tool response text found; "
+                "falling back to outer session's assistant text"
+            )
+    else:
+        final_text = outer_result_text or last_assistant_text or "\n\n".join(final_text_parts)
+        invocation_mode = "raw-prompt"
+
+    return {
+        "final_text": final_text,
+        "tool_calls": tool_calls,
+        "turns_used": 0,
+        "cost_usd": None,
+        "invocation_mode": invocation_mode,
+        "usage": {},
         "_parse_warnings": warnings,
     }
 

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -166,6 +166,14 @@ def _methodology_pair_for_backend(backend: str) -> tuple[str, ...]:
 # Per-task pytest timeout (Brief: <120 s held-out test budget).
 _PYTEST_TIMEOUT_SECONDS = 120
 
+# Agent-mode CLI timeout: Claude typically completes within 240 s; Kimi needs
+# more headroom for the same SWE-bench tasks (observed: ~4-5 min for simple
+# tasks, up to 10 min for complex multi-file fixes).
+_FIX_TIMEOUT_SECONDS: dict[str, int] = {
+    "claude": _PYTEST_TIMEOUT_SECONDS * 2,   # 240 s
+    "kimi": _PYTEST_TIMEOUT_SECONDS * 5,     # 600 s
+}
+
 # TSV schema for the skill-comparison ledger.
 _TSV_HEADER: tuple[str, ...] = (
     "task_slug",
@@ -338,7 +346,7 @@ def _run_cell(
     result = invoke_run(
         prompt=prompt,
         worktree=effective_worktree,
-        timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,  # give engineer 240s
+        timeout_seconds=_FIX_TIMEOUT_SECONDS[backend],
         agent_name=agent_name,
         mode="agent",
         system_prompt=system_prompt,
@@ -638,7 +646,7 @@ def run_matrix(
                         fixture_repo_dir=None,  # base repo seeded externally
                         held_out_dir=held_out_path,
                         build_image=False,  # image already built once by ensure_image() above
-                        timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
+                        timeout_seconds=_FIX_TIMEOUT_SECONDS[backend],
                         held_out_from_fix_dir=True,
                         image_tag=_cell_image_tag,
                     )
@@ -794,7 +802,7 @@ def run_matrix(
                             cp = _Tier3Docker.run_fix_phase(
                                 ctx=tier3_ctx,
                                 prompt=_fix_prompt,
-                                timeout_seconds=_PYTEST_TIMEOUT_SECONDS * 2,
+                                timeout_seconds=_FIX_TIMEOUT_SECONDS[backend],
                                 agent_name=_agent_name,
                                 system_prompt=_system_prompt,
                                 backend=backend,


### PR DESCRIPTION
## Fixes for Kimi backend smoke-test failures

Three fixes discovered during end-to-end smoke testing of the Kimi backend:

### 1.  — Kimi stream-json format support
- Auto-detects Kimi format (role field) vs Claude format (type field)
- Parses Kimi assistant messages, tool_calls, and tool responses
- Extracts subagent text from Agent tool responses for two-level spawn
- All existing Claude parsing behavior preserved exactly

### 2.  — backend-specific CLI timeout
- Kimi needs ~4-5 min for simple SWE-bench tasks, up to 10 min for complex fixes
- Default 240s timeout caused all Kimi cells to timeout with empty stdout
- Added _FIX_TIMEOUT_SECONDS: claude=240s, kimi=600s

### 3.  — disable MCP servers for eval runs
- Broken/unavailable MCP servers caused Kimi to exit before processing prompt
- Pass --mcp-config-file with empty config to prevent interference

### Smoke test result


### Tests
436 passed, 1 skipped