### PR TITLE
feat(agents): add AST-grep guidance to investigator and debugger

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -929,6 +929,8 @@ Do not rely on training knowledge for library-specific details when Context7 is 
 
 Reserve `Bash` exclusively for: builds, installs, git operations, network calls, process management, and anything no dedicated tool covers.
 
+Exception: `sg` (AST-grep) for structural symbol-level searches is run via Bash - no dedicated harness tool wraps it. Check availability with `which sg 2>/dev/null` before use.
+
 ## Context Window Management
 
 **When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.

--- a/.codex/agents/debugger.toml
+++ b/.codex/agents/debugger.toml
@@ -23,7 +23,7 @@ Your spawn prompt will contain:
 
 ### Phase 1: Root Cause Investigation
 
-Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving.
+Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving. When tracing call sites or symbol usages, run `which sg 2>/dev/null` to check for AST-grep; if present, prefer `sg --pattern 'symbol($$$)' --lang <lang> .` via Bash over text-based Grep (`$$$` matches any argument list; `sg` is a Bash exception - no dedicated harness tool wraps structural AST search). Fall back to Grep if `sg` is not installed.
 
 ### Phase 2: Look up library docs
 

--- a/.codex/agents/investigator.toml
+++ b/.codex/agents/investigator.toml
@@ -25,7 +25,7 @@ Your spawn prompt will contain:
 
 1. **Parse the question.** What specifically needs to be understood? What decision will the conductor make from your output? Knowing the downstream use shapes what depth and breadth you need.
 
-2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first.
+2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first. For symbol-level queries (call sites of a function, usages of an exported type, class definitions), prefer `sg` (AST-grep) over text-based Grep when available - it eliminates false positives from comments, string literals, and partial name matches. Run `which sg 2>/dev/null` once at investigation start to check availability; if present, use it via Bash (no dedicated harness tool wraps structural AST search - this is an explicit exception to the Bash-for-search prohibition). Example: `sg --pattern 'myFunction($$$)' --lang ts .` finds all call sites of `myFunction` in TypeScript files (`$$$` matches any argument list). If `sg` is not installed, use Grep as normal.
 
 3. **Look up library docs.** If the investigation involves library, framework, or SDK behavior, use Context7 (`resolve-library-id` → `query-docs`) to fetch current documentation before forming any hypothesis. Training data may be outdated — verify API signatures, configuration options, and behavioral details against current docs.
 

--- a/.cursor/rules/code-standards.mdc
+++ b/.cursor/rules/code-standards.mdc
@@ -25,6 +25,8 @@ Do not rely on training knowledge for library-specific details when Context7 is 
 
 Reserve `Bash` exclusively for: builds, installs, git operations, network calls, process management, and anything no dedicated tool covers.
 
+Exception: `sg` (AST-grep) for structural symbol-level searches is run via Bash - no dedicated harness tool wraps it. Check availability with `which sg 2>/dev/null` before use.
+
 ## Context Window Management
 
 **When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -929,6 +929,8 @@ Do not rely on training knowledge for library-specific details when Context7 is 
 
 Reserve `Bash` exclusively for: builds, installs, git operations, network calls, process management, and anything no dedicated tool covers.
 
+Exception: `sg` (AST-grep) for structural symbol-level searches is run via Bash - no dedicated harness tool wraps it. Check availability with `which sg 2>/dev/null` before use.
+
 ## Context Window Management
 
 **When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.

--- a/.gemini/agents/debugger.md
+++ b/.gemini/agents/debugger.md
@@ -24,7 +24,7 @@ Your spawn prompt will contain:
 
 ### Phase 1: Root Cause Investigation
 
-Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving.
+Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving. When tracing call sites or symbol usages, run `which sg 2>/dev/null` to check for AST-grep; if present, prefer `sg --pattern 'symbol($$$)' --lang <lang> .` via Bash over text-based Grep (`$$$` matches any argument list; `sg` is a Bash exception - no dedicated harness tool wraps structural AST search). Fall back to Grep if `sg` is not installed.
 
 ### Phase 2: Look up library docs
 

--- a/.gemini/agents/investigator.md
+++ b/.gemini/agents/investigator.md
@@ -26,7 +26,7 @@ Your spawn prompt will contain:
 
 1. **Parse the question.** What specifically needs to be understood? What decision will the conductor make from your output? Knowing the downstream use shapes what depth and breadth you need.
 
-2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first.
+2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first. For symbol-level queries (call sites of a function, usages of an exported type, class definitions), prefer `sg` (AST-grep) over text-based Grep when available - it eliminates false positives from comments, string literals, and partial name matches. Run `which sg 2>/dev/null` once at investigation start to check availability; if present, use it via Bash (no dedicated harness tool wraps structural AST search - this is an explicit exception to the Bash-for-search prohibition). Example: `sg --pattern 'myFunction($$$)' --lang ts .` finds all call sites of `myFunction` in TypeScript files (`$$$` matches any argument list). If `sg` is not installed, use Grep as normal.
 
 3. **Look up library docs.** If the investigation involves library, framework, or SDK behavior, use Context7 (`resolve-library-id` → `query-docs`) to fetch current documentation before forming any hypothesis. Training data may be outdated — verify API signatures, configuration options, and behavioral details against current docs.
 

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -929,6 +929,8 @@ Do not rely on training knowledge for library-specific details when Context7 is 
 
 Reserve `Bash` exclusively for: builds, installs, git operations, network calls, process management, and anything no dedicated tool covers.
 
+Exception: `sg` (AST-grep) for structural symbol-level searches is run via Bash - no dedicated harness tool wraps it. Check availability with `which sg 2>/dev/null` before use.
+
 ## Context Window Management
 
 **When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.

--- a/.opencode/agents/debugger.md
+++ b/.opencode/agents/debugger.md
@@ -26,7 +26,7 @@ Your spawn prompt will contain:
 
 ### Phase 1: Root Cause Investigation
 
-Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving.
+Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving. When tracing call sites or symbol usages, run `which sg 2>/dev/null` to check for AST-grep; if present, prefer `sg --pattern 'symbol($$$)' --lang <lang> .` via Bash over text-based Grep (`$$$` matches any argument list; `sg` is a Bash exception - no dedicated harness tool wraps structural AST search). Fall back to Grep if `sg` is not installed.
 
 ### Phase 2: Look up library docs
 

--- a/.opencode/agents/investigator.md
+++ b/.opencode/agents/investigator.md
@@ -28,7 +28,7 @@ Your spawn prompt will contain:
 
 1. **Parse the question.** What specifically needs to be understood? What decision will the conductor make from your output? Knowing the downstream use shapes what depth and breadth you need.
 
-2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first.
+2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first. For symbol-level queries (call sites of a function, usages of an exported type, class definitions), prefer `sg` (AST-grep) over text-based Grep when available - it eliminates false positives from comments, string literals, and partial name matches. Run `which sg 2>/dev/null` once at investigation start to check availability; if present, use it via Bash (no dedicated harness tool wraps structural AST search - this is an explicit exception to the Bash-for-search prohibition). Example: `sg --pattern 'myFunction($$$)' --lang ts .` finds all call sites of `myFunction` in TypeScript files (`$$$` matches any argument list). If `sg` is not installed, use Grep as normal.
 
 3. **Look up library docs.** If the investigation involves library, framework, or SDK behavior, use Context7 (`resolve-library-id` → `query-docs`) to fetch current documentation before forming any hypothesis. Training data may be outdated — verify API signatures, configuration options, and behavioral details against current docs.
 

--- a/content/agents/debugger.md
+++ b/content/agents/debugger.md
@@ -23,7 +23,7 @@ Your spawn prompt will contain:
 
 ### Phase 1: Root Cause Investigation
 
-Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving.
+Read the error completely - do not skim. Extract: the error message, the exact failing location (file, line, function), and any relevant context (environment, inputs, timing). Reproduce the failure consistently before doing anything else. Check recent changes via `git log` and `git diff` to see what changed near the failure point. In multi-component systems, instrument at boundaries to isolate which component is misbehaving. When tracing call sites or symbol usages, run `which sg 2>/dev/null` to check for AST-grep; if present, prefer `sg --pattern 'symbol($$$)' --lang <lang> .` via Bash over text-based Grep (`$$$` matches any argument list; `sg` is a Bash exception - no dedicated harness tool wraps structural AST search). Fall back to Grep if `sg` is not installed.
 
 ### Phase 2: Look up library docs
 

--- a/content/agents/investigator.md
+++ b/content/agents/investigator.md
@@ -25,7 +25,7 @@ Your spawn prompt will contain:
 
 1. **Parse the question.** What specifically needs to be understood? What decision will the conductor make from your output? Knowing the downstream use shapes what depth and breadth you need.
 
-2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first.
+2. **Map the terrain.** Use Glob and Grep to orient quickly: find relevant files, entry points, and key symbols before diving deep. Don't read everything - form a map first. For symbol-level queries (call sites of a function, usages of an exported type, class definitions), prefer `sg` (AST-grep) over text-based Grep when available - it eliminates false positives from comments, string literals, and partial name matches. Run `which sg 2>/dev/null` once at investigation start to check availability; if present, use it via Bash (no dedicated harness tool wraps structural AST search - this is an explicit exception to the Bash-for-search prohibition). Example: `sg --pattern 'myFunction($$$)' --lang ts .` finds all call sites of `myFunction` in TypeScript files (`$$$` matches any argument list). If `sg` is not installed, use Grep as normal.
 
 3. **Look up library docs.** If the investigation involves library, framework, or SDK behavior, use Context7 (`resolve-library-id` → `query-docs`) to fetch current documentation before forming any hypothesis. Training data may be outdated — verify API signatures, configuration options, and behavioral details against current docs.
 

--- a/content/rules/code-standards.md
+++ b/content/rules/code-standards.md
@@ -19,6 +19,8 @@ Do not rely on training knowledge for library-specific details when Context7 is 
 
 Reserve `Bash` exclusively for: builds, installs, git operations, network calls, process management, and anything no dedicated tool covers.
 
+Exception: `sg` (AST-grep) for structural symbol-level searches is run via Bash - no dedicated harness tool wraps it. Check availability with `which sg 2>/dev/null` before use.
+
 ## Context Window Management
 
 **When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.


### PR DESCRIPTION
## Summary

- **investigator** Step 2: prefer `sg` (AST-grep) for symbol-level queries (call sites, type usages, class definitions) over text-based Grep; includes `which sg` availability check and annotated usage example
- **debugger** Phase 1: prefer `sg` for call site/symbol tracing during root cause analysis; same availability check pattern
- **code-standards** Tool Discipline: explicit Bash exception added for `sg` since no dedicated harness tool wraps structural AST search

Eliminates false positives from comments, string literals, and partial name matches in blast-radius mapping and root cause analysis. All 6 adapter build scripts ran successfully (13 files changed in regenerated adapter artifacts).

## Motivation

Inspired by Oh My Opencode's use of structural code search. AST-grep is harness-agnostic (CLI tool via Bash) and works across all 9 supported adapters. The "when available" + `which sg 2>/dev/null` framing keeps it gracefully optional on machines without it installed.

## Test plan

- [ ] Verify investigator Step 2 prose reads correctly in context
- [ ] Verify debugger Phase 1 prose reads correctly in context
- [ ] Verify code-standards exception is placed correctly after the Bash reservation line
- [ ] Verify all adapter build artifacts updated (13 files)