### PR TITLE
feat(protocol): Brief-informs-Architect, pre-architect ambiguity scan, cross-artifact alignment check

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -470,6 +470,7 @@ Before any architect spawn, check for an existing Brief, snapshot qa.md for Elev
   pre-existing and operator-confirmed.
 - Pass `brief_source: operator` to the Skeptic-on-Brief gate; use the operator-confirmed
   Skeptic variant (completeness-only review per `content/commands/brief.md` Section 6).
+- If `.agentic/brief-session.json` confirms `brief_source: operator`, set `operator_brief_injectionable: true` to signal Phase 3 that the Brief's committed constraints should be injected into the architect spawn brief (see Phase 3 "Pre-authored Brief injection").
 
 **If not found:** proceed normally. The promotion gate in Phase 3b determines whether a
 Brief is required based on the unit count from the orchestration-planner.
@@ -564,6 +565,33 @@ Trivial-classified tickets retain conductor-direct flow per METHODOLOGY.md §Ris
 
 ---
 
+## Phase 2b: Pre-architect ambiguity scan
+
+**Applies only when ALL of the following hold:**
+- Risk classification is Elevated
+- `operator_brief_injectionable` was NOT set in Phase 0b (no operator-authored Brief)
+- This is the single-unit path (no prior agent has decomposed the ticket into multiple units)
+
+Skip this phase entirely for Trivial, Low, multi-unit, or Brief-present tickets.
+
+**The conductor scans the ticket text for ambiguity signals:**
+- Vague scope language ("something like", "similar to", "improve", "better", "clean up") with no concrete target state
+- No explicit done condition or acceptance criteria stated anywhere in the ticket
+- Two or more mutually exclusive reasonable interpretations of the core ask
+- A load-bearing context value is unstated (target environment, performance budget, affected user type, data scale) where the implementation would materially branch on it
+
+**When one or more signals are present:** the conductor surfaces 1-3 targeted, specific questions in its user-facing turn, each with a recommended default. Format follows the surface-and-proceed protocol in `content/sections/02-delegation.md`. The conductor waits exactly one operator turn.
+- If the operator answers: fold answers verbatim into the Phase 3 architect brief under `"Operator clarifications:"`.
+- If the operator does not answer within their next turn (says "proceed", asks something else, or is silent): proceed with the recommended defaults, noted in the architect brief under `"Conductor defaults applied:"`.
+
+The scan never blocks more than one turn. Proceed to Phase 3 after the response (or default).
+
+**When no signals are present:** proceed directly to Phase 3, silently.
+
+**Stop-frequency budget:** this pre-architect planning-input scan is explicitly exempt from the stop-frequency table in `content/sections/02-delegation.md` (see the carve-out there). It does not count toward the per-task stop budget for any task shape. It is a planning-input step, not a mid-work blocker.
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:
@@ -571,6 +599,16 @@ Spawn an `architect` agent. Provide:
 - The relevant code snippets you gathered
 - The AGENTS.md conventions
 - Any architectural decisions and rationale from MEMORY.md (or the project's custom decision log) that bear on this ticket
+
+**Pre-authored Brief injection (only when `operator_brief_injectionable` was set in Phase 0b).** Check this flag before proceeding. When set, read the Brief file at `brief_path` and prepend the following to the architect spawn brief:
+- The Brief's **Problem** section, labeled: `"Committed problem statement (from operator Brief — do not redefine):"`
+- The Brief's **Success criteria** bullets, labeled: `"Committed success criteria — your plan MUST demonstrably address every one of these:"`
+- The Brief's **Non-goals**, labeled: `"Out of scope (do not design for these):"`
+- The Brief's **Constraints**, labeled: `"Hard constraints (a design that violates any of these is rejected):"`
+
+The architect treats these as fixed inputs. An uncovered committed success criterion is a Critical Skeptic finding on the architect plan.
+
+This injection does NOT apply to conductor-authored Briefs (those are downstream of the architect by design). Only operator-authored Briefs (`brief_source: operator`) carry committed constraints.
 
 Ask the architect for:
 1. A concrete implementation plan (what changes, in which files, in what order)
@@ -619,6 +657,30 @@ Also add `.agentic/` to the project's `.gitignore` if not already present.
 **Read the orchestration-planner's structured JSONL block** (the `## Task entries (machine-readable)` section at the end of the plan output). For each entry in that block, append a `pending` entry to `.agentic/tasks.jsonl`. Write tasks in dependency order - independent tasks (empty `depends_on`) first, dependent tasks after. Each entry must include the fields from the schema: `task_id`, `session_id`, `ticket_id`, `unit_slug`, `status: pending`, `depends_on`, `created_at`, `updated_at`, and the full `inputs` object (`description`, `acceptance_criteria`, `files_in_scope`, `quality_cmd`, `repo_path`, `base_branch`).
 
 Emit breadcrumb: `[phase: task-state-init | N tasks written]`
+
+### Cross-artifact alignment check (Brief present + planner returned units with non-empty criteria)
+
+**Applies only when ALL hold:**
+- `brief_path` is set (a Brief exists — operator-authored from Phase 0b, or conductor-authored at the promotion gate)
+- The orchestration-planner returned a JSONL block with at least one unit carrying a non-empty `acceptance_criteria` array
+
+When the guard does not apply (no Brief, or all units carry `acceptance_criteria: []`): emit `[phase: cross-artifact-check-skipped | no criteria to map]` and proceed to the promotion gate.
+
+**This is a conductor-direct mechanical mapping, not a subagent and not adversarial review.** It complements the Skeptic-on-Brief; it does not replace it.
+
+**Procedure:**
+1. For each **Success criterion** in the Brief: scan every orchestration unit's `acceptance_criteria` array. Mark the criterion **COVERED** if at least one unit's entry explicitly addresses it; mark it **UNCOVERED** otherwise.
+2. Produce a mapping table: `success criterion → covering unit_slug(s)`, or `"UNCOVERED"`.
+
+**On any UNCOVERED criterion:** resolve before the Skeptic-on-Brief fires by one of:
+- (a) Re-spawn the orchestration-planner with the specific uncovered criteria called out, so it adds or amends a unit's `acceptance_criteria`.
+- (b) Surface the mismatch to the operator with a recommended resolution (descope the criterion from the Brief, or expand scope to cover it).
+
+The conductor does not proceed to the Skeptic-on-Brief with an unresolved UNCOVERED criterion.
+
+**On full coverage:** emit `[phase: cross-artifact-aligned | N/N criteria covered]` and proceed to the promotion gate.
+
+See `content/sections/03-planning-artifacts.md` Gate semantics for where this step sits relative to the Skeptic-on-Brief.
 
 **ALL writes to `.agentic/tasks.jsonl` are conductor-only.** Workers do not read or write the task file. Workers return their summaries to the conductor in the normal return path; the conductor extracts results and writes all updates. No lock protocol is needed because the conductor is the sole writer.
 

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -569,7 +569,7 @@ Trivial-classified tickets retain conductor-direct flow per METHODOLOGY.md §Ris
 
 **Applies only when ALL of the following hold:**
 - Risk classification is Elevated
-- `operator_brief_injectionable` was NOT set in Phase 0b (no operator-authored Brief)
+- `brief_path` was NOT set in Phase 0b (no Brief found — neither a file-existence match nor an operator-confirmed session)
 - This is the single-unit path (no prior agent has decomposed the ticket into multiple units)
 
 Skip this phase entirely for Trivial, Low, multi-unit, or Brief-present tickets.

--- a/.claude/skills/agentic-engineering/METHODOLOGY.md
+++ b/.claude/skills/agentic-engineering/METHODOLOGY.md
@@ -131,6 +131,8 @@ the conductor surfaces the question with a recommended default and proceeds with
 | Multi-unit plan (2-5 units) | 2 across the whole plan |
 | Large multi-unit plan (6+ units) | 3 across the whole plan |
 
+**Pre-architect planning-input scans are exempt from this budget.** The Phase 2b ambiguity scan in `/implement-ticket` surfaces clarifying questions before any agent is spawned — no architect, investigator, or engineer has run yet. This is structurally different from a mid-work stop: it is bounded to exactly one operator turn, has a proceed-with-defaults fallback, and produces no work that needs to be discarded if the operator redirects. Phase 2b does not count against the per-task stop budget for any task shape.
+
 When the threshold is exceeded, the conductor stops spawning Workers and surfaces a planning concern to the user instead of another piecemeal question. Format:
 
 *"I've hit N blockers on this task: [bullet list of each blocker and why]. This is past the threshold for a [task shape] task and suggests the plan needs revisiting before we continue. Options: (a) re-spawn architect with these gaps, (b) answer the open questions upfront and resume, or (c) descope. Recommendation: [pick one]."*
@@ -271,7 +273,9 @@ Upstream deps: METHODOLOGY.md §Delegation (architect plan + Skeptic gate, Open
                METHODOLOGY.md §Cross-session loop resume (loop-state.json
                schema for brief_path / plan_path / promotion_tier);
                content/rules/module-manifest.md (manifest header contract);
-               content/agents/architect.md, content/agents/orchestration-planner.md.
+               content/agents/architect.md, content/agents/orchestration-planner.md
+               (the acceptance_criteria array field from orchestration-planner
+               JSONL output is consumed by the cross-artifact alignment step).
 
 Downstream consumers: METHODOLOGY.md §Delegation (Worker preamble references
                       brief_path / plan_path); METHODOLOGY.md §Task
@@ -281,15 +285,17 @@ Downstream consumers: METHODOLOGY.md §Delegation (Worker preamble references
                       promotion_tier); METHODOLOGY.md §Risk Classification
                       (Declaration format optionally includes Brief / Plan);
                       METHODOLOGY.md §Protocol Details (cross-link entry);
-                      /implement-ticket command (follow-on unit, out of scope
-                      here).
+                      /implement-ticket command (Gate semantics step ordering
+                      is referenced by Phase 3b cross-artifact alignment check).
 
 Failure modes: Prose; does not execute. Drift between this section and the
                cross-references above is a Major Skeptic finding (stale
-               manifest or stale cross-reference). Operator failure mode
-               this section exists to prevent: multi-unit Elevated work
-               proceeding without a committed problem statement, success
-               criteria, non-goals, and verification plan.
+               manifest or stale cross-reference). Stale step numbering in
+               Gate semantics causes misrouted cross-references across phases;
+               update inline step references whenever steps are renumbered.
+               Operator failure mode this section exists to prevent: multi-unit
+               Elevated work proceeding without a committed problem statement,
+               success criteria, non-goals, and verification plan.
 
 Performance: Standard.
 -->
@@ -433,9 +439,10 @@ The verification gate is non-skippable. **If verification cannot be specified at
 3. Open Questions on architect plan resolved.
 4. Orchestration-planner runs.
 5. Promotion check against the trigger table.
-6. If 2-5 Elevated-or-above units: check whether `.agentic/brief-session.json` exists with `status: complete` and `brief_source: operator` AND `brief_path` points to an existing file. If both conditions hold, the Brief is pre-existing and operator-confirmed - skip conductor authoring and go directly to step 7. If not, conductor authors Brief at `docs/planning/<slug>.md` using architect output, planner output, and the original ticket as inputs.
-7. Spawn Skeptic on the Brief. When the Brief is pre-existing and operator-confirmed (`brief_source: operator`), use the operator-confirmed Skeptic variant (completeness-only review - see `content/commands/brief.md` Section 6 for the exact brief text). When the Brief was conductor-authored, use the standard "Document synthesis, architecture, and planning" adversarial brief; the verification field is part of the Skeptic's review surface in both cases. The `QA criteria` field is also part of the Skeptic's review surface: for Elevated tickets, the Skeptic must validate that the field is present, that `qa_skip` is one of the 5 valid enum values or null, that `qa_skip_rationale` is populated when `qa_skip != null`, and that `scenarios[]` is non-empty when `qa_skip == null`. Absence on Elevated is a Critical finding; an invalid `qa_skip` enum is a Major finding.
-8. On Brief sign-off (and after any Open Questions in the Brief are resolved per the Open Questions hard gate in METHODOLOGY.md §Delegation), engineer(s) spawn with `brief_path` populated in their execution contract.
+6. If 2-5 Elevated-or-above units: check whether `.agentic/brief-session.json` exists with `status: complete` and `brief_source: operator` AND `brief_path` points to an existing file. If both conditions hold, the Brief is pre-existing and operator-confirmed - skip conductor authoring and go directly to step 8. If not, conductor authors Brief at `docs/planning/<slug>.md` using architect output, planner output, and the original ticket as inputs.
+7. **Cross-artifact alignment check (conductor-direct).** When a Brief exists and the orchestration-planner returned at least one unit with a non-empty `acceptance_criteria` array, the conductor mechanically maps every Brief success criterion to at least one unit's `acceptance_criteria`. Any UNCOVERED criterion is resolved (re-spawn planner with the gap called out, or surface a descope/expand decision to the operator) before the Skeptic-on-Brief runs. When no unit has non-empty `acceptance_criteria`, emit `[phase: cross-artifact-check-skipped | no criteria to map]` and proceed. Full procedure in `/implement-ticket` Phase 3b "Cross-artifact alignment check". This mechanical check complements — does not replace — the adversarial Skeptic-on-Brief.
+8. Spawn Skeptic on the Brief. When the Brief is pre-existing and operator-confirmed (`brief_source: operator`), use the operator-confirmed Skeptic variant (completeness-only review - see `content/commands/brief.md` Section 6 for the exact brief text). When the Brief was conductor-authored, use the standard "Document synthesis, architecture, and planning" adversarial brief; the verification field is part of the Skeptic's review surface in both cases. The `QA criteria` field is also part of the Skeptic's review surface: for Elevated tickets, the Skeptic must validate that the field is present, that `qa_skip` is one of the 5 valid enum values or null, that `qa_skip_rationale` is populated when `qa_skip != null`, and that `scenarios[]` is non-empty when `qa_skip == null`. Absence on Elevated is a Critical finding; an invalid `qa_skip` enum is a Major finding.
+9. On Brief sign-off (and after any Open Questions in the Brief are resolved per the Open Questions hard gate in METHODOLOGY.md §Delegation), engineer(s) spawn with `brief_path` populated in their execution contract.
 
 **Authoring sequence (Plan tier):** identical to Brief tier through step 6, plus:
 - Conductor authors `risk-register.md`, `rollback.md`, and `verification-gate.md`, and assembles the Plan directory.
@@ -449,6 +456,7 @@ The verification gate is non-skippable. **If verification cannot be specified at
 - Brief or Plan Skeptic finds Critical or Major findings: same loop semantics as architect-plan Skeptic (re-route limits apply, max 3 fix passes).
 - Brief or Plan Open Questions section non-empty: same hard gate as architect Open Questions (METHODOLOGY.md §Delegation). This section explicitly extends the existing rule rather than restating it.
 - Verification gate field set to "cannot specify": blocks Skeptic sign-off until resolved.
+- Cross-artifact alignment check has an unresolved UNCOVERED success criterion: blocks the Skeptic-on-Brief from running until resolved.
 
 **What does not block:**
 - Risk class = Elevated single-unit: no Brief required. The architect plan is the artifact. This preserves current behavior for the dominant Elevated case (single-file behavioral edits, single new file, single-config changes).

--- a/content/agents/architect.md
+++ b/content/agents/architect.md
@@ -21,6 +21,7 @@ Your spawn prompt will contain:
 2. **Codebase root path or relevant file paths** - where to look. If missing, say so clearly rather than inventing assumptions.
 3. **Constraints or preferences** - tech choices, performance requirements, patterns to follow or avoid.
 4. **Investigator brief (if provided)** - if the spawn prompt includes an Investigator brief, treat it as authoritative for "what exists" and focus your own reading on design-relevant follow-ups rather than re-mapping the terrain. Do not re-read files already covered in the Investigator brief unless you identify a specific design-relevant gap in that coverage - if you do re-read, name the gap explicitly before doing so.
+5. **Committed Brief constraints (if provided)** - if the spawn prompt contains a "Committed success criteria" block, treat the Problem statement, Success criteria, Non-goals, and Constraints as fixed inputs, not suggestions. Do not redefine the problem. Your Approach and Implementation steps must collectively address every committed success criterion; state explicitly in Approach which steps satisfy which criteria if the mapping is not self-evident. An uncovered committed success criterion is a Critical Skeptic finding on your plan.
 
 ## Exploration process
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -567,7 +567,7 @@ Trivial-classified tickets retain conductor-direct flow per METHODOLOGY.md §Ris
 
 **Applies only when ALL of the following hold:**
 - Risk classification is Elevated
-- `operator_brief_injectionable` was NOT set in Phase 0b (no operator-authored Brief)
+- `brief_path` was NOT set in Phase 0b (no Brief found — neither a file-existence match nor an operator-confirmed session)
 - This is the single-unit path (no prior agent has decomposed the ticket into multiple units)
 
 Skip this phase entirely for Trivial, Low, multi-unit, or Brief-present tickets.

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -468,6 +468,7 @@ Before any architect spawn, check for an existing Brief, snapshot qa.md for Elev
   pre-existing and operator-confirmed.
 - Pass `brief_source: operator` to the Skeptic-on-Brief gate; use the operator-confirmed
   Skeptic variant (completeness-only review per `content/commands/brief.md` Section 6).
+- If `.agentic/brief-session.json` confirms `brief_source: operator`, set `operator_brief_injectionable: true` to signal Phase 3 that the Brief's committed constraints should be injected into the architect spawn brief (see Phase 3 "Pre-authored Brief injection").
 
 **If not found:** proceed normally. The promotion gate in Phase 3b determines whether a
 Brief is required based on the unit count from the orchestration-planner.
@@ -562,6 +563,33 @@ Trivial-classified tickets retain conductor-direct flow per METHODOLOGY.md §Ris
 
 ---
 
+## Phase 2b: Pre-architect ambiguity scan
+
+**Applies only when ALL of the following hold:**
+- Risk classification is Elevated
+- `operator_brief_injectionable` was NOT set in Phase 0b (no operator-authored Brief)
+- This is the single-unit path (no prior agent has decomposed the ticket into multiple units)
+
+Skip this phase entirely for Trivial, Low, multi-unit, or Brief-present tickets.
+
+**The conductor scans the ticket text for ambiguity signals:**
+- Vague scope language ("something like", "similar to", "improve", "better", "clean up") with no concrete target state
+- No explicit done condition or acceptance criteria stated anywhere in the ticket
+- Two or more mutually exclusive reasonable interpretations of the core ask
+- A load-bearing context value is unstated (target environment, performance budget, affected user type, data scale) where the implementation would materially branch on it
+
+**When one or more signals are present:** the conductor surfaces 1-3 targeted, specific questions in its user-facing turn, each with a recommended default. Format follows the surface-and-proceed protocol in `content/sections/02-delegation.md`. The conductor waits exactly one operator turn.
+- If the operator answers: fold answers verbatim into the Phase 3 architect brief under `"Operator clarifications:"`.
+- If the operator does not answer within their next turn (says "proceed", asks something else, or is silent): proceed with the recommended defaults, noted in the architect brief under `"Conductor defaults applied:"`.
+
+The scan never blocks more than one turn. Proceed to Phase 3 after the response (or default).
+
+**When no signals are present:** proceed directly to Phase 3, silently.
+
+**Stop-frequency budget:** this pre-architect planning-input scan is explicitly exempt from the stop-frequency table in `content/sections/02-delegation.md` (see the carve-out there). It does not count toward the per-task stop budget for any task shape. It is a planning-input step, not a mid-work blocker.
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:
@@ -569,6 +597,16 @@ Spawn an `architect` agent. Provide:
 - The relevant code snippets you gathered
 - The AGENTS.md conventions
 - Any architectural decisions and rationale from MEMORY.md (or the project's custom decision log) that bear on this ticket
+
+**Pre-authored Brief injection (only when `operator_brief_injectionable` was set in Phase 0b).** Check this flag before proceeding. When set, read the Brief file at `brief_path` and prepend the following to the architect spawn brief:
+- The Brief's **Problem** section, labeled: `"Committed problem statement (from operator Brief — do not redefine):"`
+- The Brief's **Success criteria** bullets, labeled: `"Committed success criteria — your plan MUST demonstrably address every one of these:"`
+- The Brief's **Non-goals**, labeled: `"Out of scope (do not design for these):"`
+- The Brief's **Constraints**, labeled: `"Hard constraints (a design that violates any of these is rejected):"`
+
+The architect treats these as fixed inputs. An uncovered committed success criterion is a Critical Skeptic finding on the architect plan.
+
+This injection does NOT apply to conductor-authored Briefs (those are downstream of the architect by design). Only operator-authored Briefs (`brief_source: operator`) carry committed constraints.
 
 Ask the architect for:
 1. A concrete implementation plan (what changes, in which files, in what order)
@@ -617,6 +655,30 @@ Also add `.agentic/` to the project's `.gitignore` if not already present.
 **Read the orchestration-planner's structured JSONL block** (the `## Task entries (machine-readable)` section at the end of the plan output). For each entry in that block, append a `pending` entry to `.agentic/tasks.jsonl`. Write tasks in dependency order - independent tasks (empty `depends_on`) first, dependent tasks after. Each entry must include the fields from the schema: `task_id`, `session_id`, `ticket_id`, `unit_slug`, `status: pending`, `depends_on`, `created_at`, `updated_at`, and the full `inputs` object (`description`, `acceptance_criteria`, `files_in_scope`, `quality_cmd`, `repo_path`, `base_branch`).
 
 Emit breadcrumb: `[phase: task-state-init | N tasks written]`
+
+### Cross-artifact alignment check (Brief present + planner returned units with non-empty criteria)
+
+**Applies only when ALL hold:**
+- `brief_path` is set (a Brief exists — operator-authored from Phase 0b, or conductor-authored at the promotion gate)
+- The orchestration-planner returned a JSONL block with at least one unit carrying a non-empty `acceptance_criteria` array
+
+When the guard does not apply (no Brief, or all units carry `acceptance_criteria: []`): emit `[phase: cross-artifact-check-skipped | no criteria to map]` and proceed to the promotion gate.
+
+**This is a conductor-direct mechanical mapping, not a subagent and not adversarial review.** It complements the Skeptic-on-Brief; it does not replace it.
+
+**Procedure:**
+1. For each **Success criterion** in the Brief: scan every orchestration unit's `acceptance_criteria` array. Mark the criterion **COVERED** if at least one unit's entry explicitly addresses it; mark it **UNCOVERED** otherwise.
+2. Produce a mapping table: `success criterion → covering unit_slug(s)`, or `"UNCOVERED"`.
+
+**On any UNCOVERED criterion:** resolve before the Skeptic-on-Brief fires by one of:
+- (a) Re-spawn the orchestration-planner with the specific uncovered criteria called out, so it adds or amends a unit's `acceptance_criteria`.
+- (b) Surface the mismatch to the operator with a recommended resolution (descope the criterion from the Brief, or expand scope to cover it).
+
+The conductor does not proceed to the Skeptic-on-Brief with an unresolved UNCOVERED criterion.
+
+**On full coverage:** emit `[phase: cross-artifact-aligned | N/N criteria covered]` and proceed to the promotion gate.
+
+See `content/sections/03-planning-artifacts.md` Gate semantics for where this step sits relative to the Skeptic-on-Brief.
 
 **ALL writes to `.agentic/tasks.jsonl` are conductor-only.** Workers do not read or write the task file. Workers return their summaries to the conductor in the normal return path; the conductor extracts results and writes all updates. No lock protocol is needed because the conductor is the sole writer.
 

--- a/content/sections/02-delegation.md
+++ b/content/sections/02-delegation.md
@@ -69,6 +69,8 @@ the conductor surfaces the question with a recommended default and proceeds with
 | Multi-unit plan (2-5 units) | 2 across the whole plan |
 | Large multi-unit plan (6+ units) | 3 across the whole plan |
 
+**Pre-architect planning-input scans are exempt from this budget.** The Phase 2b ambiguity scan in `/implement-ticket` surfaces clarifying questions before any agent is spawned — no architect, investigator, or engineer has run yet. This is structurally different from a mid-work stop: it is bounded to exactly one operator turn, has a proceed-with-defaults fallback, and produces no work that needs to be discarded if the operator redirects. Phase 2b does not count against the per-task stop budget for any task shape.
+
 When the threshold is exceeded, the conductor stops spawning Workers and surfaces a planning concern to the user instead of another piecemeal question. Format:
 
 *"I've hit N blockers on this task: [bullet list of each blocker and why]. This is past the threshold for a [task shape] task and suggests the plan needs revisiting before we continue. Options: (a) re-spawn architect with these gaps, (b) answer the open questions upfront and resume, or (c) descope. Recommendation: [pick one]."*

--- a/content/sections/03-planning-artifacts.md
+++ b/content/sections/03-planning-artifacts.md
@@ -19,7 +19,9 @@ Upstream deps: METHODOLOGY.md §Delegation (architect plan + Skeptic gate, Open
                METHODOLOGY.md §Cross-session loop resume (loop-state.json
                schema for brief_path / plan_path / promotion_tier);
                content/rules/module-manifest.md (manifest header contract);
-               content/agents/architect.md, content/agents/orchestration-planner.md.
+               content/agents/architect.md, content/agents/orchestration-planner.md
+               (the acceptance_criteria array field from orchestration-planner
+               JSONL output is consumed by the cross-artifact alignment step).
 
 Downstream consumers: METHODOLOGY.md §Delegation (Worker preamble references
                       brief_path / plan_path); METHODOLOGY.md §Task
@@ -29,15 +31,17 @@ Downstream consumers: METHODOLOGY.md §Delegation (Worker preamble references
                       promotion_tier); METHODOLOGY.md §Risk Classification
                       (Declaration format optionally includes Brief / Plan);
                       METHODOLOGY.md §Protocol Details (cross-link entry);
-                      /implement-ticket command (follow-on unit, out of scope
-                      here).
+                      /implement-ticket command (Gate semantics step ordering
+                      is referenced by Phase 3b cross-artifact alignment check).
 
 Failure modes: Prose; does not execute. Drift between this section and the
                cross-references above is a Major Skeptic finding (stale
-               manifest or stale cross-reference). Operator failure mode
-               this section exists to prevent: multi-unit Elevated work
-               proceeding without a committed problem statement, success
-               criteria, non-goals, and verification plan.
+               manifest or stale cross-reference). Stale step numbering in
+               Gate semantics causes misrouted cross-references across phases;
+               update inline step references whenever steps are renumbered.
+               Operator failure mode this section exists to prevent: multi-unit
+               Elevated work proceeding without a committed problem statement,
+               success criteria, non-goals, and verification plan.
 
 Performance: Standard.
 -->
@@ -181,9 +185,10 @@ The verification gate is non-skippable. **If verification cannot be specified at
 3. Open Questions on architect plan resolved.
 4. Orchestration-planner runs.
 5. Promotion check against the trigger table.
-6. If 2-5 Elevated-or-above units: check whether `.agentic/brief-session.json` exists with `status: complete` and `brief_source: operator` AND `brief_path` points to an existing file. If both conditions hold, the Brief is pre-existing and operator-confirmed - skip conductor authoring and go directly to step 7. If not, conductor authors Brief at `docs/planning/<slug>.md` using architect output, planner output, and the original ticket as inputs.
-7. Spawn Skeptic on the Brief. When the Brief is pre-existing and operator-confirmed (`brief_source: operator`), use the operator-confirmed Skeptic variant (completeness-only review - see `content/commands/brief.md` Section 6 for the exact brief text). When the Brief was conductor-authored, use the standard "Document synthesis, architecture, and planning" adversarial brief; the verification field is part of the Skeptic's review surface in both cases. The `QA criteria` field is also part of the Skeptic's review surface: for Elevated tickets, the Skeptic must validate that the field is present, that `qa_skip` is one of the 5 valid enum values or null, that `qa_skip_rationale` is populated when `qa_skip != null`, and that `scenarios[]` is non-empty when `qa_skip == null`. Absence on Elevated is a Critical finding; an invalid `qa_skip` enum is a Major finding.
-8. On Brief sign-off (and after any Open Questions in the Brief are resolved per the Open Questions hard gate in METHODOLOGY.md §Delegation), engineer(s) spawn with `brief_path` populated in their execution contract.
+6. If 2-5 Elevated-or-above units: check whether `.agentic/brief-session.json` exists with `status: complete` and `brief_source: operator` AND `brief_path` points to an existing file. If both conditions hold, the Brief is pre-existing and operator-confirmed - skip conductor authoring and go directly to step 8. If not, conductor authors Brief at `docs/planning/<slug>.md` using architect output, planner output, and the original ticket as inputs.
+7. **Cross-artifact alignment check (conductor-direct).** When a Brief exists and the orchestration-planner returned at least one unit with a non-empty `acceptance_criteria` array, the conductor mechanically maps every Brief success criterion to at least one unit's `acceptance_criteria`. Any UNCOVERED criterion is resolved (re-spawn planner with the gap called out, or surface a descope/expand decision to the operator) before the Skeptic-on-Brief runs. When no unit has non-empty `acceptance_criteria`, emit `[phase: cross-artifact-check-skipped | no criteria to map]` and proceed. Full procedure in `/implement-ticket` Phase 3b "Cross-artifact alignment check". This mechanical check complements — does not replace — the adversarial Skeptic-on-Brief.
+8. Spawn Skeptic on the Brief. When the Brief is pre-existing and operator-confirmed (`brief_source: operator`), use the operator-confirmed Skeptic variant (completeness-only review - see `content/commands/brief.md` Section 6 for the exact brief text). When the Brief was conductor-authored, use the standard "Document synthesis, architecture, and planning" adversarial brief; the verification field is part of the Skeptic's review surface in both cases. The `QA criteria` field is also part of the Skeptic's review surface: for Elevated tickets, the Skeptic must validate that the field is present, that `qa_skip` is one of the 5 valid enum values or null, that `qa_skip_rationale` is populated when `qa_skip != null`, and that `scenarios[]` is non-empty when `qa_skip == null`. Absence on Elevated is a Critical finding; an invalid `qa_skip` enum is a Major finding.
+9. On Brief sign-off (and after any Open Questions in the Brief are resolved per the Open Questions hard gate in METHODOLOGY.md §Delegation), engineer(s) spawn with `brief_path` populated in their execution contract.
 
 **Authoring sequence (Plan tier):** identical to Brief tier through step 6, plus:
 - Conductor authors `risk-register.md`, `rollback.md`, and `verification-gate.md`, and assembles the Plan directory.
@@ -197,6 +202,7 @@ The verification gate is non-skippable. **If verification cannot be specified at
 - Brief or Plan Skeptic finds Critical or Major findings: same loop semantics as architect-plan Skeptic (re-route limits apply, max 3 fix passes).
 - Brief or Plan Open Questions section non-empty: same hard gate as architect Open Questions (METHODOLOGY.md §Delegation). This section explicitly extends the existing rule rather than restating it.
 - Verification gate field set to "cannot specify": blocks Skeptic sign-off until resolved.
+- Cross-artifact alignment check has an unresolved UNCOVERED success criterion: blocks the Skeptic-on-Brief from running until resolved.
 
 **What does not block:**
 - Risk class = Elevated single-unit: no Brief required. The architect plan is the artifact. This preserves current behavior for the dominant Elevated case (single-file behavioral edits, single new file, single-config changes).


### PR DESCRIPTION
## Summary

Three coordinated improvements to the planning pipeline, inspired by comparing agentic-engineering against GitHub's Spec Kit methodology:

- **Brief-informs-Architect**: when an operator-authored Brief exists (`brief_source: operator`), its Problem, Success criteria, Non-goals, and Constraints are injected into the architect spawn brief as fixed inputs. An uncovered success criterion is a Critical Skeptic finding on the architect plan.
- **Pre-architect ambiguity scan (Phase 2b)**: for single-unit Elevated tickets with no Brief, the conductor scans for vague scope, missing acceptance criteria, or unstated load-bearing context before spawning the architect. Surfaces 1-3 targeted questions bounded to one operator turn. Exempt from the stop-frequency budget.
- **Cross-artifact alignment check**: after orchestration-planner returns, mechanically maps every Brief success criterion to at least one unit's `acceptance_criteria`. Unresolved UNCOVERED criteria block the Skeptic-on-Brief from running.

## Files changed

- `content/agents/architect.md` - input #5: Committed Brief constraints
- `content/commands/implement-ticket.md` - Phase 0b flag, Phase 2b (new), Phase 3 injection, Phase 3b alignment check
- `content/sections/03-planning-artifacts.md` - Gate semantics step 7 inserted, steps renumbered, manifest updated
- `content/sections/02-delegation.md` - stop-frequency carve-out for Phase 2b

## Review process

- Investigator deep-dive confirmed gaps (no pre-architect clarification for single-unit, no cross-artifact consistency check, Brief downstream of architect)
- Architect plan (Opus) designed precise changes
- Skeptic-on-plan: 4 Major findings resolved before implementation
- Engineer implemented in worktree
- Skeptic-on-diff: 1 Major finding (Phase 2b guard gap) caught and fixed
- Final Skeptic: clean sign-off