### PR TITLE
chore(docs): sync stale README/CONTRIBUTING enumerations to ground truth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@
 
 **Edit in `content/`, never in adapter files directly.** The `content/` directory is the single source of truth:
 - `content/rules/` - the 3 rule files (agent-methodology, code-standards, conventions)
-- `content/references/` - the 4 reference docs (skeptic-protocol, subagent-protocol, agent-team, design-goals)
-- `content/commands/` - the 6 command files (implement, init-project, memory-update, skeptic, update-agentic-engineering, wrap)
-- `content/agents/` - the 10 agent definitions (adr-drift-detector, adr-generator, architect, debugger, engineer, investigator, orchestration-planner, qa-engineer, security-auditor, skeptic)
+- `content/references/` - the 6 reference docs (agent-team, design-goals, multi-developer-coordination, regression-test-obligation, skeptic-protocol, subagent-protocol)
+- `content/commands/` - the 14 command files (agentic-cost, agentic-disable, agentic-status, brief, cleanup-worktrees, implement-ticket, init-project, memory-update, prune-harness, representation-audit, skeptic, test-suite-comprehension, update-agentic-engineering, wrap)
+- `content/agents/` - the 16 agent definitions (adr-drift-detector, adr-generator, architect, debugger, dependency-auditor, engineer, investigator, learning-extractor, learnings-agent, orchestration-planner, perf-analyst, qa-engineer, release-orchestrator, security-auditor, skeptic, wrap-ticket)
 
 Build scripts regenerate adapter files from `content/`:
 - `.claude/build.sh` - rebuilds `.claude/commands/*.md` by prepending the `/agentic-engineering` prerequisite blockquote to each `content/commands/*.md` source. Rules, references, and agents need no copy step - `.claude/skills/agentic-engineering/rules`, `.claude/skills/agentic-engineering/references`, and `.claude/agents/` are all symlinks pointing directly into `content/`.

--- a/README.md
+++ b/README.md
@@ -153,19 +153,23 @@ See [ADAPTERS.md](ADAPTERS.md) for how to create adapters for other tools.
 - Code standards - tool discipline, quality gates, package management, browser verification
 - Conventions - writing style, project structure, session context, git workflow
 
-**Reference docs** (5 files) - detailed protocol specs loaded on trigger:
+**Reference docs** (6 files) - detailed protocol specs loaded on trigger:
 - Skeptic protocol - adversarial review loop, findings classification, sign-off format
 - Subagent protocol - parallel spawning, worktree isolation, task decomposition
 - Agent team - roles, composed flows, decision rules, spawn requirements
 - Design goals - system design principles and intent
+- Multi-developer coordination - parallel sessions, branch and worktree hygiene
+- Regression test obligation - when a fix requires a regression test and what counts
 
-**Agents** (13) - named specialist roles:
-architect, debugger, engineer, investigator, orchestration-planner, perf-analyst, dependency-auditor, release-orchestrator, security-auditor, skeptic, adr-drift-detector, adr-generator, qa-engineer
+**Agents** (16) - named specialist roles:
+adr-drift-detector, adr-generator, architect, debugger, dependency-auditor, engineer, investigator, learning-extractor, learnings-agent, orchestration-planner, perf-analyst, qa-engineer, release-orchestrator, security-auditor, skeptic, wrap-ticket
 
-**Commands** (10) - workflow shortcuts:
-skeptic, implement-ticket, init-project, wrap, memory-update, cleanup-worktrees, update-agentic-engineering, prune-harness, representation-audit, agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`)
+**Commands** (14) - workflow shortcuts:
+agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`), agentic-disable, agentic-status, brief, cleanup-worktrees, implement-ticket, init-project, memory-update, prune-harness, representation-audit, skeptic, test-suite-comprehension, update-agentic-engineering, wrap
 
 **Hooks / Plugins** - lifecycle event handlers for risk reminders and session context saving. Claude Code uses native hooks; OpenCode uses a plugin that writes session context when the session becomes idle.
+
+**Project config / overview layer** - the committed `.agentic/config.json` holds three operator-tunable methodology toggles: `debugger_on_failure` (bool, default `false`; interposes a Debugger diagnosis step before each Phase 7 engineer fix pass), `qa_default_skip` (reserved; no-op, does not alter QA-gate behavior), and `model_profile` (`default` | `budget`; `budget` routes eligible spawns to Tier 1). The operator-owned `docs/overview/{vision,requirements}.md` files capture durable product intent above the task level; Architect and Investigator read them when present and must not contradict them. Both are optional and graceful - if absent, defaults apply and nothing breaks.
 
 ## Repo structure
 
@@ -194,8 +198,8 @@ agentic-engineering/
 - `~/agentic-engineering/docs/slides/getting-started-slides.html` - install flow and the first focused session
 - `~/agentic-engineering/docs/slides/context-management-slides.html` - why context hygiene is the real bottleneck
 - `~/agentic-engineering/docs/slides/agent-team-slides.html` - the agent team and how they compose
-- `~/agentic-engineering/docs/slides/quality-assurance-slides.html` - how the qa-engineer uses `.claude/qa.md` as project QA memory
-- `~/agentic-engineering/docs/slides/work-tracking-slides.html` - how the orchestration-planner uses `.claude/tracking.md`
+- `~/agentic-engineering/docs/slides/quality-assurance-slides.html` - how the qa-engineer uses `.agentic/qa.md` (legacy `.claude/qa.md` fallback) as project QA memory
+- `~/agentic-engineering/docs/slides/work-tracking-slides.html` - how the orchestration-planner tracks work in `.agentic/tasks.jsonl` / `.agentic/loop-state.json`
 - `~/agentic-engineering/docs/slides/skill-creator-slides.html` - how agents and skills are built and evaluated with the skill creator
 - `~/agentic-engineering/docs/slides/skeptic-protocol-slides.html` - adversarial review methodology and the Skeptic loop
 - `~/agentic-engineering/docs/slides/agents-md-hierarchy-slides.html` - the three-tier AGENTS.md context hierarchy


### PR DESCRIPTION
## Summary

Surfaced by a post-#103 documentation-accuracy audit. The GSD-steal methodology content was documentation-clean; this fixes stale human-facing enumerations in `README.md` and `CONTRIBUTING.md` (mostly pre-existing count drift across many prior PRs, brought in-scope by #103's `content/agents/` edits per the repo's own AGENTS.md docs-sync rule).

Counts corrected to ground truth (verified by independent `ls`, confirmed by Skeptic recount):

- `content/agents/`: 16 (was stated 10 in CONTRIBUTING, 13 in README)
- `content/commands/`: 14 (was 6 / 10)
- `content/references/`: 6 (was 4 / 5)

Each enumeration now lists the full alphabetical basename set in both files. Also: added a README note for the #103 `.agentic/config.json` 3-toggle layer and operator-owned `docs/overview/{vision,requirements}.md` (wording aligned to `content/rules/conventions.md`, `qa_default_skip` correctly stated as reserved/no-op); corrected the qa.md resolver to `.agentic/qa.md` (legacy `.claude/qa.md` fallback); replaced the nonexistent `.claude/tracking.md` reference with `.agentic/tasks.jsonl` / `.agentic/loop-state.json`.

## Review

Engineer used live `ls` ground truth (caught that the audit's own quoted numbers were partially wrong). Independent Skeptic recount: SIGN-OFF GRANTED, no findings - every name exact-matches an actual file, no stale form survives, no contradiction with `conventions.md`.

## Scope

Docs-only: only `README.md` + `CONTRIBUTING.md`. Not assembled into any adapter; no build regeneration; `METHODOLOGY.md` unchanged (drift gate unaffected).