### PR TITLE
feat(ci): advisory adapter-drift gate + wire .pi + close .pi prune false-negative

### DIFF
--- a/.claude/build.sh
+++ b/.claude/build.sh
@@ -16,6 +16,15 @@ REFS_DST="$SKILL_DST/references"
 
 PREREQ='> **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.'
 
+# Portable inode helper (macOS uses -f, Linux uses -c)
+get_inode() {
+  if stat -c %i /dev/null >/dev/null 2>&1; then
+    stat -c %i "$1"
+  else
+    stat -f %i "$1"
+  fi
+}
+
 # Methodology: assemble content/sections/*.md into a single METHODOLOGY.md.
 mkdir -p "$SKILL_DST"
 bash "$REPO_DIR/scripts/build-methodology.sh" > "$SKILL_DST/METHODOLOGY.md"
@@ -50,7 +59,7 @@ mkdir -p "$REFS_DST"
 for src in "$CONTENT/references/"*.md; do
   name="$(basename "$src")"
   dst="$REFS_DST/$name"
-  if [[ -e "$dst" ]] && [[ "$(stat -f %i "$src")" == "$(stat -f %i "$dst")" ]]; then
+  if [[ -e "$dst" ]] && [[ "$(get_inode "$src")" == "$(get_inode "$dst")" ]]; then
     continue
   fi
   rm -f "$dst"

--- a/.cursor/build.sh
+++ b/.cursor/build.sh
@@ -23,6 +23,15 @@ REFS_DST="$REPO_DIR/.cursor/rules/references"
 COMMANDS_DST="$REPO_DIR/.cursor/commands"
 FRONTMATTER_DIR="$REPO_DIR/.cursor/rules/frontmatter"
 
+# Portable inode helper (macOS uses -f, Linux uses -c)
+get_inode() {
+  if stat -c %i /dev/null >/dev/null 2>&1; then
+    stat -c %i "$1"
+  else
+    stat -f %i "$1"
+  fi
+}
+
 # Methodology: assemble from content/sections/ then prepend YAML frontmatter.
 # content/rules/agent-methodology.md was deleted in Wave 1; the loop below
 # covers only the remaining 3 rules files.
@@ -47,7 +56,7 @@ done
 hardlink_from_content() {
   local src="$1"
   local dst="$2"
-  if [[ -e "$dst" ]] && [[ "$(stat -f %i "$src")" == "$(stat -f %i "$dst")" ]]; then
+  if [[ -e "$dst" ]] && [[ "$(get_inode "$src")" == "$(get_inode "$dst")" ]]; then
     return
   fi
   rm -f "$dst"

--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -1,0 +1,27 @@
+name: adapter-sync
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  check-adapter-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rebuild all adapters
+        run: |
+          bash .claude/build.sh
+          bash .cursor/build.sh
+          bash .codex/build.sh
+          bash .gemini/build.sh
+          bash .kimi/build.sh
+          bash .opencode/build.sh
+          bash .omp/build.sh
+          bash .pi/build.sh
+      - name: Fail on adapter drift
+        run: |
+          if ! git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi; then
+            echo "::error::Adapter output is out of sync with content/. Run the build scripts locally and commit the regenerated adapter files." >&2
+            exit 1
+          fi

--- a/.pi/build.sh
+++ b/.pi/build.sh
@@ -4,7 +4,9 @@
 # Upstream deps: content/commands/, content/references/, content/rules/, content/agents/,
 #               content/sections/, content/SKILL.md, scripts/build-methodology.sh.
 # Downstream consumers: .pi/skills/agentic-engineering/, .pi/prompts/.
-# Failure modes: exits non-zero on missing inputs or assembly failure.
+# Failure modes: exits non-zero on missing inputs or assembly failure. Idempotent;
+#               prunes orphan .pi/prompts/*.md whose source content/commands/*.md
+#               was removed (safe to re-run).
 # Performance: standard.
 
 set -euo pipefail
@@ -81,9 +83,12 @@ link_dir "../../../content/agents" "$SKILL_DST/agents"
 
 # Pi prompt templates are project-local slash-command equivalents. They expand
 # into instructions that load the skill and then read the canonical command doc.
+declare -a generated_prompts=()
 for src in "$CONTENT/commands/"*.md; do
+  [[ -e "$src" ]] || continue
   name="$(basename "$src" .md)"
   dst="$PROMPTS_DST/$name.md"
+  generated_prompts+=("$name.md")
   title="$(sed -n '1s/^# *//p' "$src")"
   if [[ -z "$title" ]]; then
     title="$name"
@@ -97,6 +102,24 @@ Use the /skill:agentic-engineering skill. Load /skill:agentic-engineering, then 
 
 \$ARGUMENTS
 PROMPT_EOF
+done
+
+# Remove stale prompt templates whose source content/commands/*.md was deleted.
+# Scoped strictly to $PROMPTS_DST/*.md - never touches the $SKILL_DST symlinks.
+for existing in "$PROMPTS_DST"/*.md; do
+  [[ -e "$existing" ]] || continue
+  bname="$(basename "$existing")"
+  found=0
+  for gen in "${generated_prompts[@]}"; do
+    if [[ "$gen" == "$bname" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ $found -eq 0 ]]; then
+    rm "$existing"
+    echo "  - removed stale prompt template: $bname"
+  fi
 done
 
 for script in "$REPO_DIR/.pi"/*.sh; do

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,6 +8,10 @@
 
 - **2026-04-28:** This project uses `main` as the sole integration branch. Do not use `develop`/`development` branching model for this repository - all feature/fix/chore work branches from `main` and merges back to `main`.
 
+## Decisions
+
+- **2026-05-18: Adapter-drift CI gate is advisory-only (descoped from hard block).** `adapter-sync.yml` makes content/adapter drift CI-visible (red X) on every PR but is NOT a required status check - Solara6/agentic-engineering is a private repo on a free GitHub plan, which does not support required status checks / branch protection (`gh api repos/.../branches/main/protection` returns 403). Drift is therefore CI-visible but not hard-blocked at merge. To upgrade to a hard merge block: make the repo public OR upgrade to GitHub Pro/Team, then add the `check-adapter-sync` job as a required status check on `main`. Accepted by operator 2026-05-18.
+
 ## Active migrations
 
 - **Path 1 restructure (Wave 1 shipped 2026-04-30, Wave 1.5 + Wave 2 pending):** see docs/planning/p1-path1-restructure-handoff.md

--- a/docs/planning/adapter-drift-ci-gate.md
+++ b/docs/planning/adapter-drift-ci-gate.md
@@ -1,0 +1,29 @@
+# Brief: Advisory CI adapter-drift gate
+
+**Problem:** `content/` changes developed in a git worktree merge with stale per-harness adapter outputs because `hooks/pre-commit` self-skips inside worktrees (this happened: PR #101 shipped content-only, required remediation PR #102). `.pi/` is a second standing drift hole - tracked but never wired into the pre-commit build/stage lists, and `.pi/build.sh` has no stale-prune so a deleted `content/commands/*.md` leaves an undetected orphan. Nothing surfaces this drift before merge.
+
+**Success criteria:**
+- Every PR runs a CI check that rebuilds all 8 adapters and fails (red, advisory) when committed adapter output differs from `content/`
+- `.pi` is wired into `hooks/pre-commit` (build + stage) so local main-tree commits keep it in sync
+- `.pi/build.sh` prunes orphan `.pi/prompts/*.md` whose source `content/commands/*.md` was deleted (closes the false-negative)
+- The advisory-only scope (no required status check on this private free-plan repo) is recorded as an explicit decision
+
+**Non-goals:**
+- Hard merge-blocking / required status check (descoped: private free-plan repo cannot set branch protection; operator-accepted advisory)
+- Auditing/fixing stale-prune across the other 7 build scripts (pre-existing, deferred follow-up)
+- Any change to the worktree-skip block, HTML-stamp block, `methodology-drift.yml`, or `check-methodology-drift.sh`
+
+**Constraints:** No `gh api`/branch-protection step anywhere. CI `git diff` MUST be the scoped form `git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi` (prior-Skeptic-mandated load-bearing positive scoping, not bare diff). `.pi/build.sh` prune scoped only to `$PROMPTS_DST/*.md` (must not touch the 4 symlinks or `$SKILL_DST` outputs). `SKILL.frontmatter.yaml` is a tracked input - never staged. All 4 units ship in ONE PR.
+
+**Verification:** (1) `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/adapter-sync.yml'))"` parses clean; (2) `bash -n hooks/pre-commit` exits 0 AND a staged-commit dry-run on a throwaway branch where `git diff --cached --name-only | grep -q '^\.pi/'` returns TRUE; (3) `bash -n .pi/build.sh` exits 0, `bash .pi/build.sh` run twice from clean tree yields no git diff (idempotent), and deleting a `content/commands/*.md` then running `.pi/build.sh` removes the matching `.pi/prompts/<name>.md` and prints the removal line; (4) MEMORY.md `## Decisions` entry present, dated 2026-05-18, referencing the `check-adapter-sync` job and the public/Pro upgrade path; (5) running the full 8-build sequence then the scoped `git diff --exit-code` is green on a synced tree and red when an orphan/drift is uncommitted.
+
+**QA criteria:**
+```yaml
+qa_criteria:
+  qa_skip: config-only
+  qa_skip_rationale: "Pure CI/build-infra change (new GitHub Actions workflow, pre-commit hook wiring, build-script prune loop, MEMORY.md decision record); no runtime-observable application surface. Verification is shell/CI dry-run, not browser/api."
+  scenarios: []
+  manual_smoke: "none"
+```
+
+**Linked artifacts:** architect-plan: inline Revision 2 (this session, conductor-amended per Skeptic fix pass 1); orchestration: inline JSONL (4 units: memory-decision-record [Low], adapter-sync-workflow [Elevated], pi-buildsh-prune [Elevated], precommit-pi-staging [Elevated])

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -21,6 +21,7 @@ if git diff --cached --name-only | grep -q "^content/"; then
   bash "$REPO_DIR/.kimi/build.sh"
   bash "$REPO_DIR/.opencode/build.sh"
   bash "$REPO_DIR/.omp/build.sh"
+  bash "$REPO_DIR/.pi/build.sh"
 
   # Stage generated files
   git add \
@@ -45,7 +46,10 @@ if git diff --cached --name-only | grep -q "^content/"; then
     "$REPO_DIR/.omp/skills/agentic-engineering/references" \
     "$REPO_DIR/.omp/skills/agentic-engineering/rules" \
     "$REPO_DIR/.omp/skills/agentic-engineering/commands" \
-    "$REPO_DIR/.omp/skills/agentic-engineering/agents"
+    "$REPO_DIR/.omp/skills/agentic-engineering/agents" \
+    "$REPO_DIR/.pi/skills/agentic-engineering/METHODOLOGY.md" \
+    "$REPO_DIR/.pi/skills/agentic-engineering/SKILL.md" \
+    "$REPO_DIR/.pi/prompts/"*.md
 
   echo "[pre-commit] Generated files staged."
 fi


### PR DESCRIPTION
## Problem

`content/` changes developed in a git worktree merge with stale per-harness adapter outputs because `hooks/pre-commit` self-skips inside worktrees (this happened: PR #101 shipped content-only, required remediation PR #102). `.pi/` was a second standing drift hole - tracked but never wired into the pre-commit build/stage lists, and `.pi/build.sh` had no stale-prune so a deleted `content/commands/*.md` left an undetected orphan.

## Change (4 units, Brief-tier, one PR)

- **Unit A** `.github/workflows/adapter-sync.yml` (new): advisory CI gate - rebuilds all 8 adapters on every PR/push-main, fails (red, advisory) on the prior-Skeptic-mandated scoped `git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi`. No `gh api`/branch-protection.
- **Unit B** `hooks/pre-commit`: wire `.pi` into the build + git-add lists so local main-tree commits keep `.pi` in sync (backslash-continuation balance verified).
- **Unit C** `.pi/build.sh`: add a stale-prune loop (mirrors `.gemini` idiom) scoped strictly to `$PROMPTS_DST/*.md` so a deleted `content/commands/*.md` no longer leaves an undetected orphan; manifest updated.
- **Unit D** `MEMORY.md`: records the advisory-only scope decision (private free-plan repo cannot set required status checks; upgrade path documented).

## Scope / non-goals

Advisory only - NOT a required status check (private free-plan repo, operator-accepted; `MEMORY.md ## Decisions` documents the public/Pro upgrade path). Does not audit stale-prune across the other 7 build scripts (pre-existing, deferred follow-up). Worktree-skip block, HTML-stamp block, and `methodology-drift.yml` untouched.

## Verification

Architect plan Skeptic-approved (Rev2, conductor-amended); Brief Skeptic-signed-off; all 3 Elevated units per-unit Skeptic-signed-off (0 findings each); authoritative non-worktree pre-commit dry-run confirms `.pi` outputs stage correctly on a real commit; `.pi/build.sh` idempotent + deletion-prune verified; `adapter-sync.yml` parses clean.

Brief: `docs/planning/adapter-drift-ci-gate.md`