### PR TITLE
fix(evals): skill-comparison infrastructure compatibility patches

### DIFF
--- a/evals/runner/Dockerfile.swebench
+++ b/evals/runner/Dockerfile.swebench
@@ -36,7 +36,10 @@ LABEL org.opencontainers.image.title="ae-eval-swebench" \
 #   urllib3 chardet certifi idna - requests stack (requests-3362, etc.)
 RUN pip install --no-cache-dir \
     pytest==8.3.5 pytest-timeout==2.4.0 \
-    urllib3 chardet certifi idna
+    urllib3 chardet certifi idna \
+    flask pytz sqlparse asgiref \
+    astroid==2.11.6 py "numpy==1.26.4" \
+    tomlkit mpmath isort dill attrs colorama more_itertools toml
 
 # Create a non-root user for running eval commands.
 RUN groupadd --gid 1001 evaluser && \

--- a/evals/runner/Dockerfile.swebench-py310
+++ b/evals/runner/Dockerfile.swebench-py310
@@ -24,12 +24,19 @@ LABEL org.opencontainers.image.title="ae-eval-swebench-py310" \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ make git \
     libopenblas-dev gfortran liblapack-dev \
+    libfreetype-dev libpng-dev libqhull-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # GCC 14+ treats incompatible pointer types as errors.  The C extensions in
 # astropy and scikit-learn were generated for older GCC/numpy and need this
 # workaround until they are regenerated with modern Cython.
 ENV CFLAGS="-Wno-error=incompatible-pointer-types"
+
+# Python 3.10 removed collections.Sequence/Mapping/Iterable/Sized (moved to
+# collections.abc). Old scikit-learn and astropy code still imports from
+# collections. Monkey-patch them back at interpreter startup.
+RUN echo "import collections.abc; collections.Sequence = collections.abc.Sequence; collections.Mapping = collections.abc.Mapping; collections.Iterable = collections.abc.Iterable; collections.Sized = collections.abc.Sized" > /usr/local/lib/python3.10/site-packages/collections_compat_startup.py && \
+    echo "import collections_compat_startup" > /usr/local/lib/python3.10/site-packages/collections_compat.pth
 
 # Install pytest, test utilities, and task-specific runtime dependencies.
 # Network is available at BUILD time only.
@@ -59,9 +66,9 @@ ENV CFLAGS="-Wno-error=incompatible-pointer-types"
 RUN pip install --no-cache-dir \
     pytest==8.3.5 pytest-timeout==2.4.0 \
     urllib3 chardet certifi idna requests \
-    docutils pytest-doctestplus setuptools-scm \
-    "setuptools<58" wheel extension-helpers "cython==0.29.22" \
-    "numpy==1.26.4"
+    docutils pytest-doctestplus setuptools-scm setuptools_scm_git_archive \
+    "setuptools<58" wheel extension-helpers "cython==0.29.37" \
+    "numpy==1.26.4" Pillow "pyparsing==2.4.7" cycler kiwisolver fonttools python-dateutil
 
 RUN pip install --no-cache-dir \
     scipy hypothesis pyerfa PyYAML \

--- a/evals/runner/invoker.py
+++ b/evals/runner/invoker.py
@@ -40,6 +40,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -47,6 +48,10 @@ from .normalizer import parse_stream_json
 
 CLAUDE_BIN = "claude"
 KIMI_BIN = "kimi"
+
+_MCP_EMPTY = Path(tempfile.gettempdir()) / "ae-empty-mcp.json"
+if not _MCP_EMPTY.exists():
+    _MCP_EMPTY.write_text("{}")
 
 _LOG = logging.getLogger(__name__)
 
@@ -246,7 +251,7 @@ def invoke_run(
             )
         # Disable MCP servers for eval runs to avoid connection errors from
         # misconfigured or unavailable MCP servers interfering with the harness.
-        cmd.extend(["--mcp-config-file", "/tmp/empty-mcp.json"])
+        cmd.extend(["--mcp-config-file", str(_MCP_EMPTY)])
         # Kimi uses --work-dir instead of subprocess cwd.
         subprocess_cwd = None
     else:

--- a/evals/skill-comparison/runner.py
+++ b/evals/skill-comparison/runner.py
@@ -171,7 +171,7 @@ _PYTEST_TIMEOUT_SECONDS = 120
 # tasks, up to 10 min for complex multi-file fixes).
 _FIX_TIMEOUT_SECONDS: dict[str, int] = {
     "claude": _PYTEST_TIMEOUT_SECONDS * 2,   # 240 s
-    "kimi": _PYTEST_TIMEOUT_SECONDS * 5,     # 600 s
+    "kimi": _PYTEST_TIMEOUT_SECONDS * 10,    # 1200 s
 }
 
 # TSV schema for the skill-comparison ledger.

--- a/evals/skill-comparison/scoring.py
+++ b/evals/skill-comparison/scoring.py
@@ -469,6 +469,8 @@ def _run_pytest_tier3(
     tier3_ctx: object,  # Tier3Context (avoid hard import cycle)
     timeout: int,
     fail_to_pass: "list[str] | None" = None,
+    env: "dict[str, str] | None" = None,
+    use_timeout: bool = True,
 ) -> tuple[int, str]:
     """Run pytest inside the Tier 3 container's score phase.
 
@@ -527,11 +529,15 @@ def _run_pytest_tier3(
                 "--noconftest",
                 "--rootdir=/scoring/tests",
                 "--confcutdir=/scoring",
+                "--import-mode=append",
                 "-p", "no:cacheprovider",
                 "--tb=short",
                 "-q",
-                f"--timeout={timeout}",
             ]
+            if use_timeout:
+                cmd.append(f"--timeout={timeout}")
+            else:
+                cmd.extend(["-p", "no:timeout"])
         else:
             # Run only the specified test node-ids. The held_out_dir is mounted at
             # /scoring/tests inside the container, so prepend that path to each
@@ -556,11 +562,15 @@ def _run_pytest_tier3(
                 "python3", "-m", "pytest",
                 *test_targets,
                 "--confcutdir=/scoring",
+                "--import-mode=append",
                 "-p", "no:cacheprovider",
                 "--tb=short",
                 "-q",
-                f"--timeout={timeout}",
             ]
+            if use_timeout:
+                cmd.append(f"--timeout={timeout}")
+            else:
+                cmd.extend(["-p", "no:timeout"])
     else:
         # Full-tree case: use the original security-hardened flags.
         # --noconftest is safe here because we are running the full tree and
@@ -571,11 +581,15 @@ def _run_pytest_tier3(
             "--noconftest",
             "--rootdir=/scoring/tests",
             "--confcutdir=/scoring",
+            "--import-mode=append",
             "-p", "no:cacheprovider",
             "--tb=short",
             "-q",
-            f"--timeout={timeout}",
         ]
+        if use_timeout:
+            cmd.append(f"--timeout={timeout}")
+        else:
+            cmd.extend(["-p", "no:timeout"])
 
     _LOG.info(
         "_run_pytest_tier3: cmd=%s node_ids=%s",
@@ -586,11 +600,64 @@ def _run_pytest_tier3(
     # inside the score-phase container without pip install (network is disabled).
     # This resolves ImportError when conftest.py or test modules do
     # `from <repo_package> import ...` (e.g. `from requests.packages import ...`).
+    base_env = {"PYTHONPATH": "/workspace/repo:/workspace/repo/src:/workspace/repo/lib", "HOME": "/tmp"}
+    if env:
+        base_env.update(env)
     result = Tier3Docker.run_score_phase(
         tier3_ctx,
         cmd,
         timeout_seconds=timeout,
-        env={"PYTHONPATH": "/workspace/repo"},
+        env=base_env,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+def _run_django_tests_tier3(
+    tier3_ctx: object,
+    timeout: int,
+    fail_to_pass: "list[str] | None" = None,
+) -> tuple[int, str]:
+    """Run Django tests via tests/runtests.py inside the Tier 3 container."""
+    from evals.runner.isolator import Tier3Docker
+
+    labels: list[str] = []
+    if fail_to_pass:
+        for nid in fail_to_pass:
+            if nid.startswith("tests/"):
+                nid = nid[6:]
+            # Convert filesystem path separators to Python module dots
+            nid = nid.replace("/", ".")
+            if ".py::" in nid:
+                nid = nid.replace(".py::", ".", 1)
+            nid = nid.replace("::", ".")
+            labels.append(nid)
+
+    if labels:
+        cmd = [
+            "python3", "tests/tests/runtests.py",
+            "--verbosity", "2",
+            "--settings", "test_sqlite",
+            "--parallel", "1",
+            *labels,
+        ]
+    else:
+        cmd = [
+            "python3", "tests/tests/runtests.py",
+            "--verbosity", "2",
+            "--settings", "test_sqlite",
+            "--parallel", "1",
+        ]
+
+    env = {
+        "PYTHONPATH": "/workspace/repo:/workspace/repo/src:/workspace/repo/lib:/workspace/repo/tests",
+        "HOME": "/tmp",
+    }
+
+    result = Tier3Docker.run_score_phase(
+        tier3_ctx,
+        cmd,
+        timeout_seconds=timeout,
+        env=env,
     )
     return result.returncode, result.stdout + result.stderr
 
@@ -662,9 +729,14 @@ def score_cell(
     # 2. Compute diff hygiene.
     hygiene = compute_diff_hygiene(diff_text, known_affected)
 
-    # 3. Run held-out pytest.
+    # 3. Run held-out tests.
     if tier3_ctx is not None:
-        returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout, fail_to_pass=fail_to_pass)
+        if task_slug.startswith("django-"):
+            returncode, pytest_out = _run_django_tests_tier3(tier3_ctx, pytest_timeout, fail_to_pass=fail_to_pass)
+        else:
+            task_env: dict[str, str] | None = None
+            use_timeout = task_meta.get("use_pytest_timeout", True)
+            returncode, pytest_out = _run_pytest_tier3(tier3_ctx, pytest_timeout, fail_to_pass=fail_to_pass, env=task_env, use_timeout=use_timeout)
     else:
         returncode, pytest_out = _run_pytest_local(held_out_dir, fix_phase_dir, pytest_timeout, fail_to_pass=fail_to_pass)
 

--- a/evals/skill-comparison/tasks/corpus.yaml
+++ b/evals/skill-comparison/tasks/corpus.yaml
@@ -111,7 +111,7 @@ tasks:
     held_out_tests:
       - "tests/migrations/test_commands.py"
     fail_to_pass:
-      - "test_sqlmigrate_for_non_transactional_databases (migrations.test_commands.MigrateTests)"
+      - "tests/migrations/test_commands.py::MigrateTests::test_sqlmigrate_for_non_transactional_databases"
     estimated_test_seconds: 30
     difficulty: single-file
     known_affected_files:
@@ -127,7 +127,7 @@ tasks:
     held_out_tests:
       - "tests/model_fields/test_durationfield.py"
     fail_to_pass:
-      - "test_invalid_string (model_fields.test_durationfield.TestValidation)"
+      - "tests/model_fields/test_durationfield.py::TestValidation::test_invalid_string"
     estimated_test_seconds: 20
     difficulty: single-file
     known_affected_files:
@@ -166,6 +166,11 @@ tasks:
     difficulty: single-file
     known_affected_files:
       - "src/_pytest/skipping.py"
+    use_pytest_timeout: false
+    post_seed_commands:
+      - |
+        python3 -c "open('src/_pytest/_version.py', 'w').write('version = \"3.10.1\"\n')"
+
     problem_summary: >
       Dynamically adding an xfail marker inside a test no longer causes the
       failure to be ignored in pytest 6, breaking behaviour that was reliable
@@ -178,8 +183,8 @@ tasks:
     held_out_tests:
       - "sympy/sets/tests/test_sets.py"
     fail_to_pass:
-      - "test_imageset"
-      - "test_intersection"
+      - "sympy/sets/tests/test_sets.py::test_imageset"
+      - "sympy/sets/tests/test_sets.py::test_intersection"
     estimated_test_seconds: 35
     difficulty: single-file
     known_affected_files:
@@ -206,6 +211,13 @@ tasks:
       the _cstack helper assigns 1 instead of the right submatrix block.
     dockerfile: "Dockerfile.swebench-py310"
     post_seed_commands:
+      - |
+        python3 -c "import re, pathlib; 
+        [p.write_text(re.sub(r'from collections import (.*?)Sequence', r'from collections.abc import \1Sequence', 
+          re.sub(r'from collections import (.*?)Mapping', r'from collections.abc import \1Mapping', 
+          re.sub(r'from collections import (.*?)Iterable', r'from collections.abc import \1Iterable', 
+          re.sub(r'from collections import (.*?)Sized', r'from collections.abc import \1Sized', p.read_text()))))) 
+        for p in pathlib.Path('sklearn').rglob('*.py')]"
       - "python setup.py build_ext --inplace"
 
   pylint-7080:
@@ -238,7 +250,7 @@ tasks:
       - "lib/matplotlib/tests/test_matplotlib.py::test_parse_to_version_info[3.5.0-version_tuple0]"
       - "lib/matplotlib/tests/test_matplotlib.py::test_parse_to_version_info[3.5.0rc2-version_tuple1]"
       - "lib/matplotlib/tests/test_matplotlib.py::test_parse_to_version_info[3.5.0.dev820+g6768ef8c4c-version_tuple2]"
-      - "lib/matplotlib/tests/test_matplotlib.py::test_parse_to_version_info[1.2.3-version_tuple3]"
+      - "lib/matplotlib/tests/test_matplotlib.py::test_parse_to_version_info[3.5.0.post820+g6768ef8c4c-version_tuple3]"
     estimated_test_seconds: 40
     difficulty: multi-file
     known_affected_files:
@@ -247,6 +259,9 @@ tasks:
       matplotlib needs an easily comparable version_info tuple at the top
       level; adding it requires extending __init__.py with a parse helper and
       the new attribute.
+    dockerfile: Dockerfile.swebench-py310
+    post_seed_commands:
+      - "printf '[libs]\nsystem_freetype = True\nsystem_qhull = True\n' > setup.cfg && python setup.py build_ext --inplace"
 
   flask-5063:
     swebench_instance_id: "pallets__flask-5063"
@@ -304,6 +319,41 @@ tasks:
       in the underlying fit logic.
     dockerfile: "Dockerfile.swebench-py310"
     post_seed_commands:
+      - |
+        python3 -c "
+        import re, pathlib;
+        ABC_NAMES = {'Sequence', 'Mapping', 'Iterable', 'Sized'}
+        for p in pathlib.Path('sklearn').rglob('*.py'):
+            txt = p.read_text()
+            # Python 3.10: collections.abc migration (only move ABCs, keep other imports in collections)
+            def fix_collections_import(m):
+                prefix = m.group(1)
+                items = [x.strip() for x in m.group(2).split(',')]
+                abcs = [x for x in items if x in ABC_NAMES]
+                rest = [x for x in items if x not in ABC_NAMES]
+                lines = []
+                if rest:
+                    lines.append(f'{prefix}from collections import ' + ', '.join(rest))
+                if abcs:
+                    lines.append(f'{prefix}from collections.abc import ' + ', '.join(abcs))
+                return '\n'.join(lines)
+            new = re.sub(r'^(\s*)from collections import ([^#\n]+)', fix_collections_import, txt, flags=re.M)
+            # numpy 1.26 compatibility
+            new = re.sub(r'np\.float(?!16|32|64|128|_)', 'np.float64', new)
+            new = re.sub(r'np\.int(?!8|16|32|64|128|_)', 'np.int64', new)
+            new = re.sub(r'np\.bool(?!_)', 'np.bool_', new)
+            new = re.sub(r'np\.object(?!_)', 'object', new)
+            new = re.sub(r'np\.str(?!ing|_)', 'str', new)
+            new = re.sub(r'np\.complex(?!64|128|_)', 'np.complex128', new)
+            # scipy compatibility
+            new = re.sub(
+                r\"from scipy\.optimize\.linesearch import (line_search_wolfe2, line_search_wolfe1)\",
+                r\"try:\n    from scipy.optimize.linesearch import \1\nexcept ImportError:\n    from scipy.optimize._linesearch import \1\",
+                new
+            )
+            if new != txt:
+                p.write_text(new)
+        "
       - "python setup.py build_ext --inplace"
 
   # -----------------------------------------------------------------------
@@ -319,22 +369,19 @@ tasks:
       - "tests/admin_widgets/test_autocomplete_widget.py"
       - "tests/forms_tests/tests/test_media.py"
     fail_to_pass:
-      - "test_combine_media (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_construction (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_form_media (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_media_inheritance (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_media_inheritance_from_mixin (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_media_inheritance_single_type (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_multi_media (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_merge_css_three_way (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_merge_js_three_way (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_merge_warning (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_merge (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_media_deduplication (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_media_ordering (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_add_js_to_media (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_add_css_to_media (forms_tests.tests.test_media.FormsMediaTestCase)"
-      - "test_empty_media (forms_tests.tests.test_media.FormsMediaTestCase)"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_construction"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_combine_media"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_media_deduplication"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_media_property"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_media_inheritance"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_media_inheritance_single_type"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_multi_media"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_form_media"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_merge"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_merge_warning"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_merge_js_three_way"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_merge_js_three_way2"
+      - "tests/forms_tests/tests/test_media.py::FormsMediaTestCase::test_merge_css_three_way"
     estimated_test_seconds: 90
     difficulty: design-y
     known_affected_files:
@@ -343,3 +390,4 @@ tasks:
       Merging 3 or more Media objects throws unnecessary MediaOrderConflictWarnings
       because the merge algorithm does not handle transitive dependency ordering
       correctly; fixing it requires redesigning the merge strategy.
+


### PR DESCRIPTION
Infrastructure fixes from Kimi backend porting of skill-comparison eval system.

### Changes
- **Dockerfile.swebench**: add flask, pytz, sqlparse, astroid, numpy, tomlkit and other runtime deps needed by corpus tasks
- **Dockerfile.swebench-py310**: add build deps (freetype, png, qhull, pkg-config), collections.abc startup compat patch for Python 3.10, more Python deps (Pillow, pyparsing, cycler, kiwisolver, fonttools, python-dateutil)
- **invoker.py**: portable MCP empty-config path via tempfile instead of hardcoded /tmp
- **runner.py**: bump Kimi fix timeout 600s -> 1200s for SWE-bench complexity
- **scoring.py**: --import-mode=append, optional pytest-timeout, expanded PYTHONPATH, Django test runner support
- **corpus.yaml**: fix test node IDs, per-task dockerfile routing, post_seed_commands for collections.abc patches, numpy aliases, SCM version writing, setup.cfg