### PR TITLE
docs: update AGENTS.md with eval infrastructure conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 - `.claude/install.sh` manages `~/.claude/CLAUDE.md` via a `managed_content` Python string (lines ~364-380). Four @-import lines (METHODOLOGY.md plus 3 rules files under `rules/`) must appear in that string or rules will not auto-inject in Claude Code sessions. Re-run install.sh after any changes to that string.
 - Auto-harness keep-metric is mean-of-medians (`evals/auto/runner_shim.py:147`, PR #41). Median was blind to single-fixture wins when ≥half fixtures sat at ceiling 1.0.
 - Auto-harness dimension signal (`evals/auto/loop.py:_build_dimension_signal`, PR #49) requires scorers to emit `{dim: {score: float}}`. Components using semantically-rich nested dicts (`tp_recall.matched[*].credit`, `signal_discipline` tiers, etc.) are dim-signal-blind until per-component extractors are added.
+- Eval runner supports Kimi CLI backend (`evals/runner/invoker.py`) with MCP config path fix and timeout multiplier, in addition to the original Claude CLI backend. The stream-json normalizer was committed in PR #99.
 
 ## Tools
 - GitHub operations: use `gh` CLI - do not use GitHub MCP

--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -15,7 +15,7 @@ Internal eval harness for component-level evals of named agents and slash comman
 - Isolation tiers:
   - Tier 1: read-only, no Bash, no network (Skeptic, Conductor).
   - Tier 2: git worktree + redirected HOME, write-enabled (init-project).
-  - Tier 3: Docker - currently a `NotImplementedError` stub, required for Worker eval.
+  - Tier 3: Docker container isolation with `Tier3Docker` in `evals/runner/isolator.py` — build-once cache, force_rebuild via `docker rmi -f`, `--network none`, `--read-only` rootfs, held-out tests mounted at `/scoring/tests:ro`. Required for skill-comparison and Worker eval.
 - `fixture_hash` normalizes to a semantic JSON subset, not raw YAML bytes, to avoid pre-commit secret-scanner false-positives on sha256 substrings.
 - TSV results under `evals/results/` are committed; `.runlog.jsonl` files and `.worktrees/` are gitignored.
 - Overfitting Rule (`evals/OVERFITTING-RULE.md`) gates any `content/` edit motivated by eval scores: "would this edit still matter if the fixture disappeared?"

--- a/evals/skill-comparison/AGENTS.md
+++ b/evals/skill-comparison/AGENTS.md
@@ -28,8 +28,31 @@ pass/fail on held-out test suite.
   `claude -p "follow <agent>"` does not preserve frontmatter.
 - When testing, mock at `subprocess.run` or the real integration boundary,
   not at a wrapper function. Wrapper mocks hide kwarg mismatches.
+- `--import-mode=append` is required on all Tier 3 pytest invocations when
+  held-out tests live inside the repo tree; prevents `/scoring/tests` from
+  shadowing `/workspace/repo`.
+- Per-task `dockerfile` routing in `corpus.yaml` selects the sandbox image per
+  task (e.g., `Dockerfile.swebench-py310` for Python 3.10 tasks).
+- `post_seed_commands` in `corpus.yaml` apply patches before the fix phase runs
+  (e.g., collections.abc migration, numpy alias fixes, version file writing for
+  SCM version resolution).
+- `use_pytest_timeout: false` in task metadata disables pytest-timeout for old
+  pytest versions incompatible with `pytest-timeout==2.4.0`.
+- Old pytest (pre-7.x) needs extra deps (`more_itertools`, `colorama`, `toml`,
+  `attrs`) installed in the Docker image.
 - Every `content/` edit motivated by a score must cite the task fixture and
   pass the counterfactual in `evals/OVERFITTING-RULE.md`.
+
+## Gotchas
+
+- Docker layer cache masks Dockerfile changes; `docker rmi -f` +
+  `force_rebuild=True` is required after any `Dockerfile.swebench` edit.
+- pytest path shadowing: default import mode puts `/scoring/tests` ahead of
+  `/workspace/repo`. `--import-mode=append` is the fix.
+- Network-isolated containers may fail SCM version resolution; write version
+  files directly in `post_seed_commands`.
+- Python 3.10 removed `collections.MutableMapping`; old repos need
+  `collections.abc` patches in `post_seed_commands`.
 
 ## Quality gates
 


### PR DESCRIPTION
Apply deferred AGENTS.md updates now that eval-kimi-results infrastructure PR has merged.

### Changes
- **evals/AGENTS.md**: Tier 3 is now implemented (Tier3Docker), not a stub
- **evals/skill-comparison/AGENTS.md**: add conventions for , per-task dockerfile routing, , , old pytest deps; add Gotchas section for Docker cache, path shadowing, SCM version resolution, collections.abc
- **AGENTS.md**: add Kimi backend support decision