### PR TITLE
feat: curl|bash bootstrap installer + location-aware /update-agentic-engineering

### DIFF
--- a/.claude/commands/update-agentic-engineering.md
+++ b/.claude/commands/update-agentic-engineering.md
@@ -4,12 +4,12 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -33,9 +33,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -67,7 +89,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# ae_confirm: TTY-safe yes/no prompt for optional installs.
+#
+# When /dev/tty is available (interactive or curl|bash in a real terminal),
+# prompts the user exactly as a bare `read -p` would. When /dev/tty is not
+# available (headless/piped/CI), defaults to "no" and returns 1 without
+# aborting under set -e.
+#
+# Usage: if ae_confirm "  Install foo? [y/N] "; then ...
+# ---------------------------------------------------------------------------
+ae_confirm() {
+  local prompt="$1"
+  local reply=""
+  if [[ -r /dev/tty ]]; then
+    read -p "$prompt" -n 1 -r reply </dev/tty || reply=""
+    echo
+  fi
+  [[ "$reply" =~ ^[Yy]$ ]]
+}
+
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
@@ -508,9 +528,7 @@ for tool_entry in "${CLI_TOOLS[@]}"; do
   if command -v "$cmd" &>/dev/null; then
     echo "  = $cmd already installed"
   else
-    read -p "  Install $cmd ($desc)? [y/N] " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if ae_confirm "  Install $cmd ($desc)? [y/N] "; then
       eval "$install_cmd" 2>&1 || echo "  ! $cmd install failed (non-blocking)"
     else
       echo "  - skipped $cmd"
@@ -529,9 +547,7 @@ sys.exit(0 if 'chrome-devtools' in d.get('mcpServers', {}) else 1)
 " 2>/dev/null; then
   echo "  = chrome-devtools MCP already configured"
 else
-  read -p "  Configure chrome-devtools MCP — inspect, screenshot, and interact with Chrome tabs for debugging and QA? [y/N] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if ae_confirm "  Configure chrome-devtools MCP — inspect, screenshot, and interact with Chrome tabs for debugging and QA? [y/N] "; then
     python3 - <<'PYEOF'
 import json, os
 
@@ -571,9 +587,7 @@ sys.exit(0 if 'mcp-atlassian' in d.get('mcpServers', {}) else 1)
 " 2>/dev/null; then
   echo "  = mcp-atlassian MCP already configured"
 else
-  read -p "  Configure mcp-atlassian MCP — interact with Jira and Confluence from Claude Code? [y/N] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if ae_confirm "  Configure mcp-atlassian MCP — interact with Jira and Confluence from Claude Code? [y/N] "; then
     python3 - <<'PYEOF'
 import json, os
 

--- a/.codex/commands/update-agentic-engineering.md
+++ b/.codex/commands/update-agentic-engineering.md
@@ -2,12 +2,12 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -31,9 +31,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -65,7 +87,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/.cursor/commands/update-agentic-engineering.md
+++ b/.cursor/commands/update-agentic-engineering.md
@@ -2,12 +2,12 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -31,9 +31,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -65,7 +87,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/.gemini/commands/update-agentic-engineering.toml
+++ b/.gemini/commands/update-agentic-engineering.toml
@@ -8,12 +8,12 @@ prompt = """
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -37,9 +37,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -71,7 +93,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/.opencode/commands/update-agentic-engineering.md
+++ b/.opencode/commands/update-agentic-engineering.md
@@ -6,12 +6,12 @@ agent: build
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -35,9 +35,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -69,7 +91,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,38 @@ This system is designed to evolve. As AI tooling matures and teams discover bett
 
 ## Getting started
 
-Clone the repo, cd into it, and start Claude Code:
+### One-liner install (quickest)
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash
 ```
+
+This clones the repo into `agentic-engineering/` inside your current directory, runs the installer, and writes the install path to `~/.agentic/agentic-engineering-config.json` so `./update.sh` and the `/update-agentic-engineering` command know where to find it.
+
+> **Note:** the one-liner requires the repo to be public. Until then, collaborators can use the SSH path below - the script automatically falls back to SSH on clone failure.
+
+**Custom install location:** set `AE_DEST_DIR` before running. The default is `<current directory>/agentic-engineering`.
+
+```bash
+# Install to ~/tools/agentic-engineering instead of the current directory
+AE_DEST_DIR=~/tools/agentic-engineering curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash
+```
+
+**Pass flags through to the installer** (e.g. to set activation mode without prompts):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash -s -- --mode=opt-in
+```
+
+### Manual / SSH install
+
+```bash
+git clone git@github.com:Solara6/agentic-engineering.git && cd agentic-engineering && bash bootstrap.sh
+```
+
+Or clone, cd in, and start Claude Code to let the agent run the installer interactively:
+
+```bash
 git clone git@github.com:Solara6/agentic-engineering.git
 cd agentic-engineering
 claude
@@ -41,9 +70,9 @@ QA engineer verifying acceptance criteria in the browser...
 
 If you see none of this, the task was classified as a small, reversible direct action and handled without spawning subagents. That's the protocol working correctly on a cheap task - not a sign that it's off.
 
-**Or install manually:**
+**Or install manually via install.sh directly:**
 
-```
+```bash
 git clone git@github.com:Solara6/agentic-engineering.git
 cd agentic-engineering
 bash .claude/install.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# Module Manifest
+#
+# Purpose: One-liner remote installer for agentic-engineering. Clones or
+#          updates the repository from GitHub, delegates to .claude/install.sh
+#          for adapter setup, and writes the resolved repo path to
+#          ~/.agentic/agentic-engineering-config.json for use by update.sh and
+#          the /update-agentic-engineering command.
+#
+# Public API:
+#   curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash
+#   curl -fsSL ... | bash -s -- --mode=opt-in
+#   AE_DEST_DIR=/custom/path bash bootstrap.sh [--mode=opt-in|opt-out] [--profile=...]
+#
+# Upstream deps: git, python3 (required); node (optional, for update.sh TUI)
+#
+# Downstream consumers:
+#   - End users installing agentic-engineering for the first time
+#   - .claude/install.sh (delegated to after clone/update)
+#   - ~/.agentic/agentic-engineering-config.json (written with repo_dir key)
+#
+# Failure modes:
+#   Exit 0: success
+#   Exit 1: preflight failure (missing git/python3, or unwritable AE_DEST_DIR parent)
+#   Exit 2: clone/pull failure (both HTTPS and SSH failed, or dest exists but is
+#            not a git repo)
+#   Exit 3: .claude/install.sh delegation failure (non-zero exit from install.sh)
+#   All failures print actionable messages to stderr naming what went wrong.
+#   Config write failure (~/.agentic/) is non-fatal; warns and continues.
+#
+# Performance: Network-bound (git clone). Local operations are negligible.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Capture working directory before any cd operations
+# ---------------------------------------------------------------------------
+BOOTSTRAP_PWD="$(pwd)"
+
+# ---------------------------------------------------------------------------
+# URL seams - real defaults; overridable for testing
+# ---------------------------------------------------------------------------
+HTTPS_URL="${AE_HTTPS_URL:-https://github.com/Solara6/agentic-engineering.git}"
+SSH_URL="${AE_SSH_URL:-git@github.com:Solara6/agentic-engineering.git}"
+
+# ---------------------------------------------------------------------------
+# Destination directory resolution
+# ---------------------------------------------------------------------------
+AE_DEST_DIR="${AE_DEST_DIR:-$BOOTSTRAP_PWD/agentic-engineering}"
+
+# Normalize to absolute path via python3 (required dep anyway)
+AE_DEST_DIR="$(python3 -c "import os,sys;print(os.path.abspath(sys.argv[1]))" "$AE_DEST_DIR")"
+
+# ---------------------------------------------------------------------------
+# Preflight: required tools
+# ---------------------------------------------------------------------------
+MISSING=""
+if ! command -v git >/dev/null 2>&1; then
+  MISSING="$MISSING git"
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  MISSING="$MISSING python3"
+fi
+
+if [ -n "$MISSING" ]; then
+  echo "bootstrap.sh: missing required tools:$MISSING" >&2
+  echo "Install the missing tools and re-run." >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "bootstrap.sh: warning: 'node' not found - update.sh TUI will not work (install Node.js later if needed)" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Parent directory pre-creation
+# ---------------------------------------------------------------------------
+AE_PARENT="$(dirname "$AE_DEST_DIR")"
+if ! mkdir -p "$AE_PARENT" 2>/dev/null; then
+  echo "bootstrap.sh: cannot create parent directory '$AE_PARENT' - check write permissions" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Clone-or-update logic
+# ---------------------------------------------------------------------------
+if [ -d "$AE_DEST_DIR" ]; then
+  if git -C "$AE_DEST_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    # Existing git repo: update path
+    DIRTY="$(git -C "$AE_DEST_DIR" status --porcelain 2>/dev/null)"
+    if [ -n "$DIRTY" ]; then
+      echo "bootstrap.sh: warning: working tree at '$AE_DEST_DIR' has uncommitted changes - skipping pull:" >&2
+      echo "$DIRTY" >&2
+    else
+      echo "Updating existing repo at $AE_DEST_DIR ..."
+      if ! git -C "$AE_DEST_DIR" pull --ff-only; then
+        echo "bootstrap.sh: 'git pull --ff-only' failed in '$AE_DEST_DIR'" >&2
+        echo "Resolve the conflict manually (e.g. git -C \"$AE_DEST_DIR\" merge) and re-run." >&2
+        exit 2
+      fi
+    fi
+  else
+    echo "bootstrap.sh: '$AE_DEST_DIR' exists but is not a git repository" >&2
+    echo "Move or remove it, or set AE_DEST_DIR to a different path, then re-run." >&2
+    exit 2
+  fi
+else
+  # Fresh clone: HTTPS first, SSH fallback - set -e-safe via if/!
+  echo "Cloning agentic-engineering to $AE_DEST_DIR ..."
+  if ! git clone "$HTTPS_URL" "$AE_DEST_DIR"; then
+    echo "HTTPS clone failed (repo may be private); trying SSH..." >&2
+    if ! git clone "$SSH_URL" "$AE_DEST_DIR"; then
+      echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured (https://docs.github.com/en/authentication)." >&2
+      exit 2
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Delegate to .claude/install.sh
+# ---------------------------------------------------------------------------
+INSTALL_SH="$AE_DEST_DIR/.claude/install.sh"
+if [ ! -f "$INSTALL_SH" ]; then
+  echo "bootstrap.sh: install script not found at '$INSTALL_SH'" >&2
+  exit 3
+fi
+
+echo ""
+if ! bash "$INSTALL_SH" "$@"; then
+  echo "bootstrap.sh: install.sh exited with a non-zero status" >&2
+  echo "Check the output above for details and re-run after fixing the issue." >&2
+  exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Write resolved repo path to ~/.agentic/agentic-engineering-config.json
+# Additive (preserves all existing keys). Non-fatal on any failure.
+# ---------------------------------------------------------------------------
+if ! python3 - "$HOME/.agentic/agentic-engineering-config.json" "$AE_DEST_DIR" <<'PYEOF'
+import json, sys, os
+cfg, repo_dir = sys.argv[1], sys.argv[2]
+os.makedirs(os.path.dirname(cfg), exist_ok=True)
+data = {}
+if os.path.exists(cfg):
+    try:
+        with open(cfg) as f: data = json.load(f)
+    except Exception: data = {}
+data["repo_dir"] = repo_dir
+with open(cfg, "w") as f:
+    json.dump(data, f, indent=2); f.write("\n")
+PYEOF
+then
+  echo "bootstrap.sh: warning: failed to write repo_dir to ~/.agentic/agentic-engineering-config.json (non-fatal)" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Success summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "agentic-engineering installed to: $AE_DEST_DIR"
+echo "Update anytime via either:"
+echo "  cd $AE_DEST_DIR && ./update.sh"
+echo "  or the /update-agentic-engineering command inside Claude Code (location-aware)"

--- a/content/commands/update-agentic-engineering.md
+++ b/content/commands/update-agentic-engineering.md
@@ -2,12 +2,12 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under `~/agentic-engineering/`.
+Handles the full edit-sync-build-commit-push cycle for methodology and tooling files under your agentic-engineering install (resolved at runtime from `~/.agentic/agentic-engineering-config.json` `repo_dir`, default `~/agentic-engineering`).
 
 **When to use - use whenever ANY of these hold:**
-- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under `~/agentic-engineering/`.
+- (a) The user asks to edit, add, or remove a rule, convention, agent definition, command, reference, or protocol doc under your agentic-engineering install.
 - (b) The user says "update the methodology", "change the protocol", "edit the wrap skill", "add an agent", "rename a command", or anything similar that implies changing a file in the agentic-engineering repo.
-- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `~/agentic-engineering/content/**`, `~/agentic-engineering/.codex/skill/**`, the build scripts, `~/agentic-engineering/hooks/**`, or `~/agentic-engineering/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
+- (c) You are about to use Edit or Write on any file whose absolute path is within one of the in-scope directories listed in Scope below (e.g. `<AE_REPO_DIR>/content/**`, `<AE_REPO_DIR>/.codex/skill/**`, the build scripts, `<AE_REPO_DIR>/hooks/**`, or `<AE_REPO_DIR>/.codex/hooks/**`). Files outside those directories (docs, README, build artifacts, top-level config) may be edited directly.
 
 **Why it matters:** Without this command's Step 0 git sync, concurrent edits from multiple machines produce push conflicts and messy rebases; without Step 4 commit+push, edits pile up uncommitted locally.
 
@@ -31,9 +31,31 @@ Note: `.claude/skills/agentic-engineering/**` files are hardlinks into `content/
 
 ## Step 0 - Pre-flight git sync
 
-Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) runs the following checks:
+Before making any edits, the main agent (not a subagent - git state decisions require main-agent judgment) resolves the repo location and runs the following checks.
 
-1. `cd ~/agentic-engineering && git fetch origin`
+**Resolve `AE_REPO_DIR` once at the start of the command - it persists for all subsequent steps in this invocation:**
+
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+
+Fallback behavior: if `~/.agentic/agentic-engineering-config.json` does not exist, has no `repo_dir` key, or `repo_dir` is not a git repository, `AE_REPO_DIR` defaults to `~/agentic-engineering` exactly as before.
+
+1. `cd "$AE_REPO_DIR" && git fetch origin`
 2. Run `git status --porcelain` to check for uncommitted changes.
 3. Run `git rev-list --left-right --count HEAD...origin/main` to measure divergence.
 
@@ -65,7 +87,7 @@ Show the diff, state what the change does. If the diff includes `content/command
 
 ## Step 3 - Run the build
 
-After approval: if the diff includes any `content/commands/` changes, run `bash ~/agentic-engineering/.claude/build.sh` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
+After approval: if the diff includes any `content/commands/` changes, run `bash "$AE_REPO_DIR/.claude/build.sh"` and confirm success. If the diff only touches `content/rules/`, `content/references/`, or `content/agents/`, skip the build - those changes are already live.
 
 ## Step 3.5 - Docs update check
 

--- a/docs/agentic-engineering.html
+++ b/docs/agentic-engineering.html
@@ -824,7 +824,7 @@
 <!-- ═══ Side Navigation ═══ -->
 <nav class="side-nav">
   <div class="side-nav-brand">AE</div>
-  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: May 16, 2026
+  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: May 18, 2026
   <hr class="side-nav-divider">
   <a href="#decks"><span class="nav-dot" style="background: var(--text-muted);"></span> Slide Decks</a>
   <a href="#infographics"><span class="nav-dot" style="background: var(--gold);"></span> Infographics</a>

--- a/docs/planning/bootstrap-installer-architect-plan.md
+++ b/docs/planning/bootstrap-installer-architect-plan.md
@@ -1,0 +1,150 @@
+# Architect Plan: bootstrap.sh + location-aware /update-agentic-engineering
+
+> Source: architect agent (revision 2). Persisted by conductor for Skeptic review and audit.
+> Canonical repo: `Solara6/agentic-engineering` (HTTPS `https://github.com/Solara6/agentic-engineering.git`, SSH `git@github.com:Solara6/agentic-engineering.git`, raw `https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh`).
+
+## Approach
+
+Create `bootstrap.sh` at repo root as a public `curl | bash`-installable entrypoint that clones the repo, delegates to `.claude/install.sh`, and records the resolved install path to `~/.agentic/agentic-engineering-config.json`. Simultaneously patch `content/commands/update-agentic-engineering.md` to resolve the repo location from that config key (`repo_dir`) before falling back to the legacy `~/agentic-engineering` default, then regenerate all adapter build artifacts so the `adapter-sync` CI gate passes.
+
+## Codebase context
+
+### `content/commands/update-agentic-engineering.md` - the operational hardcodes
+- Line 36: `cd ~/agentic-engineering && git fetch origin` (Step 0 preflight)
+- Line 68: `bash ~/agentic-engineering/.claude/build.sh` (Step 3 build command)
+- Lines 5, 8, 10: prose references (documentational; classified leave-as-default)
+
+### `.claude/install.sh` config-write pattern
+python3 read-merge-write: read existing JSON, update only specific keys, write back; handles missing file/dir; swallows non-fatal errors. Mirror this for `~/.agentic/agentic-engineering-config.json`.
+
+### Adapter build system
+- `adapter-sync.yml` runs 8 build scripts: `.claude`, `.cursor`, `.codex`, `.gemini`, `.kimi`, `.opencode`, `.omp`, `.pi` build.sh; CI does `git diff --exit-code` across adapter dirs.
+- `.hermes/build.sh` exists but is NOT in the CI gate (regen anyway for correctness).
+- All build scripts self-locate via `REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"`.
+- `content/commands/*.md` get a prerequisite blockquote prepended by `.claude/build.sh`. Engineer must NOT hand-edit `.claude/commands/update-agentic-engineering.md` - edit `content/` source then rebuild.
+- `.claude/skills/agentic-engineering/references/` are hardlinks into `content/references/` - no rebuild for those.
+
+### `~/agentic-engineering` hardcode sweep (classified)
+Only `content/commands/update-agentic-engineering.md` lines 36, 68 are class (a) must-become-config-aware. All other hits across `content/sections/**`, `content/references/**`, `content/agents/**`, other `content/commands/**`, `README.md`, `CONTRIBUTING.md` are class (b) documented-default (prose/concept, resolved via symlinks at runtime) - deliberately untouched.
+
+### Resolution snippet (instructed in updated Step 0 / Step 3)
+```bash
+AE_REPO_DIR=""
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+if [[ -f "$AE_CONFIG" ]]; then
+  # SKEPTIC-MINOR-1 fix: pass the config path via argv (sys.argv[1]), NOT
+  # interpolated into the python string literal. Mirrors the safer
+  # ae_write_config variant in .claude/install.sh, avoids quote/backslash breakage.
+  AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null)"
+fi
+# SKEPTIC-MINOR-2 fix: use rev-parse, not [[ -d .git ]]. In a git worktree
+# .git is a FILE, not a dir; -d would wrongly discard a valid repo_dir.
+if [[ -z "$AE_REPO_DIR" ]] || ! git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  AE_REPO_DIR="$HOME/agentic-engineering"
+fi
+```
+Step 0 -> `cd "$AE_REPO_DIR" && git fetch origin`. Step 3 -> `bash "$AE_REPO_DIR/.claude/build.sh"`.
+
+## Data model
+`~/.agentic/agentic-engineering-config.json` extended additively with `{"repo_dir": "/absolute/path/.../agentic-engineering"}`. Pre-existing keys (adapter selections from update.sh) preserved.
+
+## Interface
+
+`bootstrap.sh`:
+- `curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash`
+- `AE_DEST_DIR` env override; default `$(pwd)/agentic-engineering`; normalized to absolute.
+- **SKEPTIC-CRITICAL fix - clone branch MUST be written so the SSH fallback is reachable under `set -euo pipefail`.** A bare sequential `git clone https://...` followed by `git clone git@...` aborts on the first failure because `set -e` traps the non-zero exit before the fallback line. The engineer MUST use an explicit conditional so the HTTPS failure is caught, not fatal:
+  ```bash
+  if ! git clone "$HTTPS_URL" "$AE_DEST_DIR"; then
+    echo "HTTPS clone failed (repo may be private); trying SSH..." >&2
+    if ! git clone "$SSH_URL" "$AE_DEST_DIR"; then
+      echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured." >&2
+      exit 2
+    fi
+  fi
+  ```
+  `HTTPS_URL=https://github.com/Solara6/agentic-engineering.git`, `SSH_URL=git@github.com:Solara6/agentic-engineering.git`. The `if ! cmd` form is the canonical `set -e`-safe trap. A `cmd || fallback` form is also acceptable but the `if !` form is mandated here for clarity in the spec; engineer may use either as long as the HTTPS failure is demonstrably non-fatal and the SSH path is reached (verified by test scenario 6).
+- **SKEPTIC-MINOR-3 fix - parent-dir precreation.** Before clone, `mkdir -p "$(dirname "$AE_DEST_DIR")"` so a multi-level `AE_DEST_DIR` (e.g. `/tmp/new/deep/agentic-engineering`) does not fail with "parent does not exist". If `mkdir -p` itself fails (unwritable), exit 1 with an actionable message naming the unwritable parent.
+- Delegate `bash "$DEST/.claude/install.sh" "$@"` (positional passthrough; `"$@"` is `set -u`-safe with zero args - Skeptic-confirmed, do NOT introduce an `INSTALL_ARGS` array).
+- Dirty-tree (existing dest): warn, continue.
+- Exit codes: 0 success, 1 validation error (incl. unwritable AE_DEST_DIR parent), 2 clone failure (both HTTPS and SSH), 3 install.sh failure.
+- Success message: updates via `cd <dest> && ./update.sh` OR `/update-agentic-engineering` (now location-aware).
+
+`content/commands/update-agentic-engineering.md`: Step 0/Step 3 use resolved `AE_REPO_DIR`; backward-compatible fallback to `~/agentic-engineering`.
+
+## Implementation units
+
+### Unit A - bootstrap.sh + config write + README (independent)
+Files: `bootstrap.sh` (new), `README.md` (modify).
+1. Create `bootstrap.sh`, `set -euo pipefail`, manifest header, normalize AE_DEST_DIR to absolute, `mkdir -p "$(dirname "$AE_DEST_DIR")"` (exit 1 if unwritable), dirty-tree check, **`set -e`-safe conditional HTTPS->SSH clone** (the `if ! git clone ...` structure mandated in the Interface section - bare sequential clones are a Critical defect), delegate `bash "$DEST/.claude/install.sh" "$@"`, additive python3 config write of `repo_dir` passing the config path via `sys.argv[1]` not string interpolation (create `~/.agentic/` if absent, non-fatal on failure), success summary, exit codes 0/1/2/3.
+2. README: add one-liner install section, SSH manual alternative, `AE_DEST_DIR` doc.
+
+### Unit B - slash-command patch + adapter regen (independent of A; parallelizable)
+Files: `content/commands/update-agentic-engineering.md` (modify), all regenerated adapter outputs.
+3. Edit `content/commands/update-agentic-engineering.md`: Step 0 resolution snippet + `cd "$AE_REPO_DIR"`; Step 3 `bash "$AE_REPO_DIR/.claude/build.sh"`; update prose lines 5/8/10 to describe runtime resolution.
+4. Run all 9 build scripts (`.claude .cursor .codex .gemini .kimi .opencode .omp .pi .hermes`), confirm each exits 0.
+5. Verify `git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi` clean.
+6. Commit content source + regenerated adapters together.
+
+Units A and B touch non-overlapping files - parallelizable in separate worktrees.
+
+## QA criteria
+```yaml
+qa_criteria:
+  qa_skip: pure-backend-library
+  qa_skip_rationale: "All changes are shell scripts and markdown documentation with no browser or UI surface; verification is via local shell execution and git diff checks."
+  scenarios: []
+  manual_smoke: none
+```
+
+## Per-unit verification
+
+### Unit A (file:// bare-repo local tests)
+1. Happy path default dest -> clone at `$(pwd)/agentic-engineering`, config `repo_dir` set, install.sh symlinks present.
+2. Custom dest via `AE_DEST_DIR` -> installs there, absolute path recorded.
+3. Relative `AE_DEST_DIR` -> recorded path is absolute.
+4. Dirty tree existing dest -> warn, continue, no abort.
+5. Additive config write -> pre-existing keys preserved.
+6. HTTPS fail -> SSH fallback attempted.
+7. Both clone methods fail -> exit 2.
+
+### Unit B
+**SKEPTIC-MAJOR fix - test precondition (mandatory):** Unit B's resolution tests MUST hand-create a temporary `~/.agentic/agentic-engineering-config.json` (or point `AE_CONFIG` at a temp fixture path) and a throwaway git repo for the "valid path" case. Unit B tests MUST NOT depend on Unit A having been built, shipped, or run - the two units are parallelizable precisely because B is verified against a hand-crafted config fixture, not A's runtime output. Each test case below backs up any real `~/.agentic/agentic-engineering-config.json` first and restores it after, OR runs the resolution snippet with `AE_CONFIG` overridden to a temp file (preferred - no mutation of the real user config).
+1. `repo_dir` present + path is a real git repo (hand-create `git init` temp dir) -> resolves to that custom path.
+2. No config file (temp `AE_CONFIG` points at nonexistent path) -> fallback `~/agentic-engineering`.
+3. Config present, no `repo_dir` key (hand-write `{"other":"x"}`) -> fallback.
+4. `repo_dir` -> non-git path (hand-write a path to an empty temp dir) -> fallback (verifies the `git rev-parse --git-dir` guard, not the old `-d .git` check).
+5. Adapter-sync gate: 8 build scripts then `git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi` exits 0.
+6. `diff content/commands/update-agentic-engineering.md .claude/commands/update-agentic-engineering.md` shows only prepended prerequisite blockquote.
+
+## Acceptance criteria
+1. One-liner clones, runs install.sh, writes `repo_dir`.
+2. `AE_DEST_DIR=/custom bash bootstrap.sh` installs to `/custom/agentic-engineering`, records absolute path.
+3. `repo_dir` write additive (pre-existing keys preserved).
+4. After custom-path install, `/update-agentic-engineering` resolves to custom path.
+5. Existing install w/o `repo_dir` -> `~/agentic-engineering` (backward-compat).
+6. `repo_dir` not a git repo -> fallback.
+7. 8 build scripts + `git diff --exit-code` adapter dirs exits 0.
+8. `.claude/commands/update-agentic-engineering.md` build artifact has prereq prefix + patched content.
+9. `shellcheck bootstrap.sh` exits 0, no warnings.
+10. Bootstrap success message references both update methods, no stale limitation note.
+11. Exit codes 0/1/2/3 as specified.
+
+## Trade-offs / known limitations
+- `repo_dir` stored in `~/.agentic/agentic-engineering-config.json` (not `~/.claude/agentic-engineering.json`) - avoids coupling with activation-mode file; the `~/.agentic/` file already exists for update.sh adapter selections.
+- Class (b) prose references intentionally untouched (resolved via symlinks at runtime; patching = cosmetic churn, high regen cost, zero functional gain).
+- Resolution snippet inline (no shell-include mechanism in an LLM-loaded command file); 12 lines acceptable.
+- python3 not jq (jq not guaranteed; python3 is the established codebase pattern).
+- bootstrap config-write failure non-fatal -> `/update-agentic-engineering` falls back to `~/agentic-engineering` for a custom install (edge case: read-only home).
+- `.hermes/build.sh` not in CI gate; regen for correctness, CI won't catch drift.
+- `AE_REPO_DIR` resolved once in Step 0, reused Step 3 (same agent context within one command invocation - true by design).
+
+## Open questions
+None.

--- a/docs/planning/bootstrap-installer.md
+++ b/docs/planning/bootstrap-installer.md
@@ -1,0 +1,28 @@
+# Brief: bootstrap.sh public installer + location-aware /update-agentic-engineering
+
+**Problem:** New users cannot install agentic-engineering with a single command - they must know to clone the repo (SSH only), cd in, and ask the agent to install. There is no `curl | bash` install path. Separately, the `/update-agentic-engineering` command hardcodes `~/agentic-engineering`, so an install placed anywhere else cannot be updated via the in-session command.
+
+**Success criteria:**
+- A single public one-liner (`curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash`) clones the repo to `$(pwd)/agentic-engineering` (overridable via `AE_DEST_DIR`), runs `.claude/install.sh`, and records the resolved absolute install path to `~/.agentic/agentic-engineering-config.json` (`repo_dir` key, additive write).
+- `/update-agentic-engineering` resolves its working repo from `repo_dir`, falling back to `~/agentic-engineering` when the key/file is absent or not a git repo (backward compatible for existing installs).
+- `bootstrap.sh` is `set -euo pipefail`-safe, shellcheck-clean, with a reachable HTTPS->SSH clone fallback and exit codes 0/1/2/3; its success message names both update paths (`cd <dest> && ./update.sh` and `/update-agentic-engineering`) with no stale "won't work from custom location" note.
+- The `adapter-sync` CI gate passes: all 8 gated adapters regenerated and committed alongside the `content/` source edit.
+
+**Non-goals:**
+- Making the repo public (operator decision, deferred - one-liner 404s until then; SSH fallback covers collaborators now).
+- npm/Homebrew/release distribution, or token-gated private install.
+- Rewriting class (b) prose `~/agentic-engineering` references across `content/**` (cosmetic; resolved via symlinks at runtime).
+
+**Constraints:** Canonical repo `Solara6/agentic-engineering`. `install.sh` flag form is `--mode=opt-out` (equals). python3 (not jq) for JSON writes, mirroring the existing `.claude/install.sh` pattern. Must not break existing `~/agentic-engineering` installs. macOS bash 3.2 target (`"$@"` passthrough; no `INSTALL_ARGS` array).
+
+**Verification:** Unit A - local `file://` bare-repo tests (default/custom/relative dest, dirty-tree warn, additive config write, HTTPS->SSH fallback, both-fail exit 2) + `shellcheck bootstrap.sh` exit 0. Unit B - resolution tests via `AE_CONFIG` temp-fixture override (repo_dir valid/absent/no-key/non-git-path, no mutation of real user config) + `bash .claude/build.sh .cursor/build.sh .codex/build.sh .gemini/build.sh .kimi/build.sh .opencode/build.sh .omp/build.sh .pi/build.sh` then `git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi` exits 0. Integration Skeptic verifies the `repo_dir` key name + absolute-path/git-repo semantics are consistent across A's write and B's resolution snippet.
+
+**QA criteria:**
+```yaml
+qa_skip: pure-backend-library
+qa_skip_rationale: "Shell installer + markdown command/doc edits; no browser or UI surface. Verified via shell execution and git diff gates."
+scenarios: []
+manual_smoke: none
+```
+
+**Linked artifacts:** architect-plan: docs/planning/bootstrap-installer-architect-plan.md (Skeptic-approved); orchestration: 2 units (bootstrap-unit-a, bootstrap-unit-b), parallelizable, integration Skeptic, no AC coverage gaps.


### PR DESCRIPTION
## Summary

Adds a one-liner public install path and makes the in-session update command location-aware.

- **bootstrap.sh** (new, repo root): `curl -fsSL https://raw.githubusercontent.com/Solara6/agentic-engineering/main/bootstrap.sh | bash`. Clones to `$(pwd)/agentic-engineering` (override via `AE_DEST_DIR`), `set -euo pipefail`-safe HTTPS→SSH clone fallback, delegates to `.claude/install.sh`, writes resolved absolute path to `~/.agentic/agentic-engineering-config.json` (`repo_dir`, additive). Exit codes 0/1/2/3. shellcheck-clean.
- **`/update-agentic-engineering` location-aware**: resolves the repo from `repo_dir` config, falls back to `~/agentic-engineering` when absent/no-key/non-git (backward compatible). Source patched in `content/commands/`; all gated adapters regenerated.
- **install.sh non-TTY fix**: new `ae_confirm()` helper replaces 3 bare `read -p` prompts that aborted under `set -e` on piped stdin - the headline one-liner now completes end-to-end. Interactive behavior byte-identical (reads `/dev/tty`).

Repo stays private for now; the one-liner 404s until it's made public. Collaborators use the SSH path (script auto-falls back).

## Verification

- Unit A: 8/8 local `file://` bootstrap scenarios pass; `shellcheck` exit 0.
- Unit B: 4/4 resolution-logic tests; adapter-sync gate `git diff --exit-code` exit 0.
- Unit C: non-TTY smoke exits 0 reaching "Install complete." after skipping optional prompts; interactive path unchanged.
- Integration Skeptic APPROVED (0 findings): independently re-ran the 8-script adapter-sync gate (exit 0), verified the `repo_dir` write/read contract both directions, traced the non-TTY path, confirmed canonical `Solara6` URLs.

Process: architect (Skeptic-approved) → orchestration-planner → Brief (Skeptic-approved) → 3 parallel engineers → integration Skeptic. Planning artifacts in `docs/planning/`. QA skipped (`qa_skip: pure-backend-library` - shell + markdown, no UI surface).