### PR TITLE
fix(kimi): portable relative symlinks in install.sh

### DIFF
--- a/.kimi/install.sh
+++ b/.kimi/install.sh
@@ -15,8 +15,9 @@
 #                the per-adapter skill source.
 #
 # Downstream consumers: humans installing the adapter manually;
-#                       update.js (the Kimi adapter updater) may re-invoke
-#                       this script after pulling new content.
+#                       scripts/update.js (generic multi-adapter updater,
+#                       launched via ./update.sh) invokes this script for
+#                       each selected adapter after pulling new content.
 #
 # Failure modes: exits non-zero on build.sh failure (propagated). Partial
 #                install is possible if the script exits mid-run; re-running

--- a/.kimi/install.sh
+++ b/.kimi/install.sh
@@ -192,16 +192,29 @@ SKILL_DST="$HOME/.kimi/skills/agentic-engineering"
 echo ""
 echo "Global skill install (optional)..."
 
+# If $SKILL_DST is a symlink pointing back into the repo (stale install style),
+# remove it and create a real directory. Writing individual files through a
+# dir-symlink that resolves to $SKILL_SRC would corrupt tracked repo symlinks.
+if [[ -L "$SKILL_DST" ]]; then
+  _dst_real="$(python3 -c "import os.path; print(os.path.realpath('$SKILL_DST'))")"
+  _src_real="$(python3 -c "import os.path; print(os.path.realpath('$SKILL_SRC'))")"
+  if [[ "$_dst_real" == "$_src_real" ]]; then
+    rm "$SKILL_DST"
+    echo "  ~ removed stale dir-symlink at $SKILL_DST (was pointing into repo)"
+  fi
+fi
 mkdir -p "$SKILL_DST"
 
-# Absolute symlinks for content dirs so they resolve from ~/.kimi/skills/"
+# Absolute symlinks for content dirs so they resolve from ~/.kimi/skills/
+# Canonical comparison (realpath both sides) so a no-op install is truly a no-op.
 link_abs() {
   local src="$1"
   local dst="$2"
   if [[ -L "$dst" ]]; then
-    local current
-    current="$(readlink "$dst")"
-    if [[ "$current" == "$src" ]]; then
+    local current_abs src_abs
+    current_abs="$(python3 -c "import os.path; print(os.path.realpath('$(readlink "$dst")'))" 2>/dev/null || python3 -c "import os.path; print(os.path.realpath(os.path.join('$(dirname "$dst")', os.readlink('$dst'))))")"
+    src_abs="$(python3 -c "import os.path; print(os.path.realpath('$src'))")"
+    if [[ "$current_abs" == "$src_abs" ]]; then
       echo "  = $(basename "$dst") (already linked)"
     else
       rm "$dst"
@@ -216,8 +229,10 @@ link_abs() {
   fi
 }
 
-# Symlink SKILL.md (same treatment as content dirs)
-link_abs "$SKILL_SRC/SKILL.md" "$SKILL_DST/SKILL.md"
+# SKILL.md: point at the actual content file, not the intermediate repo symlink.
+# Using $REPO_DIR/content/SKILL.md avoids a self-referential link when $SKILL_DST
+# is a stale dir-symlink pointing at $SKILL_SRC.
+link_abs "$REPO_DIR/content/SKILL.md"  "$SKILL_DST/SKILL.md"
 
 link_abs "$REPO_DIR/content/commands"   "$SKILL_DST/commands"
 link_abs "$REPO_DIR/content/references" "$SKILL_DST/references"

--- a/.kimi/install.sh
+++ b/.kimi/install.sh
@@ -1,4 +1,35 @@
 #!/usr/bin/env bash
+# Purpose: Installs the agentic-engineering skill for the Kimi CLI adapter.
+#          Runs build.sh to generate AGENTS.md and per-command skills, writes
+#          the activation mode/profile to ~/.claude/agentic-engineering.json,
+#          and wires up global skill symlinks under ~/.kimi/skills/.
+#
+# Public API: bash .kimi/install.sh [--mode=opt-in|opt-out] [--profile=relaxed|default|strict]
+#             Safe to re-run (idempotent). No required arguments.
+#             When invoked non-interactively (stdin not a TTY), defaults to
+#             mode=opt-out, profile=default without prompting.
+#
+# Upstream deps: bash 3.2+, python3 (for JSON config reads/writes and realpath
+#                resolution), git (via build.sh), REPO_DIR layout with content/
+#                tree, .kimi/build.sh, .kimi/skills/agentic-engineering/ as
+#                the per-adapter skill source.
+#
+# Downstream consumers: humans installing the adapter manually;
+#                       update.js (the Kimi adapter updater) may re-invoke
+#                       this script after pulling new content.
+#
+# Failure modes: exits non-zero on build.sh failure (propagated). Partial
+#                install is possible if the script exits mid-run; re-running
+#                is safe. The dir-symlink guard prevents write-through
+#                corruption: if ~/.kimi/skills/agentic-engineering is a
+#                directory symlink pointing into the repo, the symlink is
+#                removed and replaced with a real directory before any files
+#                are written, ensuring tracked repo symlinks (SKILL.md, agents,
+#                commands, references) are never clobbered. The sections/rules
+#                migration is a 5-case contract; Case 4 (both exist) exits 1
+#                and requires manual intervention.
+#
+# Performance: ~2-5 s wall time (dominated by build.sh git operations).
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/bin/tests/test_kimi_install_symlink.sh
+++ b/bin/tests/test_kimi_install_symlink.sh
@@ -156,7 +156,7 @@ fi
 
 # ---- Test 3: dst is absent (clean install) - must not disturb repo symlinks ----
 
-rm -rf "$FAKE_HOME"
+if [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]]; then rm -rf "$FAKE_HOME"; fi
 FAKE_HOME="$(mktemp -d)"
 mkdir -p "$FAKE_HOME/.kimi/skills"
 # No symlink or directory at dst - clean install path.

--- a/bin/tests/test_kimi_install_symlink.sh
+++ b/bin/tests/test_kimi_install_symlink.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Purpose: Regression test for .kimi/install.sh dir-symlink write-through guard.
+#          Ensures that when ~/.kimi/skills/agentic-engineering is a directory
+#          symlink pointing into the repo, install.sh replaces it with a real
+#          directory and does NOT clobber tracked repo symlinks inside it.
+#
+# Public API: ./bin/tests/test_kimi_install_symlink.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, git, python3 (used by install.sh internally), mktemp.
+#
+# Downstream consumers: developer running locally before commit; can be
+#                       wired into CI.
+#
+# Failure modes: any assertion failure prints the failing assertion and exits 1.
+#                A temporary fake HOME is used; the real ~/.kimi is never touched.
+#                Tracked repo symlinks are restored on exit via trap.
+#
+# Performance: ~5 s wall time on a developer machine (runs install.sh twice).
+#
+# Regression coverage:
+#   - Major (Skeptic PR-114): a stale dir-symlink at ~/.kimi/skills/agentic-engineering
+#     pointing into the repo caused install.sh to write individual file-symlinks
+#     through the dir-symlink, corrupting tracked repo symlinks (SKILL.md,
+#     agents, commands, references). The fix detects this and replaces the
+#     dir-symlink with a real directory before writing into it. This test
+#     re-creates the bug-trigger scenario to prevent regression.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO_DIR/.kimi/install.sh"
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+  echo "FAIL: $INSTALL_SH not found" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# ---- Setup: save and restore tracked symlinks on exit ----
+SKILL_SRC="$REPO_DIR/.kimi/skills/agentic-engineering"
+TRACKED_TARGETS=()
+for item in SKILL.md agents commands references; do
+  if [[ -L "$SKILL_SRC/$item" ]]; then
+    TRACKED_TARGETS+=("$item=$(readlink "$SKILL_SRC/$item")")
+  fi
+done
+
+_restore_symlinks() {
+  for entry in "${TRACKED_TARGETS[@]:-}"; do
+    local name="${entry%%=*}"
+    local target="${entry#*=}"
+    local path="$SKILL_SRC/$name"
+    # Only restore if it was corrupted (no longer a symlink or wrong target)
+    if [[ ! -L "$path" ]] || [[ "$(readlink "$path")" != "$target" ]]; then
+      rm -f "$path"
+      ln -s "$target" "$path"
+    fi
+  done
+}
+
+FAKE_HOME=""
+_cleanup() {
+  if [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]]; then
+    rm -rf "$FAKE_HOME"
+  fi
+  _restore_symlinks
+}
+trap _cleanup EXIT
+
+# ---- Helper: assert git status is clean for tracked skill items ----
+_assert_git_clean() {
+  local label="$1"
+  local dirty
+  dirty="$(git -C "$REPO_DIR" status --porcelain \
+    -- ".kimi/skills/agentic-engineering/SKILL.md" \
+       ".kimi/skills/agentic-engineering/agents" \
+       ".kimi/skills/agentic-engineering/commands" \
+       ".kimi/skills/agentic-engineering/references" \
+    2>&1)"
+  if [[ -n "$dirty" ]]; then
+    _fail "$label: tracked repo symlinks were clobbered. git status output:"$'\n'"$dirty"
+  else
+    _pass "$label: tracked repo symlinks intact (git status clean)"
+  fi
+}
+
+# ---- Reset tracked symlinks to a known clean state before each run ----
+_reset_repo_symlinks() {
+  git -C "$REPO_DIR" checkout -- \
+    ".kimi/skills/agentic-engineering/SKILL.md" \
+    ".kimi/skills/agentic-engineering/agents" \
+    ".kimi/skills/agentic-engineering/commands" \
+    ".kimi/skills/agentic-engineering/references" \
+    2>/dev/null || true
+}
+
+# ---- Run install.sh with a fake HOME, suppressing interactive prompts ----
+_run_install() {
+  local fake_home="$1"
+  # Pipe /dev/null to stdin to skip any interactive prompts (e.g. skill_auto_load).
+  # Pass --mode=opt-out and --profile=default to skip interactive mode/profile selection.
+  HOME="$fake_home" bash "$INSTALL_SH" --mode=opt-out --profile=default \
+    < /dev/null > "$fake_home/.install_out" 2>&1
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "  [install.sh output]:" >&2
+    cat "$fake_home/.install_out" >&2
+    _fail "install.sh exited with code $rc"
+  fi
+  return $rc
+}
+
+# ============================================================
+# Test 1: Regression - dir-symlink at dst triggers guard
+# ============================================================
+
+FAKE_HOME="$(mktemp -d)"
+
+# Create the bug-trigger scenario: a directory symlink at
+# <fakeHOME>/.kimi/skills/agentic-engineering pointing into the repo.
+mkdir -p "$FAKE_HOME/.kimi/skills"
+ln -s "$SKILL_SRC" "$FAKE_HOME/.kimi/skills/agentic-engineering"
+
+# Ensure the repo symlinks are clean before running.
+_reset_repo_symlinks
+
+# First run
+if _run_install "$FAKE_HOME"; then
+  _assert_git_clean "regression-dir-symlink (first run)"
+else
+  : # _run_install already called _fail
+fi
+
+# ---- Test 2: Idempotency - second run must also leave git status clean ----
+
+_reset_repo_symlinks
+
+if _run_install "$FAKE_HOME"; then
+  _assert_git_clean "regression-dir-symlink (idempotent second run)"
+else
+  : # _run_install already called _fail
+fi
+
+# ---- Test 3: dst is absent (clean install) - must not disturb repo symlinks ----
+
+rm -rf "$FAKE_HOME"
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.kimi/skills"
+# No symlink or directory at dst - clean install path.
+
+_reset_repo_symlinks
+
+if _run_install "$FAKE_HOME"; then
+  _assert_git_clean "clean-install (no prior dst)"
+else
+  : # _run_install already called _fail
+fi
+
+# ---- Results ----
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Two defects in \`.kimi/install.sh\` caused the repo's committed portable-relative symlinks under \`.kimi/skills/agentic-engineering/\` to be clobbered on every install run.

**Defect 1 - stale dir-symlink write-through.** An earlier install style created \`~/.kimi/skills/agentic-engineering\` as a dir-symlink pointing at the repo's \`.kimi/skills/agentic-engineering/\`. When \`link_abs\` then wrote individual files into \`$SKILL_DST\`, it resolved through the dir-symlink and overwrote tracked files in the repo with machine-specific absolute paths. Fix: detect and remove the stale dir-symlink before \`mkdir -p\` creates a real directory.

**Defect 2 - self-referential SKILL.md target.** \`link_abs\` used \`\$SKILL_SRC/SKILL.md\` as the link target. When the dir-symlink write-through was active, this made the link point at itself. Fix: use \`\$REPO_DIR/content/SKILL.md\` directly (the actual file, not the intermediate repo symlink).

**Defect 3 - non-idempotent comparison.** \`link_abs\` compared \`readlink\` output (possibly relative) against an absolute src string, always seeing a mismatch and always re-writing. Fix: canonical \`realpath\`-both-sides comparison, matching the pattern from commit 3830c88 in \`build.sh\`.

**Verification:** After the fix, running \`bash .kimi/install.sh\` followed by \`git status --porcelain -- .kimi/skills/agentic-engineering/\` produces empty output. A second run is a true no-op (all links reported as "already linked"). All four tracked symlinks retain their committed portable-relative targets (\`../../../content/...\`).