### PR TITLE
docs: correct expected-title string in deploy runbook smoke test

### DIFF
--- a/docs/technical/deploy.md
+++ b/docs/technical/deploy.md
@@ -93,7 +93,7 @@ curl -sSI https://agentic-engineering-deploy.vercel.app/
 curl -sS https://agentic-engineering-deploy.vercel.app/ | head -c 300
 ```
 
-Expect HTTP 200 and a body containing `<title>Agentic Software Engineering</title>`. The custom alias may take 10-30 seconds to flip after the deploy returns.
+Expect HTTP 200 and a body containing `<title>Agentic Engineering</title>`. The custom alias may take 10-30 seconds to flip after the deploy returns.
 
 ## Footgun: silent auto-create on the wrong account
 


### PR DESCRIPTION
The smoke-test step in `docs/technical/deploy.md` expected `<title>Agentic Software Engineering</title>` but the actual hub page title (`docs/agentic-engineering.html` line 6) is `<title>Agentic Engineering</title>`. The stale string produced a false "deviation from runbook" warning on the last docs deploy.

Single-line correction. Independent Skeptic review: **APPROVED**, 0 findings (title verified character-for-character against the source HTML at the same commit; scope confirmed to exactly one line in one file).