### PR TITLE
feat(implement-ticket): tracker-state discovery preflight + init scaffolding (PR 3/4)

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -653,6 +653,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/.claude/commands/init-project.md
+++ b/.claude/commands/init-project.md
@@ -411,6 +411,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -727,12 +736,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -833,6 +845,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -870,6 +888,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -651,6 +651,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/.codex/commands/init-project.md
+++ b/.codex/commands/init-project.md
@@ -409,6 +409,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -725,12 +734,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -831,6 +843,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -868,6 +886,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -651,6 +651,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/.cursor/commands/init-project.md
+++ b/.cursor/commands/init-project.md
@@ -409,6 +409,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -725,12 +734,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -831,6 +843,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -868,6 +886,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -657,6 +657,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/.gemini/commands/init-project.toml
+++ b/.gemini/commands/init-project.toml
@@ -415,6 +415,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -731,12 +740,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -837,6 +849,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -874,6 +892,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -655,6 +655,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/.opencode/commands/init-project.md
+++ b/.opencode/commands/init-project.md
@@ -413,6 +413,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -729,12 +738,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -835,6 +847,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -872,6 +890,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -651,6 +651,44 @@ The scan never blocks more than one turn. Proceed to Phase 3 after the response 
 
 ---
 
+## Phase 2c: Tracker state discovery (conditional)
+
+Runs only when `TRACKER != none`. Skipped silently otherwise. Purpose: fetch the tracker's workflow states once, cache them, and validate the configured `TRACKER_STATE_*` names so misconfigurations surface as a warning at planning time rather than as a silent no-op transition at runtime.
+
+**Cache check.** Read `.agentic/tracker-states.json` if present. Use the cache when ALL hold: file exists, `fetched_at` is within 24 hours of now, `tracker` matches the resolved `TRACKER`, and `workspace` matches the resolved workspace/base-url. Otherwise fetch fresh.
+
+**Fetch.**
+- Linear: call `mcp__linear__list_workflow_states` (filter by the resolved team when available). Collect `{id, name, type}` for each state.
+- Jira: call `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (the first unresolved ticket in the batch, or `$TICKET_PREFIX-1` as a fallback probe). On 404 or error, fall back to an empty state list and skip validation. Map each transition's target status to `{id, name, type}` where `type` derives from the status category (`new`->`unstarted`, `indeterminate`->`started`, `done`->`completed`).
+
+**Write cache** atomically (tmp + `mv`) to `.agentic/tracker-states.json`:
+
+```json
+{
+  "fetched_at": "<ISO8601 UTC>",
+  "tracker": "linear|jira",
+  "workspace": "<workspace-slug-or-base-url>",
+  "states": [{"id": "...", "name": "In Progress", "type": "started"}],
+  "warnings": []
+}
+```
+
+`.agentic/tracker-states.json` is a runtime cache, gitignored under the `.agentic/` umbrella (NOT committed - it is machine-local and may be stale on a fresh checkout; that is acceptable since this preflight is soft-fail).
+
+**Validate.** For each of the 5 resolved `TRACKER_STATE_*` values, look for an exact (case-insensitive) name match in `states[].name`. For each miss, compute the closest match by case-insensitive Levenshtein distance and emit one operator-visible warning:
+
+```
+WARNING: configured state '<name>' not found in <tracker> workflow. Closest match: '<closest>'. Proceeding with configured name - transition may be silently skipped at runtime.
+```
+
+Append each warning to the cache's `warnings[]` array. Do NOT block execution.
+
+**Soft-fail.** Any MCP/API error during fetch is logged and the phase proceeds (no cache write on fetch failure; validation skipped). Never block planning on tracker discovery.
+
+Emit breadcrumb: `[phase: tracker-state-discovery | cached=<true|false> | misses=<N>]`
+
+---
+
 ## Phase 3: Architecture plan
 
 Spawn an `architect` agent. Provide:

--- a/content/commands/init-project.md
+++ b/content/commands/init-project.md
@@ -409,6 +409,15 @@ After sign-off: write the curated `AGENTS.md`, then merge the Worker's memory en
   - **Glossary** - see `glossary.md` for the project's domain terms (Ubiquitous Language).
   - <!-- TODO: Add project conventions as they emerge -->
   ```
+- `## PR Workflow` section - optional reviewer assignment fallback (commented out by default; CODEOWNERS takes precedence when present):
+  ```markdown
+  ## PR Workflow
+  # Uncomment and fill in Reviewers: only if you have NO CODEOWNERS file and want
+  # automatic reviewer assignment when /implement-ticket marks a PR ready for review.
+  # CODEOWNERS (at .github/CODEOWNERS, docs/CODEOWNERS, or repo root) takes precedence.
+  # Reviewers: github-user-1, github-user-2
+  ```
+  Always include this section (commented out). It is a no-op until the operator explicitly uncomments it.
 - `## Session start` section - tool-agnostic instruction for the session agent to verify scaffolding on the first interaction of each new session:
   ```markdown
   ## Session start
@@ -725,12 +734,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 .agentic/wrap.lock/
 .agentic/preferences.json
 .agentic/compression-state.json
+.agentic/tracker-states.json
+# tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
+# machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
 # .agentic/tracking.md - these are tool-agnostic agent config and belong in
 # source control.
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), and `compression-state.json` (compression bookkeeping). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config.
 
 ### 10. Create `docs/` structure
 
@@ -831,6 +843,12 @@ If `lc` was already installed, run `lc doctor` to verify the connection. If it f
 - QA assignee ID: [Linear user UUID — optional, omit line if not provided]
 - Branch prefix: Include issue ID (e.g., `feature/[TEAM]-12-description`)
 - Projects: [comma-separated project names, or omit this line if none provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# State In Progress: In Progress
+# State In Review: In Review
+# State QA: Testing
+# State Blocked: Blocked
+# State Done: Done
 ```
 
 Place after `## Tools`. Prompt for: team key (required), workspace slug (required), QA assignee UUID (optional — "press Enter to skip"). If the user did not provide project names, omit the `Projects:` line.
@@ -868,6 +886,12 @@ TICKET_PREFIX: [project key, e.g. PROJ]
 JIRA_BASE_URL: [e.g. https://acme.atlassian.net]
 JIRA_QA_ASSIGNEE_ACCOUNT_ID: [Atlassian account ID — optional, omit line if not provided]
 JIRA_QA_TRANSITION: [transition name — optional, omit line if not provided]
+# Optional workflow-state name overrides (defaults shown; uncomment to override):
+# JIRA_STATE_IN_PROGRESS: In Progress
+# JIRA_STATE_IN_REVIEW: In Review
+# JIRA_STATE_QA: QA
+# JIRA_STATE_BLOCKED: Blocked
+# JIRA_STATE_DONE: Done
 ```
 
 Place after `## Tools`. Prompt for: TICKET_PREFIX (required), JIRA_BASE_URL (required), JIRA_QA_ASSIGNEE_ACCOUNT_ID (optional), JIRA_QA_TRANSITION (optional). **Do not use a default value for `JIRA_QA_TRANSITION`** — if the user does not provide one, omit the line entirely. `/implement-ticket` Phase 11 will skip the transition step when absent rather than guessing a transition name.


### PR DESCRIPTION
## Summary

PR 3 of 4. Adds a tracker-state discovery preflight so misconfigured state names surface as warnings at planning time instead of silent no-op transitions at runtime. Plus AGENTS.md scaffolding in `/init-project`.

## New Phase 2c (conditional on TRACKER != none)

Inserted between Phase 2b (Brief check) and Phase 3 (Architect):

- **Cache:** read `.agentic/tracker-states.json`; use it only when ALL hold — file exists, `fetched_at` within 24h, `tracker` matches, `workspace` matches. Else fetch fresh.
- **Fetch:** Linear via `mcp__linear__list_workflow_states`; Jira via `mcp__mcp-atlassian__jira_get_transitions` on a probe ticket (404 → empty list + skip validation).
- **Write:** atomic (tmp + mv) to `.agentic/tracker-states.json` (gitignored runtime cache, 24h TTL, NOT committed).
- **Validate:** for each of the 5 `TRACKER_STATE_*` config values, exact case-insensitive name match; on miss, emit one operator-visible warning with the closest Levenshtein match.
- **Soft-fail:** any MCP error logs and proceeds; never blocks planning.
- Breadcrumb: `[phase: tracker-state-discovery | cached=<bool> | misses=<N>]`

## init-project scaffolding

- AGENTS.md `## PR Workflow` section (commented `Reviewers:` fallback for projects without CODEOWNERS)
- 5 optional state-name override fields (commented) in both `## Linear` (`State QA: Testing`) and `## Tracker` (`JIRA_STATE_QA: QA`) templates
- `.agentic/tracker-states.json` added to the Step 9 gitignore block (intentionally ignored runtime cache)

## Review history

- Architect: 4-PR unified plan (PR 3 = prior plan's discovery preflight)
- Engineer executed PR 3 scope; ran all 8 adapter builds (lesson from PR 2's adapter-sync miss)
- Skeptic on diff: 0 Critical, 0 Major, 0 Minor — signed off
  - Verified: field-name consistency between init-project scaffolding and PR 2's Setup reads (no silent-override-failure risk), full 8-adapter drift clean, baseline correctly unchanged (Phase 2c is a command file, not a methodology section)

## Out of scope (final PR)

- PR 4: `/ticket-status-sync` command for human-merge reconciliation

## Verification

- `bash scripts/check-methodology-drift.sh` PASS (baseline unchanged)
- Full 8-adapter `git diff --exit-code` CLEAN
- Phase 2c present; cache logic has all 4 validity conditions; Jira/Linear field names match PR 2 Setup parser exactly