### PR TITLE
feat(qa-engineer): machine-parseable screenshot evidence block

### DIFF
--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -295,7 +295,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -341,7 +341,7 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
 
-## Screenshot Evidence
+## Screenshot Evidence JSON
 ~~~qa-screenshots-json
 [
   {
@@ -360,9 +360,10 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ~~~
 
 Emission rules:
-- Emit `[]` if no screenshots were taken.
+- Emit `[]` if no screenshots were taken, including when the overall result is BLOCKED.
 - When overall result is PASS: emit only PASS entries.
 - When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- When overall result is BLOCKED: emit `[]`.
 - A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -295,7 +295,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -340,6 +340,30 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ## Screenshots
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
+
+## Screenshot Evidence
+~~~qa-screenshots-json
+[
+  {
+    "path": "/tmp/qa_1716000000_homepage_load.png",
+    "description": "Homepage initial load - layout and heading visible",
+    "criterion_id": 1,
+    "result": "PASS"
+  },
+  {
+    "path": "/tmp/qa_1716000001_nav_missing_link.png",
+    "description": "Sidebar missing Sessions link",
+    "criterion_id": 2,
+    "result": "FAIL"
+  }
+]
+~~~
+
+Emission rules:
+- Emit `[]` if no screenshots were taken.
+- When overall result is PASS: emit only PASS entries.
+- When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues
 [For each blocking issue:]

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -296,7 +296,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -342,7 +342,7 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
 
-## Screenshot Evidence
+## Screenshot Evidence JSON
 ~~~qa-screenshots-json
 [
   {
@@ -361,9 +361,10 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ~~~
 
 Emission rules:
-- Emit `[]` if no screenshots were taken.
+- Emit `[]` if no screenshots were taken, including when the overall result is BLOCKED.
 - When overall result is PASS: emit only PASS entries.
 - When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- When overall result is BLOCKED: emit `[]`.
 - A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -296,7 +296,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -341,6 +341,30 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ## Screenshots
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
+
+## Screenshot Evidence
+~~~qa-screenshots-json
+[
+  {
+    "path": "/tmp/qa_1716000000_homepage_load.png",
+    "description": "Homepage initial load - layout and heading visible",
+    "criterion_id": 1,
+    "result": "PASS"
+  },
+  {
+    "path": "/tmp/qa_1716000001_nav_missing_link.png",
+    "description": "Sidebar missing Sessions link",
+    "criterion_id": 2,
+    "result": "FAIL"
+  }
+]
+~~~
+
+Emission rules:
+- Emit `[]` if no screenshots were taken.
+- When overall result is PASS: emit only PASS entries.
+- When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues
 [For each blocking issue:]

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -298,7 +298,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -344,7 +344,7 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
 
-## Screenshot Evidence
+## Screenshot Evidence JSON
 ~~~qa-screenshots-json
 [
   {
@@ -363,9 +363,10 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ~~~
 
 Emission rules:
-- Emit `[]` if no screenshots were taken.
+- Emit `[]` if no screenshots were taken, including when the overall result is BLOCKED.
 - When overall result is PASS: emit only PASS entries.
 - When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- When overall result is BLOCKED: emit `[]`.
 - A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -298,7 +298,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -343,6 +343,30 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ## Screenshots
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
+
+## Screenshot Evidence
+~~~qa-screenshots-json
+[
+  {
+    "path": "/tmp/qa_1716000000_homepage_load.png",
+    "description": "Homepage initial load - layout and heading visible",
+    "criterion_id": 1,
+    "result": "PASS"
+  },
+  {
+    "path": "/tmp/qa_1716000001_nav_missing_link.png",
+    "description": "Sidebar missing Sessions link",
+    "criterion_id": 2,
+    "result": "FAIL"
+  }
+]
+~~~
+
+Emission rules:
+- Emit `[]` if no screenshots were taken.
+- When overall result is PASS: emit only PASS entries.
+- When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues
 [For each blocking issue:]

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -295,7 +295,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -341,7 +341,7 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
 
-## Screenshot Evidence
+## Screenshot Evidence JSON
 ~~~qa-screenshots-json
 [
   {
@@ -360,9 +360,10 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ~~~
 
 Emission rules:
-- Emit `[]` if no screenshots were taken.
+- Emit `[]` if no screenshots were taken, including when the overall result is BLOCKED.
 - When overall result is PASS: emit only PASS entries.
 - When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- When overall result is BLOCKED: emit `[]`.
 - A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -295,7 +295,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion.
+Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence` JSON block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -340,6 +340,30 @@ Return this exact structure. Replace all brackets with real content. If a sectio
 ## Screenshots
 - [/tmp/qa_timestamp_what.png - description]
 - [list all screenshots taken, or "None - agent-browser snapshot only"]
+
+## Screenshot Evidence
+~~~qa-screenshots-json
+[
+  {
+    "path": "/tmp/qa_1716000000_homepage_load.png",
+    "description": "Homepage initial load - layout and heading visible",
+    "criterion_id": 1,
+    "result": "PASS"
+  },
+  {
+    "path": "/tmp/qa_1716000001_nav_missing_link.png",
+    "description": "Sidebar missing Sessions link",
+    "criterion_id": 2,
+    "result": "FAIL"
+  }
+]
+~~~
+
+Emission rules:
+- Emit `[]` if no screenshots were taken.
+- When overall result is PASS: emit only PASS entries.
+- When overall result is FAIL or PARTIAL: emit all entries regardless of individual result.
+- A malformed or absent block is treated as `[]` by downstream consumers and never causes a hard error.
 
 ## Blocking Issues
 [For each blocking issue:]


### PR DESCRIPTION
## Summary
- Adds a `## Screenshot Evidence JSON` section to the qa-engineer output contract: a `qa-screenshots-json` fenced block (array of `{path, description, criterion_id, result}`).
- Lets the implement-ticket conductor parse screenshot metadata reliably instead of scraping the human-readable list.
- Emission rules: `[]` if none (incl. BLOCKED); PASS-only on overall PASS; all entries on FAIL/PARTIAL; malformed/absent treated as `[]`.

Unit A of the QA screenshot-proof plan (`docs/planning/qa-evidence-proof.md`). Paired with the implement-ticket PR (fence-agnostic parser consumes this block).

## Review
Skeptic-reviewed (2 rounds): initial review + fix pass for BLOCKED emission rule and heading-case clash. Signed off clean.

## Test plan
- [ ] Spec-only change (agent-spec doc, no runtime). Verified by Skeptic review against the plan contract.