### PR TITLE
chore(deps): fix tmp CVE in scripts/

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"


### PR DESCRIPTION
## Summary

Addresses 1 of 2 targeted CVEs from the recent dependency audit. The second (uuid in `.opencode/`) is blocked - see Out of Scope below.

## Fix

**scripts/**: transitive `tmp` 0.2.5 → 0.2.7 via `npm audit fix`
- Advisory: [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65)
- Severity: High
- Ecosystem: npm
- Mechanism: Path traversal via unsanitized prefix/postfix enabling directory escape
- Diff: lockfile-only, 3 lines. No top-level dep bumps. No `overrides` block needed.

## npm audit before/after

```
scripts/ before: 1 high (tmp <0.2.6)
scripts/ after:  0 vulnerabilities
```

## Out of scope (blocked)

**`.opencode/` uuid 13.0.0 → 13.0.1** ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), moderate): cannot be committed via this PR. `.opencode/package.json` and `.opencode/package-lock.json` are listed in `.opencode/.gitignore` as user-local config. The fix was applied locally and verified (`npm audit --omit=dev` → 0 vulnerabilities) but the artifacts are non-shippable. Recommend either (a) untracking those files from .gitignore in a separate PR if they should be shared project config, or (b) documenting in `.opencode/README.md` that users should run `npm install uuid@13.0.1` after install.

## Scope note

This addresses 1 of the ~150 vulnerabilities Dependabot reports on this repo (5 Critical / 50 High / 70 Moderate / 25 Low). Broader triage is tracked separately.