### PR TITLE
docs(protocol): add External Comment Discipline rule for PR and tracker comments

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -1627,6 +1627,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1823,7 +1825,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -941,6 +941,23 @@ Agents must be mindful of context-window consumption. Large outputs increase lat
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
+## External Comment Discipline
+
+Agents author artifacts that humans read outside the session - PR titles and bodies, PR review comments, Linear comments, Jira comments, commit messages that summarise work, deploy and release notes. These surfaces have a different cost profile from in-session output: humans read them under time pressure, often on a phone, often days after the work landed. Verbosity is not free here - it is a tax on every future reader.
+
+Apply these rules to every external-facing comment:
+
+- **Lead with the result and the link.** The first line should answer "what changed and where do I look?" - not restate the ticket, not narrate the journey.
+- **Bullets over prose.** Each bullet earns its place by adding something the diff, screenshot, or linked artifact does not already show. If a bullet just describes what the diff shows, delete it.
+- **Cut what the reader can see for themselves.** Do not restate the ticket. Do not narrate the agent's own process ("I reviewed", "we investigated", "after analysis"). Do not summarise a diff that is one click away.
+- **Evidence beats description.** A screenshot, a test URL, a log excerpt, or a link to the failing line is worth more than a paragraph of explanation. Link, do not transcribe.
+- **No marketing voice, no emojis, no agent attribution footers.** The writing-style rules elsewhere in this methodology (plain verbs, no rule-of-three triads, no AI vocabulary, no em dashes) apply with extra force on external surfaces because humans read them quickly and judgmentally.
+- **Length is not the metric; signal-per-line is.** A long comment is fine when every line is load-bearing. A three-line comment that restates the ticket is too long.
+- **Skeptic findings posted as PR review comments** are one finding per comment in the form `[Severity] path:line - issue. Fix: <one-line action>.` No preamble, no sign-off banner, no "Active search" line on per-finding comments - that line belongs to the conductor-internal sign-off, not the PR surface.
+- **Self-check before posting.** Re-read this section. For each sentence ask: is this load-bearing for a human deciding "do I need to act on this?" If not, delete it.
+
+This rule layers conciseness expectations on top of the structural templates in `content/commands/implement-ticket.md` (PR body, tracker comment). The templates still apply; this rule governs the substance that fills them.
+
 ---
 
 # Module Manifests

--- a/.codex/agents/release-orchestrator.toml
+++ b/.codex/agents/release-orchestrator.toml
@@ -126,6 +126,8 @@ Include:
 
 Do not editorialize. Copy the commit messages faithfully. Do not add entries for commits outside the changeset boundary.
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ### Phase 4 - Version bump
 
 Locate the version source (e.g., `package.json`, `pyproject.toml`, `version.txt`, or project-specific convention). Bump the version field to match the decision from Phase 2. Write the file. Verify the write:

--- a/.codex/agents/wrap-ticket.toml
+++ b/.codex/agents/wrap-ticket.toml
@@ -67,6 +67,8 @@ You are a **constrained automated subset of `/wrap`**. The differences are inten
 
 You do not write code. You do not modify application files. You do not spawn subagents. You write only to MEMORY.md, decisions.md, and .agentic/context.md (Recent Focus only).
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ## Reading your spawn prompt
 
 Your spawn prompt provides the following inputs (all required unless noted):

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1625,6 +1625,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1821,7 +1823,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1625,6 +1625,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1821,7 +1823,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -142,3 +142,20 @@ Agents must be mindful of context-window consumption. Large outputs increase lat
 - **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
+
+## External Comment Discipline
+
+Agents author artifacts that humans read outside the session - PR titles and bodies, PR review comments, Linear comments, Jira comments, commit messages that summarise work, deploy and release notes. These surfaces have a different cost profile from in-session output: humans read them under time pressure, often on a phone, often days after the work landed. Verbosity is not free here - it is a tax on every future reader.
+
+Apply these rules to every external-facing comment:
+
+- **Lead with the result and the link.** The first line should answer "what changed and where do I look?" - not restate the ticket, not narrate the journey.
+- **Bullets over prose.** Each bullet earns its place by adding something the diff, screenshot, or linked artifact does not already show. If a bullet just describes what the diff shows, delete it.
+- **Cut what the reader can see for themselves.** Do not restate the ticket. Do not narrate the agent's own process ("I reviewed", "we investigated", "after analysis"). Do not summarise a diff that is one click away.
+- **Evidence beats description.** A screenshot, a test URL, a log excerpt, or a link to the failing line is worth more than a paragraph of explanation. Link, do not transcribe.
+- **No marketing voice, no emojis, no agent attribution footers.** The writing-style rules elsewhere in this methodology (plain verbs, no rule-of-three triads, no AI vocabulary, no em dashes) apply with extra force on external surfaces because humans read them quickly and judgmentally.
+- **Length is not the metric; signal-per-line is.** A long comment is fine when every line is load-bearing. A three-line comment that restates the ticket is too long.
+- **Skeptic findings posted as PR review comments** are one finding per comment in the form `[Severity] path:line - issue. Fix: <one-line action>.` No preamble, no sign-off banner, no "Active search" line on per-finding comments - that line belongs to the conductor-internal sign-off, not the PR surface.
+- **Self-check before posting.** Re-read this section. For each sentence ask: is this load-bearing for a human deciding "do I need to act on this?" If not, delete it.
+
+This rule layers conciseness expectations on top of the structural templates in `content/commands/implement-ticket.md` (PR body, tracker comment). The templates still apply; this rule governs the substance that fills them.

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -941,6 +941,23 @@ Agents must be mindful of context-window consumption. Large outputs increase lat
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
+## External Comment Discipline
+
+Agents author artifacts that humans read outside the session - PR titles and bodies, PR review comments, Linear comments, Jira comments, commit messages that summarise work, deploy and release notes. These surfaces have a different cost profile from in-session output: humans read them under time pressure, often on a phone, often days after the work landed. Verbosity is not free here - it is a tax on every future reader.
+
+Apply these rules to every external-facing comment:
+
+- **Lead with the result and the link.** The first line should answer "what changed and where do I look?" - not restate the ticket, not narrate the journey.
+- **Bullets over prose.** Each bullet earns its place by adding something the diff, screenshot, or linked artifact does not already show. If a bullet just describes what the diff shows, delete it.
+- **Cut what the reader can see for themselves.** Do not restate the ticket. Do not narrate the agent's own process ("I reviewed", "we investigated", "after analysis"). Do not summarise a diff that is one click away.
+- **Evidence beats description.** A screenshot, a test URL, a log excerpt, or a link to the failing line is worth more than a paragraph of explanation. Link, do not transcribe.
+- **No marketing voice, no emojis, no agent attribution footers.** The writing-style rules elsewhere in this methodology (plain verbs, no rule-of-three triads, no AI vocabulary, no em dashes) apply with extra force on external surfaces because humans read them quickly and judgmentally.
+- **Length is not the metric; signal-per-line is.** A long comment is fine when every line is load-bearing. A three-line comment that restates the ticket is too long.
+- **Skeptic findings posted as PR review comments** are one finding per comment in the form `[Severity] path:line - issue. Fix: <one-line action>.` No preamble, no sign-off banner, no "Active search" line on per-finding comments - that line belongs to the conductor-internal sign-off, not the PR surface.
+- **Self-check before posting.** Re-read this section. For each sentence ask: is this load-bearing for a human deciding "do I need to act on this?" If not, delete it.
+
+This rule layers conciseness expectations on top of the structural templates in `content/commands/implement-ticket.md` (PR body, tracker comment). The templates still apply; this rule governs the substance that fills them.
+
 
 ---
 

--- a/.gemini/agents/release-orchestrator.md
+++ b/.gemini/agents/release-orchestrator.md
@@ -127,6 +127,8 @@ Include:
 
 Do not editorialize. Copy the commit messages faithfully. Do not add entries for commits outside the changeset boundary.
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ### Phase 4 - Version bump
 
 Locate the version source (e.g., `package.json`, `pyproject.toml`, `version.txt`, or project-specific convention). Bump the version field to match the decision from Phase 2. Write the file. Verify the write:

--- a/.gemini/agents/wrap-ticket.md
+++ b/.gemini/agents/wrap-ticket.md
@@ -68,6 +68,8 @@ You are a **constrained automated subset of `/wrap`**. The differences are inten
 
 You do not write code. You do not modify application files. You do not spawn subagents. You write only to MEMORY.md, decisions.md, and .agentic/context.md (Recent Focus only).
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ## Reading your spawn prompt
 
 Your spawn prompt provides the following inputs (all required unless noted):

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -1631,6 +1631,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1827,7 +1829,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -941,6 +941,23 @@ Agents must be mindful of context-window consumption. Large outputs increase lat
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
 
+## External Comment Discipline
+
+Agents author artifacts that humans read outside the session - PR titles and bodies, PR review comments, Linear comments, Jira comments, commit messages that summarise work, deploy and release notes. These surfaces have a different cost profile from in-session output: humans read them under time pressure, often on a phone, often days after the work landed. Verbosity is not free here - it is a tax on every future reader.
+
+Apply these rules to every external-facing comment:
+
+- **Lead with the result and the link.** The first line should answer "what changed and where do I look?" - not restate the ticket, not narrate the journey.
+- **Bullets over prose.** Each bullet earns its place by adding something the diff, screenshot, or linked artifact does not already show. If a bullet just describes what the diff shows, delete it.
+- **Cut what the reader can see for themselves.** Do not restate the ticket. Do not narrate the agent's own process ("I reviewed", "we investigated", "after analysis"). Do not summarise a diff that is one click away.
+- **Evidence beats description.** A screenshot, a test URL, a log excerpt, or a link to the failing line is worth more than a paragraph of explanation. Link, do not transcribe.
+- **No marketing voice, no emojis, no agent attribution footers.** The writing-style rules elsewhere in this methodology (plain verbs, no rule-of-three triads, no AI vocabulary, no em dashes) apply with extra force on external surfaces because humans read them quickly and judgmentally.
+- **Length is not the metric; signal-per-line is.** A long comment is fine when every line is load-bearing. A three-line comment that restates the ticket is too long.
+- **Skeptic findings posted as PR review comments** are one finding per comment in the form `[Severity] path:line - issue. Fix: <one-line action>.` No preamble, no sign-off banner, no "Active search" line on per-finding comments - that line belongs to the conductor-internal sign-off, not the PR surface.
+- **Self-check before posting.** Re-read this section. For each sentence ask: is this load-bearing for a human deciding "do I need to act on this?" If not, delete it.
+
+This rule layers conciseness expectations on top of the structural templates in `content/commands/implement-ticket.md` (PR body, tracker comment). The templates still apply; this rule governs the substance that fills them.
+
 ---
 
 # Module Manifests

--- a/.opencode/agents/release-orchestrator.md
+++ b/.opencode/agents/release-orchestrator.md
@@ -125,6 +125,8 @@ Include:
 
 Do not editorialize. Copy the commit messages faithfully. Do not add entries for commits outside the changeset boundary.
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ### Phase 4 - Version bump
 
 Locate the version source (e.g., `package.json`, `pyproject.toml`, `version.txt`, or project-specific convention). Bump the version field to match the decision from Phase 2. Write the file. Verify the write:

--- a/.opencode/agents/wrap-ticket.md
+++ b/.opencode/agents/wrap-ticket.md
@@ -66,6 +66,8 @@ You are a **constrained automated subset of `/wrap`**. The differences are inten
 
 You do not write code. You do not modify application files. You do not spawn subagents. You write only to MEMORY.md, decisions.md, and .agentic/context.md (Recent Focus only).
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ## Reading your spawn prompt
 
 Your spawn prompt provides the following inputs (all required unless noted):

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -1629,6 +1629,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1825,7 +1827,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/content/agents/release-orchestrator.md
+++ b/content/agents/release-orchestrator.md
@@ -126,6 +126,8 @@ Include:
 
 Do not editorialize. Copy the commit messages faithfully. Do not add entries for commits outside the changeset boundary.
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ### Phase 4 - Version bump
 
 Locate the version source (e.g., `package.json`, `pyproject.toml`, `version.txt`, or project-specific convention). Bump the version field to match the decision from Phase 2. Write the file. Verify the write:

--- a/content/agents/wrap-ticket.md
+++ b/content/agents/wrap-ticket.md
@@ -67,6 +67,8 @@ You are a **constrained automated subset of `/wrap`**. The differences are inten
 
 You do not write code. You do not modify application files. You do not spawn subagents. You write only to MEMORY.md, decisions.md, and .agentic/context.md (Recent Focus only).
 
+External comments follow §External Comment Discipline in `content/rules/conventions.md`.
+
 ## Reading your spawn prompt
 
 Your spawn prompt provides the following inputs (all required unless noted):

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1625,6 +1625,8 @@ Omit the tracker reference block entirely. The PR body will have only Summary an
 
 Open as draft PR. GitHub does not request reviewers on a draft; reviewers are assigned in Phase 10b after CI passes.
 
+Authoring rule: §External Comment Discipline in `content/rules/conventions.md` applies - lead with the result, bullets over prose, cut anything the diff already shows.
+
 Run:
 
 ```bash
@@ -1821,7 +1823,7 @@ Spawn a tracker-writeback subagent (Tier 1, `general-purpose` agent type). The c
 > - `TICKET_ID`: e.g. `[TICKET_PREFIX]-NNN`
 > - `PR_URL`: `https://github.com/[GH_REPO]/pull/[PR_NUMBER]`
 > - `TEST_URL`: extracted from CI (or the literal string `pending — see PR` if Phase 10 timed out)
-> - `qa_summary`: 1-2 sentences on what specifically to test and any known limitations from the Skeptic review
+> - `qa_summary`: Per §External Comment Discipline in `content/rules/conventions.md`: lead with status + PR link, then bullet only what the reviewer cannot see from the PR itself (QA caveats, known limitations, what to focus testing on). Omit restating the ticket.
 > - `target_state`: `$TRACKER_STATE_QA` (resolved in Setup; defaults to `"Testing"` for Linear, `"QA"` for Jira)
 > - `forward_only_guard`: `true`
 > - For Linear: `LINEAR_QA_ASSIGNEE_ID` (optional - omit if not configured)

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -137,3 +137,20 @@ Agents must be mindful of context-window consumption. Large outputs increase lat
 - **Structured blocks over prose.** Prefer the JSON structured block for machine-readable data (file lists, gate results) and keep prose for human-readable narrative only.
 
 Multi-developer coordination guidance lives in `content/references/multi-developer-coordination.md`.
+
+## External Comment Discipline
+
+Agents author artifacts that humans read outside the session - PR titles and bodies, PR review comments, Linear comments, Jira comments, commit messages that summarise work, deploy and release notes. These surfaces have a different cost profile from in-session output: humans read them under time pressure, often on a phone, often days after the work landed. Verbosity is not free here - it is a tax on every future reader.
+
+Apply these rules to every external-facing comment:
+
+- **Lead with the result and the link.** The first line should answer "what changed and where do I look?" - not restate the ticket, not narrate the journey.
+- **Bullets over prose.** Each bullet earns its place by adding something the diff, screenshot, or linked artifact does not already show. If a bullet just describes what the diff shows, delete it.
+- **Cut what the reader can see for themselves.** Do not restate the ticket. Do not narrate the agent's own process ("I reviewed", "we investigated", "after analysis"). Do not summarise a diff that is one click away.
+- **Evidence beats description.** A screenshot, a test URL, a log excerpt, or a link to the failing line is worth more than a paragraph of explanation. Link, do not transcribe.
+- **No marketing voice, no emojis, no agent attribution footers.** The writing-style rules elsewhere in this methodology (plain verbs, no rule-of-three triads, no AI vocabulary, no em dashes) apply with extra force on external surfaces because humans read them quickly and judgmentally.
+- **Length is not the metric; signal-per-line is.** A long comment is fine when every line is load-bearing. A three-line comment that restates the ticket is too long.
+- **Skeptic findings posted as PR review comments** are one finding per comment in the form `[Severity] path:line - issue. Fix: <one-line action>.` No preamble, no sign-off banner, no "Active search" line on per-finding comments - that line belongs to the conductor-internal sign-off, not the PR surface.
+- **Self-check before posting.** Re-read this section. For each sentence ask: is this load-bearing for a human deciding "do I need to act on this?" If not, delete it.
+
+This rule layers conciseness expectations on top of the structural templates in `content/commands/implement-ticket.md` (PR body, tracker comment). The templates still apply; this rule governs the substance that fills them.


### PR DESCRIPTION
## Summary

- Adds `## External Comment Discipline` to `content/rules/conventions.md` - qualitative rules only, no numeric caps
- Wires the rule into `implement-ticket.md`: authoring directive on the PR body and updated `qa_summary` guidance
- Cross-references from `wrap-ticket.md` and `release-orchestrator.md`

## Reviewer focus

- Rule substance in `content/rules/conventions.md` - check that the bullets are actionable and not contradicting existing style guidance
- `qa_summary` replacement in Phase 11 tracker comment block - confirm it still fits the surrounding template
- Adapter artifacts are regenerated (`.claude/`, `.codex/`, `.cursor/`) - spot-check one adapter file for fidelity

## Test plan

- [ ] Doc-only change - no runtime tests; Skeptic review is the gate