### PR TITLE
feat(community): OSS launch community files - wave 1 (IR-4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_request.yml
@@ -1,0 +1,47 @@
+name: Adapter request
+description: Request support for a new tool, or improvements to an existing adapter.
+title: "[adapter] "
+labels: ["adapter-request"]
+body:
+  - type: dropdown
+    id: target_adapter
+    attributes:
+      label: Target adapter
+      description: Which tool would this adapter target?
+      options:
+        - Claude Code
+        - Cursor
+        - Codex CLI
+        - Gemini CLI
+        - Kimi Code
+        - OpenCode
+        - Pi coding agent
+        - Pi oh-my-pi
+        - Hermes
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What do you want to do with this adapter? What's the workflow?
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Known constraints
+      description: Tool-specific limitations, missing features, or quirks the adapter would need to work around.
+    validations:
+      required: false
+  - type: dropdown
+    id: willing_to_contribute
+    attributes:
+      label: Willing to contribute
+      description: Would you be willing to help build or maintain this adapter?
+      options:
+        - "yes"
+        - "no"
+        - "maybe"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible defect in the methodology, an adapter, or a script.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please confirm the issue reproduces against the latest `main` and search existing issues before submitting.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong? Be specific.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce. Include commands, prompts, or configs.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: adapter
+    attributes:
+      label: Adapter
+      description: Which adapter is affected?
+      options:
+        - Claude Code
+        - Cursor
+        - Codex CLI
+        - Gemini CLI
+        - Kimi Code
+        - OpenCode
+        - Pi coding agent
+        - Pi oh-my-pi
+        - Hermes
+        - multiple
+        - n/a
+    validations:
+      required: true
+  - type: input
+    id: adapter_version
+    attributes:
+      label: Adapter version
+      description: Version or commit SHA of the adapter / tool in use.
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 14.5, Ubuntu 22.04, Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste relevant logs, transcripts, or error output. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a new capability or enhancement.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Who is affected?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you'd prefer the proposed one.
+    validations:
+      required: false
+  - type: checkboxes
+    id: affected_adapters
+    attributes:
+      label: Affected adapters
+      description: Tick all that apply.
+      options:
+        - label: Claude Code
+        - label: Cursor
+        - label: Codex CLI
+        - label: Gemini CLI
+        - label: Kimi Code
+        - label: OpenCode
+        - label: Pi coding agent
+        - label: Pi oh-my-pi
+        - label: Hermes
+        - label: None (methodology / docs only)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/protocol_change.yml
+++ b/.github/ISSUE_TEMPLATE/protocol_change.yml
@@ -1,0 +1,63 @@
+name: Protocol change
+description: Propose a change to the methodology - conductor rules, Skeptic protocol, risk classification, memory persistence, worktree lifecycle, slash commands, or agent definitions.
+title: "[protocol] "
+labels: ["protocol-change"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Protocol changes are reviewed before a PR is opened. Describe the motivation and tradeoffs here; the lead maintainer will approve, request revisions, or decline before implementation work begins. See [GOVERNANCE.md](../../GOVERNANCE.md) for the full flow.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One paragraph on what would change.
+    validations:
+      required: true
+  - type: dropdown
+    id: protocol_area
+    attributes:
+      label: Protocol area
+      options:
+        - conductor rules
+        - Skeptic protocol
+        - risk classification
+        - memory persistence
+        - worktree lifecycle
+        - slash commands
+        - agent definition
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? What is the current pain?
+    validations:
+      required: true
+  - type: textarea
+    id: backward_compatibility
+    attributes:
+      label: Backward-compatibility impact
+      description: Will existing projects, adapters, or workflows need to change? Migration path?
+    validations:
+      required: true
+  - type: checkboxes
+    id: affected_adapters
+    attributes:
+      label: Affected adapters
+      description: Tick all that apply.
+      options:
+        - label: Claude Code
+        - label: Cursor
+        - label: Codex CLI
+        - label: Gemini CLI
+        - label: Kimi Code
+        - label: OpenCode
+        - label: Pi coding agent
+        - label: Pi oh-my-pi
+        - label: Hermes
+        - label: None (methodology / docs only)
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!-- Describe the *why* in addition to the *what*. Link related issues. -->
+
+## Summary
+
+<!-- One or two sentences on the motivation and the change. -->
+
+## Related issues
+
+<!-- e.g. Closes #123, Refs #456 -->
+
+## Checklist
+
+- [ ] DCO sign-off on every commit (`git commit -s`)
+- [ ] Affected adapters declared
+- [ ] Before/after transcript included for agent-behavior changes
+- [ ] `install.sh` re-run locally and behavior verified
+- [ ] Tests/lint passing
+- [ ] Docs updated if behavior changed
+
+## Affected adapters
+
+<!-- Tick all that apply. -->
+
+- [ ] Claude Code
+- [ ] Cursor
+- [ ] Codex CLI
+- [ ] Gemini CLI
+- [ ] Kimi Code
+- [ ] OpenCode
+- [ ] Pi coding agent
+- [ ] Pi oh-my-pi
+- [ ] Hermes
+- [ ] None (methodology / docs only)
+
+## Before/after transcript
+
+<!-- For agent-behavior changes, paste a short before/after transcript. Omit if not applicable. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a first release is tagged.
+
+## [Unreleased]
+
+### Added
+- Community files for the open-source launch (SUPPORT, GOVERNANCE, ROADMAP, CHANGELOG, issue and PR templates).
+
+[Unreleased]: https://github.com/Solara6/agentic-engineering/compare/HEAD...HEAD

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `conduct@<TBD>` (placeholder - requires human update before publication). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,27 @@
 - New adapters for other tools (see [ADAPTERS.md](ADAPTERS.md))
 - Documentation improvements
 
+### What's not welcome
+
+- Customer-specific or branded workflows
+- Private credentials, internal paths, or client names
+- Bypasses of the project's safety conventions presented as features
+- Automation that weakens the deny-list
+- Wholesale rewrites of methodology rules without a protocol-change issue first
+
+## Protocol-change process
+
+Changes to the methodology itself - conductor rules, the Skeptic protocol, risk classification, memory persistence, worktree lifecycle, slash commands, or agent definitions - go through the protocol-change RFC flow before a PR is opened. Open an issue using the [Protocol change template](.github/ISSUE_TEMPLATE/protocol_change.yml) describing the motivation, the proposed change, backward-compatibility impact, and affected adapters. The lead maintainer approves the direction, requests revisions, or declines. Once approved, open a PR referencing the issue. See [GOVERNANCE.md](GOVERNANCE.md) for the full flow.
+
 ## PR guidelines
 
 - One concern per PR — don't bundle unrelated changes
 - Describe the *why* in the PR body, not just the *what*
 - Test locally before opening: re-run `install.sh`, open a Claude Code session, verify the change works as expected
+
+### Adapter compatibility declaration
+
+Every PR must declare which adapters it affects. The PR template includes a checklist - tick all that apply (Claude Code, Cursor, Codex CLI, Gemini CLI, Kimi Code, OpenCode, Pi coding agent, Pi oh-my-pi, Hermes, or "None" for methodology / docs-only changes). For changes that touch `content/` (the single source of truth), assume all adapters are affected unless the change is scoped to adapter-specific files. For agent-behavior changes, include a short before/after transcript in the PR body so reviewers can see the effect without re-running the scenario locally.
 
 ## Before editing
 
@@ -50,6 +66,29 @@ A third build script, `scripts/build-slides.sh`, regenerates `docs/slides/*.html
 ## Architecture guardrails
 
 **Methodology vs. adapters.** Rules and references live in `content/rules/` and `content/references/`. Adapters (`.claude/`, `.cursor/`) translate those into tool-specific formats. Content changes go in `content/` - never edit generated adapter files directly.
+
+## Developer Certificate of Origin (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org) as a lightweight alternative to a CLA. By adding a `Signed-off-by` line to your commits, you certify that you wrote the contribution or otherwise have the right to submit it under the project's license.
+
+### How to sign a commit
+
+```bash
+git commit -s -m "your message"
+```
+
+The `-s` flag appends a line like `Signed-off-by: Your Name <you@example.com>` using the name and email from your local git config.
+
+### Fixing missing sign-offs
+
+- Last commit only: `git commit --amend --signoff` then `git push --force-with-lease`
+- Multiple commits in a PR: `git rebase --signoff <base-branch>` then force-push
+
+### AI-assisted contributions
+
+If you used AI assistance to author your contribution, certify in the PR description that you reviewed the AI-generated content and have the right to submit it under the project license. The DCO sign-off applies regardless of how the contribution was authored.
+
+PRs without a signed-off commit on every commit will be blocked by the DCO check (configured by `.github/workflows/dco.yml`).
 
 ## Style
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,36 @@
+# Governance
+
+## Current model
+
+agentic-engineering is led by a single lead maintainer (the project creator) with informal community input. This model is expected to evolve toward a small maintainer group as the contributor base grows.
+
+- **Lead maintainer:** `<lead maintainer handle TBD>`
+- **Decision authority:** the lead maintainer has final say on protocol direction, releases, and contributor access. Day-to-day PR review may be delegated as the contributor base grows.
+
+## How decisions are made
+
+Most changes go through the standard PR flow described in [CONTRIBUTING.md](CONTRIBUTING.md). The lead maintainer reviews and merges.
+
+For larger or load-bearing changes - the protocol itself, risk classification, the Skeptic loop, conductor rules, worktree lifecycle, slash commands, agent definitions, memory persistence - use the **protocol-change RFC flow**:
+
+1. Open an issue using the **Protocol change** template ([.github/ISSUE_TEMPLATE/protocol_change.yml](.github/ISSUE_TEMPLATE/protocol_change.yml)).
+2. Describe the motivation, the proposed change, backward-compatibility impact, and affected adapters.
+3. Discussion happens on the issue. The lead maintainer either approves the direction (allowing a PR to follow), requests revisions, or declines with a reason.
+4. If approved, open a PR referencing the protocol-change issue. The PR is reviewed against the agreed-upon design.
+
+Protocol changes that bypass this flow may be closed with a request to open an RFC issue first.
+
+## Maintainer responsibilities
+
+- Review PRs in a reasonable timeframe
+- Keep the methodology coherent across adapters
+- Tag and document releases in [CHANGELOG.md](CHANGELOG.md)
+- Maintain the issue and PR backlog
+
+## Becoming a maintainer
+
+The project will add maintainers as the contributor base grows. There is no formal application process yet. Sustained, high-quality contributions and engagement in reviews are the path.
+
+## Changing this document
+
+Governance changes follow the same protocol-change RFC flow described above.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ agentic-engineering/
 
 This framework is a safety rail, not a complete boundary. The recommended permissions setup pairs `bypassPermissions` mode with an allow list for routine tools (Bash, Write, Edit) and a deny list for the destructive commands documented in the [Recommended permissions](#recommended-permissions) section above (`git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`, `sudo rm`, `dd if=`, `shutdown`, `reboot`). The Skeptic loop, risk classification, and worktree isolation add further layers, but none of these guarantee that an agent cannot cause harm. Treat the framework as defense in depth, not as a sandbox: review what agents do, especially on shared state and irreversible operations.
 
-License pending - see issue IR-2.
-
 ## Community
 
 - [GitHub Discussions](https://github.com/Solara6/agentic-engineering/discussions) - questions, ideas, design discussion
@@ -259,3 +257,7 @@ After installation, offer the user a quick orientation: present the files listed
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+License pending - see issue IR-2.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,21 @@ agentic-engineering/
 - `~/agentic-engineering/docs/slides/agents-md-hierarchy-slides.html` - the three-tier AGENTS.md context hierarchy
 - `~/agentic-engineering/docs/slides/contributing-slides.html` - how to contribute to the repo
 
+## Safety model
+
+This framework is a safety rail, not a complete boundary. The recommended permissions setup pairs `bypassPermissions` mode with an allow list for routine tools (Bash, Write, Edit) and a deny list for the destructive commands documented in the [Recommended permissions](#recommended-permissions) section above (`git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`, `sudo rm`, `dd if=`, `shutdown`, `reboot`). The Skeptic loop, risk classification, and worktree isolation add further layers, but none of these guarantee that an agent cannot cause harm. Treat the framework as defense in depth, not as a sandbox: review what agents do, especially on shared state and irreversible operations.
+
+License pending - see issue IR-2.
+
+## Community
+
+- [GitHub Discussions](https://github.com/Solara6/agentic-engineering/discussions) - questions, ideas, design discussion
+- [GitHub Issues](https://github.com/Solara6/agentic-engineering/issues) - bug reports, feature requests, protocol-change RFCs, adapter requests
+- Discord: TBD (link will be added once the server is live)
+- [SUPPORT.md](SUPPORT.md) - where to ask what
+- [GOVERNANCE.md](GOVERNANCE.md) - how decisions get made
+- [ROADMAP.md](ROADMAP.md) - what's in flight
+
 ## For agents working in this repo
 
 Contributions use a branch + PR workflow. Create a feature branch, make changes, and open a PR.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+This file is a light scaffold. The detailed, current roadmap is tracked on GitHub Issues and Projects.
+
+## Where to look
+
+- **Active and planned work:** [GitHub Issues](https://github.com/Solara6/agentic-engineering/issues) and the project board (TBD - link will be added once the public board is set up).
+- **Released changes:** [CHANGELOG.md](CHANGELOG.md)
+- **Design artifacts for in-flight work:** `docs/planning/`
+
+## How the roadmap is maintained
+
+- Larger initiatives are tracked as GitHub Issues with the `roadmap` label.
+- Smaller items are tracked as ordinary Issues without the label.
+- Priorities shift as the project evolves; nothing here is a commitment to ship by a specific date.
+
+## Themes
+
+Broad areas of focus, in no particular order:
+
+- Methodology refinement (rules, references, Skeptic loop, risk classification)
+- Adapter coverage for additional tools (see [ADAPTERS.md](ADAPTERS.md))
+- Eval harness improvements
+- Documentation and onboarding
+
+## Proposing a roadmap item
+
+Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.yml) or, for protocol-level changes, a [protocol change](.github/ISSUE_TEMPLATE/protocol_change.yml) issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security
+
+## Supported versions
+
+The latest minor of the latest major is supported.
+
+## Reporting
+
+Report suspected framework-level issues privately via GitHub Security Advisories on this repo: https://github.com/Solara6/agentic-engineering/security/advisories/new
+
+Fallback email: `security@<TBD>` (placeholder, requires human update).
+
+## In scope
+
+Framework-level bugs that could enable unsafe behavior: bypasses of the deny-list, unintended secret exposure, worktree-state corruption, dependency-chain issues.
+
+## Out of scope
+
+General model behavior unrelated to a reproducible framework flaw.
+
+## Response
+
+Acknowledge within 5 business days; initial assessment within 10 business days.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+## Where to ask
+
+- **Questions, ideas, discussion** - [GitHub Discussions](https://github.com/Solara6/agentic-engineering/discussions)
+- **Bugs and reproducible defects** - [GitHub Issues](https://github.com/Solara6/agentic-engineering/issues) using the bug report template
+- **Feature requests** - GitHub Issues using the feature request template
+- **Protocol changes** (conductor rules, Skeptic protocol, risk classification, memory persistence, worktree lifecycle, slash commands, agent definitions) - GitHub Issues using the protocol change template
+- **Adapter requests** (support for a new tool) - GitHub Issues using the adapter request template
+- **Chat** - Discord: TBD (link will be added once the server is live)
+
+## Before opening an issue
+
+- Search existing Issues and Discussions to avoid duplicates
+- Confirm the issue reproduces against the latest `main`
+- Include adapter name and version, OS, and a minimal reproduction
+
+## What this project is not
+
+This project does not provide commercial support. Maintainers respond on a best-effort basis.


### PR DESCRIPTION
**Merge order:** merge #130 (IR-3 DCO) before this PR so the DCO workflow referenced in CONTRIBUTING.md exists at merge time.

## Summary

Wave 1 of community files for the open-source launch (Jira IR-4). Adds the foundational community surface needed before going public: SUPPORT, GOVERNANCE, ROADMAP, CHANGELOG, four GitHub issue templates, and a PR template. Extends README and CONTRIBUTING with additive sections only - existing content is preserved verbatim.

**Wave 2 (CODE_OF_CONDUCT + SECURITY) landed in commit b073a98.**

## Files created (9)

- `SUPPORT.md` - where to ask what (Discussions / Issues / Discord placeholder)
- `GOVERNANCE.md` - current single-lead-maintainer model, protocol-change RFC flow
- `ROADMAP.md` - light scaffold pointing to GitHub Issues / Projects
- `CHANGELOG.md` - Keep a Changelog format, `[Unreleased]` only
- `.github/PULL_REQUEST_TEMPLATE.md` - checklist (DCO sign-off, adapters declared, etc.)
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/protocol_change.yml`
- `.github/ISSUE_TEMPLATE/adapter_request.yml`

## Files modified (2 - additions only)

- `README.md` - added "Safety model" section (framework as safety rail, not complete boundary; LICENSE pending IR-2 noted) and "Community" section (Discussions / Issues / Discord TBD links)
- `CONTRIBUTING.md` - added "What's not welcome" (under What to contribute), "Protocol-change process" pointer, "Adapter compatibility declaration" subsection under PR guidelines, and a full DCO section before the existing Style section

## Deferred pending IR-2

- `LICENSE`
- `NOTICE`
- `TRADEMARKS.md`
- `MAINTAINERS.md`

These are blocked on the IR-2 / project-name / personal-handle decisions. README uses the literal text `License pending - see issue IR-2.` in place of a LICENSE link.

## Verification

- All four `.github/ISSUE_TEMPLATE/*.yml` files parse as valid YAML.
- README and CONTRIBUTING existing content is preserved; only new sections added.
- `<lead maintainer handle TBD>` placeholder used in GOVERNANCE.
- Discord URL placeholder ("TBD") used in SUPPORT and README.

Refs: IR-4


