### PR TITLE
feat(fe-discipline): reference doc + engineer addendum + Skeptic findings (P1 U3)

### DIFF
--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -161,3 +161,17 @@ Keep prose brief. A reviewer reading the structured block plus prose summary plu
 - **Regression tests for Skeptic findings.** When fixing a Critical or Major Skeptic finding, add a regression test that would have caught the failure mode. Reference it in the fix summary: `[finding ID] → fixed by [description]. Regression test: [file, test name].` If a regression test is genuinely not possible, state the reason explicitly — absence without explanation is a Major finding in the next Skeptic round. See `~/agentic-engineering/.claude/skills/agentic-engineering/references/regression-test-obligation.md` for what counts as a valid regression test.
 - **Doc-sync for reality-asserting changes.** When a change adds, removes, or renames a command, agent, reference, or rule; changes a documented path, convention, config, or behavior; or alters any count or list a doc states, update the affected intent-layer docs (README, CONTRIBUTING, SKILL.md, and cross-references) in the same change and attest in the summary: `Doc-sync: [clause N triggered] -> updated [doc paths]: [what changed].` (or `Doc-sync: predicate not triggered` when it does not trip). See `~/agentic-engineering/.claude/skills/agentic-engineering/references/doc-sync-obligation.md` for the trigger predicate, exemptions, and tiers.
 - **Module manifests for non-trivial files.** When creating or substantially modifying a file that exports a public symbol consumed by another module, exceeds ~50 LOC, or implements a side-effecting operation, include a manifest header. See `~/agentic-engineering/.claude/skills/agentic-engineering/rules/module-manifest.md` for required fields and language-specific examples.
+
+## Front-end discipline
+
+When your diff touches FE files matching the glob `**/*.{tsx,jsx,vue,svelte,astro,css,scss,html,mdx}` - excluding `content/**`, `docs/**/*.{mdx,html}`, `**/docs/**/*.{mdx,html}`, `**/*.stories.{tsx,jsx,ts,js}`, `**/*.test.{tsx,jsx,ts,js}`, and `**/*.spec.{tsx,jsx,ts,js}` - apply the rules in `content/references/frontend-discipline.md` before declaring done.
+
+- **Semantic HTML** - use native elements with correct semantics; `button` for actions, `a` for navigation.
+- **ARIA** - ARIA is an escape hatch; no ARIA on elements that already have native semantics.
+- **Keyboard** - all interactive elements keyboard-reachable with visible focus indicator and `onKeyDown` handler.
+- **Focus management** - modals/drawers trap focus on open and return focus to trigger on close.
+- **Reduced motion** - wrap all animations/transitions in a `prefers-reduced-motion: reduce` media query.
+- **Design tokens** - no hardcoded color/spacing/font values when a token system is detected.
+- **Responsive** - no fixed-width containers without responsive override on multi-breakpoint surfaces.
+
+See `content/references/frontend-discipline.md` for full rules and canonical violation examples.

--- a/content/references/frontend-discipline.md
+++ b/content/references/frontend-discipline.md
@@ -1,0 +1,215 @@
+<!--
+Purpose: Defines the FE-discipline rule set for the agentic engineering
+         methodology. Engineers apply these rules when a diff touches FE files;
+         Skeptics cite these sections when raising FE-discipline findings.
+
+Public API: Referenced by section number from content/agents/engineer.md and
+            from the FE-discipline findings table in
+            content/references/skeptic-protocol.md.
+
+Upstream deps: None (standalone reference document).
+
+Downstream consumers: content/agents/engineer.md (## Front-end discipline),
+                      content/references/skeptic-protocol.md
+                      (### FE-discipline findings)
+
+Failure modes: If sections are renumbered or removed, Skeptic finding citations
+               become invalid. Section headings are cross-referenced by name -
+               rename carefully and update all citation sites.
+
+Performance: N/A - methodology document consumed by LLMs at spawn time.
+-->
+# Front-End Discipline Reference
+
+Rules applied when a diff touches files matching the FE-glob defined in
+`content/agents/engineer.md`. Skeptic findings MUST cite both the file:line and
+the section below that the finding maps to; findings missing either citation are
+invalid.
+
+---
+
+## 1. Semantic HTML
+
+Use native HTML elements that carry the correct semantics for their role.
+Heading levels (`h1`-`h6`) must reflect document hierarchy, not visual size.
+Landmark regions (`header`, `nav`, `main`, `footer`, `aside`) should frame the
+page structure. Interactive triggers use `<button>` for actions that do not
+navigate, and `<a href>` for navigation to a URL.
+
+**Violation example:**
+```tsx
+// Wrong - div with click handler has no semantics, role, or keyboard support
+<div onClick={handleSubmit}>Submit</div>
+
+// Correct
+<button onClick={handleSubmit}>Submit</button>
+```
+
+---
+
+## 2. ARIA
+
+ARIA is an escape hatch for cases where native HTML semantics are insufficient.
+Do not add ARIA attributes to elements that already carry the needed role
+natively - the redundancy creates noise for assistive technology and is often
+wrong. `role="presentation"` must never appear on focusable elements because it
+removes all keyboard and AT interaction from the element.
+
+**Violation example:**
+```tsx
+// Wrong - button already has role=button; aria-label is also redundant here
+<button role="button" aria-label="Click">Click</button>
+
+// Wrong - removes AT semantics from a focusable element
+<a href="/about" role="presentation">About</a>
+
+// Correct
+<button onClick={handler}>Click</button>
+```
+
+---
+
+## 3. Keyboard support
+
+Every interactive element must be reachable and operable by keyboard alone.
+Non-native-interactive elements that receive `onClick` must also carry
+`tabIndex={0}` (or equivalent) and an `onKeyDown` handler that triggers the
+action on Enter/Space. The focus indicator must be visible; removing the
+browser default outline without a replacement is a violation.
+
+**Violation examples:**
+```tsx
+// Wrong - not keyboard-reachable and no key handler
+<div onClick={toggle}>Toggle panel</div>
+
+// Correct
+<div
+  role="button"
+  tabIndex={0}
+  onClick={toggle}
+  onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggle()}
+>
+  Toggle panel
+</div>
+```
+
+```css
+/* Wrong - removes focus ring with no replacement */
+* { outline: none; }
+
+/* Correct - replace, don't remove */
+*:focus-visible { outline: 2px solid var(--color-focus-ring); }
+```
+
+---
+
+## 4. Focus management
+
+When a modal, drawer, dialog, or popover-style overlay opens, focus must move
+into it and be trapped there - Tab and Shift-Tab must not reach elements behind
+the overlay while it is open. When the overlay closes, focus must return to the
+element that triggered it.
+
+**Violation example:**
+```tsx
+// Wrong - modal renders but Tab still cycles through the background page
+function Modal({ onClose }) {
+  return (
+    <div className="modal">
+      <button onClick={onClose}>Close</button>
+      <input placeholder="Name" />
+    </div>
+  );
+  // Missing: focus trap (e.g. focus-trap-react, aria-modal, or manual management)
+  // Missing: restore focus to trigger element on close
+}
+```
+
+---
+
+## 5. Reduced motion
+
+Any CSS animation, transition, or scroll effect must be guarded by the
+`prefers-reduced-motion: reduce` media query so users who have requested reduced
+motion are not exposed to motion that can cause discomfort or vestibular
+disruption. JavaScript-driven animations must read the media query value before
+running.
+
+**Violation examples:**
+```css
+/* Wrong - no reduced-motion guard */
+.card:hover {
+  transform: translateY(-4px);
+  transition: transform 0.3s ease;
+}
+
+/* Correct */
+.card:hover {
+  transform: translateY(-4px);
+  transition: transform 0.3s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .card:hover { transform: none; transition: none; }
+}
+```
+
+```tsx
+// Wrong - parallax with no motion check
+<div style={{ transform: `translateY(${scrollY * 0.5}px)` }}>Hero</div>
+
+// Correct
+const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+<div style={{ transform: prefersReduced ? 'none' : `translateY(${scrollY * 0.5}px)` }}>
+  Hero
+</div>
+```
+
+---
+
+## 6. Design tokens
+
+In a codebase where a token system is detected (see heuristics below), do not
+hardcode color, spacing, or font values when an equivalent token exists. Use the
+token instead. This keeps the UI consistent and makes theme changes tractable.
+
+**Token-system detection heuristics (any one triggers "token system present"):**
+
+- **(a)** `tailwind.config.{ts,js,mjs,cjs}` exists at the repo root AND contains
+  a `theme.extend` block with `colors` or `spacing`.
+- **(b)** Any CSS file (per FE-glob) contains `:root` with at least two
+  `--`-prefixed custom properties that are used elsewhere in the codebase.
+- **(c)** A `tokens.{ts,js,json}` or `design-tokens.{ts,js,json}` file at the
+  repo root.
+- **(d)** A `theme.{ts,js}` or `themes/` directory exporting an object literal.
+
+The Skeptic finding `hardcoded-token-instead-of-design-token` MUST cite which
+heuristic ((a), (b), (c), or (d)) triggered detection. A finding that omits the
+heuristic citation is invalid.
+
+**Violation example:**
+```tsx
+// Wrong - hardcoded hex in a Tailwind codebase that defines colors.primary
+<div style={{ color: '#3b82f6', padding: '16px' }}>Content</div>
+
+// Correct (Tailwind token)
+<div className="text-primary p-4">Content</div>
+```
+
+---
+
+## 7. Responsive patterns
+
+Do not use fixed-width containers without a responsive override when the surface
+is expected to work across multiple breakpoints. Fixed widths silently break
+layouts on narrow viewports and are almost always unintentional on surfaces that
+are otherwise responsive.
+
+**Violation example:**
+```tsx
+// Wrong - fixed width with no responsive variant on a multi-breakpoint surface
+<div className="w-[500px]">Sidebar</div>
+
+// Correct
+<div className="w-full sm:w-[500px]">Sidebar</div>
+// or use a responsive utility class appropriate for the design
+```

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -347,6 +347,30 @@ When reviewing a Brief or architect plan where `.agentic/config.json` has `theme
 
 When reviewing a Brief or architect plan where any scenario has `story_id` set AND that scenario's method is NOT `visual_conformance` or `accessibility` (i.e., the method is `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding regardless of config state. Rationale: `perceptual_diff` would have ambiguous baseline-path semantics when the story render and live-app render differ; `api` and `runtime-required` have no browser surface; `browser` interaction flows do not compose with Storybook's isolated component render. `story_id` on a config-disabled project (`storybook_enabled: false` or absent) while using a compatible method (`visual_conformance` or `accessibility`) is NOT a plan-time finding - the runtime gate (INCONCLUSIVE with operator message) handles that case. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
+### FE-discipline findings (auto-apply on FE diffs)
+
+**Trigger:** the diff touches one or more files matching
+`**/*.{tsx,jsx,vue,svelte,astro,css,scss,html,mdx}` AND the file is NOT in the
+exclusion set: `content/**`, `docs/**/*.{mdx,html}`,
+`**/docs/**/*.{mdx,html}`, `**/*.stories.{tsx,jsx,ts,js}`,
+`**/*.test.{tsx,jsx,ts,js}`, `**/*.spec.{tsx,jsx,ts,js}`.
+
+When the trigger fires, the Skeptic applies the findings table below. Every
+finding MUST cite (a) the file:line and (b) the matching section in
+`content/references/frontend-discipline.md`. Findings missing either citation
+are invalid.
+
+| Finding ID | Severity | Trigger condition |
+|---|---|---|
+| `semantic-html-misuse` | Major | non-semantic element used where a native semantic element exists (e.g., `div onClick` instead of `button`) |
+| `aria-needs-no-aria` | Major | ARIA attribute added to an element that already has native semantics (e.g., `<button role="button">`) |
+| `missing-focus-management` | Major | modal/drawer/popover-style component lacks focus trap or focus restore to trigger |
+| `hardcoded-token-instead-of-design-token` | Major | hardcoded color/spacing/font value in a codebase where a token system is detected (heuristics in `content/references/frontend-discipline.md` §6); the finding MUST cite which heuristic triggered detection |
+| `missing-keyboard-support` | Major | element with `onClick` handler is not a native interactive element and lacks both `onKeyDown` handler and `tabIndex` |
+| `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
+| `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
+| `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
 ---
 
 ## 5. Escalation Protocol


### PR DESCRIPTION
P1 Brief U3: FE-discipline foundation.

## Scope
- NEW content/references/frontend-discipline.md (7 sections: Semantic HTML, ARIA, Keyboard, Focus, Reduced motion, Design tokens, Responsive; module manifest; violation examples)
- content/agents/engineer.md - Front-end discipline section with FE-glob and category summaries
- content/references/skeptic-protocol.md - FE-discipline findings subsection after story_id enforcement (8 finding IDs: 7 Major, 1 Minor; citation requirement)

## Brief
docs/planning/p1-frontend-qa-methods.md

## Skeptic
Round 1 sign-off (0 Critical/Major; 4 non-blocking Minors on prose length/example counts/SKILL.md doc-sync - can be cleaned up later).