### PR TITLE
feat(skeptic): motion enforcement + theme allowlist expansion (P2 U3)

### DIFF
--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -24,10 +24,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -119,6 +120,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -653,9 +655,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:

--- a/.codex/references/skeptic-protocol.md
+++ b/.codex/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.cursor/rules/references/skeptic-protocol.md
+++ b/.cursor/rules/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -23,10 +23,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -120,6 +121,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -654,9 +656,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -27,10 +27,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -121,6 +122,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -655,9 +657,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 


### PR DESCRIPTION
P2 Brief U3: Skeptic enforcement updates.

- New ### motion enforcement subsection (auto-Major when motion_aware:true + UI-visible Elevated + no motion scenario)
- theme allowlist expanded to {visual_conformance, accessibility, motion}
- story_id allowlist UNCHANGED (stays {visual_conformance, accessibility})

Brief: docs/planning/p2-frontend-qa-methods.md
Skeptic R1 sign-off (1 cosmetic Minor on parenthetical enum staleness).