### PR TITLE
feat(agents): populate capabilities in 8 agent files (P2 U5)

### DIFF
--- a/content/agents/architect.md
+++ b/content/agents/architect.md
@@ -7,7 +7,10 @@ tools: Read, Glob, Grep, Bash
 ```yaml
 capabilities:
   required: []
-  optional: []
+  optional:
+    - tool: "context7"
+      check: "test -f .claude/settings.json && grep -q 'context7' .claude/settings.json"
+      install_hint: "configure Context7 MCP server in .claude/settings.json"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/debugger.md
+++ b/content/agents/debugger.md
@@ -6,8 +6,16 @@ tools: Read, Glob, Grep, Bash
 
 ```yaml
 capabilities:
-  required: []
-  optional: []
+  required:
+    - tool: "node"
+      check: "command -v node"
+      required_when: "brief.has_field('stack_trace')"
+    - tool: "git"
+      check: "command -v git"
+  optional:
+    - tool: "context7"
+      check: "test -f .claude/settings.json && grep -q 'context7' .claude/settings.json"
+      install_hint: "configure Context7 MCP server in .claude/settings.json"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/dependency-auditor.md
+++ b/content/agents/dependency-auditor.md
@@ -6,8 +6,20 @@ tools: Read, Glob, Grep, Bash
 
 ```yaml
 capabilities:
-  required: []
-  optional: []
+  required:
+    - tool: "git"
+      check: "command -v git"
+    - tool: "node"
+      check: "command -v node"
+      required_when: "brief.has_field('package_json')"
+    - tool: "npm"
+      check: "command -v npm"
+      required_when: "brief.has_field('package_json')"
+  optional:
+    - tool: "pip"
+      check: "command -v pip"
+    - tool: "cargo"
+      check: "command -v cargo"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -6,8 +6,15 @@ tools: Read, Glob, Grep, Bash, Write, Edit
 
 ```yaml
 capabilities:
-  required: []
-  optional: []
+  required:
+    - tool: "node"
+      check: "command -v node"
+    - tool: "git"
+      check: "command -v git"
+  optional:
+    - tool: "context7"
+      check: "test -f .claude/settings.json && grep -q 'context7' .claude/settings.json"
+      install_hint: "configure Context7 MCP server in .claude/settings.json"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/investigator.md
+++ b/content/agents/investigator.md
@@ -7,7 +7,10 @@ tools: Read, Glob, Grep, Bash
 ```yaml
 capabilities:
   required: []
-  optional: []
+  optional:
+    - tool: "context7"
+      check: "test -f .claude/settings.json && grep -q 'context7' .claude/settings.json"
+      install_hint: "configure Context7 MCP server in .claude/settings.json"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/perf-analyst.md
+++ b/content/agents/perf-analyst.md
@@ -11,6 +11,12 @@ capabilities:
     - tool: "playwright-python"
       check: "python -c 'import playwright'"
       install_hint: "pip install playwright && playwright install chromium"
+    - tool: "lighthouse"
+      check: "command -v lighthouse"
+      install_hint: "npm install -g lighthouse"
+    - tool: "k6"
+      check: "command -v k6"
+      install_hint: "see k6 install docs at https://k6.io/docs/get-started/installation/"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/content/agents/release-orchestrator.md
+++ b/content/agents/release-orchestrator.md
@@ -6,7 +6,12 @@ tools: Read, Glob, Grep, Bash, Write, Edit
 
 ```yaml
 capabilities:
-  required: []
+  required:
+    - tool: "git"
+      check: "command -v git"
+    - tool: "gh"
+      check: "command -v gh"
+      install_hint: "brew install gh"
   optional: []
 ```
 

--- a/content/agents/security-auditor.md
+++ b/content/agents/security-auditor.md
@@ -6,8 +6,13 @@ tools: Read, Glob, Grep, Bash
 
 ```yaml
 capabilities:
-  required: []
-  optional: []
+  required:
+    - tool: "git"
+      check: "command -v git"
+  optional:
+    - tool: "semgrep"
+      check: "command -v semgrep"
+      install_hint: "pip install semgrep"
 ```
 
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.


### PR DESCRIPTION
P2 Brief U5: populate empty capability blocks.

8 agents populated; skeptic and orchestration-planner kept as deliberate no-ops.

perf-analyst preserves existing playwright-python (P0 U3 authorization) and adds P2's lighthouse + k6.

Brief: docs/planning/p2-frontend-qa-methods.md