### PR TITLE
feat(qa-engineer): motion procedure + SB6 URL branching (P2 U2)

### DIFF
--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -2,7 +2,7 @@
 # Do not edit directly - edit the source markdown file instead.
 
 name        = "qa-engineer"
-description = "Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says \"run QA\", \"verify in the browser\", \"check the feature works\", \"test the acceptance criteria\", or \"does it work\". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), and perceptual_diff (pixel regression via pixelmatch). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs."
+description = "Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says \"run QA\", \"verify in the browser\", \"check the feature works\", \"test the acceptance criteria\", or \"does it work\". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs."
 
 developer_instructions = """
 
@@ -24,10 +24,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -57,7 +58,7 @@ Your spawn prompt will contain some combination of:
 
 1. **What changed** - brief description or diff summary of the implementation
 2. **Acceptance criteria** - specific things to verify. If absent, derive them conservatively from the feature description.
-3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path` - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
+3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff, motion}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path`; `motion` carries `route` and `elements` (CSS selector list or `"auto"`) - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
 4. **`ticket_id`** - the ticket identifier (used for knowledge attribution in qa.md entries).
 5. **URLs** - dev server or deployed URLs to test against
 6. **Test commands** (optional) - specific test suites to run
@@ -119,6 +120,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -653,9 +655,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:
@@ -675,6 +690,98 @@ Each per-tuple evidence object gains two additional fields:
 ```
 
 **Storybook scenario composition note:** storybook scenarios compose with viewport iteration (each `story × viewport` pair) and with theme (each `story × viewport × theme` triple when `theme_aware: true`). Each tuple is an independent pass/fail row.
+
+## Motion scenarios
+
+When a scenario has `method: motion`, you verify that the page respects `prefers-reduced-motion: reduce` by emulating the media feature via CDP and inspecting computed styles.
+
+**`story_id` is NOT valid on motion scenarios.** Motion scenarios use the `route` field (a URL or page path) directly. Setting `story_id` on a motion scenario is invalid (Skeptic raises Critical per schema rules).
+
+**Preflight:**
+
+1. Read `.agentic/config.json`.
+   - If `motion_aware` is `false` or the key is absent AND the scenario has `method: motion`: proceed normally. `motion_aware` controls Skeptic auto-Major enforcement at planning time, not qa-engineer execution. Still run the scenario.
+
+2. **Capability gate** - verify `playwright-python` is available:
+   ```bash
+   python -c 'import playwright' 2>/dev/null
+   ```
+   If the import fails: return **INCONCLUSIVE** for all motion scenarios with operator message "playwright-python required for motion scenarios; install with `pip install playwright && playwright install chromium`". Do NOT fail on a tooling gap.
+
+3. **Resolve the route**: use the qa.md `motion` knowledge tag override when present (format: `motion: /route [selector,selector,...]` or `motion: /route auto`); otherwise use the scenario's `route` field.
+
+4. **Resolve the elements**: use the qa.md `motion` knowledge tag element list when present; otherwise use the scenario's `elements` field (a CSS selector list or the literal `auto`).
+
+**Verification procedure** (per scenario, per resolved viewport, per effective theme when `theme_aware: true` and scenario carries a `theme` field):
+
+For each `(scenario × viewport × theme)` tuple:
+
+1. Launch Playwright and navigate to the resolved `route` URL.
+2. Set the viewport using the canonical sizes or qa.md `viewport` override.
+3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
+4. Emulate `prefers-reduced-motion: reduce` via CDP:
+   ```python
+   page.emulate_media(color_scheme=None)
+   cdp = page.context.new_cdp_session(page)
+   cdp.send("Emulation.setEmulatedMedia", {
+       "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
+   })
+   ```
+5. For each target element, capture computed styles:
+   - Properties to check: `animation-name`, `animation-duration`, `transition-property`, `transition-duration`.
+   - **Explicit selector mode** (when `elements` is a CSS selector list): scan only the listed selectors.
+   - **Auto mode** (when `elements` is `"auto"`): scan all elements on the page using the binding property set above. Explicitly EXCLUDE:
+     - SVG `<animate>`, `<animateTransform>`, and `<animateMotion>` elements (SMIL animations)
+     - `@keyframes` blocks with opacity-only changes
+     - Vendor-prefixed properties (`-webkit-`, `-moz-`) without an unprefixed equivalent
+     - These excluded surfaces return INCONCLUSIVE for that specific element (not FAIL), so they do not drive overall scenario result.
+6. **Pass criteria**: an element passes when all detected motion is either absent OR has `animation-play-state: paused` / `transition-duration: 0s` / is wrapped in a `prefers-reduced-motion: reduce` media query in source CSS.
+7. **FAIL** when any non-excluded element still has active motion after CDP emulation. Report the element selector and its offending computed styles.
+8. **INCONCLUSIVE** when the only detected motion is on SVG/SMIL elements or vendor-prefixed-without-unprefixed properties (no standard-property violations found).
+
+**Evidence JSON extensions for motion tuples:**
+
+Each per-tuple evidence object gains these additional fields alongside the standard fields:
+
+```json
+{
+  "route": "/dashboard",
+  "viewport": "desktop",
+  "theme": "dark",
+  "elements_scanned": ["#hero-banner", ".nav-fade-in"],
+  "motion_present_elements": [
+    {
+      "selector": "#hero-banner",
+      "animation_name": "pulse",
+      "animation_duration": "1s",
+      "transition_property": "none",
+      "transition_duration": "0s"
+    }
+  ]
+}
+```
+
+`motion_present_elements` is empty `[]` on PASS. When INCONCLUSIVE due to excluded surfaces only, include them with a `"excluded": true` flag and `"exclusion_reason": "svg-smil"` or `"exclusion_reason": "vendor-prefixed-only"`.
+
+**Per-tuple report format:**
+
+### N. [Scenario description] (method: motion, viewport: desktop, theme: dark)
+- **Result:** PASS | FAIL | INCONCLUSIVE
+- **Route:** /dashboard
+- **Viewport:** desktop (1440x900)
+- **Theme:** dark (when applicable)
+- **Elements scanned:** `#hero-banner`, `.nav-fade-in` (or "full-page auto scan")
+- **Motion present:**
+  - `#hero-banner` - `animation-name: pulse`, `animation-duration: 1s` - motion active after CDP emulation (FAIL)
+- **Screenshot:** [path]
+
+A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
+
+**INCONCLUSIVE cases:**
+- `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
+- Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+- Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios
 

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -721,7 +721,6 @@ For each `(scenario × viewport × theme)` tuple:
 3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
 4. Emulate `prefers-reduced-motion: reduce` via CDP:
    ```python
-   page.emulate_media(color_scheme=None)
    cdp = page.context.new_cdp_session(page)
    cdp.send("Emulation.setEmulatedMedia", {
        "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
@@ -777,10 +776,12 @@ Each per-tuple evidence object gains these additional fields alongside the stand
 
 A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
 
+**FAIL cases:**
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+
 **INCONCLUSIVE cases:**
 - `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
 - Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
-- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
 - Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios

--- a/.codex/references/skeptic-protocol.md
+++ b/.codex/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.cursor/rules/references/skeptic-protocol.md
+++ b/.cursor/rules/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -722,7 +722,6 @@ For each `(scenario × viewport × theme)` tuple:
 3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
 4. Emulate `prefers-reduced-motion: reduce` via CDP:
    ```python
-   page.emulate_media(color_scheme=None)
    cdp = page.context.new_cdp_session(page)
    cdp.send("Emulation.setEmulatedMedia", {
        "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
@@ -778,10 +777,12 @@ Each per-tuple evidence object gains these additional fields alongside the stand
 
 A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
 
+**FAIL cases:**
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+
 **INCONCLUSIVE cases:**
 - `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
 - Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
-- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
 - Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: qa-engineer
-description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), and perceptual_diff (pixel regression via pixelmatch). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
+description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
 tools: Read, Glob, Grep, Bash
 kind: local
 ---
@@ -23,10 +23,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -58,7 +59,7 @@ Your spawn prompt will contain some combination of:
 
 1. **What changed** - brief description or diff summary of the implementation
 2. **Acceptance criteria** - specific things to verify. If absent, derive them conservatively from the feature description.
-3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path` - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
+3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff, motion}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path`; `motion` carries `route` and `elements` (CSS selector list or `"auto"`) - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
 4. **`ticket_id`** - the ticket identifier (used for knowledge attribution in qa.md entries).
 5. **URLs** - dev server or deployed URLs to test against
 6. **Test commands** (optional) - specific test suites to run
@@ -120,6 +121,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -654,9 +656,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:
@@ -676,6 +691,98 @@ Each per-tuple evidence object gains two additional fields:
 ```
 
 **Storybook scenario composition note:** storybook scenarios compose with viewport iteration (each `story × viewport` pair) and with theme (each `story × viewport × theme` triple when `theme_aware: true`). Each tuple is an independent pass/fail row.
+
+## Motion scenarios
+
+When a scenario has `method: motion`, you verify that the page respects `prefers-reduced-motion: reduce` by emulating the media feature via CDP and inspecting computed styles.
+
+**`story_id` is NOT valid on motion scenarios.** Motion scenarios use the `route` field (a URL or page path) directly. Setting `story_id` on a motion scenario is invalid (Skeptic raises Critical per schema rules).
+
+**Preflight:**
+
+1. Read `.agentic/config.json`.
+   - If `motion_aware` is `false` or the key is absent AND the scenario has `method: motion`: proceed normally. `motion_aware` controls Skeptic auto-Major enforcement at planning time, not qa-engineer execution. Still run the scenario.
+
+2. **Capability gate** - verify `playwright-python` is available:
+   ```bash
+   python -c 'import playwright' 2>/dev/null
+   ```
+   If the import fails: return **INCONCLUSIVE** for all motion scenarios with operator message "playwright-python required for motion scenarios; install with `pip install playwright && playwright install chromium`". Do NOT fail on a tooling gap.
+
+3. **Resolve the route**: use the qa.md `motion` knowledge tag override when present (format: `motion: /route [selector,selector,...]` or `motion: /route auto`); otherwise use the scenario's `route` field.
+
+4. **Resolve the elements**: use the qa.md `motion` knowledge tag element list when present; otherwise use the scenario's `elements` field (a CSS selector list or the literal `auto`).
+
+**Verification procedure** (per scenario, per resolved viewport, per effective theme when `theme_aware: true` and scenario carries a `theme` field):
+
+For each `(scenario × viewport × theme)` tuple:
+
+1. Launch Playwright and navigate to the resolved `route` URL.
+2. Set the viewport using the canonical sizes or qa.md `viewport` override.
+3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
+4. Emulate `prefers-reduced-motion: reduce` via CDP:
+   ```python
+   page.emulate_media(color_scheme=None)
+   cdp = page.context.new_cdp_session(page)
+   cdp.send("Emulation.setEmulatedMedia", {
+       "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
+   })
+   ```
+5. For each target element, capture computed styles:
+   - Properties to check: `animation-name`, `animation-duration`, `transition-property`, `transition-duration`.
+   - **Explicit selector mode** (when `elements` is a CSS selector list): scan only the listed selectors.
+   - **Auto mode** (when `elements` is `"auto"`): scan all elements on the page using the binding property set above. Explicitly EXCLUDE:
+     - SVG `<animate>`, `<animateTransform>`, and `<animateMotion>` elements (SMIL animations)
+     - `@keyframes` blocks with opacity-only changes
+     - Vendor-prefixed properties (`-webkit-`, `-moz-`) without an unprefixed equivalent
+     - These excluded surfaces return INCONCLUSIVE for that specific element (not FAIL), so they do not drive overall scenario result.
+6. **Pass criteria**: an element passes when all detected motion is either absent OR has `animation-play-state: paused` / `transition-duration: 0s` / is wrapped in a `prefers-reduced-motion: reduce` media query in source CSS.
+7. **FAIL** when any non-excluded element still has active motion after CDP emulation. Report the element selector and its offending computed styles.
+8. **INCONCLUSIVE** when the only detected motion is on SVG/SMIL elements or vendor-prefixed-without-unprefixed properties (no standard-property violations found).
+
+**Evidence JSON extensions for motion tuples:**
+
+Each per-tuple evidence object gains these additional fields alongside the standard fields:
+
+```json
+{
+  "route": "/dashboard",
+  "viewport": "desktop",
+  "theme": "dark",
+  "elements_scanned": ["#hero-banner", ".nav-fade-in"],
+  "motion_present_elements": [
+    {
+      "selector": "#hero-banner",
+      "animation_name": "pulse",
+      "animation_duration": "1s",
+      "transition_property": "none",
+      "transition_duration": "0s"
+    }
+  ]
+}
+```
+
+`motion_present_elements` is empty `[]` on PASS. When INCONCLUSIVE due to excluded surfaces only, include them with a `"excluded": true` flag and `"exclusion_reason": "svg-smil"` or `"exclusion_reason": "vendor-prefixed-only"`.
+
+**Per-tuple report format:**
+
+### N. [Scenario description] (method: motion, viewport: desktop, theme: dark)
+- **Result:** PASS | FAIL | INCONCLUSIVE
+- **Route:** /dashboard
+- **Viewport:** desktop (1440x900)
+- **Theme:** dark (when applicable)
+- **Elements scanned:** `#hero-banner`, `.nav-fade-in` (or "full-page auto scan")
+- **Motion present:**
+  - `#hero-banner` - `animation-name: pulse`, `animation-duration: 1s` - motion active after CDP emulation (FAIL)
+- **Screenshot:** [path]
+
+A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
+
+**INCONCLUSIVE cases:**
+- `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
+- Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+- Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios
 

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -1,5 +1,5 @@
 ---
-description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), and perceptual_diff (pixel regression via pixelmatch). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
+description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
 mode: subagent
 permission:
   edit: deny
@@ -27,10 +27,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -59,7 +60,7 @@ Your spawn prompt will contain some combination of:
 
 1. **What changed** - brief description or diff summary of the implementation
 2. **Acceptance criteria** - specific things to verify. If absent, derive them conservatively from the feature description.
-3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path` - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
+3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff, motion}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path`; `motion` carries `route` and `elements` (CSS selector list or `"auto"`) - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
 4. **`ticket_id`** - the ticket identifier (used for knowledge attribution in qa.md entries).
 5. **URLs** - dev server or deployed URLs to test against
 6. **Test commands** (optional) - specific test suites to run
@@ -121,6 +122,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -655,9 +657,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:
@@ -677,6 +692,98 @@ Each per-tuple evidence object gains two additional fields:
 ```
 
 **Storybook scenario composition note:** storybook scenarios compose with viewport iteration (each `story × viewport` pair) and with theme (each `story × viewport × theme` triple when `theme_aware: true`). Each tuple is an independent pass/fail row.
+
+## Motion scenarios
+
+When a scenario has `method: motion`, you verify that the page respects `prefers-reduced-motion: reduce` by emulating the media feature via CDP and inspecting computed styles.
+
+**`story_id` is NOT valid on motion scenarios.** Motion scenarios use the `route` field (a URL or page path) directly. Setting `story_id` on a motion scenario is invalid (Skeptic raises Critical per schema rules).
+
+**Preflight:**
+
+1. Read `.agentic/config.json`.
+   - If `motion_aware` is `false` or the key is absent AND the scenario has `method: motion`: proceed normally. `motion_aware` controls Skeptic auto-Major enforcement at planning time, not qa-engineer execution. Still run the scenario.
+
+2. **Capability gate** - verify `playwright-python` is available:
+   ```bash
+   python -c 'import playwright' 2>/dev/null
+   ```
+   If the import fails: return **INCONCLUSIVE** for all motion scenarios with operator message "playwright-python required for motion scenarios; install with `pip install playwright && playwright install chromium`". Do NOT fail on a tooling gap.
+
+3. **Resolve the route**: use the qa.md `motion` knowledge tag override when present (format: `motion: /route [selector,selector,...]` or `motion: /route auto`); otherwise use the scenario's `route` field.
+
+4. **Resolve the elements**: use the qa.md `motion` knowledge tag element list when present; otherwise use the scenario's `elements` field (a CSS selector list or the literal `auto`).
+
+**Verification procedure** (per scenario, per resolved viewport, per effective theme when `theme_aware: true` and scenario carries a `theme` field):
+
+For each `(scenario × viewport × theme)` tuple:
+
+1. Launch Playwright and navigate to the resolved `route` URL.
+2. Set the viewport using the canonical sizes or qa.md `viewport` override.
+3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
+4. Emulate `prefers-reduced-motion: reduce` via CDP:
+   ```python
+   page.emulate_media(color_scheme=None)
+   cdp = page.context.new_cdp_session(page)
+   cdp.send("Emulation.setEmulatedMedia", {
+       "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
+   })
+   ```
+5. For each target element, capture computed styles:
+   - Properties to check: `animation-name`, `animation-duration`, `transition-property`, `transition-duration`.
+   - **Explicit selector mode** (when `elements` is a CSS selector list): scan only the listed selectors.
+   - **Auto mode** (when `elements` is `"auto"`): scan all elements on the page using the binding property set above. Explicitly EXCLUDE:
+     - SVG `<animate>`, `<animateTransform>`, and `<animateMotion>` elements (SMIL animations)
+     - `@keyframes` blocks with opacity-only changes
+     - Vendor-prefixed properties (`-webkit-`, `-moz-`) without an unprefixed equivalent
+     - These excluded surfaces return INCONCLUSIVE for that specific element (not FAIL), so they do not drive overall scenario result.
+6. **Pass criteria**: an element passes when all detected motion is either absent OR has `animation-play-state: paused` / `transition-duration: 0s` / is wrapped in a `prefers-reduced-motion: reduce` media query in source CSS.
+7. **FAIL** when any non-excluded element still has active motion after CDP emulation. Report the element selector and its offending computed styles.
+8. **INCONCLUSIVE** when the only detected motion is on SVG/SMIL elements or vendor-prefixed-without-unprefixed properties (no standard-property violations found).
+
+**Evidence JSON extensions for motion tuples:**
+
+Each per-tuple evidence object gains these additional fields alongside the standard fields:
+
+```json
+{
+  "route": "/dashboard",
+  "viewport": "desktop",
+  "theme": "dark",
+  "elements_scanned": ["#hero-banner", ".nav-fade-in"],
+  "motion_present_elements": [
+    {
+      "selector": "#hero-banner",
+      "animation_name": "pulse",
+      "animation_duration": "1s",
+      "transition_property": "none",
+      "transition_duration": "0s"
+    }
+  ]
+}
+```
+
+`motion_present_elements` is empty `[]` on PASS. When INCONCLUSIVE due to excluded surfaces only, include them with a `"excluded": true` flag and `"exclusion_reason": "svg-smil"` or `"exclusion_reason": "vendor-prefixed-only"`.
+
+**Per-tuple report format:**
+
+### N. [Scenario description] (method: motion, viewport: desktop, theme: dark)
+- **Result:** PASS | FAIL | INCONCLUSIVE
+- **Route:** /dashboard
+- **Viewport:** desktop (1440x900)
+- **Theme:** dark (when applicable)
+- **Elements scanned:** `#hero-banner`, `.nav-fade-in` (or "full-page auto scan")
+- **Motion present:**
+  - `#hero-banner` - `animation-name: pulse`, `animation-duration: 1s` - motion active after CDP emulation (FAIL)
+- **Screenshot:** [path]
+
+A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
+
+**INCONCLUSIVE cases:**
+- `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
+- Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+- Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios
 

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -723,7 +723,6 @@ For each `(scenario × viewport × theme)` tuple:
 3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
 4. Emulate `prefers-reduced-motion: reduce` via CDP:
    ```python
-   page.emulate_media(color_scheme=None)
    cdp = page.context.new_cdp_session(page)
    cdp.send("Emulation.setEmulatedMedia", {
        "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
@@ -779,10 +778,12 @@ Each per-tuple evidence object gains these additional fields alongside the stand
 
 A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
 
+**FAIL cases:**
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+
 **INCONCLUSIVE cases:**
 - `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
 - Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
-- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
 - Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -721,7 +721,6 @@ For each `(scenario × viewport × theme)` tuple:
 3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
 4. Emulate `prefers-reduced-motion: reduce` via CDP:
    ```python
-   page.emulate_media(color_scheme=None)
    cdp = page.context.new_cdp_session(page)
    cdp.send("Emulation.setEmulatedMedia", {
        "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
@@ -777,10 +776,12 @@ Each per-tuple evidence object gains these additional fields alongside the stand
 
 A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
 
+**FAIL cases:**
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+
 **INCONCLUSIVE cases:**
 - `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
 - Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
-- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
 - Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: qa-engineer
-description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), and perceptual_diff (pixel regression via pixelmatch). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
+description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
 tools: Read, Glob, Grep, Bash
 ---
 
@@ -22,10 +22,11 @@ capabilities:
       install: "npm install --no-save pngjs"
       auto_install: true
       required_when: "scenario.method == 'perceptual_diff'"
-  optional:
     - tool: "playwright-python"
-      check: "python -c 'import playwright'"
+      check: "python -c 'import playwright' 2>/dev/null"
       install_hint: "pip install playwright && playwright install chromium"
+      required_when: "scenario.method == 'motion'"
+  optional:
     - tool: "agent-browser"
       check: "command -v agent-browser"
       install_hint: "npm install -g agent-browser"
@@ -57,7 +58,7 @@ Your spawn prompt will contain some combination of:
 
 1. **What changed** - brief description or diff summary of the implementation
 2. **Acceptance criteria** - specific things to verify. If absent, derive them conservatively from the feature description.
-3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path` - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
+3. **`qa_criteria`** (required for Elevated units) - the architect-emitted YAML block from the Brief or architect plan. Schema: `qa_skip` (null when QA fires, or one of 5 enum values when skipped), `qa_skip_rationale` (when applicable), `viewport` (root-level list, default `[desktop]`; per-scenario override replaces this list), `scenarios[]` (each with `id`, `description`, `method` ∈ {browser, api, runtime-required, visual_conformance, accessibility, perceptual_diff, motion}, `evidence`, optional `viewport` override; method-specific fields: `visual_conformance` carries `source_quote` and `expected_visual_claims[]`; `accessibility` carries `wcag_level` and optional `axe_tags`; `perceptual_diff` carries optional `tolerance` and `baseline_path`; `motion` carries `route` and `elements` (CSS selector list or `"auto"`) - see the method-specific sections below), `manual_smoke`. **When `qa_criteria` is present, the `scenarios[]` are the authoritative test plan and override any conservative-derivation fallback.** Use the conservative fallback only when `qa_criteria` is absent (legacy spawns or smoke-test mode).
 4. **`ticket_id`** - the ticket identifier (used for knowledge attribution in qa.md entries).
 5. **URLs** - dev server or deployed URLs to test against
 6. **Test commands** (optional) - specific test suites to run
@@ -119,6 +120,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `axe-rule` entries: project-wide axe rule additions or exclusions applied to every accessibility scenario; format: `axe-rule: exclude=region` (prefer scenario-level `axe_tags` for targeted overrides)
 - `theme` entries: selector or custom action recipe for the project's theme toggle mechanism; used by the Theme-aware scenarios section when neither the class-based nor data-attribute defaults produce a visible state change. Format examples: `theme: selector=button[data-theme-toggle]` or `theme: action=localStorage.setItem('theme','dark');location.reload()`
 - `story-url` entries: override the Storybook base URL for this project; used by the Storybook scenarios section. Format: `story-url: http://localhost:9009`
+- `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
 
@@ -653,9 +655,22 @@ When `.agentic/config.json` has `storybook_enabled: true` AND a scenario has a `
    ```
    A non-200 response returns INCONCLUSIVE with operator message "Storybook dev server not reachable at `<url>`. Start it with `npm run storybook` or set storybook_url." Do NOT return FAIL or clean-skip - CI must surface the unmet precondition.
 
+**SB6 URL conversion (when `storybook_version: 6` in `.agentic/config.json`):**
+
+Read `.agentic/config.json` `storybook_version` (default `7` when absent).
+
+- If `7` or absent: use `<storybook_url>/iframe.html?id=<story_id>` (current format).
+- If `6`: apply the SB6 conversion algorithm:
+  1. Split `story_id` on `--`. Left = kind segment; right = story segment.
+  2. If no `--` separator is present: return **FAIL** with operator message "Invalid story_id format: missing '--' separator. Correct the story_id field in your qa_criteria." (Not INCONCLUSIVE - this is malformed operator input.)
+  3. Kind segment: replace `-` with `/`, then Title Case each path part. Example: `components-button` → `Components/Button`.
+  4. Story segment: replace `-` with ` `, then Title Case each word. Example: `with-icon` → `With Icon`.
+  5. Build URL: `<storybook_url>/iframe.html?selectedKind=<percent-encoded kind>&selectedStory=<percent-encoded story>`.
+  6. Verify reachability: `curl -s -o /dev/null -w '%{http_code}' <converted_url>`. If non-200: return INCONCLUSIVE with "SB6 story-name convention mismatch; set explicit URL via qa.md `story-url` tag override."
+
 **Verification procedure:**
 
-1. Navigate to `<storybook_url>/iframe.html?id=<story_id>` (Storybook 7+ URL format).
+1. Navigate to the resolved URL (SB7: `?id=<story_id>`; SB6: `?selectedKind=...&selectedStory=...`).
 2. Set the viewport using the canonical sizes or qa.md override.
 3. If the scenario also has a `theme` field and `theme_aware: true` in config, apply the theme-aware loop (see Theme-aware scenarios section). The full iteration is `(scenario × viewport × theme)`.
 4. Run the scenario's method against the iframe content:
@@ -675,6 +690,98 @@ Each per-tuple evidence object gains two additional fields:
 ```
 
 **Storybook scenario composition note:** storybook scenarios compose with viewport iteration (each `story × viewport` pair) and with theme (each `story × viewport × theme` triple when `theme_aware: true`). Each tuple is an independent pass/fail row.
+
+## Motion scenarios
+
+When a scenario has `method: motion`, you verify that the page respects `prefers-reduced-motion: reduce` by emulating the media feature via CDP and inspecting computed styles.
+
+**`story_id` is NOT valid on motion scenarios.** Motion scenarios use the `route` field (a URL or page path) directly. Setting `story_id` on a motion scenario is invalid (Skeptic raises Critical per schema rules).
+
+**Preflight:**
+
+1. Read `.agentic/config.json`.
+   - If `motion_aware` is `false` or the key is absent AND the scenario has `method: motion`: proceed normally. `motion_aware` controls Skeptic auto-Major enforcement at planning time, not qa-engineer execution. Still run the scenario.
+
+2. **Capability gate** - verify `playwright-python` is available:
+   ```bash
+   python -c 'import playwright' 2>/dev/null
+   ```
+   If the import fails: return **INCONCLUSIVE** for all motion scenarios with operator message "playwright-python required for motion scenarios; install with `pip install playwright && playwright install chromium`". Do NOT fail on a tooling gap.
+
+3. **Resolve the route**: use the qa.md `motion` knowledge tag override when present (format: `motion: /route [selector,selector,...]` or `motion: /route auto`); otherwise use the scenario's `route` field.
+
+4. **Resolve the elements**: use the qa.md `motion` knowledge tag element list when present; otherwise use the scenario's `elements` field (a CSS selector list or the literal `auto`).
+
+**Verification procedure** (per scenario, per resolved viewport, per effective theme when `theme_aware: true` and scenario carries a `theme` field):
+
+For each `(scenario × viewport × theme)` tuple:
+
+1. Launch Playwright and navigate to the resolved `route` URL.
+2. Set the viewport using the canonical sizes or qa.md `viewport` override.
+3. If the scenario has a `theme` field and `theme_aware: true`, apply the theme-aware loop (see Theme-aware scenarios section) before emulating the media feature.
+4. Emulate `prefers-reduced-motion: reduce` via CDP:
+   ```python
+   page.emulate_media(color_scheme=None)
+   cdp = page.context.new_cdp_session(page)
+   cdp.send("Emulation.setEmulatedMedia", {
+       "features": [{"name": "prefers-reduced-motion", "value": "reduce"}]
+   })
+   ```
+5. For each target element, capture computed styles:
+   - Properties to check: `animation-name`, `animation-duration`, `transition-property`, `transition-duration`.
+   - **Explicit selector mode** (when `elements` is a CSS selector list): scan only the listed selectors.
+   - **Auto mode** (when `elements` is `"auto"`): scan all elements on the page using the binding property set above. Explicitly EXCLUDE:
+     - SVG `<animate>`, `<animateTransform>`, and `<animateMotion>` elements (SMIL animations)
+     - `@keyframes` blocks with opacity-only changes
+     - Vendor-prefixed properties (`-webkit-`, `-moz-`) without an unprefixed equivalent
+     - These excluded surfaces return INCONCLUSIVE for that specific element (not FAIL), so they do not drive overall scenario result.
+6. **Pass criteria**: an element passes when all detected motion is either absent OR has `animation-play-state: paused` / `transition-duration: 0s` / is wrapped in a `prefers-reduced-motion: reduce` media query in source CSS.
+7. **FAIL** when any non-excluded element still has active motion after CDP emulation. Report the element selector and its offending computed styles.
+8. **INCONCLUSIVE** when the only detected motion is on SVG/SMIL elements or vendor-prefixed-without-unprefixed properties (no standard-property violations found).
+
+**Evidence JSON extensions for motion tuples:**
+
+Each per-tuple evidence object gains these additional fields alongside the standard fields:
+
+```json
+{
+  "route": "/dashboard",
+  "viewport": "desktop",
+  "theme": "dark",
+  "elements_scanned": ["#hero-banner", ".nav-fade-in"],
+  "motion_present_elements": [
+    {
+      "selector": "#hero-banner",
+      "animation_name": "pulse",
+      "animation_duration": "1s",
+      "transition_property": "none",
+      "transition_duration": "0s"
+    }
+  ]
+}
+```
+
+`motion_present_elements` is empty `[]` on PASS. When INCONCLUSIVE due to excluded surfaces only, include them with a `"excluded": true` flag and `"exclusion_reason": "svg-smil"` or `"exclusion_reason": "vendor-prefixed-only"`.
+
+**Per-tuple report format:**
+
+### N. [Scenario description] (method: motion, viewport: desktop, theme: dark)
+- **Result:** PASS | FAIL | INCONCLUSIVE
+- **Route:** /dashboard
+- **Viewport:** desktop (1440x900)
+- **Theme:** dark (when applicable)
+- **Elements scanned:** `#hero-banner`, `.nav-fade-in` (or "full-page auto scan")
+- **Motion present:**
+  - `#hero-banner` - `animation-name: pulse`, `animation-duration: 1s` - motion active after CDP emulation (FAIL)
+- **Screenshot:** [path]
+
+A motion scenario PASSES when zero non-excluded elements have active motion after CDP `prefers-reduced-motion: reduce` emulation across all its viewports and themes. A single viewport/theme failure causes the scenario to FAIL.
+
+**INCONCLUSIVE cases:**
+- `playwright-python` not installed - return INCONCLUSIVE with install message (see Preflight).
+- Only SVG/SMIL or vendor-prefixed-without-unprefixed motion detected in auto mode - no standard-property violation, return INCONCLUSIVE.
+- `route` field contains a `story:<story_id>` form: return FAIL with "story_id is not valid on motion scenarios (P2 constraint). Use the `route` field with a direct URL or page path."
+- Page failed to load (navigate error, auth block) - report BLOCKED per the standard auth-handling rules.
 
 ## Perceptual diff scenarios
 

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -341,7 +341,7 @@ When reviewing a Brief or architect plan whose unit is clearly responsive - mobi
 
 ### `theme` enforcement (auto-Major rule)
 
-When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance` or `accessibility` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT `visual_conformance` or `accessibility` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these two methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
+When reviewing a Brief or architect plan where `.agentic/config.json` has `theme_aware: true` AND a scenario's method is `visual_conformance`, `accessibility`, or `motion` AND the `theme` field is absent on that scenario, the Skeptic raises a **Major** finding. This rule is opt-in: when `theme_aware` is absent or `false`, this rule does NOT fire. When `theme` is present on any scenario whose method is NOT in `{visual_conformance, accessibility, motion}` (i.e., `perceptual_diff`, `browser`, `api`, or `runtime-required`), the Skeptic raises a **Critical** finding - `theme` is restricted to these three methods only. Valid `theme` values are `light`, `dark`, and `both`; any other value is a Major finding. The canonical statement of the schema, field rules, and trigger predicate lives in `content/references/planning-artifacts.md` (Field guidance, QA criteria entry) - this section mirrors only enough to ensure a Skeptic reviewer cannot miss the rule.
 
 ### `story_id` enforcement (auto-Critical for compatibility)
 
@@ -370,6 +370,16 @@ are invalid.
 | `motion-not-reduced-motion-aware` | Major | CSS animation or transition present without a `prefers-reduced-motion: reduce` media query guard |
 | `outline-none-without-replacement` | Major | `outline: none` or `outline: 0` applied without a `:focus-visible` replacement focus indicator |
 | `missing-responsive-class` | Minor | fixed-width or single-breakpoint sizing on a surface that is otherwise responsive (often intentional on desktop-only surfaces; Skeptic judgment required) |
+
+### motion enforcement (auto-Major)
+
+**Trigger:** `.agentic/config.json` has `motion_aware: true` AND the unit is UI-visible AND risk is Elevated AND `qa_skip == null` AND no scenario with `method: motion` is present in `qa_criteria.scenarios`.
+
+When all trigger conditions hold, the Skeptic raises a **Major** finding. Rationale: a motion-aware project has declared that reduced-motion behavior is a testable concern; omitting a `motion` scenario from an Elevated UI-visible change leaves the `prefers-reduced-motion: reduce` path unverified. The finding must cite `content/references/frontend-discipline.md` §5 (Reduced motion).
+
+This rule is opt-in: when `motion_aware` is absent or `false`, this rule does NOT fire. When the unit is not UI-visible (e.g., `qa_skip: pure-backend-library`), this rule does NOT fire.
+
+Note: P2 motion scenarios do not support `story_id`; see `content/references/planning-artifacts.md` per-method table.
 
 ---
 


### PR DESCRIPTION
P2 Brief U2: qa-engineer procedures for motion + SB6.

- ## Motion scenarios section (CDP Emulation.setEmulatedMedia, per-(scenario × viewport × theme), binding property set, SVG/vendor-prefixed exclusions)
- SB6 URL conversion within ## Storybook scenarios (kind/story Title Case, FAIL on missing --, INCONCLUSIVE on non-200)
- motion knowledge tag
- playwright-python promoted to required (required_when motion)

Brief: docs/planning/p2-frontend-qa-methods.md

Skeptic R1 resolution: removed harmful page.emulate_media reset; restructured FAIL vs INCONCLUSIVE headings.