### PR TITLE
chore(deps): bump tmp to 0.2.7 and add scoped dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Scopes Dependabot version-update PRs to real project manifests.
+# evals/fixtures/** is deliberately excluded - those are intentional
+# vulnerable test fixtures used by the dependency-auditor / init-project evals.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/evals"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    exclude-paths:
+      - "fixtures/**"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"


### PR DESCRIPTION
Fixes the one real Dependabot alert in project code and stops future fixture-PR spam.

- **`scripts/package-lock.json`**: `tmp` 0.2.5 -> 0.2.7 (lockfile-only; `package.json` untouched). Resolves the HIGH-severity path-traversal in `tmp` (GHSA, patched at 0.2.6). `tmp` is transitive via `@marp-team/marp-cli`; `^0.2.5` already permits 0.2.7. `npm install` reports 0 vulnerabilities.
- **`.github/dependabot.yml`** (new): scopes version-update PRs to the real manifests - `/scripts` (npm), `/evals` (pip, `fixtures/**` excluded), `/` (github-actions), weekly, PR limit 5. The ~150 alerts under `evals/fixtures/**` are intentional vulnerable test fixtures for the dependency-auditor / init-project evals.

Note: `dependabot.yml` governs Dependabot *PRs*, not Security-tab *alerts* - the fixture alerts are cleared separately via bulk-dismissal, not by this config.

Skeptic: signed off, 0 findings (schema valid, lockfile integrity confirmed, no scope creep, full manifest coverage).