### PR TITLE
chore(ci): ignore @marp-team/* in dependabot (pinned, coordinated manually)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # @marp-team/* is pinned to exact versions and upgraded only as a coordinated
+    # same-PR action (bump all three packages + lockfile + rebuild slides). Single-
+    # package automated bumps break the slides-sync CI gate.
+    ignore:
+      - dependency-name: "@marp-team/*"
 
   - package-ecosystem: "pip"
     directory: "/evals"


### PR DESCRIPTION
The Marp toolchain in `scripts/package.json` is intentionally pinned to exact versions and upgraded as a single coordinated action (bump `marp-cli` + `marp-core` + `marpit` together, regenerate the lockfile, rebuild all 15 `docs/slides/*.html` via `scripts/build-slides.sh`). Dependabot's single-package bumps leave the rendered HTML stale and break the `slides-sync` gate (see closed #162).

Adds an `ignore: @marp-team/*` rule to the npm entry so Dependabot stops raising these. Marp upgrades stay manual and coordinated.

Skeptic: signed off, 0 findings (valid v2 `ignore` syntax, scoped glob matches only @marp-team packages, npm-entry-only diff).