### PR TITLE
feat(hooks): SessionStart newer-version-available notice

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -5,7 +5,7 @@
 - **Skill** (`/agentic-engineering`) - loads the full engineering methodology on demand
 - **Agents** (11) - architect, debugger, engineer, investigator, orchestration-planner, security-auditor, skeptic, adr-drift-detector, adr-generator, qa-engineer, learnings-agent
 - **Commands** (5) - skeptic, memory-update, wrap, init-project, implement
-- **Hooks** - UserPromptSubmit risk-classification reminder, Stop context saver
+- **Hooks** - UserPromptSubmit risk-classification reminder, PreToolUse background-spawn enforcement, Stop context saver, SessionStart newer-version-available notice
 
 ## Installation
 

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -439,6 +439,39 @@ else:
     })
     print("  + Added PreToolUse background-spawn enforcement hook")
 
+# ---- SessionStart newer-version-available notice hook -----------------------
+VERSION_CHECK_CMD = f"bash {repo_dir}/hooks/session-start-version-check.sh"
+
+ss_list = hooks.setdefault("SessionStart", [])
+
+# Find or create a matcher "startup" block
+ss_startup = None
+for block in ss_list:
+    if block.get("matcher") == "startup":
+        ss_startup = block
+        break
+
+if ss_startup is None:
+    ss_startup = {"matcher": "startup", "hooks": []}
+    ss_list.append(ss_startup)
+
+ss_startup.setdefault("hooks", [])
+
+already_has_version_check = any(
+    "session-start-version-check.sh" in entry.get("command", "")
+    for entry in ss_startup["hooks"]
+)
+
+if already_has_version_check:
+    print("  = SessionStart version-check hook already present")
+else:
+    ss_startup["hooks"].append({
+        "type": "command",
+        "command": VERSION_CHECK_CMD,
+        "timeout": 5
+    })
+    print("  + Added SessionStart version-check hook")
+
 # ---- Write back -------------------------------------------------------------
 with open(settings_path, "w") as f:
     json.dump(settings, f, indent=2)

--- a/.kimi/hooks/session-start.sh
+++ b/.kimi/hooks/session-start.sh
@@ -77,4 +77,16 @@ if [[ "$skill_auto_load" == "true" ]]; then
   echo "Do not implement directly - follow the delegation and risk classification protocol in that file."
 fi
 
+# Newer-version-available notice (shared core; Kimi cannot use systemMessage,
+# so the message is printed to stderr like the activation reminder above).
+# The core resolves the clone dir + cache and prints the notice only when the
+# local clone is behind upstream. AGENTIC_QUIET=1 suppresses it.
+version_core="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/hooks/lib/version-check-core.sh"
+if [[ "${AGENTIC_QUIET:-}" != "1" && -f "$version_core" ]]; then
+  version_msg="$(bash "$version_core" 2>/dev/null || echo "")"
+  if [[ -n "$version_msg" ]]; then
+    >&2 echo "$version_msg"
+  fi
+fi
+
 exit 0

--- a/ADAPTERS.md
+++ b/ADAPTERS.md
@@ -21,6 +21,7 @@ Each tool has its own mechanisms for the same core concepts:
 | Lifecycle hooks | `settings.json` hooks | `.cursor/hooks.json` | `~/.codex/hooks.json` | `~/.gemini/settings.json` | `[[hooks]]` in `~/.kimi/config.toml` | Not available | Extension events available but not required for this adapter | Not available | Not available |
 | Risk reminder | UserPromptSubmit hook | beforeSubmitPrompt hook | UserPromptSubmit hook | BeforeAgent hook | `PreToolUse` hook | Embedded in skill content | Embedded in skill content; future extension can inject `before_agent_start` reminders | Embedded in skill content | Embedded in skill content |
 | Session context save | Stop hook | stop hook | Stop hook | SessionEnd hook | `Stop` hook | Not available | Future extension can use `session_shutdown`; not implemented in this adapter | Not available | Not available |
+| Version-update notice | SessionStart hook (`systemMessage`) | Not available | Not available | Not available | SessionStart hook (stderr) | Not available | Not available | Not available | Not available |
 
 ## Checklist for a new adapter
 

--- a/hooks/lib/version-check-core.sh
+++ b/hooks/lib/version-check-core.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Purpose: Adapter-neutral core for the "newer version available" SessionStart
+#          notice. Resolves the agentic-engineering clone dir, reads a small
+#          cache of how far the local clone is behind upstream, and prints a
+#          single generic update notice to stdout when behind. Kicks off a
+#          detached, TTL-throttled background refresh that runs `git fetch` and
+#          recomputes the behind-count without ever blocking the caller.
+# Public API: bash hooks/lib/version-check-core.sh
+#             (no args; prints the notice to stdout when behind_count > 0,
+#              otherwise prints nothing. Always exits 0.)
+# Upstream deps: ~/.agentic/agentic-engineering-config.json (optional; repo_dir),
+#                ~/.agentic/version-check-cache.json (optional cache),
+#                git, python3 (cache parse + atomic JSON write). All optional;
+#                any missing piece is handled fail-open.
+# Downstream consumers: hooks/session-start-version-check.sh (Claude Code wrapper),
+#                       .kimi/hooks/session-start.sh (Kimi, prints to stderr).
+# Failure modes: always exits 0 (fail-open). No cache, offline, non-git dir,
+#                missing python3/git, or malformed cache => prints nothing,
+#                still exits 0. Detached refresh redirects all of
+#                stdin/stdout/stderr so the parent returns immediately; a failed
+#                fetch leaves the prior cache untouched. Cache writes are atomic
+#                (tmp file + mv) so a torn read just fails open on the next run.
+# Performance: read path is a single file read + one python3 parse (sub-10ms,
+#              no network). The network (git fetch) only ever runs in a detached
+#              background process, so the caller never waits on it.
+
+set -euo pipefail
+
+# Time-to-live for the cached behind-count, in seconds. Detached refresh only
+# runs when the cache is older than this, so many rapid sessions do not each
+# spawn a `git fetch`. ~6 hours: freshness lags by at most one TTL window, which
+# is acceptable for a passive update nudge.
+VERSION_CHECK_TTL_SECONDS=21600
+
+AE_CONFIG="$HOME/.agentic/agentic-engineering-config.json"
+CACHE_FILE="$HOME/.agentic/version-check-cache.json"
+
+# --- Resolve the clone dir (same resolver as /update-agentic-engineering Step 0) ---
+ae_repo_dir=""
+if [[ -f "$AE_CONFIG" ]]; then
+  ae_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$AE_CONFIG" 2>/dev/null || echo "")"
+fi
+if [[ -z "$ae_repo_dir" ]] || ! git -C "$ae_repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  ae_repo_dir="$HOME/agentic-engineering"
+fi
+
+# --- Maybe kick off a detached refresh (TTL-throttled) ---
+# Reads the cache timestamp; if absent or older than the TTL, launches a fully
+# detached process that fetches and rewrites the cache atomically. All three
+# standard fds are redirected so the parent (and Claude Code's hook runner)
+# never waits on an inherited pipe. This is the single most important detail:
+# without the redirects the SessionStart hook would block on git fetch.
+maybe_refresh() {
+  local now last_fetch=0 age
+  now="$(date +%s 2>/dev/null || echo 0)"
+
+  if [[ -f "$CACHE_FILE" ]]; then
+    last_fetch="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(int(json.load(f).get('last_fetch_epoch', 0)))
+except Exception:
+    print(0)
+" "$CACHE_FILE" 2>/dev/null || echo 0)"
+  fi
+
+  # Make fail-open structural: never let a non-numeric timestamp reach the
+  # arithmetic below (set -u plus a bad value would abort the hook). Mirrors the
+  # read-path guard on behind_count.
+  [[ "$last_fetch" =~ ^[0-9]+$ ]] || last_fetch=0
+
+  age=$(( now - last_fetch ))
+  # Refresh when there is no usable timestamp, the clock looks off, or the cache
+  # has aged past the TTL.
+  if [[ "$last_fetch" -gt 0 && "$age" -lt "$VERSION_CHECK_TTL_SECONDS" && "$age" -ge 0 ]]; then
+    return 0
+  fi
+
+  # Detached, fully-redirected background refresh. nohup + & + all-fds-redirected
+  # so the caller returns immediately and never blocks on git fetch.
+  nohup bash -c '
+    repo="$1"
+    cache="$2"
+    git -C "$repo" fetch --quiet origin >/dev/null 2>&1 || exit 0
+    behind="$(git -C "$repo" rev-list --count HEAD..@{u} 2>/dev/null || echo "")"
+    case "$behind" in
+      ""|*[!0-9]*) exit 0 ;;
+    esac
+    now="$(date +%s 2>/dev/null || echo 0)"
+    tmp="${cache}.tmp.$$"
+    if printf "{\"behind_count\": %s, \"last_fetch_epoch\": %s}\n" "$behind" "$now" > "$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$cache" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    fi
+  ' _ "$ae_repo_dir" "$CACHE_FILE" </dev/null >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+}
+
+# --- Read path: print the notice iff cached behind_count > 0 ---
+behind_count="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(int(json.load(f).get('behind_count', 0)))
+except Exception:
+    print(0)
+" "$CACHE_FILE" 2>/dev/null || echo 0)"
+
+# Ensure the cache dir exists so the detached refresh can write into it.
+mkdir -p "$HOME/.agentic" >/dev/null 2>&1 || true
+
+maybe_refresh
+
+if [[ "$behind_count" =~ ^[0-9]+$ ]] && [[ "$behind_count" -gt 0 ]]; then
+  echo "⚠️ agentic-engineering: newer version available. Update with /update-agentic-engineering (in session) or ${ae_repo_dir}/update.sh (shell)."
+fi
+
+exit 0

--- a/hooks/session-start-version-check.sh
+++ b/hooks/session-start-version-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Purpose: Claude Code SessionStart wrapper for the "newer version available"
+#          notice. Calls the adapter-neutral core and, when the core prints a
+#          non-empty notice, emits it as a SessionStart `systemMessage` (shown
+#          to the user, NOT added to Claude's context). When there is nothing to
+#          say, emits a bare `{"suppressOutput": true}`.
+# Public API: bash hooks/session-start-version-check.sh
+#             (reads SessionStart JSON on stdin, ignores it; writes a single
+#              JSON object to stdout; always exits 0.)
+# Upstream deps: hooks/lib/version-check-core.sh (resolution + cache + refresh),
+#                python3 (JSON-escapes the message), AGENTIC_QUIET env var.
+# Downstream consumers: Claude Code SessionStart hook, wired via
+#                       ~/.claude/settings.json by .claude/install.sh.
+# Failure modes: always exits 0 (fail-open). If the core fails or prints nothing
+#                the wrapper emits `{"suppressOutput": true}`. AGENTIC_QUIET=1
+#                suppresses the systemMessage but still emits suppressOutput so
+#                the SessionStart contract is satisfied.
+# Performance: one subshell call to the core (read path is sub-10ms, no blocking
+#              network) plus one python3 invocation to build JSON.
+
+set -euo pipefail
+
+# Drain stdin without blocking the hook if no payload is sent.
+cat >/dev/null 2>&1 || true
+
+CORE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/version-check-core.sh"
+
+msg=""
+if [[ -f "$CORE" ]]; then
+  msg="$(bash "$CORE" 2>/dev/null || echo "")"
+fi
+
+# AGENTIC_QUIET=1 suppresses the user-facing message but still satisfies the
+# SessionStart JSON contract with suppressOutput.
+if [[ "${AGENTIC_QUIET:-}" == "1" ]]; then
+  msg=""
+fi
+
+if [[ -n "$msg" ]]; then
+  # Build the JSON with python3 so the message is correctly escaped.
+  python3 -c "
+import json, sys
+print(json.dumps({'systemMessage': sys.argv[1], 'suppressOutput': True}))
+" "$msg" 2>/dev/null || printf '{"suppressOutput": true}\n'
+else
+  printf '{"suppressOutput": true}\n'
+fi
+
+exit 0

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -71,6 +71,30 @@ function saveConfig(selectedAdapters) {
   }
 }
 
+// Reset the SessionStart version-check cache to behind_count: 0 after a
+// successful pull, so the "newer version available" notice clears immediately
+// instead of lingering until the next TTL-gated refresh. Atomic write (tmp + mv)
+// to match the core's write discipline. Best-effort: failures are warned, never
+// fatal - the cache self-heals on the next background refresh.
+function resetVersionCheckCache() {
+  const home = process.env.HOME || process.env.USERPROFILE || '.';
+  const cacheDir = path.join(home, '.agentic');
+  const cachePath = path.join(cacheDir, 'version-check-cache.json');
+  const tmpPath = `${cachePath}.tmp.${process.pid}`;
+  const payload = JSON.stringify({
+    behind_count: 0,
+    last_fetch_epoch: Math.floor(Date.now() / 1000)
+  }) + '\n';
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(tmpPath, payload, 'utf8');
+    fs.renameSync(tmpPath, cachePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch (_) { /* ignore */ }
+    console.warn(`Warning: failed to reset version-check cache: ${err.message}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Adapter discovery
 // ---------------------------------------------------------------------------
@@ -554,6 +578,11 @@ async function main() {
     const countResult = git(resolvedRepoDir, 'rev-list', '--count', `${oldHead}..${newHead}`);
     commitsPulled = countResult.success ? parseInt(countResult.stdout, 10) : 0;
   }
+
+  // Pull succeeded: clear the version-check cache so the SessionStart "newer
+  // version available" notice disappears on the next session immediately,
+  // rather than waiting for the next TTL-gated background refresh.
+  resetVersionCheckCache();
 
   // Run install scripts (fail-fast: stop on first failure)
   const successes = [];


### PR DESCRIPTION
SessionStart hook that shows a one-line "newer version available" notice when the local clone is behind `origin/main`, without entering the agent context. Cache-backed so startup never blocks on the network.

<img width="952" height="280" alt="image" src="https://github.com/user-attachments/assets/dfa0d9a3-35c6-4c15-b5bf-e8f1c728b7f4" />

## Changes
- `hooks/lib/version-check-core.sh` (new) - adapter-neutral core: resolves the clone dir (same resolver as `/update-agentic-engineering`), reads `~/.agentic/version-check-cache.json`, prints the notice when `behind_count > 0`. A TTL-gated (~6h) fully-detached `git fetch` refreshes the cache; the read path is cache-only.
- `hooks/session-start-version-check.sh` (new) - Claude Code wrapper: emits a `systemMessage` field (user-visible, not added to context) or `suppressOutput` only. Honors `AGENTIC_QUIET=1`.
- `.claude/install.sh` - idempotent SessionStart (`startup`) registration.
- `.kimi/hooks/session-start.sh` - prints the notice to stderr (Kimi has no `systemMessage`), reusing the core.
- `scripts/update.js` - clears the cache after a successful pull so the notice clears immediately.
- Docs: `.claude/README.md` hook inventory + `ADAPTERS.md` capability matrix.

## Notes
- Fail-open: exits 0 on every error path (no cache, offline, non-git dir, malformed cache).
- Reviewed via Skeptic (0 Critical / 0 Major); SessionStart `systemMessage` rendering confirmed live.
- Existing installs pick up the registration automatically on the next `update.sh` (`.claude` is a locked adapter).
- Surface limited to Claude Code + Kimi (the only SessionStart-capable adapters); `startup` matcher only. statusLine colorization was scoped out (one statusLine per user; cannot ship without clobbering an existing one).