### PR TITLE
chore: add .mailmap consolidating maintainer identity to tyhummel@gmail.com

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+# .mailmap - Consolidates the maintainer's historical git aliases to a single canonical identity.
+# Prepared ahead of open-sourcing so git log, git shortlog, and GitHub's contributor view
+# all attribute work to one person.
+#
+# Canonical identity: Tyson Hummel <tyhummel@gmail.com>
+#
+# Format: Canonical Name <canonical@email> <old@email>
+# (email-only match on the right catches all name variants for that old address)
+
+Tyson Hummel <tyhummel@gmail.com> <admin@fullmetalblanket.com>
+Tyson Hummel <tyhummel@gmail.com> <tyson@solara6.com>
+Tyson Hummel <tyhummel@gmail.com> <thummel@crocs.com>
+Tyson Hummel <tyhummel@gmail.com> <thummelbiz@gmail.com>
+Tyson Hummel <tyhummel@gmail.com> tysonhummel <tyhummel@gmail.com>


### PR DESCRIPTION
Consolidates the maintainer's historical git aliases to a single canonical identity, `Tyson Hummel <tyhummel@gmail.com>`, ahead of open-sourcing. Non-destructive - a committed `.mailmap`, no history rewrite.

`git shortlog -sne` before → after: 9 author entries collapse to 4 (538 commits to the canonical identity; Tristan Lee, Heitor Ramon Ribeiro, and dependabot left untouched).

Pairs with two out-of-band steps (not in this PR): repo-local git config now authors new commits as the canonical identity, and the historical emails are being verified on the github.com/tysonhummel account for contribution-graph attribution.

Skeptic: signed off, 0 findings (valid mailmap syntax, complete owner-alias coverage, no false attribution of external contributors, canonical email verified char-for-char).