### PR TITLE
feat(identity): auto-identity + pending buffer + operator rollup (behavioral, ae-identity-v1 PR1)

### DIFF
--- a/bin/agentic-cost
+++ b/bin/agentic-cost
@@ -502,7 +502,7 @@ def _render_operator_table(agg: dict) -> str:
     lines: list[str] = []
     lines.append("Operator rollup (all projects)")
     header = (
-        f"{'project':<24}{'sessions':>9}{'in_tok':>10}{'out_tok':>10}"
+        f"{'developer/project':<24}{'sessions':>9}{'in_tok':>10}{'out_tok':>10}"
         f"{'cache_cr':>10}{'cache_rd':>10}{'wall(s)':>10}"
     )
     lines.append(header)

--- a/bin/agentic-cost
+++ b/bin/agentic-cost
@@ -3,20 +3,24 @@
 Purpose: Read .agentic/events.jsonl and render per-agent / per-task /
          per-project token and wall-time rollups. Also reads
          .agentic/session-log/*.jsonl for team-level per-developer aggregation.
-         Optionally renders dollar columns when ~/.agentic/pricing.yml is present
-         (opt-in, never invented). The CLI for the /agentic-cost command.
-         Also provides `retro` subcommand for pre-telemetry historical rollups
-         reconstructed from git log and gh pr list.
+         Reads ~/.agentic/session-log/*.jsonl for operator-level cross-project
+         rollup. Optionally renders dollar columns when ~/.agentic/pricing.yml
+         is present (opt-in, never invented). The CLI for the /agentic-cost
+         command. Also provides `retro` subcommand for pre-telemetry historical
+         rollups reconstructed from git log and gh pr list.
 
 Public API: agentic-cost session [<session_uuid>]
             agentic-cost task <task_id>
             agentic-cost project [--since <YYYY-MM-DD>]
             agentic-cost team [--json]
+            agentic-cost operator [--since YYYY-MM-DD] [--json]
             agentic-cost retro [--since YYYY-MM-DD] [--until YYYY-MM-DD]
                                [--author <handle>] [--json]
             All subcommands print a fixed-width table to stdout. Every
             output ends with the V1 disclosure footer line per
             acceptance criterion 12.
+            `operator` reads the global mirror ~/.agentic/session-log/*.jsonl
+            and aggregates by developer_id + project_slug across all projects.
 
 Upstream deps: Python 3 stdlib (json, sys, os, argparse, datetime, pathlib,
                subprocess, re). Optional pyyaml soft dependency for
@@ -35,6 +39,8 @@ Failure modes: missing .agentic/events.jsonl -> prints empty rollup with
                and the missing model is listed in a footnote.
                missing/empty .agentic/session-log/ -> prints guidance message
                and exits 0.
+               missing/empty ~/.agentic/session-log/ -> prints empty-data
+               message and exits 0.
                `retro` not in a git repo -> exit 1, friendly message.
                `retro` gh unavailable or unauthenticated -> git-only mode with
                one-line warning.
@@ -62,6 +68,7 @@ V1_FOOTER = (
 
 EVENTS_PATH = Path(".agentic/events.jsonl")
 SESSION_LOG_DIR = Path(".agentic/session-log")
+GLOBAL_SESSION_LOG_DIR = Path(os.path.expanduser("~/.agentic/session-log"))
 PRICING_PATH = Path(os.path.expanduser("~/.agentic/pricing.yml"))
 
 
@@ -335,17 +342,18 @@ def cmd_project(args: argparse.Namespace) -> int:
     return 0
 
 
-def _load_session_logs() -> tuple[list[dict], int]:
-    """Load all JSONL lines from .agentic/session-log/*.jsonl.
+def _load_jsonl_dir(log_dir: Path) -> tuple[list[dict], int]:
+    """Load all JSONL lines from <log_dir>/*.jsonl (non-recursive).
 
     Returns (records, skipped_count). Each record is the parsed JSON object
     from a single session-log line. Malformed lines are skipped and counted.
+    The caller is responsible for ensuring log_dir exists before calling.
     """
-    if not SESSION_LOG_DIR.is_dir():
+    if not log_dir.is_dir():
         return [], 0
     records: list[dict] = []
     skipped = 0
-    for jsonl_file in sorted(SESSION_LOG_DIR.glob("*.jsonl")):
+    for jsonl_file in sorted(log_dir.glob("*.jsonl")):
         try:
             with jsonl_file.open("r", encoding="utf-8", errors="replace") as fh:
                 for raw in fh:
@@ -359,6 +367,15 @@ def _load_session_logs() -> tuple[list[dict], int]:
         except OSError:
             pass
     return records, skipped
+
+
+def _load_session_logs() -> tuple[list[dict], int]:
+    """Load all JSONL lines from .agentic/session-log/*.jsonl.
+
+    Returns (records, skipped_count). Each record is the parsed JSON object
+    from a single session-log line. Malformed lines are skipped and counted.
+    """
+    return _load_jsonl_dir(SESSION_LOG_DIR)
 
 
 def _aggregate_team(records: list[dict]) -> dict:
@@ -440,6 +457,134 @@ def cmd_team(args: argparse.Namespace) -> int:
         return 0
 
     sys.stdout.write(_render_team_table(agg))
+    if skipped:
+        print(f"{skipped} lines skipped due to malformed JSONL.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# operator helpers
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_operator(records: list[dict]) -> dict:
+    """Aggregate global session-log records by (developer_id, project_slug).
+
+    Returns:
+      {(developer_id, project_slug): {sessions, wall_seconds,
+                                       tokens: {input, output,
+                                                cache_creation, cache_read}}}
+    """
+    agg: dict = {}
+    for rec in records:
+        dev = rec.get("developer_id")
+        if not dev:
+            continue
+        project = rec.get("project_slug") or "(unknown)"
+        data = rec.get("data") or {}
+        key = (dev, project)
+        bucket = agg.setdefault(key, {
+            "sessions": 0,
+            "wall_seconds": 0.0,
+            "tokens": {"input": 0, "output": 0,
+                       "cache_creation": 0, "cache_read": 0},
+        })
+        bucket["sessions"] += 1
+        bucket["wall_seconds"] += float(data.get("wall_seconds") or 0)
+        toks = data.get("tokens") or {}
+        for k in ("input", "output", "cache_creation", "cache_read"):
+            bucket["tokens"][k] += int(toks.get(k) or 0)
+    return agg
+
+
+def _render_operator_table(agg: dict) -> str:
+    """Render fixed-width operator rollup table sorted by total tokens desc."""
+    lines: list[str] = []
+    lines.append("Operator rollup (all projects)")
+    header = (
+        f"{'project':<24}{'sessions':>9}{'in_tok':>10}{'out_tok':>10}"
+        f"{'cache_cr':>10}{'cache_rd':>10}{'wall(s)':>10}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    def _tok_total(b: dict) -> int:
+        t = b["tokens"]
+        return t["input"] + t["output"] + t["cache_creation"] + t["cache_read"]
+
+    sorted_keys = sorted(
+        agg.keys(),
+        key=lambda k: _tok_total(agg[k]),
+        reverse=True,
+    )
+    for (dev, project) in sorted_keys:
+        b = agg[(dev, project)]
+        t = b["tokens"]
+        label = f"{dev}/{project}"
+        lines.append(
+            f"{label:<24}{b['sessions']:>9}{t['input']:>10}{t['output']:>10}"
+            f"{t['cache_creation']:>10}{t['cache_read']:>10}"
+            f"{b['wall_seconds']:>10.1f}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _filter_records_since(records: list[dict], since: str) -> list[dict]:
+    """Return records whose ts >= since (YYYY-MM-DD). Drops records without ts."""
+    try:
+        cutoff = _dt.date.fromisoformat(since)
+    except ValueError:
+        return records
+    filtered = []
+    for rec in records:
+        ts = rec.get("ts") or ""
+        try:
+            d = _dt.datetime.fromisoformat(
+                ts.replace("Z", "+00:00")
+            ).date()
+        except ValueError:
+            continue
+        if d >= cutoff:
+            filtered.append(rec)
+    return filtered
+
+
+def cmd_operator(args: argparse.Namespace) -> int:
+    """Cross-project rollup from ~/.agentic/session-log/*.jsonl."""
+    GLOBAL_SESSION_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    records, skipped = _load_jsonl_dir(GLOBAL_SESSION_LOG_DIR)
+
+    if not records:
+        print(
+            "No operator session data. "
+            "Run sessions with a confirmed identity to populate."
+        )
+        return 0
+
+    since = getattr(args, "since", None)
+    if since:
+        records = _filter_records_since(records, since)
+        if not records:
+            print(
+                "No operator session data. "
+                "Run sessions with a confirmed identity to populate."
+            )
+            return 0
+
+    agg = _aggregate_operator(records)
+
+    if getattr(args, "json", False):
+        json_out: dict = {}
+        for (dev, project), b in agg.items():
+            json_out.setdefault(dev, {})[project] = {
+                "sessions": b["sessions"],
+                "wall_seconds": b["wall_seconds"],
+                "tokens": b["tokens"],
+            }
+        sys.stdout.write(json.dumps(json_out, indent=2) + "\n")
+        return 0
+
+    sys.stdout.write(_render_operator_table(agg))
     if skipped:
         print(f"{skipped} lines skipped due to malformed JSONL.")
     return 0
@@ -853,6 +998,19 @@ def main(argv: list[str]) -> int:
     p_team.add_argument("--json", action="store_true",
                         help="emit machine-readable JSON instead of a table")
     p_team.set_defaults(func=cmd_team)
+    p_operator = sub.add_parser(
+        "operator",
+        help="cross-project rollup from ~/.agentic/session-log/ (all projects)",
+    )
+    p_operator.add_argument(
+        "--since", default=None,
+        help="YYYY-MM-DD lower bound on session timestamp",
+    )
+    p_operator.add_argument(
+        "--json", action="store_true",
+        help="emit machine-readable JSON instead of a table",
+    )
+    p_operator.set_defaults(func=cmd_operator)
     p_retro = sub.add_parser(
         "retro",
         help=(

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
 """
 Purpose: CLI for managing the per-developer identity file (~/.agentic/identity.yml)
-         used by the Stop hook to write per-developer session telemetry.
+         used by the Stop hook to write per-developer session telemetry. Supports
+         automatic identity derivation from gh CLI (provisional) and confirmation
+         which flushes the pending session-log buffer.
 
 Public API:
   agentic-identity init <handle> [--display-name "<name>"] [--force]
   agentic-identity show
+  agentic-identity auto [--force]
+  agentic-identity confirm
   agentic-identity --help
 
-Upstream deps: Python 3 stdlib only (argparse, os, re, sys, datetime, pathlib).
+Data model:
+  ~/.agentic/identity.yml fields: developer_id, display_name (optional),
+    created_at, provisional (optional, absent=confirmed), derived_from (optional).
+  ~/.agentic/session-log/.pending/<uuid>.json: pre-attribution session records;
+    flushed to global + per-project logs on confirm/init.
+
+Upstream deps: Python 3 stdlib only (argparse, fcntl, glob, json, os, re, signal,
+               subprocess, sys, datetime, pathlib, time).
 
 Downstream consumers: hooks/stop-context.js (reads ~/.agentic/identity.yml);
                       bin/agentic-cost team (reads .agentic/session-log/ written
@@ -16,25 +27,40 @@ Downstream consumers: hooks/stop-context.js (reads ~/.agentic/identity.yml);
 
 Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                Never writes partial files (write to temp, rename).
+               flushPendingBuffer: serialized via fcntl.flock on .flush.lock;
+               30s timeout via LOCK_NB+sleep loop (SIGALRM avoided for portability);
+               on timeout prints stderr warning and returns without data loss.
 
-Performance: Standard. File I/O only.
+Performance: Standard. File I/O only; subprocess for gh CLI in auto subcommand.
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
+import glob
+import json
 import os
 import re
+import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
 IDENTITY_PATH = Path(os.path.expanduser("~/.agentic/identity.yml"))
+PENDING_DIR = Path(os.path.expanduser("~/.agentic/session-log/.pending"))
+GLOBAL_SESSION_LOG_DIR = Path(os.path.expanduser("~/.agentic/session-log"))
+FLUSH_LOCK_PATH = Path(os.path.expanduser("~/.agentic/session-log/.flush.lock"))
 HANDLE_RE = re.compile(r'^[a-z0-9._-]{1,64}$')
 
 
 def _read_identity() -> dict | None:
-    """Return parsed identity dict or None if absent/malformed."""
+    """Return parsed identity dict or None if absent/malformed.
+
+    Fields returned: developer_id (required), display_name, created_at,
+    provisional (absent => False), derived_from.
+    """
     if not IDENTITY_PATH.is_file():
         return None
     raw = IDENTITY_PATH.read_text(encoding="utf-8")
@@ -48,7 +74,170 @@ def _read_identity() -> dict | None:
     ca = re.search(r'^created_at:\s*(\S+)\s*$', raw, re.MULTILINE)
     if ca:
         result["created_at"] = ca.group(1)
+    prov = re.search(r'^provisional:\s*(true|false)\s*$', raw, re.MULTILINE)
+    if prov:
+        result["provisional"] = prov.group(1) == "true"
+    df = re.search(r'^derived_from:\s*(\S+)\s*$', raw, re.MULTILINE)
+    if df:
+        result["derived_from"] = df.group(1)
     return result
+
+
+def _write_identity(lines: list[str]) -> int:
+    """Atomically write identity file from lines list. Returns 0 on success, 1 on error."""
+    content = "\n".join(lines) + "\n"
+    IDENTITY_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp = IDENTITY_PATH.with_suffix(".yml.tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        tmp.rename(IDENTITY_PATH)
+    except Exception as exc:
+        print(f"agentic-identity: write failed: {exc}", file=sys.stderr)
+        tmp.unlink(missing_ok=True)
+        return 1
+    return 0
+
+
+def flushPendingBuffer(confirmed_dev_id: str) -> int:
+    """Flush ~/.agentic/session-log/.pending/*.json to global + per-project logs.
+
+    Race-safe via fcntl.flock exclusive lock on .flush.lock for the whole loop.
+    Uses LOCK_NB + sleep loop (30s timeout) for portability over SIGALRM.
+    Returns number of records flushed (0 on no pending or timeout).
+    """
+    # Ensure lock file and parent dirs exist.
+    FLUSH_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    FLUSH_LOCK_PATH.touch(exist_ok=True)
+
+    try:
+        fd = open(FLUSH_LOCK_PATH, 'r')
+    except OSError as exc:
+        print(f"agentic-identity confirm: cannot open lock file: {exc}", file=sys.stderr)
+        return 0
+
+    # LOCK_NB + sleep loop, 30s total.
+    deadline = time.monotonic() + 30.0
+    acquired = False
+    while time.monotonic() < deadline:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+            break
+        except BlockingIOError:
+            time.sleep(0.1)
+
+    if not acquired:
+        fd.close()
+        print(
+            "agentic-identity confirm: lock timeout after 30s; retry.",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        pending_pattern = str(PENDING_DIR / "*.json")
+        pending_files = sorted(glob.glob(pending_pattern))
+        flushed = 0
+
+        for pending_path in pending_files:
+            # Parse pending record.
+            try:
+                with open(pending_path, encoding="utf-8") as f:
+                    record = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                # Skip malformed records silently.
+                continue
+
+            session_uuid = record.get("session_uuid", "")
+
+            # Dedup: scan global log for this session_uuid.
+            global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"
+            already_flushed = False
+            if session_uuid and global_log.is_file():
+                try:
+                    if session_uuid in global_log.read_text(encoding="utf-8"):
+                        already_flushed = True
+                except OSError:
+                    pass
+
+            if already_flushed:
+                try:
+                    os.unlink(pending_path)
+                except OSError:
+                    pass
+                continue
+
+            # Build attributed line.
+            attributed = dict(record)
+            attributed["developer_id"] = confirmed_dev_id
+            # Preserve original ts from pending record.
+            attributed_line = json.dumps(attributed, separators=(",", ":"))
+
+            # Repo root validation.
+            repo_root = record.get("repo_root", "")
+            project_slug = record.get("project_slug", "")
+            wrote_per_project = False
+            if repo_root and project_slug:
+                try:
+                    result = subprocess.check_output(
+                        ["git", "-C", repo_root, "rev-parse", "--show-toplevel"],
+                        timeout=3,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    toplevel = result.decode().strip()
+                    if os.path.basename(toplevel) == project_slug:
+                        per_project_log_dir = Path(toplevel) / ".agentic" / "session-log"
+                        per_project_log_dir.mkdir(parents=True, exist_ok=True)
+                        per_project_log = per_project_log_dir / f"{confirmed_dev_id}.jsonl"
+                        with open(per_project_log, "a", encoding="utf-8") as pf:
+                            pf.write(attributed_line + "\n")
+                        wrote_per_project = True
+                    else:
+                        print(
+                            f"agentic-identity: repo_root '{repo_root}' basename "
+                            f"'{os.path.basename(toplevel)}' != project_slug "
+                            f"'{project_slug}'; skipping per-project write.",
+                            file=sys.stderr,
+                        )
+                except (subprocess.TimeoutExpired, subprocess.CalledProcessError,
+                        OSError, FileNotFoundError):
+                    print(
+                        f"agentic-identity: repo_root '{repo_root}' unreachable; "
+                        "skipping per-project write.",
+                        file=sys.stderr,
+                    )
+
+            # Always append to global log.
+            global_append_ok = False
+            try:
+                GLOBAL_SESSION_LOG_DIR.mkdir(parents=True, exist_ok=True)
+                with open(global_log, "a", encoding="utf-8") as gf:
+                    gf.write(attributed_line + "\n")
+                global_append_ok = True
+            except OSError as exc:
+                print(
+                    f"agentic-identity: global log write failed: {exc}; "
+                    "leaving pending file for retry.",
+                    file=sys.stderr,
+                )
+
+            # Unlink pending file only after all attempted appends succeeded.
+            # Per-project write failure is non-blocking; global failure leaves file.
+            if global_append_ok:
+                try:
+                    os.unlink(pending_path)
+                except OSError:
+                    pass
+                flushed += 1
+
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+    if flushed > 0:
+        print(f"Flushed {flushed} pending session(s).")
+    return flushed
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -61,8 +250,11 @@ def cmd_init(args: argparse.Namespace) -> int:
         )
         return 1
 
+    existing = _read_identity() if IDENTITY_PATH.is_file() else None
+    is_overwriting_provisional = existing is not None and existing.get("provisional", False)
+    is_fresh = existing is None
+
     if IDENTITY_PATH.is_file() and not args.force:
-        existing = _read_identity()
         current = existing.get("developer_id", "?") if existing else "?"
         print(
             f"agentic-identity: identity already set to '{current}'. "
@@ -72,26 +264,118 @@ def cmd_init(args: argparse.Namespace) -> int:
         return 2
 
     created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    lines = [
-        f"developer_id: {handle}",
-    ]
+    lines = [f"developer_id: {handle}"]
     if args.display_name:
         lines.append(f"display_name: {args.display_name}")
     lines.append(f"created_at: {created_at}")
-    content = "\n".join(lines) + "\n"
 
-    IDENTITY_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    tmp = IDENTITY_PATH.with_suffix(".yml.tmp")
-    try:
-        tmp.write_text(content, encoding="utf-8")
-        os.chmod(tmp, 0o600)
-        tmp.rename(IDENTITY_PATH)
-    except Exception as exc:
-        print(f"agentic-identity: write failed: {exc}", file=sys.stderr)
-        tmp.unlink(missing_ok=True)
-        return 1
+    rc = _write_identity(lines)
+    if rc != 0:
+        return rc
 
     print(f"Identity set: developer_id={handle}, created_at={created_at}")
+
+    # Flush pending buffer when writing over a provisional identity or writing fresh.
+    if is_overwriting_provisional or is_fresh:
+        flushPendingBuffer(handle)
+
+    return 0
+
+
+def cmd_auto(args: argparse.Namespace) -> int:
+    """Derive identity from gh CLI (writes provisional)."""
+    # Run gh api user --jq .login with 5s timeout.
+    try:
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        print(
+            "agentic-identity: gh CLI unavailable or unauthenticated. "
+            "Run 'gh auth login' first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if result.returncode != 0:
+        print(
+            "agentic-identity: gh CLI unavailable or unauthenticated. "
+            "Run 'gh auth login' first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    login = result.stdout.strip().lower()
+    if not HANDLE_RE.match(login):
+        print(
+            f"agentic-identity: derived handle '{login}' is not a valid agentic handle. "
+            "Run 'agentic-identity init <handle>' manually.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Check existing identity.
+    existing = _read_identity()
+    if existing is not None:
+        is_provisional = existing.get("provisional", False)
+        current_handle = existing.get("developer_id", "?")
+        if not is_provisional and not args.force:
+            print(
+                f"agentic-identity: confirmed identity already set to '{current_handle}'. "
+                "Use --force to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+        # Provisional + no --force: overwrite silently (fall through).
+
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines = [
+        f"developer_id: {login}",
+        f"created_at: {created_at}",
+        "provisional: true",
+        "derived_from: gh",
+    ]
+
+    rc = _write_identity(lines)
+    if rc != 0:
+        return rc
+
+    print(
+        f"Identity derived (provisional): developer_id={login}. "
+        "Confirm at next session start."
+    )
+    return 0
+
+
+def cmd_confirm(args: argparse.Namespace) -> int:
+    """Confirm provisional identity: strip provisional/derived_from, flush pending buffer."""
+    identity = _read_identity()
+    if identity is None:
+        print(
+            "agentic-identity: no identity set. Run 'agentic-identity init <handle>' first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dev_id = identity["developer_id"]
+
+    # Rewrite identity file with provisional: and derived_from: stripped.
+    lines = [f"developer_id: {dev_id}"]
+    if "display_name" in identity:
+        lines.append(f"display_name: {identity['display_name']}")
+    if "created_at" in identity:
+        lines.append(f"created_at: {identity['created_at']}")
+    # Intentionally omit provisional and derived_from.
+
+    rc = _write_identity(lines)
+    if rc != 0:
+        return rc
+
+    flushPendingBuffer(dev_id)
+    print(f"Identity confirmed: developer_id={dev_id}")
     return 0
 
 
@@ -105,6 +389,8 @@ def cmd_show(args: argparse.Namespace) -> int:
         print(f"display_name:  {identity['display_name']}")
     if "created_at" in identity:
         print(f"created_at:    {identity['created_at']}")
+    if identity.get("provisional", False):
+        print("provisional:   true")
     return 0
 
 
@@ -125,6 +411,23 @@ def main(argv: list[str]) -> int:
 
     p_show = sub.add_parser("show", help="Print current identity")
     p_show.set_defaults(func=cmd_show)
+
+    p_auto = sub.add_parser(
+        "auto",
+        help="Derive identity automatically from gh CLI (writes provisional)",
+    )
+    p_auto.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing confirmed identity",
+    )
+    p_auto.set_defaults(func=cmd_auto)
+
+    p_confirm = sub.add_parser(
+        "confirm",
+        help="Confirm provisional identity and flush pending session buffer",
+    )
+    p_confirm.set_defaults(func=cmd_confirm)
 
     args = p.parse_args(argv[1:])
     return args.func(args)

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -168,10 +168,22 @@ def flushPendingBuffer(confirmed_dev_id: str) -> int:
                     pass
                 continue
 
-            # Build attributed line.
-            attributed = dict(record)
-            attributed["developer_id"] = confirmed_dev_id
-            # Preserve original ts from pending record.
+            # Build attributed line in canonical session-total shape to match
+            # writeSessionLog / writeSessionLogGlobal in hooks/stop-context.js.
+            # Fields NOT in canonical shape (schema_version, repo_root) are used
+            # only for routing/bookkeeping above and must NOT appear in the line.
+            attributed = {
+                "ts": record.get("ts"),
+                "phase": "session_end",
+                "event": "session_total",
+                "agent": None,
+                "task_id": None,
+                "developer_id": confirmed_dev_id,
+                "session_uuid": record.get("session_uuid"),
+                "project_slug": record.get("project_slug"),
+                "branch": record.get("branch", ""),
+                "data": record.get("data", {}),
+            }
             attributed_line = json.dumps(attributed, separators=(",", ":"))
 
             # Repo root validation.

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Regression test for flushPendingBuffer canonical shape fix.
+
+Verifies that flushed session-log lines match the canonical shape written by
+hooks/stop-context.js writeSessionLog / writeSessionLogGlobal:
+  {ts, phase, event, agent, task_id, developer_id, session_uuid,
+   project_slug, branch, data}
+
+The pre-fix behavior (dict(record) + developer_id) would produce lines that
+include schema_version and repo_root, which are absent from the canonical
+shape. Any consumer filtering on phase == 'session_end' / event == 'session_total'
+would silently drop or misparse flushed records in a mixed-schema file.
+
+Regression test obligation: content/references/regression-test-obligation.md
+Run with: python3 bin/tests/test_agentic_identity.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load agentic-identity as a module (no .py extension)
+# ---------------------------------------------------------------------------
+_BIN_PATH = Path(__file__).parent.parent / "agentic-identity"
+_loader = importlib.machinery.SourceFileLoader("agentic_identity", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_identity", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-identity from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+flushPendingBuffer = _mod.flushPendingBuffer
+
+
+def _write_pending(pending_dir: Path, record: dict) -> Path:
+    """Write a pending record file. Returns the path."""
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    p = pending_dir / f"{record['session_uuid']}.json"
+    p.write_text(json.dumps(record), encoding="utf-8")
+    return p
+
+
+def test_flushed_line_canonical_shape():
+    """flushed line must match canonical shape; must NOT contain schema_version or repo_root."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir = tmp_path / "session-log" / ".pending"
+        global_log_dir = tmp_path / "session-log"
+        flush_lock = tmp_path / "session-log" / ".flush.lock"
+
+        # Patch module-level paths
+        _mod.PENDING_DIR = pending_dir
+        _mod.GLOBAL_SESSION_LOG_DIR = global_log_dir
+        _mod.FLUSH_LOCK_PATH = flush_lock
+
+        # Pending record mimics what writePendingBuffer in stop-context.js writes.
+        # Includes schema_version and repo_root - fields that must NOT appear in
+        # the canonical output line.
+        pending_record = {
+            "schema_version": "1",
+            "session_uuid": "test-uuid-1234",
+            "ts": "2026-06-04T00:00:00.000Z",
+            "project_slug": "my-project",
+            "repo_root": "/home/user/my-project",
+            "branch": "main",
+            "data": {
+                "wall_seconds": 42.0,
+                "tokens": {"input": 100, "output": 50,
+                           "cache_creation": 0, "cache_read": 0},
+                "spawn_count": 3,
+                "by_agent": {},
+            },
+        }
+        _write_pending(pending_dir, pending_record)
+        flush_lock.parent.mkdir(parents=True, exist_ok=True)
+        flush_lock.touch(exist_ok=True)
+
+        dev_id = "testdev"
+        count = flushPendingBuffer(dev_id)
+        assert count == 1, f"Expected 1 flushed, got {count}"
+
+        global_log = global_log_dir / f"{dev_id}.jsonl"
+        assert global_log.is_file(), "Global log not written"
+
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1, f"Expected 1 line in global log, got {len(lines)}"
+
+        row = json.loads(lines[0])
+
+        # --- canonical fields must be present and correct ---
+        assert row.get("phase") == "session_end", \
+            f"phase should be 'session_end', got {row.get('phase')!r}"
+        assert row.get("event") == "session_total", \
+            f"event should be 'session_total', got {row.get('event')!r}"
+        assert row.get("developer_id") == dev_id, \
+            f"developer_id should be {dev_id!r}, got {row.get('developer_id')!r}"
+        assert row.get("session_uuid") == "test-uuid-1234", \
+            f"session_uuid mismatch: {row.get('session_uuid')!r}"
+        assert "agent" in row, "canonical field 'agent' missing"
+        assert "task_id" in row, "canonical field 'task_id' missing"
+        assert row.get("project_slug") == "my-project", \
+            f"project_slug mismatch: {row.get('project_slug')!r}"
+        assert row.get("branch") == "main", \
+            f"branch mismatch: {row.get('branch')!r}"
+        assert "data" in row, "canonical field 'data' missing"
+
+        # --- non-canonical fields must NOT appear (pre-fix regression sentinel) ---
+        assert "schema_version" not in row, \
+            "schema_version must NOT appear in canonical session-log line (pre-fix regression)"
+        assert "repo_root" not in row, \
+            "repo_root must NOT appear in canonical session-log line (pre-fix regression)"
+
+        print("PASS test_flushed_line_canonical_shape")
+
+
+if __name__ == "__main__":
+    test_flushed_line_canonical_shape()
+    print("All tests passed.")

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -4,9 +4,11 @@
  * Purpose: Reads the Claude Code Stop hook JSON payload from stdin and writes
  *          session context to disk so the next session's Workers have lightweight
  *          context about what was happening. Also marks any active orchestration
- *          loop as interrupted so the next session can offer to resume. Additionally
- *          writes a per-developer session rollup to .agentic/session-log/ when a
- *          developer identity is set, or appends a one-time nudge to context.md.
+ *          loop as interrupted so the next session can offer to resume. Writes
+ *          per-developer session telemetry via a three-branch identity gate:
+ *          confirmed identity -> per-project log + global mirror; provisional
+ *          identity or no identity -> pending buffer (~/.agentic/session-log/.pending/);
+ *          no identity also appends a one-time nudge to context.md.
  *
  * Public API: run() — invoked immediately at module load via run() call at
  *             bottom of file. Not imported; executed as a CLI script by the
@@ -14,6 +16,8 @@
  *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId),
  *             writeSessionTotal(cwd, sessionId), computeSessionTotals(cwd, sessionId),
  *             getIdentity(), writeSessionLog(cwd, identity, sessionId),
+ *             writeSessionLogGlobal(identity, sessionId, data),
+ *             writePendingBuffer(cwd, sessionId),
  *             appendIdentityNudgeToContextMd(repoRoot).
  *
  * Upstream deps: Node built-ins only (fs, path, os, child_process). No npm
@@ -21,7 +25,9 @@
  *                ~/.claude/projects/[hash]/context.md,
  *                [cwd]/.agentic/loop-state.json,
  *                [cwd]/.agentic/batch-state.json,
- *                [cwd]/.agentic/session-log/<developer_id>.jsonl, and
+ *                [cwd]/.agentic/session-log/<developer_id>.jsonl,
+ *                ~/.agentic/session-log/<developer_id>.jsonl (global mirror),
+ *                ~/.agentic/session-log/.pending/<session_uuid>.json (pending buffer), and
  *                ~/.agentic/identity.yml (read-only).
  *
  * Downstream consumers: Claude Code Stop hook (configured in
@@ -29,8 +35,12 @@
  *                        Output files are read by Worker agents at session start.
  *                        bin/agentic-cost team reads .agentic/session-log/ for
  *                        team-level aggregation.
+ *                        bin/agentic-cost operator reads ~/.agentic/session-log/*.jsonl
+ *                        for global operator rollup. The .pending/ subdir is NOT
+ *                        globbed by agentic-cost (operator or team) - it is consumed
+ *                        only by agentic-identity confirm/init via flushPendingBuffer.
  *
- * Failure modes: All failures are silent (process.exit(0)). Six independent
+ * Failure modes: All failures are silent (process.exit(0)). Eight independent
  *                write paths: (1) context.md write is best-effort; any fs error
  *                is swallowed and the file may not be written. (2) loop-state.json
  *                write is also best-effort; any fs error is swallowed independently
@@ -47,7 +57,14 @@
  *                any fs error is swallowed independently of all other paths.
  *                (6) appendIdentityNudgeToContextMd appends to context.md; any
  *                fs error is swallowed independently.
- *                All six paths are independent - a failure in one does not
+ *                (7) writeSessionLogGlobal appends to ~/.agentic/session-log/<dev>.jsonl;
+ *                any fs error is swallowed independently of the per-project write
+ *                (path 5) - a global failure never affects the per-project write.
+ *                (8) writePendingBuffer writes atomically (tmp+rename) to
+ *                ~/.agentic/session-log/.pending/<uuid>.json; enforces cap-100
+ *                (drops oldest by ts with one stderr notice); any fs error swallowed
+ *                independently of all other paths.
+ *                All eight paths are independent - a failure in one does not
  *                affect the others. The 10-minute implicit-interrupt heuristic
  *                handles missed loop-state writes. cwd values with path
  *                traversal components are rejected for the loop-state and
@@ -297,10 +314,11 @@ function removeLearningsAgentSession(cwd, sessionId) {
 }
 
 /**
- * Read ~/.agentic/identity.yml and return {developer_id} or null.
+ * Read ~/.agentic/identity.yml and return {developer_id, provisional} or null.
+ * Parses the optional `provisional:` line; absent means confirmed (provisional: false).
  * Silent on ENOENT or any parse error.
  *
- * @returns {{developer_id: string}|null}
+ * @returns {{developer_id: string, provisional: boolean}|null}
  */
 function getIdentity() {
   try {
@@ -309,7 +327,9 @@ function getIdentity() {
     const raw = fs.readFileSync(identityPath, 'utf8');
     const m = raw.match(/^developer_id:\s*(\S+)\s*$/m);
     if (!m) return null;
-    return { developer_id: m[1] };
+    const pm = raw.match(/^provisional:\s*(true|false)\s*$/m);
+    const provisional = pm ? pm[1] === 'true' : false;
+    return { developer_id: m[1], provisional };
   } catch (_) {
     return null;
   }
@@ -424,6 +444,154 @@ function writeSessionLog(cwd, identity, sessionId) {
     fs.mkdirSync(sessionLogDir, { recursive: true });
     const logFile = path.join(sessionLogDir, `${identity.developer_id}.jsonl`);
     fs.appendFileSync(logFile, logLine + '\n', 'utf8');
+  } catch (_) {
+    // Silent failure - consistent with all other write paths
+  }
+}
+
+/**
+ * Write the same session-log line that writeSessionLog writes per-project,
+ * but to the global operator mirror: ~/.agentic/session-log/<dev>.jsonl.
+ * Independent of the per-project write - a failure here never affects it.
+ * Creates the directory if needed. Silent failure on any fs error.
+ *
+ * @param {{developer_id: string, provisional: boolean}} identity - From getIdentity().
+ * @param {string|null} sessionId - Current session uuid.
+ * @param {{wall_seconds: number, tokens: object, spawn_count: number, by_agent: object}} data - Telemetry.
+ */
+function writeSessionLogGlobal(identity, sessionId, data) {
+  try {
+    const globalLogDir = path.join(os.homedir(), '.agentic', 'session-log');
+    fs.mkdirSync(globalLogDir, { recursive: true });
+    const logLine = JSON.stringify({
+      ts: new Date().toISOString(),
+      phase: 'session_end',
+      event: 'session_total',
+      agent: null,
+      task_id: null,
+      developer_id: identity.developer_id,
+      session_uuid: sessionId || null,
+      project_slug: data.project_slug || null,
+      branch: data.branch || '',
+      data: {
+        wall_seconds: data.wall_seconds,
+        tokens: data.tokens,
+        spawn_count: data.spawn_count,
+        by_agent: data.by_agent,
+      },
+    });
+    const logFile = path.join(globalLogDir, `${identity.developer_id}.jsonl`);
+    fs.appendFileSync(logFile, logLine + '\n', 'utf8');
+  } catch (_) {
+    // Silent failure - independent of per-project write
+  }
+}
+
+/**
+ * Generate a UUID v4 using crypto.randomUUID when available (Node 14.17+),
+ * falling back to a Math.random-based implementation for older runtimes.
+ *
+ * @returns {string} UUID v4 string.
+ */
+function generateUuid() {
+  try {
+    const crypto = require('crypto');
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (_) { /* no crypto module */ }
+  // Fallback: RFC 4122 v4 via Math.random
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Write unattributed session telemetry to the pending buffer.
+ * Used when identity is null (no identity) or provisional (not yet confirmed).
+ * Writes atomically via tmp+rename to ~/.agentic/session-log/.pending/<uuid>.json.
+ * Enforces a cap of 100 pending files: when at or above cap, deletes the single
+ * oldest file by `ts` field and emits one stderr notice before writing.
+ * No developer_id field in the pending record - it is unattributed until flush.
+ * Silent failure on any fs error.
+ *
+ * @param {string} cwd - Verified project directory.
+ * @param {string|null} sessionId - Current session uuid (uuid v4 generated if null).
+ */
+function writePendingBuffer(cwd, sessionId) {
+  try {
+    const pendingDir = path.join(os.homedir(), '.agentic', 'session-log', '.pending');
+    fs.mkdirSync(pendingDir, { recursive: true });
+
+    // Enforce cap-100: count existing pending files
+    let existingFiles = [];
+    try {
+      existingFiles = fs.readdirSync(pendingDir).filter((f) => f.endsWith('.json'));
+    } catch (_) { /* silent */ }
+
+    if (existingFiles.length >= 100) {
+      // Parse ts from each file, find oldest, delete it
+      let oldestTs = null;
+      let oldestFile = null;
+      for (const fname of existingFiles) {
+        try {
+          const raw = fs.readFileSync(path.join(pendingDir, fname), 'utf8');
+          const obj = JSON.parse(raw);
+          const ts = obj.ts || '';
+          if (oldestTs === null || ts < oldestTs) {
+            oldestTs = ts;
+            oldestFile = fname;
+          }
+        } catch (_) { /* skip unreadable files */ }
+      }
+      if (oldestFile) {
+        try { fs.unlinkSync(path.join(pendingDir, oldestFile)); } catch (_) { /* silent */ }
+        process.stderr.write('agentic-engineering: pending buffer at cap (100); oldest session dropped\n');
+      }
+    }
+
+    // Compute telemetry
+    const totals = computeSessionTotals(cwd, sessionId);
+    const data = totals || {
+      wall_seconds: 0,
+      tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+      spawn_count: 0,
+      by_agent: {},
+    };
+
+    // Resolve metadata
+    const projectSlug = path.basename(cwd);
+    const repoRoot = cwd;
+    let branch = '';
+    try {
+      branch = execSync('git symbolic-ref --short HEAD', {
+        cwd, timeout: 3000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch (_) { /* detached HEAD or non-git dir */ }
+
+    const sessionUuid = sessionId || generateUuid();
+    const record = {
+      schema_version: 1,
+      session_uuid: sessionUuid,
+      ts: new Date().toISOString(),
+      project_slug: projectSlug,
+      repo_root: repoRoot,
+      branch,
+      data: {
+        wall_seconds: data.wall_seconds,
+        tokens: data.tokens,
+        spawn_count: data.spawn_count,
+        by_agent: data.by_agent,
+      },
+    };
+
+    // Atomic write: tmp + rename
+    const outFile = path.join(pendingDir, `${sessionUuid}.json`);
+    const tmpFile = outFile + '.tmp';
+    fs.writeFileSync(tmpFile, JSON.stringify(record, null, 2), 'utf8');
+    fs.renameSync(tmpFile, outFile);
   } catch (_) {
     // Silent failure - consistent with all other write paths
   }
@@ -653,20 +821,44 @@ ${toolsLine}
       writeBatchState(cwd, sessionId);
       // Write session_total to events.jsonl on this exit path too.
       writeSessionTotal(cwd, sessionId);
-      // Write per-developer session log or nudge (independent of all other paths).
+      // Three-branch identity gate (independent of all other paths).
       try {
         const identity = getIdentity();
-        if (identity) {
+        if (identity && !identity.provisional) {
+          // Confirmed identity: per-project write + global mirror
           writeSessionLog(cwd, identity, sessionId);
-        } else {
-          const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
+          // Build shared metadata for global mirror
+          const totals = computeSessionTotals(cwd, sessionId);
+          const globalData = Object.assign(
+            {
+              wall_seconds: 0,
+              tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+              spawn_count: 0,
+              by_agent: {},
+            },
+            totals,
+            { project_slug: path.basename(cwd), branch: '' }
+          );
           try {
-            fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
-            fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
-            // Write succeeded - sentinel did not exist, so nudge once
-            appendIdentityNudgeToContextMd(cwd);
-          } catch (_nudgeErr) {
-            // EEXIST means sentinel already written - skip nudge silently
+            globalData.branch = execSync('git symbolic-ref --short HEAD', {
+              cwd, timeout: 3000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+            }).trim();
+          } catch (_) { /* detached HEAD or non-git dir */ }
+          writeSessionLogGlobal(identity, sessionId, globalData);
+        } else {
+          // Provisional or no identity: pending buffer
+          writePendingBuffer(cwd, sessionId);
+          if (!identity) {
+            // No identity at all: also nudge once
+            const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
+            try {
+              fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
+              fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
+              // Write succeeded - sentinel did not exist, so nudge once
+              appendIdentityNudgeToContextMd(cwd);
+            } catch (_nudgeErr) {
+              // EEXIST means sentinel already written - skip nudge silently
+            }
           }
         }
       } catch (_) {
@@ -701,21 +893,45 @@ ${toolsLine}
   // Independent best-effort write; any failure swallowed.
   writeSessionTotal(cwd, sessionId);
 
-  // --- 13. Write per-developer session log or identity nudge ---
+  // --- 13. Three-branch identity gate: session log, global mirror, or pending buffer ---
   // Independent best-effort write; any failure swallowed. Never blocks exit.
   try {
     const identity = getIdentity();
-    if (identity) {
+    if (identity && !identity.provisional) {
+      // Confirmed identity: per-project write + global mirror
       writeSessionLog(cwd, identity, sessionId);
-    } else {
-      const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
+      // Build shared metadata for global mirror
+      const totals = computeSessionTotals(cwd, sessionId);
+      const globalData = Object.assign(
+        {
+          wall_seconds: 0,
+          tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+          spawn_count: 0,
+          by_agent: {},
+        },
+        totals,
+        { project_slug: path.basename(cwd), branch: '' }
+      );
       try {
-        fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
-        fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
-        // Sentinel did not exist - nudge once
-        appendIdentityNudgeToContextMd(cwd);
-      } catch (_nudgeErr) {
-        // EEXIST: sentinel already written, skip nudge
+        globalData.branch = execSync('git symbolic-ref --short HEAD', {
+          cwd, timeout: 3000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch (_) { /* detached HEAD or non-git dir */ }
+      writeSessionLogGlobal(identity, sessionId, globalData);
+    } else {
+      // Provisional or no identity: pending buffer
+      writePendingBuffer(cwd, sessionId);
+      if (!identity) {
+        // No identity at all: also nudge once
+        const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
+        try {
+          fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
+          fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
+          // Sentinel did not exist - nudge once
+          appendIdentityNudgeToContextMd(cwd);
+        } catch (_nudgeErr) {
+          // EEXIST: sentinel already written, skip nudge
+        }
       }
     }
   } catch (_) {


### PR DESCRIPTION
PR1 of 2 for ae-identity-v1 (behavioral units U1-U3; `bin/` + `hooks/` only, no content/adapters - no adapter-sync/drift gating here). Plan: `docs/planning/ae-identity-v1/`.

- **U1 `bin/agentic-identity`**: `auto` (derive provisional handle from gh) + `confirm` subcommands; race-safe `flushPendingBuffer` (fcntl.flock, session_uuid dedup, repo_root validation, canonical session-total line shape); `cmd_init` flush; `show` prints provisional. + regression test.
- **U2 `hooks/stop-context.js`**: provisional gate (telemetry deferred until confirmed); `writePendingBuffer` (atomic, cap-100); `writeSessionLogGlobal` mirror.
- **U3 `bin/agentic-cost`**: `operator` cross-repo rollup; `team` unchanged.

Reviews: integration Skeptic (1 Major + 1 Minor, both fixed - flushed-line shape normalized to match U2 field-for-field + regression test; operator table header). Merge before PR2 (content references `agentic-identity confirm`).