### PR TITLE
chore(rename): fix bare-slug repo refs in AGENTS.md + MEMORY.md [DS-13]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,10 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 
 ## Tools
 - GitHub operations: use `gh` CLI - do not use GitHub MCP
-- `gh pr create` for this repo requires an explicit token: `GITHUB_TOKEN=$(gh auth token --user tyson-solara6 2>/dev/null) gh pr create --repo Space-Dinosaurs/agentic-engineering` (SSH-alias remote not recognized by default gh auth)
+- `gh pr create` for this repo requires an explicit token: `GITHUB_TOKEN=$(gh auth token --user tyson-solara6 2>/dev/null) gh pr create --repo Space-Dinosaurs/DinoStack` (SSH-alias remote not recognized by default gh auth)
 - `rm -rf` is blocked by Claude Code permissions in this repo; remove files individually: `rm <file>` then `rmdir <dir>`
 - `bin/agentic-memory` — lightweight memory retrieval tool for querying `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md` on demand.
-- The `fullmetalblanket` git remote points to a non-existent GitHub repo - never push or PR to it. `origin` (`Space-Dinosaurs/agentic-engineering`, what `main` tracks) is the only canonical remote.
+- The `fullmetalblanket` git remote points to a non-existent GitHub repo - never push or PR to it. `origin` (`Space-Dinosaurs/DinoStack`, what `main` tracks) is the only canonical remote.
 
 ## Deploy
 - Docs site: see `docs/technical/deploy.md`. Always verify the linked project ID before running `vercel --prod`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,7 +10,7 @@
 
 ## Decisions
 
-- **2026-05-18: Adapter-drift CI gate is advisory-only (descoped from hard block).** `adapter-sync.yml` makes content/adapter drift CI-visible (red X) on every PR but is NOT a required status check - Space-Dinosaurs/agentic-engineering is a private repo on a free GitHub plan, which does not support required status checks / branch protection (`gh api repos/.../branches/main/protection` returns 403). Drift is therefore CI-visible but not hard-blocked at merge. To upgrade to a hard merge block: make the repo public OR upgrade to GitHub Pro/Team, then add the `check-adapter-sync` job as a required status check on `main`. Accepted by operator 2026-05-18.
+- **2026-05-18: Adapter-drift CI gate is advisory-only (descoped from hard block).** `adapter-sync.yml` makes content/adapter drift CI-visible (red X) on every PR but is NOT a required status check - Space-Dinosaurs/DinoStack is a private repo on a free GitHub plan, which does not support required status checks / branch protection (`gh api repos/.../branches/main/protection` returns 403). Drift is therefore CI-visible but not hard-blocked at merge. To upgrade to a hard merge block: make the repo public OR upgrade to GitHub Pro/Team, then add the `check-adapter-sync` job as a required status check on `main`. Accepted by operator 2026-05-18.
 
 ## Slides (Marp decks, docs/slides/)
 


### PR DESCRIPTION
Follow-up to #187: fixes 3 bare-slug `Space-Dinosaurs/agentic-engineering` -> `DinoStack` references the URL-pattern grep missed (gh pr-create command + origin description in AGENTS.md, one dated decision entry in MEMORY.md). `git grep` for the old slug now returns zero.