### PR TITLE
feat(install): add docs.dinostack.ai/install.sh vanity redirect [DS-14]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This system is designed to evolve. As AI tooling matures and teams discover bett
 ### One-liner install (quickest)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh | bash
+curl -fsSL https://docs.dinostack.ai/install.sh | bash
 ```
 
 This clones the repo into `agentic-engineering/` inside your current directory, runs the installer, and writes the install path to `~/.agentic/agentic-engineering-config.json` so `./update.sh` and the `/update-agentic-engineering` command know where to find it.
@@ -22,13 +22,13 @@ This clones the repo into `agentic-engineering/` inside your current directory, 
 
 ```bash
 # Install to ~/tools/agentic-engineering instead of the current directory
-AE_DEST_DIR=~/tools/agentic-engineering curl -fsSL https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh | bash
+AE_DEST_DIR=~/tools/agentic-engineering curl -fsSL https://docs.dinostack.ai/install.sh | bash
 ```
 
 **Pass flags through to the installer** (e.g. to set activation mode without prompts):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh | bash -s -- --mode=opt-in
+curl -fsSL https://docs.dinostack.ai/install.sh | bash -s -- --mode=opt-in
 ```
 
 ### Manual / SSH install

--- a/docs/technical/deploy.md
+++ b/docs/technical/deploy.md
@@ -17,6 +17,7 @@ The docs site (hub page at `docs/index.html` plus slide decks under `docs/slides
 - Vercel CLI installed (`vercel --version`)
 - Marp CLI installed (`marp --version`, expects v4.x)
 - `vercel.json` at repo root sets `outputDirectory: "docs"` and rewrites `/` to `/index.html`
+- `/install.sh` on this domain is a 307 redirect to the raw GitHub bootstrap URL. To update the redirect destination after a repo rename, change the `redirects[0].destination` value in `vercel.json` and redeploy.
 
 ## Procedure
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "outputDirectory": "docs",
+  "redirects": [
+    { "source": "/install.sh", "destination": "https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh", "permanent": false }
+  ],
   "rewrites": [
     { "source": "/", "destination": "/index.html" }
   ]


### PR DESCRIPTION
Future-proofs the install URL so a repo/org rename is a one-line change.

- `vercel.json`: new `redirects` entry maps `/install.sh` -> the raw GitHub bootstrap URL with `permanent: false` (307; a 301 hard-caches in clients and defeats the purpose)
- `README.md`: all 3 `curl … | bash` install one-liners now use `https://docs.dinostack.ai/install.sh`
- `docs/technical/deploy.md`: note pointing future renamers at `vercel.json` as the single place to change the destination

Bootstrap internals and `git clone` commands untouched. Skeptic-approved, zero findings.

Go-live (operator): requires the `dinostack-docs` project to deploy this `vercel.json` to `docs.dinostack.ai`, and the repo to be public for the raw target to resolve.