### PR TITLE
chore(docs): fix stale Live-docs URL -> docs.dinostack.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 
 This system is designed to evolve. As AI tooling matures and teams discover better patterns, the rules, agents, and workflows change with them. Nothing here is final - treat it as a living system, not a finished product.
 
-**Live docs:** https://agentic-engineering-tyhummel.vercel.app
+**Live docs:** https://docs.dinostack.ai/
 
 ## Getting started
 


### PR DESCRIPTION
README `Live docs:` link still pointed at the old personal Vercel URL (`agentic-engineering-tyhummel.vercel.app`); repointed to the production docs URL `https://docs.dinostack.ai/` per deploy.md. One line.