### PR TITLE
feat(identity): project-scope override with 4-tier resolution [DS handle override]

### DIFF
--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -1,27 +1,37 @@
 #!/usr/bin/env python3
 """
-Purpose: CLI for managing the per-developer identity file (~/.agentic/identity.yml)
-         used by the Stop hook to write per-developer session telemetry. Supports
-         automatic identity derivation from gh CLI (provisional) and confirmation
-         which flushes the pending session-log buffer.
+Purpose: CLI for managing per-developer identity files used by the Stop hook
+         to write per-developer session telemetry. Supports global identity
+         (~/.agentic/identity.yml) and project-local identity
+         (<repo>/.agentic/identity.yml), with a 4-tier confirmation-first
+         resolution: project-confirmed > global-confirmed > project-provisional
+         > global-provisional > none.
 
 Public API:
-  agentic-identity init <handle> [--display-name "<name>"] [--force]
-  agentic-identity show
-  agentic-identity auto [--force]
-  agentic-identity confirm
+  agentic-identity init <handle> [--display-name "<name>"] [--force] [--scope {global,project}]
+  agentic-identity show [--scope {global,project,effective}]
+  agentic-identity auto [--force] [--scope {global,project}]
+  agentic-identity confirm [--scope {global,project}]
   agentic-identity --help
 
+  Helpers: _read_identity(path=None), _write_identity(lines, target_path=None),
+           _project_identity_path(cwd=None), _resolve_effective_identity(cwd),
+           flushPendingBuffer(confirmed_dev_id, repo_root_filter=None).
+
 Data model:
-  ~/.agentic/identity.yml fields: developer_id, display_name (optional),
-    created_at, provisional (optional, absent=confirmed), derived_from (optional).
+  Global:  ~/.agentic/identity.yml
+  Project: <repo>/.agentic/identity.yml  (gitignored via .agentic/* umbrella)
+  Fields: developer_id, display_name (optional), created_at,
+          provisional (optional, absent=confirmed), derived_from (optional).
   ~/.agentic/session-log/.pending/<uuid>.json: pre-attribution session records;
     flushed to global + per-project logs on confirm/init.
+  Internal keys _scope ("project"/"global") and _confirmed (bool) are tagged
+    on resolved-identity dicts; never written to any file or log.
 
 Upstream deps: Python 3 stdlib only (argparse, fcntl, glob, json, os, re, signal,
                subprocess, sys, datetime, pathlib, time).
 
-Downstream consumers: hooks/stop-context.js (reads ~/.agentic/identity.yml);
+Downstream consumers: hooks/stop-context.js (reads identity files);
                       bin/agentic-cost team (reads .agentic/session-log/ written
                       after identity is set).
 
@@ -30,6 +40,10 @@ Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                flushPendingBuffer: serialized via fcntl.flock on .flush.lock;
                30s timeout via LOCK_NB+sleep loop (SIGALRM avoided for portability);
                on timeout prints stderr warning and returns without data loss.
+               flushPendingBuffer with repo_root_filter: records whose repo_root
+               does not match the filter are skipped (left in the buffer, not
+               unlinked); records with no/empty repo_root are also skipped under
+               a filter (conservative).
 
 Performance: Standard. File I/O only; subprocess for gh CLI in auto subcommand.
 """
@@ -55,15 +69,24 @@ FLUSH_LOCK_PATH = Path(os.path.expanduser("~/.agentic/session-log/.flush.lock"))
 HANDLE_RE = re.compile(r'^[a-z0-9._-]{1,64}$')
 
 
-def _read_identity() -> dict | None:
+def _project_identity_path(cwd: Path | None = None) -> Path:
+    """Return the project-local identity file path for cwd (or Path.cwd())."""
+    return Path(cwd or Path.cwd()) / ".agentic" / "identity.yml"
+
+
+def _read_identity(path: Path | None = None) -> dict | None:
     """Return parsed identity dict or None if absent/malformed.
+
+    When path is None, reads the global IDENTITY_PATH (default behavior,
+    unchanged for all existing callers). When path is provided, reads that path.
 
     Fields returned: developer_id (required), display_name, created_at,
     provisional (absent => False), derived_from.
     """
-    if not IDENTITY_PATH.is_file():
+    target = path if path is not None else IDENTITY_PATH
+    if not target.is_file():
         return None
-    raw = IDENTITY_PATH.read_text(encoding="utf-8")
+    raw = target.read_text(encoding="utf-8")
     m = re.search(r'^developer_id:\s*(\S+)\s*$', raw, re.MULTILINE)
     if not m:
         return None
@@ -83,15 +106,56 @@ def _read_identity() -> dict | None:
     return result
 
 
-def _write_identity(lines: list[str]) -> int:
-    """Atomically write identity file from lines list. Returns 0 on success, 1 on error."""
+def _resolve_effective_identity(cwd: Path) -> dict | None:
+    """Resolve effective identity via 4-tier total ordering.
+
+    Tier order: project-confirmed > global-confirmed >
+                project-provisional > global-provisional > None.
+
+    Two-pass:
+      Pass 1 (confirmed): project file first, then global - return first confirmed.
+      Pass 2 (provisional): project file first, then global - return first provisional.
+
+    Returns identity dict tagged with internal _scope ("project"/"global")
+    and _confirmed (bool) keys. These are never written to any file or log.
+    """
+    proj_path = _project_identity_path(cwd)
+    proj_id = _read_identity(proj_path)
+    glob_id = _read_identity(None)  # global IDENTITY_PATH
+
+    # Pass 1: confirmed candidates in [project, global] order
+    for identity, scope in [(proj_id, "project"), (glob_id, "global")]:
+        if identity is not None and not identity.get("provisional", False):
+            result = dict(identity)
+            result["_scope"] = scope
+            result["_confirmed"] = True
+            return result
+
+    # Pass 2: provisional candidates in [project, global] order
+    for identity, scope in [(proj_id, "project"), (glob_id, "global")]:
+        if identity is not None:
+            result = dict(identity)
+            result["_scope"] = scope
+            result["_confirmed"] = False
+            return result
+
+    return None
+
+
+def _write_identity(lines: list[str], target_path: Path | None = None) -> int:
+    """Atomically write identity file from lines list. Returns 0 on success, 1 on error.
+
+    When target_path is None, writes to global IDENTITY_PATH (default, unchanged
+    for all existing callers). When provided, writes to that path (mkdir -p parent).
+    """
+    dest = target_path if target_path is not None else IDENTITY_PATH
     content = "\n".join(lines) + "\n"
-    IDENTITY_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    tmp = IDENTITY_PATH.with_suffix(".yml.tmp")
+    dest.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp = dest.with_suffix(".yml.tmp")
     try:
         tmp.write_text(content, encoding="utf-8")
         os.chmod(tmp, 0o600)
-        tmp.rename(IDENTITY_PATH)
+        tmp.rename(dest)
     except Exception as exc:
         print(f"agentic-identity: write failed: {exc}", file=sys.stderr)
         tmp.unlink(missing_ok=True)
@@ -99,12 +163,20 @@ def _write_identity(lines: list[str]) -> int:
     return 0
 
 
-def flushPendingBuffer(confirmed_dev_id: str) -> int:
+def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = None) -> int:
     """Flush ~/.agentic/session-log/.pending/*.json to global + per-project logs.
 
     Race-safe via fcntl.flock exclusive lock on .flush.lock for the whole loop.
     Uses LOCK_NB + sleep loop (30s timeout) for portability over SIGALRM.
     Returns number of records flushed (0 on no pending or timeout).
+
+    When repo_root_filter is None (default): current behavior exactly - all
+    pending records are attributed to confirmed_dev_id.
+
+    When repo_root_filter is set (e.g. project-scope init/confirm): only records
+    whose repo_root exactly matches repo_root_filter are flushed. Records whose
+    repo_root does not match, or whose repo_root is absent/empty, are left in the
+    buffer (not unlinked, not attributed) for later global flush.
     """
     # Ensure lock file and parent dirs exist.
     FLUSH_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -149,6 +221,12 @@ def flushPendingBuffer(confirmed_dev_id: str) -> int:
                 # Skip malformed records silently.
                 continue
 
+            # repo_root_filter: skip records that don't match (leave in buffer).
+            if repo_root_filter is not None:
+                record_repo_root = record.get("repo_root", "")
+                if not record_repo_root or record_repo_root != repo_root_filter:
+                    continue
+
             session_uuid = record.get("session_uuid", "")
 
             # Dedup: scan global log for this session_uuid.
@@ -189,7 +267,6 @@ def flushPendingBuffer(confirmed_dev_id: str) -> int:
             # Repo root validation.
             repo_root = record.get("repo_root", "")
             project_slug = record.get("project_slug", "")
-            wrote_per_project = False
             if repo_root and project_slug:
                 try:
                     result = subprocess.check_output(
@@ -204,7 +281,6 @@ def flushPendingBuffer(confirmed_dev_id: str) -> int:
                         per_project_log = per_project_log_dir / f"{confirmed_dev_id}.jsonl"
                         with open(per_project_log, "a", encoding="utf-8") as pf:
                             pf.write(attributed_line + "\n")
-                        wrote_per_project = True
                     else:
                         print(
                             f"agentic-identity: repo_root '{repo_root}' basename "
@@ -252,6 +328,19 @@ def flushPendingBuffer(confirmed_dev_id: str) -> int:
     return flushed
 
 
+def _require_repo_root(cwd: Path) -> int:
+    """Return 1 (and print error) if cwd has neither .agentic/ nor .git/; else 0."""
+    if not (cwd / ".agentic").exists() and not (cwd / ".git").exists():
+        print(
+            f"agentic-identity: no repo root found at '{cwd}'. "
+            "Neither .agentic/ nor .git/ exists. "
+            "Run from a repository directory when using --scope project.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     handle = args.handle
     if not HANDLE_RE.match(handle):
@@ -262,6 +351,44 @@ def cmd_init(args: argparse.Namespace) -> int:
         )
         return 1
 
+    scope = getattr(args, "scope", "global")
+    if scope == "project":
+        cwd = Path.cwd()
+        rc = _require_repo_root(cwd)
+        if rc != 0:
+            return rc
+        target_path = _project_identity_path(cwd)
+        existing = _read_identity(target_path) if target_path.is_file() else None
+        is_overwriting_provisional = existing is not None and existing.get("provisional", False)
+        is_fresh = existing is None
+
+        if target_path.is_file() and not args.force:
+            current = existing.get("developer_id", "?") if existing else "?"
+            print(
+                f"agentic-identity: project identity already set to '{current}'. "
+                "Use --force to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+
+        created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [f"developer_id: {handle}"]
+        if args.display_name:
+            lines.append(f"display_name: {args.display_name}")
+        lines.append(f"created_at: {created_at}")
+
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        print(f"Identity set (project scope): developer_id={handle}, created_at={created_at}")
+
+        if is_overwriting_provisional or is_fresh:
+            flushPendingBuffer(handle, repo_root_filter=str(cwd.resolve()))
+
+        return 0
+
+    # --scope global (default): byte-for-byte current behavior
     existing = _read_identity() if IDENTITY_PATH.is_file() else None
     is_overwriting_provisional = existing is not None and existing.get("provisional", False)
     is_fresh = existing is None
@@ -329,7 +456,43 @@ def cmd_auto(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # Check existing identity.
+    scope = getattr(args, "scope", "global")
+    if scope == "project":
+        cwd = Path.cwd()
+        rc = _require_repo_root(cwd)
+        if rc != 0:
+            return rc
+        target_path = _project_identity_path(cwd)
+        existing = _read_identity(target_path)
+        if existing is not None:
+            is_provisional = existing.get("provisional", False)
+            current_handle = existing.get("developer_id", "?")
+            if not is_provisional and not args.force:
+                print(
+                    f"agentic-identity: confirmed project identity already set to "
+                    f"'{current_handle}'. Use --force to overwrite.",
+                    file=sys.stderr,
+                )
+                return 2
+
+        created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [
+            f"developer_id: {login}",
+            f"created_at: {created_at}",
+            "provisional: true",
+            "derived_from: gh",
+        ]
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        print(
+            f"Identity derived (provisional, project scope): developer_id={login}. "
+            "Confirm at next session start."
+        )
+        return 0
+
+    # --scope global (default): current behavior
     existing = _read_identity()
     if existing is not None:
         is_provisional = existing.get("provisional", False)
@@ -364,6 +527,39 @@ def cmd_auto(args: argparse.Namespace) -> int:
 
 def cmd_confirm(args: argparse.Namespace) -> int:
     """Confirm provisional identity: strip provisional/derived_from, flush pending buffer."""
+    scope = getattr(args, "scope", "global")
+    if scope == "project":
+        cwd = Path.cwd()
+        rc = _require_repo_root(cwd)
+        if rc != 0:
+            return rc
+        target_path = _project_identity_path(cwd)
+        identity = _read_identity(target_path)
+        if identity is None:
+            print(
+                "agentic-identity: no project identity set. "
+                "Run 'agentic-identity init <handle> --scope project' first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        dev_id = identity["developer_id"]
+        lines = [f"developer_id: {dev_id}"]
+        if "display_name" in identity:
+            lines.append(f"display_name: {identity['display_name']}")
+        if "created_at" in identity:
+            lines.append(f"created_at: {identity['created_at']}")
+        # Intentionally omit provisional and derived_from.
+
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        flushPendingBuffer(dev_id, repo_root_filter=str(cwd.resolve()))
+        print(f"Identity confirmed (project scope): developer_id={dev_id}")
+        return 0
+
+    # --scope global (default): current behavior
     identity = _read_identity()
     if identity is None:
         print(
@@ -392,6 +588,41 @@ def cmd_confirm(args: argparse.Namespace) -> int:
 
 
 def cmd_show(args: argparse.Namespace) -> int:
+    scope = getattr(args, "scope", "global")
+
+    if scope == "effective":
+        identity = _resolve_effective_identity(Path.cwd())
+        if identity is None:
+            print("No identity set. Run: agentic-identity init <handle>")
+            return 0
+        print(f"developer_id:  {identity.get('developer_id', '?')}")
+        if "display_name" in identity:
+            print(f"display_name:  {identity['display_name']}")
+        if "created_at" in identity:
+            print(f"created_at:    {identity['created_at']}")
+        print(f"scope:         {identity.get('_scope', '?')}")
+        print(f"confirmed:     {str(identity.get('_confirmed', False)).lower()}")
+        if identity.get("provisional", False):
+            print("provisional:   true")
+        return 0
+
+    if scope == "project":
+        cwd = Path.cwd()
+        target_path = _project_identity_path(cwd)
+        identity = _read_identity(target_path)
+        if identity is None:
+            print("No identity at project scope.")
+            return 0
+        print(f"developer_id:  {identity.get('developer_id', '?')}")
+        if "display_name" in identity:
+            print(f"display_name:  {identity['display_name']}")
+        if "created_at" in identity:
+            print(f"created_at:    {identity['created_at']}")
+        if identity.get("provisional", False):
+            print("provisional:   true")
+        return 0
+
+    # --scope global (default): current behavior
     identity = _read_identity()
     if identity is None:
         print("No identity set. Run: agentic-identity init <handle>")
@@ -419,9 +650,13 @@ def main(argv: list[str]) -> int:
                         help="Optional human-readable display name")
     p_init.add_argument("--force", action="store_true",
                         help="Overwrite existing identity without prompting")
+    p_init.add_argument("--scope", choices=["global", "project"], default="global",
+                        help="Write to global (~/.agentic/) or project (<cwd>/.agentic/) file")
     p_init.set_defaults(func=cmd_init)
 
     p_show = sub.add_parser("show", help="Print current identity")
+    p_show.add_argument("--scope", choices=["global", "project", "effective"], default="global",
+                        help="Show global, project, or effective (4-tier resolved) identity")
     p_show.set_defaults(func=cmd_show)
 
     p_auto = sub.add_parser(
@@ -433,12 +668,16 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="Overwrite existing confirmed identity",
     )
+    p_auto.add_argument("--scope", choices=["global", "project"], default="global",
+                        help="Write to global or project identity file")
     p_auto.set_defaults(func=cmd_auto)
 
     p_confirm = sub.add_parser(
         "confirm",
         help="Confirm provisional identity and flush pending session buffer",
     )
+    p_confirm.add_argument("--scope", choices=["global", "project"], default="global",
+                           help="Confirm global or project identity")
     p_confirm.set_defaults(func=cmd_confirm)
 
     args = p.parse_args(argv[1:])

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 """
-Regression test for flushPendingBuffer canonical shape fix.
+Regression tests for agentic-identity: canonical shape fix and project-scope override.
 
-Verifies that flushed session-log lines match the canonical shape written by
-hooks/stop-context.js writeSessionLog / writeSessionLogGlobal:
-  {ts, phase, event, agent, task_id, developer_id, session_uuid,
-   project_slug, branch, data}
-
-The pre-fix behavior (dict(record) + developer_id) would produce lines that
-include schema_version and repo_root, which are absent from the canonical
-shape. Any consumer filtering on phase == 'session_end' / event == 'session_total'
-would silently drop or misparse flushed records in a mixed-schema file.
+Test groups:
+  1. test_flushed_line_canonical_shape - flushed lines match canonical shape (original test).
+  2. test_project_scope_flush_does_not_touch_other_repo_records (A) - repo_root_filter
+     isolates flush to matching repo; other-repo pending files are left in buffer.
+  3. test_confirmed_global_not_suppressed_by_provisional_project (B) - global-confirmed
+     wins over project-provisional in 4-tier resolution.
+  4. test_project_confirmed_beats_confirmed_global (C) - project-confirmed wins over
+     global-confirmed in 4-tier resolution.
+  5. test_no_repo_root_record_skipped_by_filter (D) - records with absent/empty repo_root
+     are conservatively skipped when a repo_root_filter is active.
+  6. test_global_scope_flush_unaffected (E) - no-filter flush attributes all pending records.
 
 Regression test obligation: content/references/regression-test-obligation.md
-Run with: python3 bin/tests/test_agentic_identity.py
+Run with: python3 -m pytest bin/tests/test_agentic_identity.py -x
+       or: python3 bin/tests/test_agentic_identity.py
 """
 from __future__ import annotations
 
@@ -37,6 +40,8 @@ _mod = importlib.util.module_from_spec(_spec)
 _loader.exec_module(_mod)
 
 flushPendingBuffer = _mod.flushPendingBuffer
+_resolve_effective_identity = _mod._resolve_effective_identity
+_project_identity_path = _mod._project_identity_path
 
 
 def _write_pending(pending_dir: Path, record: dict) -> Path:
@@ -47,18 +52,37 @@ def _write_pending(pending_dir: Path, record: dict) -> Path:
     return p
 
 
+def _patch_paths(tmp_path: Path):
+    """Patch module-level paths to use tmp_path. Returns (pending_dir, log_dir, lock_path)."""
+    pending_dir = tmp_path / "session-log" / ".pending"
+    global_log_dir = tmp_path / "session-log"
+    flush_lock = tmp_path / "session-log" / ".flush.lock"
+    _mod.PENDING_DIR = pending_dir
+    _mod.GLOBAL_SESSION_LOG_DIR = global_log_dir
+    _mod.FLUSH_LOCK_PATH = flush_lock
+    flush_lock.parent.mkdir(parents=True, exist_ok=True)
+    flush_lock.touch(exist_ok=True)
+    return pending_dir, global_log_dir, flush_lock
+
+
+def _write_identity_file(path: Path, developer_id: str, provisional: bool = False) -> None:
+    """Write a minimal identity.yml at path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"developer_id: {developer_id}", "created_at: 2026-01-01T00:00:00Z"]
+    if provisional:
+        lines.append("provisional: true")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Existing test (preserved)
+# ---------------------------------------------------------------------------
+
 def test_flushed_line_canonical_shape():
     """flushed line must match canonical shape; must NOT contain schema_version or repo_root."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
-        pending_dir = tmp_path / "session-log" / ".pending"
-        global_log_dir = tmp_path / "session-log"
-        flush_lock = tmp_path / "session-log" / ".flush.lock"
-
-        # Patch module-level paths
-        _mod.PENDING_DIR = pending_dir
-        _mod.GLOBAL_SESSION_LOG_DIR = global_log_dir
-        _mod.FLUSH_LOCK_PATH = flush_lock
+        pending_dir, global_log_dir, flush_lock = _patch_paths(tmp_path)
 
         # Pending record mimics what writePendingBuffer in stop-context.js writes.
         # Includes schema_version and repo_root - fields that must NOT appear in
@@ -79,8 +103,6 @@ def test_flushed_line_canonical_shape():
             },
         }
         _write_pending(pending_dir, pending_record)
-        flush_lock.parent.mkdir(parents=True, exist_ok=True)
-        flush_lock.touch(exist_ok=True)
 
         dev_id = "testdev"
         count = flushPendingBuffer(dev_id)
@@ -120,6 +142,188 @@ def test_flushed_line_canonical_shape():
         print("PASS test_flushed_line_canonical_shape")
 
 
+# ---------------------------------------------------------------------------
+# New tests (A-E): project-scope override regression suite
+# ---------------------------------------------------------------------------
+
+def test_project_scope_flush_does_not_touch_other_repo_records():
+    """(A) repo_root_filter=/repo/a flushes only the /repo/a record; /repo/b file stays."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        record_a = {
+            "session_uuid": "uuid-repo-a",
+            "ts": "2026-06-01T00:00:00.000Z",
+            "repo_root": "/repo/a",
+            "project_slug": "a",
+            "branch": "main",
+            "data": {},
+        }
+        record_b = {
+            "session_uuid": "uuid-repo-b",
+            "ts": "2026-06-01T00:01:00.000Z",
+            "repo_root": "/repo/b",
+            "project_slug": "b",
+            "branch": "main",
+            "data": {},
+        }
+        path_a = _write_pending(pending_dir, record_a)
+        path_b = _write_pending(pending_dir, record_b)
+
+        count = flushPendingBuffer("a-dev", repo_root_filter="/repo/a")
+        assert count == 1, f"Expected 1 flushed, got {count}"
+
+        # /repo/a record was flushed - its file should be gone
+        assert not path_a.exists(), "Pending file for /repo/a should have been removed"
+
+        # /repo/b record was NOT touched - its file must still exist
+        assert path_b.exists(), "Pending file for /repo/b must remain in buffer"
+
+        # The flushed line must have developer_id == "a-dev"
+        global_log = global_log_dir / "a-dev.jsonl"
+        assert global_log.is_file(), "Global log for a-dev should exist"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1, f"Expected 1 flushed line, got {len(lines)}"
+        row = json.loads(lines[0])
+        assert row["developer_id"] == "a-dev"
+        assert row["session_uuid"] == "uuid-repo-a"
+
+        print("PASS test_project_scope_flush_does_not_touch_other_repo_records")
+
+
+def test_confirmed_global_not_suppressed_by_provisional_project():
+    """(B) provisional project + confirmed global -> effective is global-dev (_confirmed True, _scope global)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+
+        # Project identity: provisional
+        proj_path = cwd / ".agentic" / "identity.yml"
+        _write_identity_file(proj_path, "project-dev", provisional=True)
+
+        # Global identity: confirmed - patch IDENTITY_PATH on the module
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+        original_identity_path = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = original_identity_path
+
+        assert result is not None, "Expected a resolved identity"
+        assert result["developer_id"] == "global-dev", \
+            f"Expected global-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "global", \
+            f"Expected scope=global, got {result['_scope']!r}"
+        assert result["_confirmed"] is True, \
+            f"Expected _confirmed=True, got {result['_confirmed']!r}"
+
+        print("PASS test_confirmed_global_not_suppressed_by_provisional_project")
+
+
+def test_project_confirmed_beats_confirmed_global():
+    """(C) both confirmed -> project identity wins."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+
+        # Project identity: confirmed
+        proj_path = cwd / ".agentic" / "identity.yml"
+        _write_identity_file(proj_path, "project-dev", provisional=False)
+
+        # Global identity: confirmed
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+        original_identity_path = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = original_identity_path
+
+        assert result is not None, "Expected a resolved identity"
+        assert result["developer_id"] == "project-dev", \
+            f"Expected project-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "project", \
+            f"Expected scope=project, got {result['_scope']!r}"
+        assert result["_confirmed"] is True, \
+            f"Expected _confirmed=True, got {result['_confirmed']!r}"
+
+        print("PASS test_project_confirmed_beats_confirmed_global")
+
+
+def test_no_repo_root_record_skipped_by_filter():
+    """(D) record with absent repo_root is skipped by a non-None filter; file remains."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        record_no_root = {
+            "session_uuid": "uuid-no-root",
+            "ts": "2026-06-01T00:00:00.000Z",
+            # repo_root intentionally absent
+            "project_slug": "unknown",
+            "branch": "main",
+            "data": {},
+        }
+        pending_file = _write_pending(pending_dir, record_no_root)
+
+        count = flushPendingBuffer("some-dev", repo_root_filter="/repo/x")
+        assert count == 0, f"Expected 0 flushed (no-root record should be skipped), got {count}"
+
+        # File must remain in the buffer
+        assert pending_file.exists(), "Pending file with no repo_root must remain in buffer"
+
+        print("PASS test_no_repo_root_record_skipped_by_filter")
+
+
+def test_global_scope_flush_unaffected():
+    """(E) no filter (repo_root_filter=None) attributes all pending records."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        record1 = {
+            "session_uuid": "uuid-g1",
+            "ts": "2026-06-01T00:00:00.000Z",
+            "repo_root": "/repo/alpha",
+            "project_slug": "alpha",
+            "branch": "main",
+            "data": {},
+        }
+        record2 = {
+            "session_uuid": "uuid-g2",
+            "ts": "2026-06-01T00:01:00.000Z",
+            "repo_root": "/repo/beta",
+            "project_slug": "beta",
+            "branch": "main",
+            "data": {},
+        }
+        _write_pending(pending_dir, record1)
+        _write_pending(pending_dir, record2)
+
+        count = flushPendingBuffer("g-dev")  # no filter
+        assert count == 2, f"Expected 2 flushed, got {count}"
+
+        global_log = global_log_dir / "g-dev.jsonl"
+        assert global_log.is_file(), "Global log for g-dev should exist"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 2, f"Expected 2 flushed lines, got {len(lines)}"
+        uuids = {json.loads(l)["session_uuid"] for l in lines}
+        assert uuids == {"uuid-g1", "uuid-g2"}, f"Unexpected session_uuids: {uuids}"
+
+        print("PASS test_global_scope_flush_unaffected")
+
+
 if __name__ == "__main__":
     test_flushed_line_canonical_shape()
+    test_project_scope_flush_does_not_touch_other_repo_records()
+    test_confirmed_global_not_suppressed_by_provisional_project()
+    test_project_confirmed_beats_confirmed_global()
+    test_no_repo_root_record_skipped_by_filter()
+    test_global_scope_flush_unaffected()
     print("All tests passed.")

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -15,7 +15,7 @@
  *             Claude Code Stop hook. Internal helpers: writeLoopState(cwd),
  *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId),
  *             writeSessionTotal(cwd, sessionId), computeSessionTotals(cwd, sessionId),
- *             getIdentity(), writeSessionLog(cwd, identity, sessionId),
+ *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId),
  *             writeSessionLogGlobal(identity, sessionId, data),
  *             writePendingBuffer(cwd, sessionId),
  *             appendIdentityNudgeToContextMd(repoRoot).
@@ -27,8 +27,10 @@
  *                [cwd]/.agentic/batch-state.json,
  *                [cwd]/.agentic/session-log/<developer_id>.jsonl,
  *                ~/.agentic/session-log/<developer_id>.jsonl (global mirror),
- *                ~/.agentic/session-log/.pending/<session_uuid>.json (pending buffer), and
- *                ~/.agentic/identity.yml (read-only).
+ *                ~/.agentic/session-log/.pending/<session_uuid>.json (pending buffer),
+ *                ~/.agentic/identity.yml (read-only, global), and
+ *                [cwd]/.agentic/identity.yml (read-only, project-local; takes precedence
+ *                over global when confirmed, per 4-tier resolution in getIdentity(cwd)).
  *
  * Downstream consumers: Claude Code Stop hook (configured in
  *                        ~/.claude/settings.json or project .claude/settings.json).
@@ -314,17 +316,16 @@ function removeLearningsAgentSession(cwd, sessionId) {
 }
 
 /**
- * Read ~/.agentic/identity.yml and return {developer_id, provisional} or null.
- * Parses the optional `provisional:` line; absent means confirmed (provisional: false).
+ * Parse a YAML identity file at filePath. Returns {developer_id, provisional} or null.
  * Silent on ENOENT or any parse error.
  *
+ * @param {string} filePath - Absolute path to the identity.yml file.
  * @returns {{developer_id: string, provisional: boolean}|null}
  */
-function getIdentity() {
+function _parseIdentityFile(filePath) {
   try {
-    const identityPath = path.join(os.homedir(), '.agentic', 'identity.yml');
-    if (!fs.existsSync(identityPath)) return null;
-    const raw = fs.readFileSync(identityPath, 'utf8');
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf8');
     const m = raw.match(/^developer_id:\s*(\S+)\s*$/m);
     if (!m) return null;
     const pm = raw.match(/^provisional:\s*(true|false)\s*$/m);
@@ -333,6 +334,38 @@ function getIdentity() {
   } catch (_) {
     return null;
   }
+}
+
+/**
+ * Resolve effective identity via 4-tier total ordering:
+ *   project-confirmed > global-confirmed > project-provisional > global-provisional > null
+ *
+ * Reads project file (<cwd>/.agentic/identity.yml) and global file
+ * (~/.agentic/identity.yml) using two synchronous existsSync+readFileSync calls
+ * (~1ms, Node built-ins only, no subprocess).
+ *
+ * The existing three-branch write-vs-buffer gate (identity && !identity.provisional)
+ * remains valid: confirmed at either scope -> direct write; provisional -> pending buffer.
+ *
+ * @param {string} cwd - The repo working directory (already validated by run()).
+ * @returns {{developer_id: string, provisional: boolean}|null}
+ */
+function getIdentity(cwd) {
+  const projectPath = path.join(cwd, '.agentic', 'identity.yml');
+  const globalPath = path.join(os.homedir(), '.agentic', 'identity.yml');
+
+  const projId = _parseIdentityFile(projectPath);
+  const globId = _parseIdentityFile(globalPath);
+
+  // Pass 1: first confirmed candidate in [project, global] order
+  if (projId && !projId.provisional) return projId;
+  if (globId && !globId.provisional) return globId;
+
+  // Pass 2: first provisional candidate in [project, global] order
+  if (projId) return projId;
+  if (globId) return globId;
+
+  return null;
 }
 
 /**
@@ -823,7 +856,7 @@ ${toolsLine}
       writeSessionTotal(cwd, sessionId);
       // Three-branch identity gate (independent of all other paths).
       try {
-        const identity = getIdentity();
+        const identity = getIdentity(cwd);
         if (identity && !identity.provisional) {
           // Confirmed identity: per-project write + global mirror
           writeSessionLog(cwd, identity, sessionId);
@@ -896,7 +929,7 @@ ${toolsLine}
   // --- 13. Three-branch identity gate: session log, global mirror, or pending buffer ---
   // Independent best-effort write; any failure swallowed. Never blocks exit.
   try {
-    const identity = getIdentity();
+    const identity = getIdentity(cwd);
     if (identity && !identity.provisional) {
       // Confirmed identity: per-project write + global mirror
       writeSessionLog(cwd, identity, sessionId);


### PR DESCRIPTION
Adds a per-project developer-identity override for telemetry attribution. Implements the `code-impl` unit of docs/planning/project-identity-override.md (Skeptic-approved, 2 architect rounds).

- `agentic-identity --scope {global,project}` on init/confirm/auto (+ `effective` on show only); `--scope project` reads/writes `<repo>/.agentic/identity.yml` (gitignored), requires a repo root.
- 4-tier effective-identity resolution: project-confirmed > global-confirmed > project-provisional > global-provisional > none. A provisional project file never suppresses a confirmed global. Implemented identically in the Python CLI and the JS Stop hook.
- `flushPendingBuffer(confirmed_dev_id, repo_root_filter=None)`: default preserves current behavior; project scope filters to the current repo so other repos' buffered sessions are never mis-attributed.
- 5 new regression tests (flush isolation, confirmed-global-not-suppressed, precedence, no-repo_root skip, global-flush-unaffected). All 6 pass.

Back-compat: `--scope` defaults to `global`; absent project file = unchanged behavior. Docs + README land in the sibling units.