### PR TITLE
docs(readme): add Identity and Telemetry section [readme-docs]

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,56 @@ agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pri
 
 **Project config / overview layer** - the committed `.agentic/config.json` holds four operator-tunable methodology toggles: `debugger_on_failure` (bool, default `false`; interposes a Debugger diagnosis step before each Phase 7 engineer fix pass), `qa_default_skip` (reserved; no-op, does not alter QA-gate behavior), `model_profile` (`default` | `budget`; `budget` routes eligible spawns to Tier 1), and `auto_merge_on_ci_green` (bool, default `false`; when `true`, `/implement-ticket` Phase 12 squash-merges the PR after CI passes and the PR is ready with no requested changes). The operator-owned `docs/overview/{vision,requirements}.md` files capture durable product intent above the task level; Architect and Investigator read them when present and must not contradict them. Both are optional and graceful - if absent, defaults apply and nothing breaks.
 
+## Identity and Telemetry
+
+`agentic-cost` reports token and wall-time rollups per developer. For those rollups to be meaningful, each developer needs a registered handle so session logs are attributed correctly.
+
+### Registering a handle (global)
+
+The quickest path derives your handle from your GitHub login:
+
+```bash
+agentic-identity auto      # derives handle from `gh api user`, writes it provisional
+agentic-identity confirm   # strips the provisional flag and flushes buffered sessions
+```
+
+Or set a handle manually:
+
+```bash
+agentic-identity init <handle>   # writes ~/.agentic/identity.yml directly as confirmed
+```
+
+Until you confirm, telemetry is buffered in `~/.agentic/session-log/.pending/` - no sessions are lost. Confirmation flushes the buffer and starts writing attributed logs.
+
+Run `agentic-identity show` at any time to see your current identity.
+
+### Per-project override
+
+If you use a different handle for specific repos, set a project-scoped identity from inside that repo:
+
+```bash
+agentic-identity init <handle> --scope project   # writes <repo>/.agentic/identity.yml
+agentic-identity confirm --scope project          # confirm a provisional project identity
+```
+
+The project file is covered by the existing `.agentic/*` gitignore umbrella - it is per-developer and never committed. The global identity is unchanged.
+
+### Precedence
+
+When both files exist, the most-confirmed identity wins:
+
+**project-confirmed > global-confirmed > project-provisional > global-provisional > none**
+
+A provisional project file never suppresses a working confirmed-global handle. To see which handle is active in the current repo:
+
+```bash
+agentic-identity show --scope effective
+```
+
+### agentic-cost attribution
+
+`agentic-cost team` aggregates `.agentic/session-log/<dev>.jsonl` files for the current repo. A developer who uses two different handles across repos appears as two rows - this is expected. Session logs are local-only (per machine); there is no automatic cross-machine aggregation.
+
 ## Repo structure
 
 ```


### PR DESCRIPTION
Adds an "Identity and Telemetry" section to README.md (final unit of docs/planning/project-identity-override.md). Documents the now-shipped identity system: global registration (`agentic-identity auto`/`confirm`/`init`), the per-project override (`--scope project`, gitignored), the 4-tier precedence, `show --scope effective`, and the `agentic-cost` attribution link. Local-only telemetry is noted explicitly (no team-sharing over-claim - that's deferred to DS-15).

All flags verified against the shipped `bin/agentic-identity` on main (argparse `--scope` wiring at lines 653/658/671/679).