### PR TITLE
chore(telemetry): track session-log + add commit_telemetry toggle [DS-15 unit 1]

### DIFF
--- a/.agentic/config.json
+++ b/.agentic/config.json
@@ -2,5 +2,6 @@
   "debugger_on_failure": false,
   "qa_default_skip": null,
   "model_profile": "default",
-  "auto_merge_on_ci_green": true
+  "auto_merge_on_ci_green": true,
+  "commit_telemetry": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ node_modules/
 !.agentic/config.json
 !.agentic/findings.md
 !.agentic/qa-regressions.md
-# session-log is intentionally local-only telemetry (per-developer, read by
-# agentic-cost); it is NOT committed - let it fall under the .agentic/* umbrella.
+!.agentic/session-log/
+# session-log/: per-developer telemetry, committed so `agentic-cost team` works
+# across machines. Other .agentic/* runtime files stay local under the umbrella.
 .agentic/worktrees/
 .agentic/loop-state.json
 .agentic/tasks.jsonl


### PR DESCRIPTION
Unit 1 of DS-15 (docs/planning/pr-telemetry-commit-brief.md). Makes per-developer telemetry trackable and adds the opt-out toggle. Merges before the Phase 8 unit so the carve-out is present when that lands.

- `.gitignore`: `!.agentic/session-log/` carve-out (other `.agentic/*` runtime files - events.jsonl, loop-state.json, tasks.jsonl, etc. - stay ignored; Skeptic-verified).
- `.agentic/config.json`: `commit_telemetry: true`.