### PR TITLE
docs(readme): point License section at Apache-2.0 LICENSE [DS-2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,4 +310,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-License pending - see issue IR-2.
+[Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for attribution.


### PR DESCRIPTION
README footer still said "License pending - see issue IR-2" after Apache-2.0 was adopted in #186 (DS-2).

- Replaces the stale placeholder with a link to the committed `LICENSE` and `NOTICE`.

One line, docs-only.