### PR TITLE
fix(memory-update): correct write path to <cwd>/MEMORY.md + orphan warning [u4]

### DIFF
--- a/.claude/commands/memory-update.md
+++ b/.claude/commands/memory-update.md
@@ -10,7 +10,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.codex/commands/memory-update.md
+++ b/.codex/commands/memory-update.md
@@ -8,7 +8,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.cursor/commands/memory-update.md
+++ b/.cursor/commands/memory-update.md
@@ -8,7 +8,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.gemini/commands/memory-update.toml
+++ b/.gemini/commands/memory-update.toml
@@ -14,7 +14,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.opencode/commands/memory-update.md
+++ b/.opencode/commands/memory-update.md
@@ -12,7 +12,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/content/commands/memory-update.md
+++ b/content/commands/memory-update.md
@@ -8,7 +8,15 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Immediately** spawn a background `general-purpose` Worker (`run_in_background: true`). Return to the conversation instantly. Do not report completion to the user unless there is an escalation.
 
-**Before spawning:** Locate the MEMORY.md path from your auto-injected context. The canonical path is Memory lives in the project at `<cwd>/.agentic/memory/``. Construct the full MEMORY.md path: `<cwd>/.agentic/memory/MEMORY.md`. Pass this path to the Worker as `$MEMORY_PATH`.
+**Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (auto-injected by Claude Code at startup). Pass this path to the Worker as `$MEMORY_PATH`.
+
+**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
+
+```
+WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
+```
+
+Do NOT auto-merge the orphaned file.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 


### PR DESCRIPTION
Part of knowledge-capture consolidation, Unit 4.

- memory-update.md: write target was `<cwd>/.agentic/memory/MEMORY.md` (a path nothing reads). Fixed to `<cwd>/MEMORY.md`.
- Added orphan-data warning (detection-only, no auto-merge) for any pre-existing `.agentic/memory/MEMORY.md`.
- subagent-protocol.md / design-goals.md: zero stale refs. All adapters rebuilt.

Skeptic: sign-off (1 Minor - init-project.md refs - deferred to Unit 10 per plan).