### PR TITLE
chore(gitignore): track .agentic/learnings.md so learnings travel [u3]

### DIFF
--- a/.agentic/learnings.md
+++ b/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules/
 !.agentic/findings.md
 !.agentic/qa-regressions.md
 !.agentic/session-log/
+!.agentic/learnings.md
 # session-log/: per-developer telemetry, committed so `agentic-cost team` works
 # across machines. Other .agentic/* runtime files stay local under the umbrella.
 .agentic/worktrees/
@@ -34,7 +35,6 @@ node_modules/
 .agentic/batch-state.json
 .agentic/events.jsonl
 .agentic/events-prev.jsonl
-.agentic/learnings.md
 .agentic/.activated
 .agentic/.meta-divergence-surfaced
 .agentic/.meta-divergence-last-sweep


### PR DESCRIPTION
Part of knowledge-capture consolidation, Unit 3 (D3 REVISED - additive negation).

- .gitignore: add `!.agentic/learnings.md` carve-out (with sibling negations); remove now-redundant explicit ignore. learnings.md is now tracked so fix-pattern learnings reach the team.
- Stage the existing stub `.agentic/learnings.md` (secret-free).

Verified: `git check-ignore` confirms learnings.md NOT ignored; identity.yml/loop-state.json/tasks.jsonl/events.jsonl all STILL ignored (no cascade).
Skeptic: sign-off, 0 findings (collateral-un-ignore check passed).