### PR TITLE
feat(scaffolding): seed + commit .agentic/learnings.md via additive negation [u2+u9]

### DIFF
--- a/.claude/build.sh
+++ b/.claude/build.sh
@@ -78,15 +78,17 @@ else
   ln "$SCAFFOLDING_SRC" "$SCAFFOLDING_DST"
 fi
 
-# templates/: hardlink .agentic/config.json seed
+# templates/: hardlink .agentic seed files
 mkdir -p "$SKILL_DST/templates/.agentic"
-TMPL_SRC="$CONTENT/templates/.agentic/config.json"
-TMPL_DST="$SKILL_DST/templates/.agentic/config.json"
-if [[ -e "$TMPL_DST" ]] && [[ "$(get_inode "$TMPL_SRC")" == "$(get_inode "$TMPL_DST")" ]]; then
-  :
-else
-  rm -f "$TMPL_DST"
-  ln "$TMPL_SRC" "$TMPL_DST"
-fi
+for tmpl_name in config.json learnings.md; do
+  TMPL_SRC="$CONTENT/templates/.agentic/$tmpl_name"
+  TMPL_DST="$SKILL_DST/templates/.agentic/$tmpl_name"
+  if [[ -e "$TMPL_DST" ]] && [[ "$(get_inode "$TMPL_SRC")" == "$(get_inode "$TMPL_DST")" ]]; then
+    :
+  else
+    rm -f "$TMPL_DST"
+    ln "$TMPL_SRC" "$TMPL_DST"
+  fi
+done
 
 echo "Claude adapter build complete."

--- a/.claude/skills/agentic-engineering/project-scaffolding.yml
+++ b/.claude/skills/agentic-engineering/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/.claude/skills/agentic-engineering/templates/.agentic/learnings.md
+++ b/.claude/skills/agentic-engineering/templates/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->

--- a/.codex/build.sh
+++ b/.codex/build.sh
@@ -150,7 +150,9 @@ echo "Rebuilt references/ hardlinks"
 # project-scaffolding.yml and templates/: hardlink into .codex/skill/ so agentic-migrate can find them
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$SKILL_DST/project-scaffolding.yml"
 mkdir -p "$SKILL_DST/templates/.agentic"
-hardlink_from_content "$CONTENT/templates/.agentic/config.json" "$SKILL_DST/templates/.agentic/config.json"
+for tmpl_name in config.json learnings.md; do
+  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$SKILL_DST/templates/.agentic/$tmpl_name"
+done
 echo "Rebuilt skill/project-scaffolding.yml and templates/"
 
 # ---------------------------------------------------------------------------

--- a/.codex/skill/project-scaffolding.yml
+++ b/.codex/skill/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/.codex/skill/templates/.agentic/learnings.md
+++ b/.codex/skill/templates/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->

--- a/.cursor/build.sh
+++ b/.cursor/build.sh
@@ -78,6 +78,8 @@ done
 CURSOR_DIR="$REPO_DIR/.cursor"
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$CURSOR_DIR/project-scaffolding.yml"
 mkdir -p "$CURSOR_DIR/templates/.agentic"
-hardlink_from_content "$CONTENT/templates/.agentic/config.json" "$CURSOR_DIR/templates/.agentic/config.json"
+for tmpl_name in config.json learnings.md; do
+  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$CURSOR_DIR/templates/.agentic/$tmpl_name"
+done
 
 echo "Cursor adapter build complete."

--- a/.cursor/project-scaffolding.yml
+++ b/.cursor/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/.cursor/templates/.agentic/learnings.md
+++ b/.cursor/templates/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->

--- a/.gemini/build.sh
+++ b/.gemini/build.sh
@@ -356,7 +356,9 @@ echo "Built ${#generated_agents[@]} agent files in .gemini/agents/"
 # project-scaffolding.yml and templates/: hardlink so agentic-migrate can resolve from adapter
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$GEMINI_DIR/project-scaffolding.yml"
 mkdir -p "$GEMINI_DIR/templates/.agentic"
-hardlink_from_content "$CONTENT/templates/.agentic/config.json" "$GEMINI_DIR/templates/.agentic/config.json"
+for tmpl_name in config.json learnings.md; do
+  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$GEMINI_DIR/templates/.agentic/$tmpl_name"
+done
 echo "Rebuilt project-scaffolding.yml and templates/"
 
 echo "Gemini adapter build complete."

--- a/.gemini/project-scaffolding.yml
+++ b/.gemini/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/.gemini/templates/.agentic/learnings.md
+++ b/.gemini/templates/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->

--- a/.opencode/skills/agentic-engineering/project-scaffolding.yml
+++ b/.opencode/skills/agentic-engineering/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/content/project-scaffolding.yml
+++ b/content/project-scaffolding.yml
@@ -2,6 +2,8 @@
 #          patterns and seed files that every agentic-engineering project should have.
 #          Consumed by bin/agentic-migrate (apply/check/diff subcommands) and surfaced
 #          at preflight Step 6 to auto-apply drift.
+#          v2: adds !.agentic/learnings.md negation + learnings.md seed so fix-patterns
+#              are committed and shared across operators by default.
 # Public API: read by bin/agentic-migrate; version field (scaffolding_version) compared
 #             against <project>/.agentic/config.json scaffolding_version stamp.
 # Upstream: none (this is the canonical source)
@@ -10,7 +12,7 @@
 # Failure modes: if malformed or missing, agentic-migrate exits 2 and skips migration;
 #                preflight swallows the error silently and proceeds with methodology active.
 
-scaffolding_version: 1
+scaffolding_version: 2
 gitignore:
   - pattern: ".agentic/*"
     purpose: "umbrella ignore"
@@ -22,8 +24,13 @@ gitignore:
     purpose: "committed: Stage 1 telemetry"
   - pattern: "!.agentic/session-log/**"
     purpose: "committed: Stage 1 telemetry contents"
+  - pattern: "!.agentic/learnings.md"
+    purpose: "committed: per-ticket fix-pattern learnings shared across operators"
 files:
   - path: ".agentic/config.json"
     seed: "templates/.agentic/config.json"
     purpose: "project methodology toggles"
+  - path: ".agentic/learnings.md"
+    seed: "templates/.agentic/learnings.md"
+    purpose: "per-ticket fix-pattern learnings - header-only stub; entries appended by agents"
 markers: []   # parsed only by /migrate-project --include-destructive; preflight apply IGNORES this key

--- a/content/templates/.agentic/learnings.md
+++ b/content/templates/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->


### PR DESCRIPTION
Part of knowledge-capture consolidation, Units 2+9 (D3 REVISED - additive negation, NO gitignore_remove).

- New template `content/templates/.agentic/learnings.md` (header-only stub).
- `project-scaffolding.yml`: bump scaffolding_version 1->2; add `!.agentic/learnings.md` negation (wins by git last-match-wins over `.agentic/*`); add files: seed entry.
- 4 hardlink-adapter build scripts updated to cover learnings.md; symlink adapters auto-pick-up.
- Existing projects self-heal on next activation via the existing safe additive apply path - no binary changes, no silent line removal.

Verified: `agentic-migrate check` detects drift (v0<v2); manifest parses; no gitignore_remove key; all 8 adapters build.