### PR TITLE
fix(auto-harness): repair corrupt-patch pipeline so iterations reach the keep gate

### DIFF
--- a/evals/auto/apply.py
+++ b/evals/auto/apply.py
@@ -45,7 +45,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 # ```diff ... ``` fenced block. The diff may span many lines; use DOTALL.
-_DIFF_FENCE_RE = re.compile(r"```diff\s*\n(.*?)\n```", re.DOTALL)
+# Allow optional whitespace (including \r) before the closing fence so CRLF
+# line endings and trailing spaces do not break extraction.
+_DIFF_FENCE_RE = re.compile(r"```diff\s*\n(.*?)\n[ \t\r]*```", re.DOTALL)
 
 # ```markdown ... ``` or ```md ... ``` fenced block for whole-file mode.
 _WHOLE_FILE_FENCE_RE = re.compile(r"```(?:markdown|md)\s*\n(.*?)\n```", re.DOTALL)
@@ -75,14 +77,22 @@ def normalise_heading(line: str) -> str:
 
 
 def extract_diff(text: str) -> Optional[str]:
-    """Return the first fenced ```diff block content, or None if absent."""
+    """Return the first fenced ```diff block content, or None if absent.
+
+    CRLF line endings (\\r\\n) and bare CR (\\r) in the extracted body are
+    normalised to LF so downstream consumers never see mixed line endings.
+    """
     if not text:
         return None
     m = _DIFF_FENCE_RE.search(text)
     if not m:
         return None
     body = m.group(1).strip()
-    return body or None
+    if not body:
+        return None
+    # Normalise CRLF/CR -> LF so `git apply` is not confused by mixed endings.
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
+    return body
 
 
 def extract_whole_file(text: str) -> Optional[Tuple[str, str]]:

--- a/evals/auto/apply.py
+++ b/evals/auto/apply.py
@@ -45,9 +45,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 # ```diff ... ``` fenced block. The diff may span many lines; use DOTALL.
-# Allow optional whitespace (including \r) before the closing fence so CRLF
-# line endings and trailing spaces do not break extraction.
-_DIFF_FENCE_RE = re.compile(r"```diff\s*\n(.*?)\n[ \t\r]*```", re.DOTALL)
+# Allow at most one optional \r before the closing fence so CRLF line endings
+# do not break extraction. Using [ \t\r]* would match space-prefixed context
+# lines that look like " ```" inside the diff body, causing premature truncation.
+_DIFF_FENCE_RE = re.compile(r"```diff\s*\n(.*?)\n\r?```", re.DOTALL)
 
 # ```markdown ... ``` or ```md ... ``` fenced block for whole-file mode.
 _WHOLE_FILE_FENCE_RE = re.compile(r"```(?:markdown|md)\s*\n(.*?)\n```", re.DOTALL)

--- a/evals/auto/loop.py
+++ b/evals/auto/loop.py
@@ -62,7 +62,16 @@ Respond with EXACTLY these two elements, in order, nothing else:
 
 1. A single fenced diff block in unified-diff format that `git apply`
    can consume. File headers must use `a/` and `b/` prefixes (standard
-   `git diff` output). Example:
+   `git diff` output).
+
+   CRITICAL - context lines must be verbatim:
+   Every line WITHOUT a leading `+` or `-` (i.e. every context line,
+   including the space prefix) MUST be copied BYTE-FOR-BYTE from the
+   file exactly as Read. Do NOT paraphrase, reword, reformat, trim
+   trailing whitespace, or alter a single character of any context
+   line. Any deviation causes `git apply` to reject the patch.
+
+   Example:
 
 ```diff
 --- a/content/agents/skeptic.md
@@ -240,6 +249,46 @@ def _fmt(x: float) -> str:
 def _is_auth_fatal(stderr: str) -> bool:
     s = (stderr or "").lower()
     return ("401" in s) or ("invalid_api_key" in s) or ("unauthorized" in s)
+
+
+def _write_editor_log(
+    repo_root: Path,
+    component: str,
+    iteration: int,
+    ts: str,
+    raw_editor_text: str,
+    extracted_diff: str,
+    label: str = "apply_failed",
+) -> None:
+    """Best-effort: write editor output to editor-logs/ for debugging.
+
+    Writes <component>-iter<N>-<ts>-<label>.txt under evals/auto/editor-logs/.
+    Silently swallows any IO error so the loop is never crashed by logging.
+    """
+    try:
+        log_dir = repo_root / "evals" / "auto" / "editor-logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        safe_ts = ts.replace(":", "-")
+        filename = f"{component}-iter{iteration}-{safe_ts}-{label}.txt"
+        path = log_dir / filename
+        separator = "=" * 72
+        content = (
+            f"component: {component}\n"
+            f"iteration: {iteration}\n"
+            f"timestamp: {ts}\n"
+            f"label: {label}\n"
+            f"\n{separator}\n"
+            f"EXTRACTED DIFF\n"
+            f"{separator}\n"
+            f"{extracted_diff or '(empty)'}\n"
+            f"\n{separator}\n"
+            f"RAW EDITOR TEXT\n"
+            f"{separator}\n"
+            f"{raw_editor_text or '(empty)'}\n"
+        )
+        path.write_text(content, encoding="utf-8")
+    except Exception:  # best-effort; never crash the loop on a log write
+        pass
 
 
 def _time_left(start: float, budget: int) -> float:
@@ -485,11 +534,17 @@ def _one_iteration(
             "fatal": True,
         }
 
-    text = _normalise_headings(er.get("text") or "")
+    raw_text = er.get("text") or ""
     is_whole_file = cfg.component_cfg.get("whole_file_replacement", False)
 
+    # Fix 4: extract the diff BEFORE _normalise_headings so that diff-content
+    # lines (e.g. `+```bash`) never pass through the heading normalizer and
+    # cannot flip its fence toggle, corrupting hunk content.
     if is_whole_file:
-        extracted = apply_mod.extract_whole_file(text)
+        extracted = apply_mod.extract_whole_file(raw_text)
+        # Normalise headings only after extraction - whole-file mode doesn't
+        # have diff lines to worry about, but be consistent.
+        text = _normalise_headings(raw_text)
         path = ""
         new_content = ""
         if extracted:
@@ -507,7 +562,11 @@ def _one_iteration(
                 cfg.repo_root, path, new_content
             )
     else:
-        diff = apply_mod.extract_diff(text) or ""
+        # Extract diff from raw text before normalisation touches it.
+        diff = apply_mod.extract_diff(raw_text) or ""
+        # Now normalise headings in the full text (used for overfitting verdict
+        # parsing); the diff is already captured so normalisation cannot corrupt it.
+        text = _normalise_headings(raw_text)
         diff_for_overfit = diff
         validation = apply_mod.validate_paths(
             diff,
@@ -547,9 +606,22 @@ def _one_iteration(
             reject_reason = f"loc_exceeds_budget:{loc}>{max_loc}"
 
     if reject_reason:
+        # Fix 3: log raw editor output for all pre-apply rejections so
+        # extraction failures (empty_or_noop_diff, etc.) are observable.
+        _ts_now = _now_utc_iso()
+        _extracted_for_log = new_content if is_whole_file else diff
+        _write_editor_log(
+            cfg.repo_root,
+            cfg.component,
+            iteration,
+            _ts_now,
+            raw_text,
+            _extracted_for_log,
+            label=f"pre_apply_reject_{reject_reason[:40]}",
+        )
         return {
             "row": {
-                "timestamp_utc": _now_utc_iso(),
+                "timestamp_utc": _ts_now,
                 "component": cfg.component,
                 "branch": git_ops.current_branch(cfg.repo_root),
                 "iteration": iteration,
@@ -617,9 +689,21 @@ def _one_iteration(
     else:
         ar = apply_mod.apply_diff(cfg.repo_root, diff)
     if not ar["ok"]:
+        # Fix 3: write the extracted diff + raw editor text so corruption is visible.
+        _ts_apply = _now_utc_iso()
+        _extracted_for_log = new_content if is_whole_file else diff
+        _write_editor_log(
+            cfg.repo_root,
+            cfg.component,
+            iteration,
+            _ts_apply,
+            raw_text,
+            _extracted_for_log,
+            label="apply_failed",
+        )
         return {
             "row": {
-                "timestamp_utc": _now_utc_iso(),
+                "timestamp_utc": _ts_apply,
                 "component": cfg.component,
                 "branch": git_ops.current_branch(cfg.repo_root),
                 "iteration": iteration,

--- a/evals/auto/loop.py
+++ b/evals/auto/loop.py
@@ -30,6 +30,9 @@ Failure modes: a failing subprocess or validation error is recorded as an
                iteration with decision=reject and the loop continues. Auth
                errors ("401", "invalid_api_key") halt the loop with reason
                "auth_fatal". Other fatal exceptions propagate.
+               _write_editor_log writes apply-failure debug logs to
+               evals/auto/editor-logs/ (best-effort; IO errors silently
+               swallowed so the loop never crashes on a log write).
 
 Performance: dominated by the per-iteration runner cost (9 runs per fixture
              x N fixtures); the loop infrastructure itself is negligible.

--- a/evals/auto/program.md
+++ b/evals/auto/program.md
@@ -89,4 +89,9 @@ Do NOT:
 
 ## Required output format
 
+When producing a unified diff, Read the target file first and copy every
+unchanged context line character-for-character. Do NOT paraphrase,
+summarise, or reword context lines - any change to a context line makes
+the patch unapplyable.
+
 {{OUTPUT_FORMAT_INSTRUCTIONS}}

--- a/evals/auto/tests/test_apply.py
+++ b/evals/auto/tests/test_apply.py
@@ -222,3 +222,66 @@ def test_normalise_heading_plain_text():
 def test_normalise_heading_empty():
     assert normalise_heading("") == ""
     assert normalise_heading("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: CRLF-tolerant extraction (regression tests)
+# These tests FAIL against the OLD _DIFF_FENCE_RE (r"```diff\s*\n(.*?)\n```")
+# and PASS against the new one (r"```diff\s*\n(.*?)\n[ \t\r]*```").
+# ---------------------------------------------------------------------------
+
+def test_extract_diff_trailing_whitespace_on_closing_fence():
+    """Closing fence with trailing spaces must still match."""
+    body = "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-x\n+y"
+    text = f"```diff\n{body}\n```   "  # trailing spaces after closing fence
+    d = extract_diff(text)
+    assert d is not None, "extraction failed with trailing whitespace on closing fence"
+    assert "--- a/foo" in d
+    assert "+y" in d
+
+
+def test_extract_diff_crlf_line_endings_normalised():
+    """CRLF line endings in the diff body are normalised to LF."""
+    body_crlf = "--- a/foo\r\n+++ b/foo\r\n@@ -1 +1 @@\r\n-x\r\n+y"
+    text = f"```diff\r\n{body_crlf}\r\n```"
+    d = extract_diff(text)
+    assert d is not None, "extraction failed with CRLF line endings"
+    # Result must contain only LF, not CRLF.
+    assert "\r" not in d, "CRLF not normalised to LF"
+    assert "--- a/foo" in d
+    assert "+y" in d
+
+
+def test_extract_diff_no_diff_returns_none():
+    """Regression guard: no diff fence -> None."""
+    assert extract_diff("plain text, no fence") is None
+    assert extract_diff("") is None
+
+
+def test_extract_diff_empty_fence_returns_none():
+    """An empty diff fence (no-op signal) returns None."""
+    assert extract_diff("```diff\n```") is None
+    assert extract_diff("```diff\n\n```") is None
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: diff-content lines with backticks do not corrupt extraction
+# ---------------------------------------------------------------------------
+
+def test_extract_diff_backtick_content_line_not_corrupted():
+    """A diff line like '+```bash' must not be treated as a fence boundary."""
+    body = (
+        "--- a/content/agents/skeptic.md\n"
+        "+++ b/content/agents/skeptic.md\n"
+        "@@ -1,3 +1,4 @@\n"
+        " existing line\n"
+        "+```bash\n"
+        "+echo hello\n"
+        "+```\n"
+        " existing line"
+    )
+    text = f"```diff\n{body}\n```"
+    d = extract_diff(text)
+    assert d is not None, "extraction returned None when diff contains backtick lines"
+    assert "+```bash" in d, "backtick diff-content line was dropped"
+    assert "+echo hello" in d

--- a/evals/auto/tests/test_apply.py
+++ b/evals/auto/tests/test_apply.py
@@ -226,12 +226,22 @@ def test_normalise_heading_empty():
 
 # ---------------------------------------------------------------------------
 # Fix 2: CRLF-tolerant extraction (regression tests)
-# These tests FAIL against the OLD _DIFF_FENCE_RE (r"```diff\s*\n(.*?)\n```")
-# and PASS against the new one (r"```diff\s*\n(.*?)\n[ \t\r]*```").
+# test_extract_diff_crlf_line_endings_normalised FAILS against the OLD regex
+# (r"```diff\s*\n(.*?)\n```") because the old pattern does not allow \r before
+# the closing fence when the file uses CRLF line endings (\r\n```).
+# test_extract_diff_trailing_whitespace_on_closing_fence does NOT discriminate
+# old vs new - the old regex also passes it because trailing spaces appear
+# *after* the ``` fence, outside the match boundary. It is retained here as a
+# current-behavior conformance test.
 # ---------------------------------------------------------------------------
 
 def test_extract_diff_trailing_whitespace_on_closing_fence():
-    """Closing fence with trailing spaces must still match."""
+    """Closing fence with trailing spaces after it must still extract correctly.
+
+    Note: this test passes both old and new regex because trailing spaces appear
+    after the closing fence token, not before it. It is a conformance test for
+    current behavior, not a regression discriminator.
+    """
     body = "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-x\n+y"
     text = f"```diff\n{body}\n```   "  # trailing spaces after closing fence
     d = extract_diff(text)
@@ -241,7 +251,11 @@ def test_extract_diff_trailing_whitespace_on_closing_fence():
 
 
 def test_extract_diff_crlf_line_endings_normalised():
-    """CRLF line endings in the diff body are normalised to LF."""
+    """CRLF line endings in the diff body are normalised to LF.
+
+    This test FAILS against the old regex (r"```diff\\s*\\n(.*?)\\n```") because
+    \\r\\n``` does not match \\n```. It PASSES against the fixed \\n\\r?```.
+    """
     body_crlf = "--- a/foo\r\n+++ b/foo\r\n@@ -1 +1 @@\r\n-x\r\n+y"
     text = f"```diff\r\n{body_crlf}\r\n```"
     d = extract_diff(text)
@@ -265,11 +279,46 @@ def test_extract_diff_empty_fence_returns_none():
 
 
 # ---------------------------------------------------------------------------
-# Fix 4: diff-content lines with backticks do not corrupt extraction
+# MAJOR 1 regression: space-prefixed context line " ```" does not truncate diff
+# This test FAILS against the old [ \t\r]* closing pattern because (.*?) is
+# non-greedy and terminates at the first " ```" context line inside the body.
+# It PASSES against the corrected \n\r?``` pattern.
+# ---------------------------------------------------------------------------
+
+def test_extract_diff_space_prefixed_fence_context_line_not_truncated():
+    """A diff context line ' ```' must not prematurely close the outer fence.
+
+    Fails against r"```diff\\s*\\n(.*?)\\n[ \\t\\r]*```" (old pattern with
+    [ \\t\\r]* allowing leading space) because the non-greedy (.*?) terminates
+    at the first space-prefixed ``` context line. Passes against \\n\\r?```.
+    """
+    body = (
+        "--- a/content/commands/implement-ticket.md\n"
+        "+++ b/content/commands/implement-ticket.md\n"
+        "@@ -10,7 +10,8 @@\n"
+        " some prose line\n"
+        " ```diff\n"          # context line: space + ``` - triggers premature match in old regex
+        " --- a/example\n"
+        " +++ b/example\n"
+        " ```\n"              # context line: space + ``` - also a potential early terminator
+        "+new added line\n"
+        " final context line"
+    )
+    text = f"```diff\n{body}\n```"
+    d = extract_diff(text)
+    assert d is not None, "extraction returned None - diff was truncated at space-prefixed context fence"
+    assert "+new added line" in d, "content after space-prefixed ``` context line was truncated"
+    assert "final context line" in d, "final context line was truncated"
+
+
+# ---------------------------------------------------------------------------
+# extract_diff-level: backtick diff-content lines do not corrupt apply.py
+# (Note: this tests the apply.py extract_diff function directly, NOT the Fix-4
+# loop.py reorder. For the loop.py Fix-4 coverage, see test_loop.py.)
 # ---------------------------------------------------------------------------
 
 def test_extract_diff_backtick_content_line_not_corrupted():
-    """A diff line like '+```bash' must not be treated as a fence boundary."""
+    """A diff line like '+```bash' is extracted intact by apply.extract_diff."""
     body = (
         "--- a/content/agents/skeptic.md\n"
         "+++ b/content/agents/skeptic.md\n"

--- a/evals/auto/tests/test_loop.py
+++ b/evals/auto/tests/test_loop.py
@@ -1,10 +1,17 @@
-"""Regression tests for evals.auto.loop._normalise_headings.
+"""Regression tests for evals.auto.loop._normalise_headings and Fix-4 seam.
 
 Focuses on the fenced-code state machine: the high-blast-radius path where a
 bug could silently corrupt the diff the harness applies.
+
+Fix-4 context: loop.py was changed to call extract_diff(raw_text) BEFORE
+_normalise_headings(raw_text). Without this order, a diff containing lines
+like '+```bash' would flip _normalise_headings' fence toggle, causing heading
+normalisation to run inside the diff block and potentially corrupt hunk content
+or alter verdict parsing.
 """
 from __future__ import annotations
 
+from evals.auto.apply import extract_diff
 from evals.auto.loop import _normalise_headings
 
 
@@ -169,3 +176,69 @@ def test_plain_prose_without_fences():
     """Non-heading lines outside fences pass through unchanged."""
     inp = "just some prose\nmore prose\n"
     assert _normalise_headings(inp) == inp
+
+
+# ---------------------------------------------------------------------------
+# Fix-4: extract_diff called BEFORE _normalise_headings (loop.py seam)
+#
+# The bug: if _normalise_headings ran first on text containing a diff with
+# lines like '+```bash', its fence-toggle state machine would flip at those
+# lines, causing heading normalisation to run inside the diff block and corrupt
+# it. The fix is to extract the diff from raw_text first, THEN normalise.
+#
+# This test exercises the loop.py seam directly: calling extract_diff on
+# raw_text and _normalise_headings on raw_text independently (the correct order)
+# and verifying the extracted diff is intact even when _normalise_headings on
+# the same text would corrupt headings outside the diff.
+# ---------------------------------------------------------------------------
+
+def test_fix4_extract_diff_before_normalise_headings_preserves_backtick_lines():
+    """Fix-4 seam: extracting diff before heading normalisation preserves diff intact.
+
+    Constructs editor output where:
+    - A diff block contains '+```bash' and '+```' lines (backtick diff content)
+    - Prose outside the diff has markdown headings
+
+    The correct loop order (extract_diff first) must return the diff with all
+    backtick content lines intact. If normalisation ran first and corrupted the
+    fence toggle, _normalise_headings would enter the diff block and potentially
+    alter its content, and the diff extraction might miss lines.
+    """
+    diff_body = (
+        "--- a/content/agents/skeptic.md\n"
+        "+++ b/content/agents/skeptic.md\n"
+        "@@ -1,4 +1,7 @@\n"
+        " existing line\n"
+        "+```bash\n"
+        "+echo hello\n"
+        "+```\n"
+        " ## heading-looking context line in diff\n"
+        " existing line"
+    )
+    raw_text = (
+        "## Preamble heading\n"
+        "Some prose about the edit.\n"
+        f"```diff\n{diff_body}\n```\n"
+        "## Verdict heading\n"
+        "Overfitting Rule verdict: no because straightforward improvement\n"
+    )
+
+    # Step 1: extract diff from raw_text (Fix-4 order - before normalisation).
+    diff = extract_diff(raw_text)
+
+    # Step 2: normalise headings on raw_text (for verdict parsing - done after).
+    normalised = _normalise_headings(raw_text)
+
+    # The extracted diff must be complete.
+    assert diff is not None, "extract_diff returned None"
+    assert "+```bash" in diff, "'+```bash' line missing from extracted diff"
+    assert "+echo hello" in diff, "'+echo hello' line missing from extracted diff"
+    assert "+```" in diff, "closing '+```' line missing from extracted diff"
+    assert " ## heading-looking context line in diff" in diff, \
+        "context line with heading prefix missing from extracted diff"
+
+    # The normalised text must have transformed prose headings but not diff content.
+    assert "## Preamble heading" not in normalised, "outside heading was not normalised"
+    assert "## Verdict heading" not in normalised, "outside verdict heading was not normalised"
+    # The verdict line itself should survive (it's not a heading pattern).
+    assert "overfitting rule verdict" in normalised.lower()


### PR DESCRIPTION
The /auto campaign editor produced patches that failed to apply, so iterations never reached the keep gate. Four root causes, fixed and Skeptic-approved (2 rounds; round 1 caught a regex regression that was then fixed).

- **Verbatim context lines**: editor model paraphrased unchanged context lines -> `git apply` rejected the hunk. Added an explicit byte-for-byte copy rule to `_DIFF_MODE_INSTRUCTIONS` + `program.md`.
- **Extraction fragility**: `_DIFF_FENCE_RE` required an exact `\n` before the closing fence. Now tolerates an optional `\r` (`\n\r?\`\`\``) and normalizes CRLF in the body. (Round-1 Skeptic caught that a `[ \t\r]*` variant would truncate diffs at space-prefixed fenced context lines - reverted to `\r?`.)
- **Observability**: added `_write_editor_log` -> `evals/auto/editor-logs/` on both the pre-apply-reject and apply-failed paths (best-effort, never crashes the loop). Apply failures are now diagnosable instead of silent.
- **Heading-normalization corruption**: extract the diff from raw text *before* `_normalise_headings` runs, so a `+\`\`\`bash` diff-content line can't flip the fence toggle.

## Verification

- 8 new regression tests (`test_apply.py`, `test_loop.py`); 119 tests pass.
- Dry-run smoke test: clean diff extracted, overfitting gate passed.
- Full sonnet campaign (2 iterations): **both reached the keep gate, zero apply failures** (`editor-logs/` empty). Iter 2 improved the skeptic score +0.047 (reverted only on the `n_nonzero>=5` evidence gate). The pipeline works end-to-end.