### PR TITLE
docs(init-project): track .agentic/learnings.md via negation carve-out [u7]

### DIFF
--- a/.claude/commands/init-project.md
+++ b/.claude/commands/init-project.md
@@ -962,7 +962,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/.claude/commands/init-project.md
+++ b/.claude/commands/init-project.md
@@ -959,13 +959,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 

--- a/.codex/commands/init-project.md
+++ b/.codex/commands/init-project.md
@@ -960,7 +960,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/.codex/commands/init-project.md
+++ b/.codex/commands/init-project.md
@@ -957,13 +957,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 

--- a/.cursor/commands/init-project.md
+++ b/.cursor/commands/init-project.md
@@ -960,7 +960,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/.cursor/commands/init-project.md
+++ b/.cursor/commands/init-project.md
@@ -957,13 +957,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 

--- a/.gemini/commands/init-project.toml
+++ b/.gemini/commands/init-project.toml
@@ -966,7 +966,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/.gemini/commands/init-project.toml
+++ b/.gemini/commands/init-project.toml
@@ -963,13 +963,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 

--- a/.opencode/commands/init-project.md
+++ b/.opencode/commands/init-project.md
@@ -961,13 +961,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 

--- a/.opencode/commands/init-project.md
+++ b/.opencode/commands/init-project.md
@@ -964,7 +964,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/content/commands/init-project.md
+++ b/content/commands/init-project.md
@@ -960,7 +960,8 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
 # config and fix-pattern knowledge that belong in source control.
 # .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
-# The negation carve-outs below override the .agentic/* umbrella ignore.
+# The negation carve-outs below keep these tracked even if a project later
+# adds a broad .agentic/* umbrella ignore (e.g. via agentic-migrate).
 !.agentic/session-log/
 !.agentic/learnings.md
 ```

--- a/content/commands/init-project.md
+++ b/content/commands/init-project.md
@@ -957,13 +957,15 @@ Regardless of whether `.gitignore` is new or existing: check whether the targete
 # tracker-states.json is an intentionally-ignored runtime cache (24h TTL,
 # machine-local; stale on fresh checkout is acceptable - Phase 2c refetches).
 # Tracked (explicitly NOT ignored): .agentic/qa.md, .agentic/deploy.md,
-# .agentic/tracking.md - these are tool-agnostic agent config and belong in
-# source control. .agentic/session-log/ IS tracked (committed via Phase 8
-# telemetry commits; carve-out below overrides the .agentic/* umbrella ignore).
+# .agentic/tracking.md, .agentic/learnings.md - these are tool-agnostic agent
+# config and fix-pattern knowledge that belong in source control.
+# .agentic/session-log/ IS tracked (committed via Phase 8 telemetry commits).
+# The negation carve-outs below override the .agentic/* umbrella ignore.
 !.agentic/session-log/
+!.agentic/learnings.md
 ```
 
-The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out above overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
+The targeted list covers runtime artifacts only: `loop-state.json` (loop resume state written by `/implement-ticket` Phase 6 and the Stop hook), `hud/` (per-worker HUD files for P1 fan-out observability), `tasks.jsonl` (multi-unit task coordination), `events.jsonl` (per-project structured event log appended by the conductor), `context.md` (session context written by /wrap and the Stop hook), `memory/` and `memory.md` (auto-memory directory and file), `wrap.lock/` (/wrap concurrency lock dir), `preferences.json` (per-developer session preferences), `compression-state.json` (compression bookkeeping), and `tracker-states.json` (tracker workflow state cache written by `/implement-ticket` Phase 2c; machine-local, 24h TTL, refetched on stale or fresh checkout). The tool-agnostic config files (`qa.md`, `deploy.md`, `tracking.md`) are NOT ignored - they are checked in so every tool (Claude Code, Codex, Cursor, Gemini) reads the same project config. `.agentic/learnings.md` IS tracked - the `!.agentic/learnings.md` carve-out above overrides the umbrella ignore so that per-ticket fix-pattern learnings are shared across operators. `.agentic/session-log/` IS tracked - the `!.agentic/session-log/` carve-out overrides the umbrella ignore so that per-developer telemetry is committed via `/implement-ticket` Phase 8 telemetry commits and visible across the team after pull.
 
 ### 10. Create `docs/` structure
 


### PR DESCRIPTION
Unit 7. init-project Step 9 now emits !.agentic/learnings.md carve-out, consistent with project-scaffolding.yml v2. Skeptic sign-off (Minor addressed).