### PR TITLE
fix(gitignore): restore .agentic/learnings.md carve-out clobbered by #203 [u3b]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules/
 !.agentic/config.json
 !.agentic/qa-regressions.md
 !.agentic/session-log/
+!.agentic/learnings.md
 # session-log/: per-developer telemetry, committed so `agentic-cost team` works
 # across machines. Other .agentic/* runtime files stay local under the umbrella.
 .agentic/worktrees/


### PR DESCRIPTION
PR #201 (u3) added the `!.agentic/learnings.md` carve-out; PR #203 rewrote .gitignore and dropped it. This restores it additively (single line, no other change). learnings.md stays committed and consistent with project-scaffolding.yml v2.

Verified: `git check-ignore .agentic/learnings.md` exits 1 (not ignored); identity.yml/loop-state.json/tasks.jsonl/events.jsonl still ignored.