### PR TITLE
fix: re-track .agentic/learnings.md untracked by #203 [u3c]

### DIFF
--- a/.agentic/learnings.md
+++ b/.agentic/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Structured, repeatable fix-patterns and gotchas encountered across sessions.
+
+## Format
+
+Each entry:
+- **Context**: what we were doing
+- **Symptom**: what went wrong
+- **Fix**: the exact steps that resolved it
+- **Prevention**: how to avoid it next time
+
+## Entries
+
+<!-- Append new entries at the bottom. -->


### PR DESCRIPTION
Completes the learnings-committed goal. PR #203 ran git rm --cached on .agentic/learnings.md; PR #210 restored the negation; this re-adds the file (canonical seed-template stub) as tracked. Single file, +15 lines.