### PR TITLE
feat(stop-hook): capture-gap backstop [U6]

### DIFF
--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -8,7 +8,9 @@
  *          per-developer session telemetry via a three-branch identity gate:
  *          confirmed identity -> per-project log + global mirror; provisional
  *          identity or no identity -> pending buffer (~/.agentic/session-log/.pending/);
- *          no identity also appends a one-time nudge to context.md.
+ *          no identity also appends a one-time nudge to context.md. Runs a
+ *          capture-gap backstop that detects learning-worthy sessions with no
+ *          captured learnings and appends a nudge to context.md.
  *
  * Public API: run() — invoked immediately at module load via run() call at
  *             bottom of file. Not imported; executed as a CLI script by the
@@ -18,7 +20,9 @@
  *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId),
  *             writeSessionLogGlobal(identity, sessionId, data),
  *             writePendingBuffer(cwd, sessionId),
- *             appendIdentityNudgeToContextMd(repoRoot).
+ *             appendIdentityNudgeToContextMd(repoRoot),
+ *             detectCaptureGap(cwd, sessionId),
+ *             appendCaptureGapNoticeToContextMd(cwd, sessionId, residualOnly).
  *
  * Upstream deps: Node built-ins only (fs, path, os, child_process). No npm
  *                dependencies. Reads from stdin (fd 0). Reads/writes
@@ -28,9 +32,13 @@
  *                [cwd]/.agentic/session-log/<developer_id>.jsonl,
  *                ~/.agentic/session-log/<developer_id>.jsonl (global mirror),
  *                ~/.agentic/session-log/.pending/<session_uuid>.json (pending buffer),
- *                ~/.agentic/identity.yml (read-only, global), and
+ *                ~/.agentic/identity.yml (read-only, global),
  *                [cwd]/.agentic/identity.yml (read-only, project-local; takes precedence
- *                over global when confirmed, per 4-tier resolution in getIdentity(cwd)).
+ *                over global when confirmed, per 4-tier resolution in getIdentity(cwd)),
+ *                [cwd]/.agentic/events.jsonl (read-only for capture-gap backstop),
+ *                [cwd]/.agentic/learnings.md (read-only for capture-gap backstop),
+ *                [cwd]/.agentic/.capture-gap-last-sweep (pagination cursor; atomic
+ *                tmp+rename on write).
  *
  * Downstream consumers: Claude Code Stop hook (configured in
  *                        ~/.claude/settings.json or project .claude/settings.json).
@@ -42,7 +50,7 @@
  *                        globbed by agentic-cost (operator or team) - it is consumed
  *                        only by agentic-identity confirm/init via flushPendingBuffer.
  *
- * Failure modes: All failures are silent (process.exit(0)). Eight independent
+ * Failure modes: All failures are silent (process.exit(0)). Nine independent
  *                write paths: (1) context.md write is best-effort; any fs error
  *                is swallowed and the file may not be written. (2) loop-state.json
  *                write is also best-effort; any fs error is swallowed independently
@@ -66,14 +74,19 @@
  *                ~/.agentic/session-log/.pending/<uuid>.json; enforces cap-100
  *                (drops oldest by ts with one stderr notice); any fs error swallowed
  *                independently of all other paths.
- *                All eight paths are independent - a failure in one does not
+ *                (9) appendCaptureGapNoticeToContextMd appends to context.md; any
+ *                fs error is swallowed independently. The .capture-gap-last-sweep
+ *                cursor update is also best-effort and never blocks exit.
+ *                All nine paths are independent - a failure in one does not
  *                affect the others. The 10-minute implicit-interrupt heuristic
  *                handles missed loop-state writes. cwd values with path
  *                traversal components are rejected for the loop-state and
  *                batch-state writes (defence in depth).
  *
- * Performance: ~5-20 ms typical; one git status subprocess call (5 s timeout).
- *              Synchronous I/O throughout; runs as a short-lived CLI process.
+ * Performance: ~5-20 ms typical; one git status subprocess call (5 s timeout)
+ *              plus one git diff subprocess call for the capture-gap backstop
+ *              (5 s timeout, soft-fail). Synchronous I/O throughout; runs as a
+ *              short-lived CLI process.
  */
 
 /**
@@ -630,6 +643,280 @@ function writePendingBuffer(cwd, sessionId) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Capture-gap backstop helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Guardrail glob patterns used to detect test / lint / schema files added
+ * during the session. Matched against the basename of each changed path.
+ * @type {RegExp[]}
+ */
+const GUARDRAIL_PATTERNS = [
+  /test/i,
+  /spec/i,
+  /\.eslintrc/i,
+  /\.schema\./i,
+  /ruff\.toml/i,
+  /mypy\.ini/i,
+];
+
+/**
+ * Normalize a string into tokens for domain-proximity matching.
+ * Splits on '/', '.', '-', '_' and lowercases; filters tokens shorter than 4
+ * chars (too generic to carry domain signal).
+ *
+ * @param {string} str
+ * @returns {string[]}
+ */
+function _tokenize(str) {
+  return str.toLowerCase().split(/[\/.\-_]/).filter((t) => t.length >= 4);
+}
+
+/**
+ * Detect whether this session has learning-worthy events with no learnings
+ * captured. Pure function: reads files, runs one git subprocess, returns a
+ * result object. Never throws - all errors are absorbed and return
+ * { shouldNudge: false }.
+ *
+ * Three conditions must ALL hold for shouldNudge === true:
+ *   (a) At least one learning-worthy event this session (debugger/investigator
+ *       spawn_complete, skeptic spawn_complete with major/critical resolved, or
+ *       tool_failure_workaround). Events without session_uuid are DELIBERATELY
+ *       EXCLUDED (inverse of scanSessionAggregate which includes absent uuids
+ *       for back-compat). This exclusion prevents false nags from legacy event
+ *       lines whose session cannot be determined. Self-heals after one post-upgrade
+ *       session where emits carry session_uuid.
+ *   (b) No today-dated [LRN- or [KNW- entries in .agentic/learnings.md.
+ *   (c) No domain-proximate guardrail added this session (suppression). The
+ *       suppressor checks git diff --name-only origin/HEAD..HEAD (all session
+ *       commits since branch diverged from upstream - primary) falling back to
+ *       git diff --name-only HEAD~1 HEAD (single-commit fallback when no
+ *       upstream ref exists). If guardrails were added but none are domain-
+ *       proximate with the event domain tokens, residualOnly is set true and
+ *       the nudge still fires with residual-WHY wording.
+ *
+ * @param {string} cwd - Project root (absolute, already validated by run()).
+ * @param {string|null} sessionId - Stop payload session_id (harness uuid).
+ * @returns {{ shouldNudge: boolean, residualOnly: boolean }}
+ */
+function detectCaptureGap(cwd, sessionId) {
+  try {
+    if (!sessionId) return { shouldNudge: false, residualOnly: false };
+
+    // --- (a) Scan events.jsonl for learning-worthy events this session ---
+    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+    // Pagination: read only lines after the last sweep cursor.
+    let lastSweepTs = '';
+    try {
+      const cursorPath = path.join(cwd, '.agentic', '.capture-gap-last-sweep');
+      if (fs.existsSync(cursorPath)) {
+        lastSweepTs = fs.readFileSync(cursorPath, 'utf8').trim();
+      }
+    } catch (_) { /* silent */ }
+
+    let rawEvents = '';
+    try {
+      if (fs.existsSync(eventsPath)) {
+        rawEvents = fs.readFileSync(eventsPath, 'utf8');
+      }
+    } catch (_) { return { shouldNudge: false, residualOnly: false }; }
+
+    const eventLines = rawEvents.split('\n');
+    // On cold start (no cursor), cap to the last 100 lines.
+    const linesToScan = lastSweepTs
+      ? eventLines
+      : eventLines.slice(-100);
+
+    const LEARNING_AGENTS = new Set(['debugger', 'investigator']);
+    let hasLearningWorthyEvent = false;
+    const eventDomainTokens = new Set();
+
+    for (const line of linesToScan) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try { obj = JSON.parse(trimmed); } catch (_) { continue; }
+
+      const data = (obj && obj.data) || {};
+
+      // DELIBERATE: lines without data.session_uuid are EXCLUDED here.
+      // This is the inverse of scanSessionAggregate (which includes absent uuids
+      // for back-compat). The backstop must not nag on legacy event lines from
+      // prior sessions that lack session attribution - that would cause false
+      // positives on every session until the file rotates. scanSessionAggregate
+      // keeps absent=include for back-compat; only this backstop uses absent=exclude.
+      if (!data.session_uuid || data.session_uuid !== sessionId) continue;
+
+      // Pagination: skip lines at or before the last sweep timestamp.
+      if (lastSweepTs && obj.ts && obj.ts <= lastSweepTs) continue;
+
+      const ev = obj.event;
+      const agentName = (obj.agent || '').toLowerCase();
+
+      let worthy = false;
+      if (ev === 'tool_failure_workaround') {
+        worthy = true;
+      } else if (ev === 'spawn_complete') {
+        if (LEARNING_AGENTS.has(agentName)) {
+          worthy = true;
+        } else if (agentName === 'skeptic') {
+          const fc = data.findings_count || {};
+          if ((Number(fc.critical) || 0) > 0 || (Number(fc.major) || 0) > 0) {
+            if (data.signed_off) worthy = true;
+          }
+        }
+      }
+
+      if (worthy) {
+        hasLearningWorthyEvent = true;
+        // Collect domain tokens from domain_tag and tool references
+        for (const src of [data.domain_tag, data.tool]) {
+          if (typeof src === 'string' && src) {
+            for (const tok of _tokenize(src)) eventDomainTokens.add(tok);
+          }
+        }
+      }
+    }
+
+    if (!hasLearningWorthyEvent) return { shouldNudge: false, residualOnly: false };
+
+    // --- (b) Check .agentic/learnings.md for today-dated entries ---
+    const todayStr = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    try {
+      const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
+      if (fs.existsSync(learningsPath)) {
+        const learningsRaw = fs.readFileSync(learningsPath, 'utf8');
+        // Match [LRN-YYYYMMDD-XXX] or [KNW-YYYYMMDD-XXX] with today's date, OR
+        // a "Discovered: YYYY-MM-DD" line dated today.
+        const dateCompact = todayStr.replace(/-/g, '');
+        const hasToday =
+          learningsRaw.includes(`[LRN-${dateCompact}`) ||
+          learningsRaw.includes(`[KNW-${dateCompact}`) ||
+          learningsRaw.includes(`Discovered: ${todayStr}`);
+        if (hasToday) return { shouldNudge: false, residualOnly: false };
+      }
+    } catch (_) { /* silent - absent learnings.md means no learning captured */ }
+
+    // --- (c) Guardrail suppression ---
+    // Collect names of guardrail files added this session via git diff.
+    // Primary: git diff --name-only origin/HEAD..HEAD  (all commits since branch diverged)
+    // Fallback: git diff --name-only HEAD~1 HEAD       (last commit only; used when no upstream)
+    let changedPaths = [];
+    try {
+      let diffOutput = '';
+      try {
+        diffOutput = execSync(
+          'git diff --name-only origin/HEAD..HEAD',
+          { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+        );
+      } catch (_primaryErr) {
+        // No upstream ref - fall back to last commit only.
+        try {
+          diffOutput = execSync(
+            'git diff --name-only HEAD~1 HEAD',
+            { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+          );
+        } catch (_) { /* no commits yet or non-git dir; diffOutput stays '' */ }
+      }
+      changedPaths = diffOutput.split('\n').map((p) => p.trim()).filter(Boolean);
+    } catch (_) { /* soft-fail: no suppression applied */ }
+
+    const addedGuardrailPaths = changedPaths.filter((p) => {
+      const base = path.basename(p);
+      if (GUARDRAIL_PATTERNS.some((re) => re.test(base))) return true;
+      // Also match directory segments: tests/, evals/, spec/
+      return /(?:^|\/)(?:tests|evals|spec)\//i.test(p + '/');
+    });
+
+    if (addedGuardrailPaths.length === 0) {
+      // No guardrails added - fire standard nudge.
+      return { shouldNudge: true, residualOnly: false };
+    }
+
+    // Check domain proximity: does any guardrail path share a >=4-char token
+    // with any event domain token?
+    let domainProximate = false;
+    if (eventDomainTokens.size > 0) {
+      for (const gp of addedGuardrailPaths) {
+        const gpTokens = _tokenize(gp);
+        if (gpTokens.some((t) => eventDomainTokens.has(t))) {
+          domainProximate = true;
+          break;
+        }
+      }
+    }
+
+    if (domainProximate) {
+      // Domain-proximate guardrail added - suppress nudge entirely.
+      return { shouldNudge: false, residualOnly: false };
+    }
+
+    // Guardrails added but none domain-proximate - fire with residual-WHY text.
+    return { shouldNudge: true, residualOnly: true };
+  } catch (_) {
+    // Top-level safety net: any unexpected error -> no nudge (never blocks exit).
+    return { shouldNudge: false, residualOnly: false };
+  }
+}
+
+/**
+ * Append a capture-gap nudge to .agentic/context.md. Sentinel-gated per session
+ * via .agentic/.capture-gap-last-sweep (ISO8601 UTC; absent = cold start). The
+ * cursor is updated atomically (tmp+rename) after a successful append so the same
+ * session does not nag twice. Silent failure on any fs error.
+ *
+ * When residualOnly === true the nudge text emphasises that a guardrail was added
+ * but is not domain-proximate, so only the residual WHY / dead-end reasoning needs
+ * capturing. When residualOnly === false the standard nudge fires.
+ *
+ * @param {string} cwd - Verified project root.
+ * @param {string|null} sessionId - Current session uuid (used only for logging context).
+ * @param {boolean} residualOnly - True when a guardrail was added but none were
+ *   domain-proximate with the learning-worthy event.
+ */
+function appendCaptureGapNoticeToContextMd(cwd, sessionId, residualOnly) {
+  try {
+    const contextPath = path.join(cwd, '.agentic', 'context.md');
+    const cursorPath = path.join(cwd, '.agentic', '.capture-gap-last-sweep');
+
+    let nudgeText;
+    if (residualOnly) {
+      nudgeText = [
+        '',
+        '---',
+        'CAPTURE-GAP: a related test or guardrail was added this session, but it is not',
+        'domain-proximate to the learning-worthy event (root cause / tool workaround).',
+        'Capture only the residual WHY and any dead-ends the test does not encode:',
+        'spawn learnings-agent or add an LRN/KNW entry to .agentic/learnings.md.',
+        '(If the guardrail fully captures it, ignore this.)',
+      ].join('\n') + '\n';
+    } else {
+      nudgeText = [
+        '',
+        '---',
+        'CAPTURE-GAP: this session resolved a root cause / worked around a tool failure',
+        'but recorded no learning. If there is a non-obvious WHY beyond what a test or',
+        'the diff already shows, capture it: spawn learnings-agent or add an LRN/KNW',
+        'entry to .agentic/learnings.md. (If the test you added fully captures it, ignore this.)',
+      ].join('\n') + '\n';
+    }
+
+    fs.appendFileSync(contextPath, nudgeText, 'utf8');
+
+    // Update pagination cursor atomically so the same session doesn't fire twice.
+    try {
+      const nowIso = new Date().toISOString();
+      const tmpCursor = cursorPath + '.tmp';
+      fs.writeFileSync(tmpCursor, nowIso, 'utf8');
+      fs.renameSync(tmpCursor, cursorPath);
+    } catch (_) { /* silent - cursor update failure is non-fatal */ }
+  } catch (_) {
+    // Silent failure - consistent with all other context.md append paths.
+  }
+}
+
 function run() {
   // --- 1. Read stdin ---
   let raw = '';
@@ -897,6 +1184,13 @@ ${toolsLine}
       } catch (_) {
         // Silent failure - never block session exit
       }
+      // Capture-gap backstop on wrap-coexistence exit path.
+      try {
+        const gap = detectCaptureGap(cwd, sessionId);
+        if (gap.shouldNudge) {
+          appendCaptureGapNoticeToContextMd(cwd, sessionId, gap.residualOnly);
+        }
+      } catch (_) { /* silent */ }
       removeLearningsAgentSession(cwd, sessionId);
       process.exit(0);
     }
@@ -973,6 +1267,16 @@ ${toolsLine}
 
   // --- 14. Remove learnings-agent session marker if owned by this session ---
   removeLearningsAgentSession(cwd, sessionId);
+
+  // --- 15. Capture-gap backstop (path 9 - independent of all other paths) ---
+  // Detects learning-worthy sessions with no captured learnings and appends a
+  // nudge to context.md. Silent failure; never blocks exit.
+  try {
+    const gap = detectCaptureGap(cwd, sessionId);
+    if (gap.shouldNudge) {
+      appendCaptureGapNoticeToContextMd(cwd, sessionId, gap.residualOnly);
+    }
+  } catch (_) { /* silent */ }
 
   process.exit(0);
 }

--- a/hooks/tests/test-capture-gap.js
+++ b/hooks/tests/test-capture-gap.js
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: stop-context.js capture-gap backstop.
+ *
+ * Tests detectCaptureGap() and appendCaptureGapNoticeToContextMd() by setting up
+ * temporary .agentic/ directories with controlled events.jsonl / learnings.md
+ * content and running the hook in-process via module exports.
+ *
+ * Test cases:
+ *   1. fires-on-debugger:              debugger spawn_complete with session_uuid -> shouldNudge true
+ *   2. fires-on-tool_failure_workaround: tool_failure_workaround event -> shouldNudge true
+ *   3. suppressed-by-domain-proximate-guardrail: matching guardrail path -> shouldNudge false
+ *   4. fires-despite-unrelated-guardrail (Major-1 regression): guardrail added but not domain-
+ *      proximate -> shouldNudge true, residualOnly true (residual-WHY text in nudge)
+ *   5. no-fire-when-learning-captured: today-dated [LRN- entry -> shouldNudge false
+ *   6. session-filter-excludes-foreign-uuid: event has different session_uuid -> shouldNudge false
+ *   7. cold-start-100-line-cap: >100 event lines, learning-worthy event in line 50 from end
+ *      (within cap) -> shouldNudge true; event beyond 100-line window -> shouldNudge false
+ *   8. silent-fail-on-malformed-line: events.jsonl contains malformed JSON lines -> no throw
+ *   9. residualOnly-text-differentiation: residualOnly=true -> nudge text contains residual wording
+ *  10. no-fire-when-no-session-uuid-on-event: absent session_uuid deliberately excluded (MAJOR regression)
+ *
+ * Run with: node hooks/tests/test-capture-gap.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Load the module under test. detectCaptureGap and appendCaptureGapNoticeToContextMd
+// are not exported by the script (it calls run() immediately), so we use a
+// custom loader that stubs out run() and exports the internal helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Load stop-context.js in a controlled way: require it in a temporary module
+ * scope that patches process.exit so run() doesn't terminate the test process,
+ * and exports the internal helper functions via a side-channel global.
+ *
+ * We load by wrapping the source with an IIFE that replaces process.exit and
+ * exposes the named functions via a global object before run() fires.
+ *
+ * Technique: read source, prepend a shim that registers the helpers on a
+ * global, append a post-run no-op, eval in a Module sandbox.
+ */
+const hookPath = path.resolve(__dirname, '..', 'stop-context.js');
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+// Shim: intercept run() and expose helpers. We do this by wrapping the source
+// in a function that overrides run before the bottom-of-file call fires.
+// The shim replaces the trailing `run();` call with a no-op so the hook
+// doesn't actually read stdin during test setup.
+const shimmedSource = hookSource
+  // Replace the final bare `run();` call so the hook doesn't try to read stdin.
+  .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
+  + `\n
+// Expose helpers for unit tests via a module-level export shim.
+// This block is appended by the test loader.
+if (typeof module !== 'undefined') {
+  module.exports = {
+    detectCaptureGap,
+    appendCaptureGapNoticeToContextMd,
+    _tokenize,
+  };
+}
+`;
+
+// Write shim to a temp file and require it.
+const tmpShimPath = path.join(os.tmpdir(), `stop-context-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+let helpers;
+try {
+  helpers = require(tmpShimPath);
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+const { detectCaptureGap, appendCaptureGapNoticeToContextMd, _tokenize } = helpers;
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual === expected) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`);
+    failed++;
+  }
+}
+
+/**
+ * Create a temporary .agentic/ directory tree and return its parent (the fake cwd).
+ * @returns {string} Absolute path to the fake project root.
+ */
+function makeTempProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+/**
+ * Build an events.jsonl line with a learning-worthy event.
+ * @param {string} sessionId
+ * @param {string} event
+ * @param {string} agent
+ * @param {object} [extra] - merged into data
+ * @returns {string}
+ */
+function makeEvent(sessionId, event, agent, extra = {}) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'test',
+    event,
+    agent: agent || null,
+    task_id: null,
+    data: Object.assign({ session_uuid: sessionId }, extra),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: fires-on-debugger
+// ---------------------------------------------------------------------------
+console.log('\nTest 1: fires-on-debugger');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-debugger-001';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === true, 'shouldNudge is true when debugger spawn_complete present');
+  assert(result.residualOnly === false, 'residualOnly is false (no guardrails added)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: fires-on-tool_failure_workaround
+// ---------------------------------------------------------------------------
+console.log('\nTest 2: fires-on-tool_failure_workaround');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-toolwk-002';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'tool_failure_workaround', null, {
+    domain_tag: 'git',
+    tool: 'git-push',
+    note: 'Used --force-with-lease instead of --force',
+  }) + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === true, 'shouldNudge is true on tool_failure_workaround');
+  assert(result.residualOnly === false, 'residualOnly false (no guardrails)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: suppressed-by-domain-proximate-guardrail
+// We cannot run an actual git repo in a temp dir easily, so we mock the git
+// diff output by monkey-patching execSync on the helpers module's closure.
+// Instead, we test via a real git repo fixture.
+// NOTE: This test verifies the suppression path by constructing a minimal real
+// git repo so detectCaptureGap can run git diff.
+// ---------------------------------------------------------------------------
+console.log('\nTest 3: suppressed-by-domain-proximate-guardrail');
+{
+  // Build a minimal git repo with one commit so git diff origin/HEAD..HEAD works.
+  // We use HEAD~1..HEAD (fallback path) since there's no upstream.
+  const cwd = makeTempProject();
+  const sessionId = 'session-guardrail-003';
+
+  try {
+    execSync('git init -b main', { cwd, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd, stdio: 'pipe' });
+    // Initial commit
+    fs.writeFileSync(path.join(cwd, 'README.md'), 'initial\n');
+    execSync('git add README.md', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd, stdio: 'pipe' });
+
+    // Add a domain-proximate test file in a second commit.
+    fs.mkdirSync(path.join(cwd, 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'tests', 'test-git-push.js'), '// test\n');
+    execSync('git add tests/test-git-push.js', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "add test"', { cwd, stdio: 'pipe' });
+
+    // Events: tool_failure_workaround with domain_tag=git
+    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+    fs.writeFileSync(eventsPath, makeEvent(sessionId, 'tool_failure_workaround', null, {
+      domain_tag: 'git',
+      tool: 'git-push',
+    }) + '\n', 'utf8');
+
+    // The guardrail path "tests/test-git-push.js" has tokens: ['test', 'push']
+    // (>=4 chars: 'test', 'push'). Domain tokens from 'git' and 'git-push': 'push'.
+    // 'push' appears in both -> domain-proximate -> suppress.
+    const result = detectCaptureGap(cwd, sessionId);
+    assert(result.shouldNudge === false, 'shouldNudge is false when domain-proximate guardrail present');
+  } catch (e) {
+    // git not available or setup failed - mark as skipped with a note
+    console.log(`  SKIP: git fixture setup failed (${e.message.split('\n')[0]})`);
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: fires-despite-unrelated-guardrail (residualOnly regression - Major-1)
+// A guardrail test file is added but has no domain-token overlap with the event.
+// Nudge MUST fire with residualOnly=true.
+// ---------------------------------------------------------------------------
+console.log('\nTest 4: fires-despite-unrelated-guardrail (residualOnly=true)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-residual-004';
+
+  try {
+    execSync('git init -b main', { cwd, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd, stdio: 'pipe' });
+    // Initial commit
+    fs.writeFileSync(path.join(cwd, 'README.md'), 'initial\n');
+    execSync('git add README.md', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd, stdio: 'pipe' });
+
+    // Add an UNRELATED test file (domain: payments, not git)
+    fs.mkdirSync(path.join(cwd, 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'tests', 'test-stripe-checkout.js'), '// test\n');
+    execSync('git add tests/test-stripe-checkout.js', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "add unrelated test"', { cwd, stdio: 'pipe' });
+
+    // Event domain: 'git', 'push'. Guardrail tokens: 'test', 'stripe', 'checkout'.
+    // No overlap -> residualOnly=true, shouldNudge=true.
+    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+    fs.writeFileSync(eventsPath, makeEvent(sessionId, 'tool_failure_workaround', null, {
+      domain_tag: 'git',
+      tool: 'git-push',
+    }) + '\n', 'utf8');
+
+    const result = detectCaptureGap(cwd, sessionId);
+    assert(result.shouldNudge === true, 'shouldNudge true despite unrelated guardrail (residual-WHY case)');
+    assert(result.residualOnly === true, 'residualOnly true when guardrail added but not domain-proximate');
+  } catch (e) {
+    console.log(`  SKIP: git fixture setup failed (${e.message.split('\n')[0]})`);
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: no-fire-when-learning-captured (today-dated [LRN- entry)
+// ---------------------------------------------------------------------------
+console.log('\nTest 5: no-fire-when-learning-captured');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-captured-005';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  const todayStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
+  fs.writeFileSync(learningsPath, `## [LRN-${todayStr}-001] Some learning\n**Discovered:** today\n`, 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false when today-dated LRN entry present');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: session-filter-excludes-foreign-uuid
+// ---------------------------------------------------------------------------
+console.log('\nTest 6: session-filter-excludes-foreign-uuid');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-current-006';
+  const foreignId = 'session-foreign-006';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  // Event has DIFFERENT session_uuid - should be excluded by session filter.
+  fs.writeFileSync(eventsPath, makeEvent(foreignId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false when only foreign-session events present');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7a: cold-start-100-line-cap - learning-worthy event within last 100 lines
+// ---------------------------------------------------------------------------
+console.log('\nTest 7a: cold-start-100-line-cap (within window)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-coldstart-007a';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  // Write 150 lines total: lines 1-100 are foreign, lines 101-150 include a match at line ~125.
+  const lines = [];
+  for (let i = 0; i < 100; i++) {
+    lines.push(makeEvent('foreign-session', 'spawn_complete', 'engineer'));
+  }
+  // Learning-worthy event at position 50 from end (within the 100-line cap).
+  for (let i = 0; i < 49; i++) {
+    lines.push(makeEvent('foreign-session', 'spawn_complete', 'engineer'));
+  }
+  lines.push(makeEvent(sessionId, 'spawn_complete', 'debugger')); // position 50 from end
+
+  fs.writeFileSync(eventsPath, lines.join('\n') + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === true, 'shouldNudge true when matching event within 100-line cold-start window');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7b: cold-start-100-line-cap - learning-worthy event BEYOND 100-line window
+// ---------------------------------------------------------------------------
+console.log('\nTest 7b: cold-start-100-line-cap (beyond window)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-coldstart-007b';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  // Write 150 lines: the matching event is at line 1 (beyond the 100-line tail window).
+  const lines = [];
+  lines.push(makeEvent(sessionId, 'spawn_complete', 'debugger')); // position 150 from end - outside window
+  for (let i = 0; i < 149; i++) {
+    lines.push(makeEvent('foreign-session', 'spawn_complete', 'engineer'));
+  }
+
+  fs.writeFileSync(eventsPath, lines.join('\n') + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false when matching event beyond 100-line cold-start window');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: silent-fail-on-malformed-line
+// ---------------------------------------------------------------------------
+console.log('\nTest 8: silent-fail-on-malformed-line');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-malformed-008';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  const malformedContent = [
+    '{bad json',
+    '',
+    'not json at all',
+    makeEvent(sessionId, 'spawn_complete', 'debugger'),
+    '{ "ts": "2024-01-01" incomplete',
+  ].join('\n') + '\n';
+  fs.writeFileSync(eventsPath, malformedContent, 'utf8');
+
+  let threw = false;
+  let result;
+  try {
+    result = detectCaptureGap(cwd, sessionId);
+  } catch (e) {
+    threw = true;
+  }
+  assert(!threw, 'detectCaptureGap does not throw on malformed events.jsonl lines');
+  // The valid event line should still be detected.
+  assert(result && result.shouldNudge === true, 'shouldNudge still true despite malformed lines');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: residualOnly text differentiation
+// appendCaptureGapNoticeToContextMd with residualOnly=true must produce different
+// text than residualOnly=false.
+// ---------------------------------------------------------------------------
+console.log('\nTest 9: residualOnly text differentiation');
+{
+  const cwd9a = makeTempProject();
+  const cwd9b = makeTempProject();
+  const sessionId = 'session-residual-009';
+
+  // Ensure context.md exists in both (function appends; parent dir must exist)
+  const ctx9a = path.join(cwd9a, '.agentic', 'context.md');
+  const ctx9b = path.join(cwd9b, '.agentic', 'context.md');
+  fs.writeFileSync(ctx9a, '# Session Context\n', 'utf8');
+  fs.writeFileSync(ctx9b, '# Session Context\n', 'utf8');
+
+  appendCaptureGapNoticeToContextMd(cwd9a, sessionId, false); // standard
+  appendCaptureGapNoticeToContextMd(cwd9b, sessionId, true);  // residual
+
+  const textStandard = fs.readFileSync(ctx9a, 'utf8');
+  const textResidual = fs.readFileSync(ctx9b, 'utf8');
+
+  assert(textStandard.includes('CAPTURE-GAP'), 'standard nudge includes CAPTURE-GAP marker');
+  assert(textResidual.includes('CAPTURE-GAP'), 'residual nudge includes CAPTURE-GAP marker');
+  assert(
+    textStandard !== textResidual,
+    'standard and residual nudge texts are different'
+  );
+  assert(
+    textResidual.includes('residual') || textResidual.includes('guardrail'),
+    'residual nudge text mentions residual/guardrail concept'
+  );
+  assert(
+    !textStandard.includes('residual'),
+    'standard nudge text does not mention residual'
+  );
+  cleanup(cwd9a);
+  cleanup(cwd9b);
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: no-fire-when-no-session-uuid-on-event (DELIBERATE exclusion regression)
+// Events lacking data.session_uuid must be excluded even when they are learning-worthy.
+// This verifies the DELIBERATE absent=exclude rule documented in detectCaptureGap.
+// ---------------------------------------------------------------------------
+console.log('\nTest 10: no-fire-when-no-session-uuid-on-event (absent=exclude)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-nouuid-010';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  // Manually craft an event WITHOUT session_uuid in data (legacy line).
+  const legacyEvent = JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'test',
+    event: 'spawn_complete',
+    agent: 'debugger',
+    task_id: null,
+    data: {}, // NO session_uuid field
+  });
+  fs.writeFileSync(eventsPath, legacyEvent + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false for events without session_uuid (deliberate exclusion)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Final unit of learnings-capture-system. Adds detectCaptureGap + capture-gap nudge to stop-context.js (both exit paths), session-filtered (absent=exclude), domain-proximity guardrail suppression, residualOnly-differentiated text, pagination, full soft-fail/never-block. 19 assertions. Skeptic: 0 Critical/Major (3 Minor coverage nits). hooks-only (no adapter/baseline).