### PR TITLE
docs(readme): clarify DinoStack brand vs agentic-engineering package naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 
 This system is designed to evolve. As AI tooling matures and teams discover better patterns, the rules, agents, and workflows change with them. Nothing here is final - treat it as a living system, not a finished product.
 
+> **DinoStack and "agentic-engineering".** DinoStack is the product. *agentic-engineering* is the methodology package it ships - the engine. You'll see `agentic-engineering` throughout the internals: the `~/.claude/agentic-engineering.json` config, the `agentic-engineering: opt-in` marker, the `.agentic/` directory, the `/agentic-*` commands. Those names are deliberate and stable - renaming them would break every existing install. DinoStack is the name on the box; agentic-engineering is the name in the wiring.
+
 **Live docs:** https://docs.dinostack.ai/
 
 ## Getting started
@@ -18,7 +20,7 @@ This clones the repo into `agentic-engineering/` inside your current directory, 
 
 > **Note:** the one-liner requires the repo to be public. Until then, collaborators can use the SSH path below - the script automatically falls back to SSH on clone failure.
 
-**Custom install location:** set `AE_DEST_DIR` before running. The default is `<current directory>/agentic-engineering`.
+**Custom install location:** set `AE_DEST_DIR` before running. The default is `<current directory>/agentic-engineering`. (The one-liner's default folder is `agentic-engineering/` - the package name; a plain `git clone` of the repo creates `DinoStack/` - the repo name instead. Either works; override the one-liner's location with `AE_DEST_DIR`.)
 
 ```bash
 # Install to ~/tools/agentic-engineering instead of the current directory

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This clones the repo into `agentic-engineering/` inside your current directory, 
 
 > **Note:** the one-liner requires the repo to be public. Until then, collaborators can use the SSH path below - the script automatically falls back to SSH on clone failure.
 
-**Custom install location:** set `AE_DEST_DIR` before running. The default is `<current directory>/agentic-engineering`. (The one-liner's default folder is `agentic-engineering/` - the package name; a plain `git clone` of the repo creates `DinoStack/` - the repo name instead. Either works; override the one-liner's location with `AE_DEST_DIR`.)
+**Custom install location:** set `AE_DEST_DIR` before running. The default is `<current directory>/agentic-engineering`.
+
+> **Folder naming:** the one-liner lands in `agentic-engineering/` (the package name); a plain `git clone` of the repo creates `DinoStack/` (the repo name). Either works - override the one-liner's location with `AE_DEST_DIR`.
 
 ```bash
 # Install to ~/tools/agentic-engineering instead of the current directory


### PR DESCRIPTION
Resolves the README reading as if every `agentic-engineering` reference were a missed rename. They are not - DinoStack is the brand, agentic-engineering is the methodology package. The split is intentional and permanent.

- Adds a naming note after the intro stating the brand-vs-package relationship, so the internal `agentic-engineering` references (config path, opt-in marker, `.agentic/`, `/agentic-*`) read as deliberate wiring.
- Splits a clone-folder note out of the `AE_DEST_DIR` sentence: the one-liner lands in `agentic-engineering/` (package name), a plain `git clone` gives `DinoStack/` (repo name) - no longer reads as a contradiction.

README-only. Every naming claim independently verified against the codebase by Skeptic (config path 511+ refs, marker string, `.agentic/` 548 refs, the 5 `/agentic-*` commands, `AE_DEST_DIR` default vs `DinoStack.git` clone output).