### PR TITLE
test(stop-hook): U6 coverage hardening + dead-param removal [U6b]

### DIFF
--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -22,7 +22,7 @@
  *             writePendingBuffer(cwd, sessionId),
  *             appendIdentityNudgeToContextMd(repoRoot),
  *             detectCaptureGap(cwd, sessionId),
- *             appendCaptureGapNoticeToContextMd(cwd, sessionId, residualOnly).
+ *             appendCaptureGapNoticeToContextMd(cwd, residualOnly).
  *
  * Upstream deps: Node built-ins only (fs, path, os, child_process). No npm
  *                dependencies. Reads from stdin (fd 0). Reads/writes
@@ -872,11 +872,10 @@ function detectCaptureGap(cwd, sessionId) {
  * capturing. When residualOnly === false the standard nudge fires.
  *
  * @param {string} cwd - Verified project root.
- * @param {string|null} sessionId - Current session uuid (used only for logging context).
  * @param {boolean} residualOnly - True when a guardrail was added but none were
  *   domain-proximate with the learning-worthy event.
  */
-function appendCaptureGapNoticeToContextMd(cwd, sessionId, residualOnly) {
+function appendCaptureGapNoticeToContextMd(cwd, residualOnly) {
   try {
     const contextPath = path.join(cwd, '.agentic', 'context.md');
     const cursorPath = path.join(cwd, '.agentic', '.capture-gap-last-sweep');
@@ -1188,7 +1187,7 @@ ${toolsLine}
       try {
         const gap = detectCaptureGap(cwd, sessionId);
         if (gap.shouldNudge) {
-          appendCaptureGapNoticeToContextMd(cwd, sessionId, gap.residualOnly);
+          appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
         }
       } catch (_) { /* silent */ }
       removeLearningsAgentSession(cwd, sessionId);

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -1273,7 +1273,7 @@ ${toolsLine}
   try {
     const gap = detectCaptureGap(cwd, sessionId);
     if (gap.shouldNudge) {
-      appendCaptureGapNoticeToContextMd(cwd, sessionId, gap.residualOnly);
+      appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
     }
   } catch (_) { /* silent */ }
 

--- a/hooks/tests/test-capture-gap.js
+++ b/hooks/tests/test-capture-gap.js
@@ -593,6 +593,54 @@ console.log('\nTest 13b: knw-tag-alone-suppresses (KNW tag without Discovered: l
 }
 
 // ---------------------------------------------------------------------------
+// Test 14: standard-exit-path-call-site-arity (regression for U6b Major)
+// Drives the REAL run() standard exit path as a subprocess and asserts the
+// capture-gap nudge uses the STANDARD (non-residual) wording when no guardrail
+// was added. This regression guards the call-site arity: a 3-arg call
+// `appendCaptureGapNoticeToContextMd(cwd, sessionId, gap.residualOnly)` passes
+// sessionId (truthy string) as residualOnly, forcing the "residual" wording even
+// when residualOnly should be false. The 2-arg `(cwd, gap.residualOnly)` is correct.
+// ---------------------------------------------------------------------------
+console.log('\nTest 14: standard-exit-path-call-site-arity (run() integration)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-runpath-014';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  // Learning-worthy debugger event, no guardrail added -> residualOnly must be false.
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  // Drive the real hook via subprocess so run()'s actual call site executes.
+  // Payload routes through the STANDARD exit path (no /wrap-authored context.md).
+  const payload = JSON.stringify({ cwd, session_id: sessionId, transcript: [] });
+  let ran = true;
+  try {
+    execSync(`node ${JSON.stringify(hookPath)}`, {
+      input: payload, cwd, timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    // The hook calls process.exit(0); execSync only throws on non-zero exit.
+    ran = false;
+    console.log(`  SKIP: hook subprocess failed (${(e.message || '').split('\n')[0]})`);
+  }
+
+  if (ran) {
+    const ctxPath = path.join(cwd, '.agentic', 'context.md');
+    let ctx = '';
+    try { ctx = fs.readFileSync(ctxPath, 'utf8'); } catch (_) { /* absent */ }
+    assert(ctx.includes('CAPTURE-GAP'), 'standard exit path appended a capture-gap nudge');
+    assert(
+      !ctx.includes('a related test or guardrail was added this session'),
+      'standard exit path uses NON-residual wording (residualOnly correctly false)'
+    );
+    assert(
+      ctx.includes('resolved a root cause / worked around a tool failure'),
+      'standard exit path nudge contains the standard (non-residual) text'
+    );
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);

--- a/hooks/tests/test-capture-gap.js
+++ b/hooks/tests/test-capture-gap.js
@@ -19,6 +19,12 @@
  *   8. silent-fail-on-malformed-line: events.jsonl contains malformed JSON lines -> no throw
  *   9. residualOnly-text-differentiation: residualOnly=true -> nudge text contains residual wording
  *  10. no-fire-when-no-session-uuid-on-event: absent session_uuid deliberately excluded (MAJOR regression)
+ *  11. skeptic-trigger-fires: skeptic spawn_complete with signed_off=true AND critical>0
+ *      -> shouldNudge true (code path existed but had no test)
+ *  12. skeptic-no-critical-major-no-fire: skeptic spawn_complete with signed_off=true but
+ *      zero critical/major -> shouldNudge false (only non-trivial skeptic reviews are learning-worthy)
+ *  13. knw-dated-suppression: today-dated [KNW-YYYYMMDD-XXX] entry with Discovered: line
+ *      -> shouldNudge false (KNW + Discovered: branch was untested; only LRN was exercised by test 5)
  *
  * Run with: node hooks/tests/test-capture-gap.js
  */
@@ -401,8 +407,8 @@ console.log('\nTest 9: residualOnly text differentiation');
   fs.writeFileSync(ctx9a, '# Session Context\n', 'utf8');
   fs.writeFileSync(ctx9b, '# Session Context\n', 'utf8');
 
-  appendCaptureGapNoticeToContextMd(cwd9a, sessionId, false); // standard
-  appendCaptureGapNoticeToContextMd(cwd9b, sessionId, true);  // residual
+  appendCaptureGapNoticeToContextMd(cwd9a, false); // standard
+  appendCaptureGapNoticeToContextMd(cwd9b, true);  // residual
 
   const textStandard = fs.readFileSync(ctx9a, 'utf8');
   const textResidual = fs.readFileSync(ctx9b, 'utf8');
@@ -449,6 +455,140 @@ console.log('\nTest 10: no-fire-when-no-session-uuid-on-event (absent=exclude)')
 
   const result = detectCaptureGap(cwd, sessionId);
   assert(result.shouldNudge === false, 'shouldNudge false for events without session_uuid (deliberate exclusion)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: skeptic-trigger-fires
+// A skeptic spawn_complete with signed_off=true AND critical > 0 must fire the nudge.
+// This path (agentName === 'skeptic' && findings_count.critical > 0 && signed_off)
+// existed in detectCaptureGap but had no test coverage until now.
+// ---------------------------------------------------------------------------
+console.log('\nTest 11: skeptic-trigger-fires (critical finding, signed_off)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-skeptic-011';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  // Positive: skeptic with signed_off=true and critical=1 -> learning-worthy
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'skeptic', {
+    signed_off: true,
+    findings_count: { critical: 1, major: 0, minor: 0 },
+  }) + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === true, 'shouldNudge true for skeptic with critical finding + signed_off');
+  assert(result.residualOnly === false, 'residualOnly false (no guardrails added)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11b: skeptic-trigger-fires (major finding only)
+// ---------------------------------------------------------------------------
+console.log('\nTest 11b: skeptic-trigger-fires (major finding, signed_off)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-skeptic-011b';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'skeptic', {
+    signed_off: true,
+    findings_count: { critical: 0, major: 2, minor: 1 },
+  }) + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === true, 'shouldNudge true for skeptic with major finding + signed_off');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: skeptic-no-critical-major-no-fire
+// A skeptic spawn_complete with signed_off=true but ZERO critical/major findings
+// must NOT count as learning-worthy (no nudge).
+// ---------------------------------------------------------------------------
+console.log('\nTest 12: skeptic-no-critical-major-no-fire (minor-only findings)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-skeptic-012';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'skeptic', {
+    signed_off: true,
+    findings_count: { critical: 0, major: 0, minor: 3 },
+  }) + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false for skeptic with minor-only findings (no learning-worthy signal)');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 12b: skeptic-not-signed-off-no-fire
+// A skeptic spawn_complete with critical findings but signed_off=false (or absent)
+// must NOT fire the nudge - the session is still unresolved.
+// ---------------------------------------------------------------------------
+console.log('\nTest 12b: skeptic-not-signed-off-no-fire');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-skeptic-012b';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'skeptic', {
+    signed_off: false,
+    findings_count: { critical: 2, major: 1, minor: 0 },
+  }) + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false for skeptic with critical findings but signed_off=false');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: knw-dated-suppression
+// A today-dated [KNW-YYYYMMDD-XXX] entry with a "Discovered: YYYY-MM-DD" line
+// must suppress the nudge. Test 5 only exercised the [LRN- prefix; the KNW +
+// Discovered: branch was untested.
+// ---------------------------------------------------------------------------
+console.log('\nTest 13: knw-dated-suppression (KNW entry with Discovered: today)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-knw-013';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  const todayCompact = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const todayDash = new Date().toISOString().slice(0, 10);
+  const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
+  // Write a KNW entry with the compact date tag AND a Discovered: line with dashed date.
+  fs.writeFileSync(learningsPath, [
+    `## [KNW-${todayCompact}-001] Workaround for git push --force`,
+    `**Discovered:** ${todayDash}`,
+    'Use --force-with-lease instead.',
+  ].join('\n') + '\n', 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false when today-dated KNW entry with Discovered: line present');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 13b: knw-tag-alone-suppresses
+// A [KNW-YYYYMMDD-XXX] prefix alone (without Discovered: line) must also suppress
+// the nudge - the code checks includes([KNW-${dateCompact}) independently.
+// ---------------------------------------------------------------------------
+console.log('\nTest 13b: knw-tag-alone-suppresses (KNW tag without Discovered: line)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'session-knw-013b';
+  const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+  fs.writeFileSync(eventsPath, makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8');
+
+  const todayCompact = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
+  fs.writeFileSync(learningsPath, `## [KNW-${todayCompact}-001] A known workaround\nDetails here.\n`, 'utf8');
+
+  const result = detectCaptureGap(cwd, sessionId);
+  assert(result.shouldNudge === false, 'shouldNudge false when today-dated KNW tag present (no Discovered: line needed)');
   cleanup(cwd);
 }
 


### PR DESCRIPTION
Closes 3 U6 Skeptic Minors: skeptic-trigger tests, KNW-suppression tests, removal of unused sessionId param (both call sites + manifest). Skeptic caught a missed call site (line 1276) mid-review -> fixed + Test 14 run()-level regression guard. 29 capture-gap + 17 session-log tests pass. hooks-only.