### PR TITLE
fix(docs): add vertical gap below pill rows on the docs page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -393,7 +393,7 @@
   .persistence-layer .section-title h2 { color: var(--gold);   text-shadow: 0 0 26px var(--gold-glow); }
 
   /* ── Node grid ── */
-  .node-grid { display: flex; flex-wrap: wrap; gap: 7px; }
+  .node-grid { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 16px; }
   .node {
     padding: 6px 12px;
     border-radius: var(--radius-sm);
@@ -699,6 +699,7 @@
     flex-wrap: wrap;
     gap: 8px;
     margin-top: 14px;
+    margin-bottom: 20px;
   }
   .atlas-chip {
     font-family: 'JetBrains Mono', monospace;


### PR DESCRIPTION
Pill/chip rows sat flush against the card/paragraph below them. Adds bottom spacing to the two shared row containers in docs/index.html:
- `.atlas-chips` -> `margin-bottom: 20px` (hero 'WHAT IS DINOSTACK' pills -> infographic card)
- `.node-grid` -> `margin-bottom: 16px` (protocol-layer pills -> description)

Root fix on the shared classes. QA-verified at desktop (1280px) + mobile (390px): 20px/16px computed gaps, full-page sweep found no other flush-against-box cases across all sections.