### PR TITLE
feat(install): collect developer identity in the guided installer

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -685,7 +685,7 @@ _ae_setup_identity() {
   echo "  Developer identity links telemetry to your handle across sessions."
   local typed_handle=""
   read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
-  typed_handle="$(echo "$typed_handle" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')"
   if [[ -z "$typed_handle" ]]; then
     echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
     return

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -40,6 +40,8 @@ export REPO_DIR
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -53,6 +55,12 @@ for arg in "$@"; do
       ;;
     --profile=*)
       echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)"
+      ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
       ;;
   esac
 done
@@ -600,6 +608,107 @@ for tool_entry in "${CLI_TOOLS[@]}"; do
   fi
 done
 
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+
+_ae_setup_identity() {
+  # Branch 1: --no-identity flag
+  if [[ "$AE_NO_IDENTITY" == "true" ]]; then
+    echo "  - identity setup skipped (--no-identity)"
+    return
+  fi
+
+  # Branch 2: agentic-identity not on PATH
+  if ! command -v agentic-identity &>/dev/null; then
+    echo "  ! agentic-identity not found on PATH - set later with 'agentic-identity init <handle>'"
+    return
+  fi
+
+  # Branch 3: detect existing identity
+  local show_out
+  show_out="$(agentic-identity show --scope effective 2>/dev/null)" || show_out=""
+  local existing_handle
+  existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')"
+  if [[ -n "$existing_handle" ]]; then
+    if echo "$show_out" | grep -q 'provisional:'; then
+      echo "  = identity already set to '$existing_handle' (provisional - run 'agentic-identity confirm' to lock it in)"
+    else
+      echo "  = identity already set to '$existing_handle' (confirmed)"
+    fi
+    return
+  fi
+
+  # Branch 4: --identity=<handle> flag set (explicit intent, use --force)
+  if [[ -n "$AE_IDENTITY_FLAG" ]]; then
+    local rc=0
+    agentic-identity init "$AE_IDENTITY_FLAG" --force >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      echo "  + identity set to '$AE_IDENTITY_FLAG' via --identity flag"
+    else
+      echo "  ! identity init failed for '$AE_IDENTITY_FLAG' (invalid handle?) - set manually with 'agentic-identity init <handle>'"
+    fi
+    return
+  fi
+
+  # Branch 5: non-TTY
+  if [[ ! -r /dev/tty ]]; then
+    echo "  - non-interactive install: skipped identity setup (run 'agentic-identity auto' or 'agentic-identity init <handle>')"
+    return
+  fi
+
+  # Branch 6: interactive + gh present and authenticated
+  local gh_login=""
+  if command -v gh &>/dev/null; then
+    gh_login="$(gh api user --jq .login 2>/dev/null | tr '[:upper:]' '[:lower:]')" || gh_login=""
+  fi
+
+  if [[ -n "$gh_login" ]] && echo "$gh_login" | grep -qE '^[a-z0-9._-]{1,64}$'; then
+    echo "  Detected GitHub handle: $gh_login"
+    if ae_confirm "  Set developer identity to '$gh_login'? [y/N] "; then
+      local rc=0
+      agentic-identity init "$gh_login" >/dev/null 2>&1 || rc=$?
+      if [[ "$rc" -eq 0 ]]; then
+        echo "  + identity set to '$gh_login' (confirmed)"
+      elif [[ "$rc" -eq 2 ]]; then
+        echo "  = identity already set (use 'agentic-identity init $gh_login --force' to change)"
+      else
+        echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
+      fi
+    else
+      echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    fi
+    return
+  fi
+
+  # Branch 7: gh absent or unauthenticated - prompt manually
+  echo "  Developer identity links telemetry to your handle across sessions."
+  local typed_handle=""
+  read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
+  typed_handle="$(echo "$typed_handle" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ -z "$typed_handle" ]]; then
+    echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    return
+  fi
+  if ! echo "$typed_handle" | grep -qE '^[a-z0-9._-]{1,64}$'; then
+    echo "  ! '$typed_handle' is not a valid handle (must match ^[a-z0-9._-]{1,64}\$) - skipping"
+    return
+  fi
+  local rc=0
+  agentic-identity init "$typed_handle" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    echo "  + identity set to '$typed_handle' (confirmed)"
+  elif [[ "$rc" -eq 2 ]]; then
+    echo "  = identity already set (use 'agentic-identity init $typed_handle --force' to change)"
+  else
+    echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
+  fi
+}
+
+echo ""
+echo "Developer identity..."
+_ae_setup_identity
+
 # chrome-devtools MCP
 echo ""
 CLAUDE_JSON="$HOME/.claude.json"
@@ -880,6 +989,10 @@ ae_install_bins
 
 echo ""
 echo "Install complete."
+echo ""
+echo "  agentic-engineering is installed. Open a new Claude Code session in any project,"
+echo "  add 'agentic-engineering: opt-in' to its AGENTS.md, and the methodology activates."
+echo "  Run 'agentic-identity show' to confirm your identity was saved."
 echo ""
 echo "Next steps (for the agent running this installer):"
 echo ""

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ DinoStack supports two global activation modes, chosen at install time and persi
 ```
 bash .claude/install.sh --mode=opt-in
 bash .claude/install.sh --mode=opt-out
+bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
+bash .claude/install.sh --no-identity          # skip the developer-identity prompt
 ```
 
 The same flag works for `.cursor/install.sh`, `.codex/install.sh`, `.gemini/install.sh`, `.opencode/install.sh`, `.pi/install.sh`, `.omp/install.sh`, and `.hermes/install.sh` - the config file is shared across adapters.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,16 @@ DinoStack supports two global activation modes, chosen at install time and persi
 ```
 bash .claude/install.sh --mode=opt-in
 bash .claude/install.sh --mode=opt-out
+```
+
+The `--mode=` flag works for `.cursor/install.sh`, `.codex/install.sh`, `.gemini/install.sh`, `.opencode/install.sh`, `.pi/install.sh`, `.omp/install.sh`, and `.hermes/install.sh` - the config file is shared across adapters.
+
+The following flags are currently supported by `.claude/install.sh` only:
+
+```
 bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
 bash .claude/install.sh --no-identity          # skip the developer-identity prompt
 ```
-
-The same flag works for `.cursor/install.sh`, `.codex/install.sh`, `.gemini/install.sh`, `.opencode/install.sh`, `.pi/install.sh`, `.omp/install.sh`, and `.hermes/install.sh` - the config file is shared across adapters.
 
 **Per-project marker:** add a single line to the project's root `AGENTS.md`:
 


### PR DESCRIPTION
Adds developer-identity (GitHub handle) collection to the guided installer (`.claude/install.sh`), which previously never asked for it - identity was left entirely to a first-session prompt.

## What changed
- **Identity step** after the optional-CLI-tools prompts: detects a handle via `gh api user` and confirms it (y/N), falls back to a manual handle prompt over `/dev/tty`, and skips cleanly when identity is already set or the install is non-interactive (`curl | bash`). Writes a confirmed identity via `agentic-identity init` since the user is present to verify it.
- **New flags:** `--identity=<handle>` (non-interactive, uses `--force`) and `--no-identity` (skip). Lets the agent-driven install path drive identity without prompts.
- **Human-facing closer** after `Install complete.` (the previous ending spoke only to the agent).
- **README:** documents the two new flags, scoped to `.claude/install.sh` (the cross-adapter sentence now correctly applies to `--mode=` only).

## Safety
- Non-TTY installs skip the prompt before any interactive read - `curl | bash` cannot hang or abort.
- All `agentic-identity` calls are guarded under `set -euo pipefail`; `init` exit 2 ("already set") is treated as idempotent, not a failure.
- `bash -n` passes; no new shellcheck warnings.

Reviewed via Skeptic (0 Critical, 0 Major; 3 Minor, 2 of which are fixed here).