### PR TITLE
feat(skeptic): clearer one-finding-per-line sign-off Findings format

### DIFF
--- a/.codex/agents/skeptic.toml
+++ b/.codex/agents/skeptic.toml
@@ -71,8 +71,9 @@ The conductor validates this format exactly. Use it verbatim - do not paraphrase
 
 ```
 Reviewed: [files/components examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List each finding: CLASSIFICATION - description with specific location]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
 ```

--- a/.codex/references/skeptic-protocol.md
+++ b/.codex/references/skeptic-protocol.md
@@ -565,8 +565,9 @@ The structured sign-off format is required for every Skeptic response, whether f
 
 ```
 Reviewed: [list of components/aspects examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List any findings with classification]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.

--- a/.cursor/rules/references/skeptic-protocol.md
+++ b/.cursor/rules/references/skeptic-protocol.md
@@ -565,8 +565,9 @@ The structured sign-off format is required for every Skeptic response, whether f
 
 ```
 Reviewed: [list of components/aspects examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List any findings with classification]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -72,8 +72,9 @@ The conductor validates this format exactly. Use it verbatim - do not paraphrase
 
 ```
 Reviewed: [files/components examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List each finding: CLASSIFICATION - description with specific location]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
 ```

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -565,8 +565,9 @@ The structured sign-off format is required for every Skeptic response, whether f
 
 ```
 Reviewed: [list of components/aspects examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List any findings with classification]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -2681,8 +2681,9 @@ The structured sign-off format is required for every Skeptic response, whether f
 
 ```
 Reviewed: [list of components/aspects examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List any findings with classification]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
@@ -7218,8 +7219,9 @@ The conductor validates this format exactly. Use it verbatim - do not paraphrase
 
 ```
 Reviewed: [files/components examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List each finding: CLASSIFICATION - description with specific location]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
 ```

--- a/.opencode/agents/skeptic.md
+++ b/.opencode/agents/skeptic.md
@@ -73,8 +73,9 @@ The conductor validates this format exactly. Use it verbatim - do not paraphrase
 
 ```
 Reviewed: [files/components examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List each finding: CLASSIFICATION - description with specific location]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
 ```

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -71,8 +71,9 @@ The conductor validates this format exactly. Use it verbatim - do not paraphrase
 
 ```
 Reviewed: [files/components examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List each finding: CLASSIFICATION - description with specific location]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.
 ```

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -565,8 +565,9 @@ The structured sign-off format is required for every Skeptic response, whether f
 
 ```
 Reviewed: [list of components/aspects examined]
-Findings: Critical: N, Major: N, Minor: N — or "No findings."
-[List any findings with classification]
+Findings: Critical: N, Major: N, Minor: N
+[Each finding on its own line: Critical - description (file:line or region)]
+If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 No unresolved Critical or Major findings. Sign-off granted.


### PR DESCRIPTION
First methodology improvement produced and kept by the self-improving eval harness (skeptic component, metric 0.29 -> 0.52; p=0.03125, n_nonzero=5).

## Change
Reformats the Skeptic sign-off `Findings:` block in `content/agents/skeptic.md`:
- One finding per line: `Critical - description (file:line or region)`
- Explicit `Findings: No findings.` rule when all counts are zero
- Drops the ambiguous em-dash inline alternative

`content/references/skeptic-protocol.md` updated to match (same-PR doc-sync), and all 9 adapters rebuilt.

## Verification
- Adapter-sync clean (all 9 rebuilt; `git diff --exit-code` over adapter dirs is empty).
- `scripts/.methodology-baseline.sha256` unchanged (no `content/sections/` touched).
- Conductor sign-off validator still satisfied (checks `Findings:` / `Active search:` / `Sign-off granted.` substrings - all preserved).
- Skeptic-reviewed (2 rounds: format soundness + doc-sync resolution).