### PR TITLE
feat(install): collect developer identity in all 9 adapter installers (shared helper)

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -597,7 +597,6 @@ done
 # Developer identity
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
 if declare -f _ae_setup_identity >/dev/null; then
   echo ""
   echo "Developer identity..."

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1,28 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# ae_confirm: TTY-safe yes/no prompt for optional installs.
-#
-# When /dev/tty is available (interactive or curl|bash in a real terminal),
-# prompts the user exactly as a bare `read -p` would. When /dev/tty is not
-# available (headless/piped/CI), defaults to "no" and returns 1 without
-# aborting under set -e.
-#
-# Usage: if ae_confirm "  Install foo? [y/N] "; then ...
-# ---------------------------------------------------------------------------
-ae_confirm() {
-  local prompt="$1"
-  local reply=""
-  if [[ -r /dev/tty ]]; then
-    read -p "$prompt" -n 1 -r reply </dev/tty || reply=""
-    echo
-  fi
-  [[ "$reply" =~ ^[Yy]$ ]]
-}
-
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
+
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
 
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters)
@@ -612,102 +597,13 @@ done
 # Developer identity
 # ---------------------------------------------------------------------------
 
-_ae_setup_identity() {
-  # Branch 1: --no-identity flag
-  if [[ "$AE_NO_IDENTITY" == "true" ]]; then
-    echo "  - identity setup skipped (--no-identity)"
-    return
-  fi
-
-  # Branch 2: agentic-identity not on PATH
-  if ! command -v agentic-identity &>/dev/null; then
-    echo "  ! agentic-identity not found on PATH - set later with 'agentic-identity init <handle>'"
-    return
-  fi
-
-  # Branch 3: detect existing identity
-  local show_out
-  show_out="$(agentic-identity show --scope effective 2>/dev/null)" || show_out=""
-  local existing_handle
-  existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')"
-  if [[ -n "$existing_handle" ]]; then
-    if echo "$show_out" | grep -q 'provisional:'; then
-      echo "  = identity already set to '$existing_handle' (provisional - run 'agentic-identity confirm' to lock it in)"
-    else
-      echo "  = identity already set to '$existing_handle' (confirmed)"
-    fi
-    return
-  fi
-
-  # Branch 4: --identity=<handle> flag set (explicit intent, use --force)
-  if [[ -n "$AE_IDENTITY_FLAG" ]]; then
-    local rc=0
-    agentic-identity init "$AE_IDENTITY_FLAG" --force >/dev/null 2>&1 || rc=$?
-    if [[ "$rc" -eq 0 ]]; then
-      echo "  + identity set to '$AE_IDENTITY_FLAG' via --identity flag"
-    else
-      echo "  ! identity init failed for '$AE_IDENTITY_FLAG' (invalid handle?) - set manually with 'agentic-identity init <handle>'"
-    fi
-    return
-  fi
-
-  # Branch 5: non-TTY
-  if [[ ! -r /dev/tty ]]; then
-    echo "  - non-interactive install: skipped identity setup (run 'agentic-identity auto' or 'agentic-identity init <handle>')"
-    return
-  fi
-
-  # Branch 6: interactive + gh present and authenticated
-  local gh_login=""
-  if command -v gh &>/dev/null; then
-    gh_login="$(gh api user --jq .login 2>/dev/null | tr '[:upper:]' '[:lower:]')" || gh_login=""
-  fi
-
-  if [[ -n "$gh_login" ]] && echo "$gh_login" | grep -qE '^[a-z0-9._-]{1,64}$'; then
-    echo "  Detected GitHub handle: $gh_login"
-    if ae_confirm "  Set developer identity to '$gh_login'? [y/N] "; then
-      local rc=0
-      agentic-identity init "$gh_login" >/dev/null 2>&1 || rc=$?
-      if [[ "$rc" -eq 0 ]]; then
-        echo "  + identity set to '$gh_login' (confirmed)"
-      elif [[ "$rc" -eq 2 ]]; then
-        echo "  = identity already set (use 'agentic-identity init $gh_login --force' to change)"
-      else
-        echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
-      fi
-    else
-      echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
-    fi
-    return
-  fi
-
-  # Branch 7: gh absent or unauthenticated - prompt manually
-  echo "  Developer identity links telemetry to your handle across sessions."
-  local typed_handle=""
-  read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
-  typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')"
-  if [[ -z "$typed_handle" ]]; then
-    echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
-    return
-  fi
-  if ! echo "$typed_handle" | grep -qE '^[a-z0-9._-]{1,64}$'; then
-    echo "  ! '$typed_handle' is not a valid handle (must match ^[a-z0-9._-]{1,64}\$) - skipping"
-    return
-  fi
-  local rc=0
-  agentic-identity init "$typed_handle" >/dev/null 2>&1 || rc=$?
-  if [[ "$rc" -eq 0 ]]; then
-    echo "  + identity set to '$typed_handle' (confirmed)"
-  elif [[ "$rc" -eq 2 ]]; then
-    echo "  = identity already set (use 'agentic-identity init $typed_handle --force' to change)"
-  else
-    echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
-  fi
-}
-
-echo ""
-echo "Developer identity..."
-_ae_setup_identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 # chrome-devtools MCP
 echo ""

--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters - see .claude/install.sh)
 # Persists to ~/.claude/agentic-engineering.json. Read by the skill preflight.
@@ -11,12 +16,20 @@ export REPO_DIR
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out) AE_MODE_FLAG="${arg#--mode=}" ;;
     --mode=*) echo "  ! ignoring unknown --mode value: ${arg#--mode=} (expected opt-in or opt-out)" ;;
     --profile=relaxed|--profile=default|--profile=strict) AE_PROFILE_FLAG="${arg#--profile=}" ;;
     --profile=*) echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)" ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
+      ;;
   esac
 done
 
@@ -442,6 +455,16 @@ ae_install_bins() {
 
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters - see .claude/install.sh)
 # Persists to ~/.claude/agentic-engineering.json. Read by the skill preflight.
@@ -10,12 +15,20 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out) AE_MODE_FLAG="${arg#--mode=}" ;;
     --mode=*) echo "  ! ignoring unknown --mode value: ${arg#--mode=} (expected opt-in or opt-out)" ;;
     --profile=relaxed|--profile=default|--profile=strict) AE_PROFILE_FLAG="${arg#--profile=}" ;;
     --profile=*) echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)" ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
+      ;;
   esac
 done
 
@@ -364,6 +377,16 @@ ae_install_bins() {
 
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.gemini/install.sh
+++ b/.gemini/install.sh
@@ -12,6 +12,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GEMINI_DIR="$REPO_DIR/.gemini"
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters - see .claude/install.sh)
 # Persists to ~/.claude/agentic-engineering.json. Read by the skill preflight.
@@ -19,12 +24,20 @@ GEMINI_DIR="$REPO_DIR/.gemini"
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out) AE_MODE_FLAG="${arg#--mode=}" ;;
     --mode=*) echo "  ! ignoring unknown --mode value: ${arg#--mode=} (expected opt-in or opt-out)" ;;
     --profile=relaxed|--profile=default|--profile=strict) AE_PROFILE_FLAG="${arg#--profile=}" ;;
     --profile=*) echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)" ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
+      ;;
   esac
 done
 
@@ -478,6 +491,16 @@ ae_install_bins() {
 
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.hermes/install.sh
+++ b/.hermes/install.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode
 # ---------------------------------------------------------------------------
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -23,6 +30,12 @@ for arg in "$@"; do
       ;;
     --profile=*)
       echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)"
+      ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
       ;;
   esac
 done
@@ -179,6 +192,18 @@ fi
 
 ln -s "$SKILL_SRC" "$SKILL_DST/SKILL.md"
 echo "  + symlinked $SKILL_DST/SKILL.md -> $SKILL_SRC"
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+  echo "  (agentic-identity binaries are wired by other adapters e.g. .claude or .codex."
+  echo "   If not on PATH, run 'agentic-identity init <handle>' after installing another adapter.)"
+fi
 
 # ---------------------------------------------------------------------------
 # Done

--- a/.kimi/install.sh
+++ b/.kimi/install.sh
@@ -36,6 +36,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Run build first (generates AGENTS.md and symlinks)
 # ---------------------------------------------------------------------------
@@ -50,6 +55,8 @@ bash "$REPO_DIR/.kimi/build.sh"
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -63,6 +70,12 @@ for arg in "$@"; do
       ;;
     --profile=*)
       echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)"
+      ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
       ;;
   esac
 done
@@ -427,6 +440,16 @@ ae_install_bins() {
 
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 echo ""
 echo "Kimi adapter install complete."

--- a/.omp/install.sh
+++ b/.omp/install.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Run build first (ensures symlinks)
 # ---------------------------------------------------------------------------
@@ -18,6 +23,8 @@ bash "$REPO_DIR/.omp/build.sh"
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -31,6 +38,12 @@ for arg in "$@"; do
       ;;
     --profile=*)
       echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)"
+      ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
       ;;
   esac
 done
@@ -298,6 +311,16 @@ ae_install_bins() {
 echo ""
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 echo ""
 echo "Pi (oh-my-pi) adapter install complete."

--- a/.opencode/install.sh
+++ b/.opencode/install.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Run build first (generates agents/ and commands/ from content/)
 # ---------------------------------------------------------------------------
@@ -17,6 +22,8 @@ bash "$REPO_DIR/.opencode/build.sh"
 
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -30,6 +37,12 @@ for arg in "$@"; do
       ;;
     --profile=*)
       echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)"
+      ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
       ;;
   esac
 done
@@ -453,6 +466,16 @@ ae_install_bins() {
 
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.pi/install.sh
+++ b/.pi/install.sh
@@ -11,14 +11,27 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export REPO_DIR
 
+# shellcheck source=scripts/lib/identity.sh
+[[ -f "$REPO_DIR/scripts/lib/identity.sh" ]] && . "$REPO_DIR/scripts/lib/identity.sh" || {
+  echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
+}
+
 AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
+AE_IDENTITY_FLAG=""
+AE_NO_IDENTITY=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out) AE_MODE_FLAG="${arg#--mode=}" ;;
     --mode=*) echo "  ! ignoring unknown --mode value: ${arg#--mode=} (expected opt-in or opt-out)" ;;
     --profile=relaxed|--profile=default|--profile=strict) AE_PROFILE_FLAG="${arg#--profile=}" ;;
     --profile=*) echo "  ! ignoring unknown --profile value: ${arg#--profile=} (expected relaxed, default, or strict)" ;;
+    --identity=*)
+      AE_IDENTITY_FLAG="${arg#--identity=}"
+      ;;
+    --no-identity)
+      AE_NO_IDENTITY=true
+      ;;
   esac
 done
 
@@ -229,6 +242,16 @@ ae_install_bins() {
 echo ""
 echo "Linking bin/ scripts to PATH..."
 ae_install_bins
+
+# ---------------------------------------------------------------------------
+# Developer identity
+# ---------------------------------------------------------------------------
+if declare -f _ae_setup_identity >/dev/null; then
+  echo ""
+  echo "Developer identity..."
+  _ae_setup_identity
+  echo "  Run 'agentic-identity show' to confirm your identity."
+fi
 
 echo ""
 echo "Pi coding agent adapter install complete."

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ bash .claude/install.sh --mode=opt-out
 The following flags work for all adapters (`.claude`, `.cursor`, `.codex`, `.gemini`, `.opencode`, `.pi`, `.omp`, `.kimi`, and `.hermes`) - the config file is shared across adapters:
 
 ```
-bash .claude/install.sh --mode=opt-in
-bash .claude/install.sh --mode=opt-out
 bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
 bash .claude/install.sh --no-identity          # skip the developer-identity prompt
 ```

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ bash .claude/install.sh --mode=opt-in
 bash .claude/install.sh --mode=opt-out
 ```
 
-The `--mode=` flag works for `.cursor/install.sh`, `.codex/install.sh`, `.gemini/install.sh`, `.opencode/install.sh`, `.pi/install.sh`, `.omp/install.sh`, and `.hermes/install.sh` - the config file is shared across adapters.
-
-The following flags are currently supported by `.claude/install.sh` only:
+The following flags work for all adapters (`.claude`, `.cursor`, `.codex`, `.gemini`, `.opencode`, `.pi`, `.omp`, `.kimi`, and `.hermes`) - the config file is shared across adapters:
 
 ```
+bash .claude/install.sh --mode=opt-in
+bash .claude/install.sh --mode=opt-out
 bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
 bash .claude/install.sh --no-identity          # skip the developer-identity prompt
 ```

--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -1,0 +1,149 @@
+# shellcheck shell=bash
+# ---------------------------------------------------------------------------
+# Purpose: Shared developer-identity setup helper sourced by every adapter
+#          installer; prompts for / resolves a GitHub handle and records it
+#          via the agentic-identity binary.
+#
+# Public API:
+#   ae_confirm <prompt>       - TTY-safe y/N prompt; returns 0 for y/Y, 1 otherwise.
+#   _ae_setup_identity        - 7-branch identity resolution (no-identity flag,
+#                               missing binary, existing identity, --identity flag,
+#                               non-TTY, gh auto-detect, manual prompt).
+#   AE_IDENTITY_FLAG          - default var (empty string); callers may set before sourcing.
+#   AE_NO_IDENTITY            - default var ("false"); callers may set before sourcing.
+#
+# Upstream dependencies:
+#   agentic-identity binary (on PATH), gh (optional, for auto-detect),
+#   /dev/tty (optional, for interactive prompts).
+#
+# Downstream consumers:
+#   .claude/install.sh, .codex/install.sh, .cursor/install.sh,
+#   .gemini/install.sh, .hermes/install.sh, .kimi/install.sh,
+#   .omp/install.sh, .opencode/install.sh, .pi/install.sh
+#
+# Failure modes:
+#   Never aborts the caller - every agentic-identity call captures rc;
+#   missing binary / no TTY / unset handle all degrade to a printed skip
+#   message. Safe to source under set -euo pipefail (no top-level side
+#   effects beyond function defs + ${VAR:-default} assignments).
+#
+# Performance:
+#   One optional `gh api user` network call only on the interactive
+#   auto-detect path; otherwise local-only.
+# ---------------------------------------------------------------------------
+
+AE_IDENTITY_FLAG="${AE_IDENTITY_FLAG:-}"
+AE_NO_IDENTITY="${AE_NO_IDENTITY:-false}"
+
+# ---------------------------------------------------------------------------
+# ae_confirm: TTY-safe yes/no prompt for optional installs.
+#
+# When /dev/tty is available (interactive or curl|bash in a real terminal),
+# prompts the user exactly as a bare `read -p` would. When /dev/tty is not
+# available (headless/piped/CI), defaults to "no" and returns 1 without
+# aborting under set -e.
+#
+# Usage: if ae_confirm "  Install foo? [y/N] "; then ...
+# ---------------------------------------------------------------------------
+ae_confirm() {
+  local prompt="$1"
+  local reply=""
+  if [[ -r /dev/tty ]]; then
+    read -p "$prompt" -n 1 -r reply </dev/tty || reply=""
+    echo
+  fi
+  [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+_ae_setup_identity() {
+  # Branch 1: --no-identity flag
+  if [[ "$AE_NO_IDENTITY" == "true" ]]; then
+    echo "  - identity setup skipped (--no-identity)"
+    return
+  fi
+
+  # Branch 2: agentic-identity not on PATH
+  if ! command -v agentic-identity &>/dev/null; then
+    echo "  ! agentic-identity not found on PATH - set later with 'agentic-identity init <handle>'"
+    return
+  fi
+
+  # Branch 3: detect existing identity
+  local show_out
+  show_out="$(agentic-identity show --scope effective 2>/dev/null)" || show_out=""
+  local existing_handle
+  existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')"
+  if [[ -n "$existing_handle" ]]; then
+    if echo "$show_out" | grep -q 'provisional:'; then
+      echo "  = identity already set to '$existing_handle' (provisional - run 'agentic-identity confirm' to lock it in)"
+    else
+      echo "  = identity already set to '$existing_handle' (confirmed)"
+    fi
+    return
+  fi
+
+  # Branch 4: --identity=<handle> flag set (explicit intent, use --force)
+  if [[ -n "$AE_IDENTITY_FLAG" ]]; then
+    local rc=0
+    agentic-identity init "$AE_IDENTITY_FLAG" --force >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      echo "  + identity set to '$AE_IDENTITY_FLAG' via --identity flag"
+    else
+      echo "  ! identity init failed for '$AE_IDENTITY_FLAG' (invalid handle?) - set manually with 'agentic-identity init <handle>'"
+    fi
+    return
+  fi
+
+  # Branch 5: non-TTY
+  if [[ ! -r /dev/tty ]]; then
+    echo "  - non-interactive install: skipped identity setup (run 'agentic-identity auto' or 'agentic-identity init <handle>')"
+    return
+  fi
+
+  # Branch 6: interactive + gh present and authenticated
+  local gh_login=""
+  if command -v gh &>/dev/null; then
+    gh_login="$(gh api user --jq .login 2>/dev/null | tr '[:upper:]' '[:lower:]')" || gh_login=""
+  fi
+
+  if [[ -n "$gh_login" ]] && echo "$gh_login" | grep -qE '^[a-z0-9._-]{1,64}$'; then
+    echo "  Detected GitHub handle: $gh_login"
+    if ae_confirm "  Set developer identity to '$gh_login'? [y/N] "; then
+      local rc=0
+      agentic-identity init "$gh_login" >/dev/null 2>&1 || rc=$?
+      if [[ "$rc" -eq 0 ]]; then
+        echo "  + identity set to '$gh_login' (confirmed)"
+      elif [[ "$rc" -eq 2 ]]; then
+        echo "  = identity already set (use 'agentic-identity init $gh_login --force' to change)"
+      else
+        echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
+      fi
+    else
+      echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    fi
+    return
+  fi
+
+  # Branch 7: gh absent or unauthenticated - prompt manually
+  echo "  Developer identity links telemetry to your handle across sessions."
+  local typed_handle=""
+  read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
+  typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$typed_handle" ]]; then
+    echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    return
+  fi
+  if ! echo "$typed_handle" | grep -qE '^[a-z0-9._-]{1,64}$'; then
+    echo "  ! '$typed_handle' is not a valid handle (must match ^[a-z0-9._-]{1,64}\$) - skipping"
+    return
+  fi
+  local rc=0
+  agentic-identity init "$typed_handle" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    echo "  + identity set to '$typed_handle' (confirmed)"
+  elif [[ "$rc" -eq 2 ]]; then
+    echo "  = identity already set (use 'agentic-identity init $typed_handle --force' to change)"
+  else
+    echo "  ! identity init failed - set manually with 'agentic-identity init <handle>'"
+  fi
+}


### PR DESCRIPTION
Ports developer-identity (GitHub handle) collection - previously only in `.claude/install.sh` (#229) - to all 9 adapter installers, via a shared sourced helper instead of copy-pasting ~100 lines nine times.

## What changed
- **New `scripts/lib/identity.sh`** - shared helper with a 6-field module manifest, holding `ae_confirm()` and `_ae_setup_identity()` extracted byte-for-byte from `.claude/install.sh` (verified identical to the shipped versions).
- **`.claude/install.sh`** refactored onto the helper (inline defs removed, sourced after `REPO_DIR`; `ae_confirm` still available for its MCP section).
- **8 other installers** (`.codex .cursor .gemini .hermes .kimi .omp .opencode .pi`) gain the source guard, `--identity=<handle>` / `--no-identity` flags, and the identity call block. `.hermes` (no bin-install) anchors after its build step and notes that `agentic-identity` is wired by other adapters.
- **README** - identity flags folded back into the shared cross-adapter flags section.

## Safety
- Every installer wraps the call in `if declare -f _ae_setup_identity` so a missing helper is a clean skip, never a `set -e` abort. Source guard is `set -e`-safe in both file-present and file-absent cases.
- `bash -n` passes on the helper + all 9 installers. SC2034 on the flag vars is a known shellcheck false-positive across the source boundary (no suppression directives added).
- install.sh files are hand-maintained (not build-generated), so no adapter rebuild / no methodology-baseline change is involved.

Reviewed: architect plan -> Skeptic-on-plan (CI claim + set-e guard verified) -> implementation -> Skeptic-on-diff (0 Critical, 0 Major; 2 Minor fixed). Follows #229 (the `--identity` flag) and #230 (`/pull-and-install`).