### PR TITLE
chore(refs): update remaining clone-dir refs from agentic-engineering to DinoStack

### DIFF
--- a/.claude/commands/pull-and-install.md
+++ b/.claude/commands/pull-and-install.md
@@ -33,7 +33,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -59,7 +59,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -299,7 +299,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/.codex/commands/pull-and-install.md
+++ b/.codex/commands/pull-and-install.md
@@ -31,7 +31,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -57,7 +57,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -297,7 +297,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/.cursor/commands/pull-and-install.md
+++ b/.cursor/commands/pull-and-install.md
@@ -31,7 +31,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -57,7 +57,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -297,7 +297,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/.gemini/commands/pull-and-install.toml
+++ b/.gemini/commands/pull-and-install.toml
@@ -37,7 +37,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -63,7 +63,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -303,7 +303,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12438,7 +12438,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -12464,7 +12464,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -12704,7 +12704,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/.kimi/README.md
+++ b/.kimi/README.md
@@ -75,7 +75,7 @@ timeout = 5
 
 [[hooks]]
 event = "Stop"
-command = "bash /path/to/agentic-engineering/hooks/stop-context.sh"
+command = "bash /path/to/DinoStack/hooks/stop-context.sh"
 timeout = 10
 ```
 

--- a/.opencode/commands/pull-and-install.md
+++ b/.opencode/commands/pull-and-install.md
@@ -35,7 +35,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -61,7 +61,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -301,7 +301,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/content/commands/pull-and-install.md
+++ b/content/commands/pull-and-install.md
@@ -31,7 +31,7 @@ fi
 **Routing logic (first match wins):**
 
 1. If `AE_REPO_DIR` is non-empty AND `git -C "$AE_REPO_DIR" rev-parse --git-dir >/dev/null 2>&1` succeeds -> **UPDATE-FLOW** against `AE_REPO_DIR`.
-2. Else, check the conventional fallback `$HOME/agentic-engineering`: if `git -C "$HOME/agentic-engineering" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/agentic-engineering` (the config entry may be stale or missing).
+2. Else, check the conventional fallback `$HOME/DinoStack`: if `git -C "$HOME/DinoStack" rev-parse --git-dir >/dev/null 2>&1` succeeds, treat it as **UPDATE-FLOW** against `$HOME/DinoStack` (the config entry may be stale or missing).
 3. Else -> **FRESH-CLONE-FLOW**.
 
 Report the detected route to the user before proceeding: "Detected existing install at `<path>` - running update flow." or "No existing install found - running fresh install."
@@ -57,7 +57,7 @@ saved_adapters = config.get("adapters", {})
 
 ### 1a - Adapters
 
-Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/agentic-engineering` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
+Discover available adapters by scanning the resolved repo directory (UPDATE-FLOW) or `$HOME/DinoStack` placeholder note for FRESH-CLONE-FLOW (adapters are discovered after clone; proceed with saved adapter config as the default selection and re-confirm after clone lands).
 
 Adapter discovery logic (mirrors `update.js` exactly - use for UPDATE-FLOW; apply same logic post-clone for FRESH-CLONE-FLOW):
 
@@ -297,7 +297,7 @@ If the config write fails, warn the user (non-fatal) and continue.
 Done.
 
   Flow: UPDATE | FRESH INSTALL
-  Repo: /path/to/agentic-engineering
+  Repo: /path/to/DinoStack
   Commits pulled: N  (or "already up to date" / "fresh install")
   Adapters installed: Claude, Codex
   Mode: opt-out | Profile: default | Identity: yourhandle (confirmed)

--- a/hooks/lib/version-check-core.sh
+++ b/hooks/lib/version-check-core.sh
@@ -48,7 +48,7 @@ except Exception:
 " "$AE_CONFIG" 2>/dev/null || echo "")"
 fi
 if [[ -z "$ae_repo_dir" ]] || ! git -C "$ae_repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
-  ae_repo_dir="$HOME/agentic-engineering"
+  ae_repo_dir="$HOME/DinoStack"
 fi
 
 # --- Maybe kick off a detached refresh (TTL-throttled) ---


### PR DESCRIPTION
## What

Cleans up the last clone-directory references to the old `agentic-engineering` repo name, completing the rename to `DinoStack`. Most refs were already migrated in #234–#236; this covers the remainder:

- `content/commands/pull-and-install.md` — `$HOME/agentic-engineering` fallback path → `$HOME/DinoStack` (3 refs)
- `hooks/lib/version-check-core.sh` — same clone-root fallback → `$HOME/DinoStack`
- `.kimi/README.md` — `/path/to/agentic-engineering` example → `/path/to/DinoStack`

Generated adapter artifacts (`.claude`/`.codex`/`.cursor`/`.gemini`/`.opencode` `pull-and-install` + `.hermes/SKILL.md`) rebuilt from `content/` source.

## What is deliberately unchanged

- **Package name** `agentic-engineering` — the skill, config files (`agentic-engineering.json`), command names (`/update-agentic-engineering`), and `skills/agentic-engineering/` path segments stay stable so existing installs keep working.
- `.codex/uninstall.sh` legacy-cleanup var — intentionally still points at the old path to clean up pre-rename installs.

## Verification

- No clone-root `agentic-engineering` refs remain (only the intentional legacy var).
- No `Solara6` references remain.
- `bootstrap.sh`, `version-check-core.sh`, and the pull-and-install fallback now all default to `$HOME/DinoStack`.
- All 9 adapters rebuild clean (verified via pre-commit hook).