### PR TITLE
fix(docs): make docs.dinostack.ai/install.sh redirect actually fire

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "/install.sh", "destination": "https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh", "permanent": false }
+  ]
+}


### PR DESCRIPTION
The public install one-liner `curl -fsSL https://docs.dinostack.ai/install.sh | bash` was 404ing. The redirect lives in the repo-root `vercel.json`, but the dinostack-docs project's Root Directory is `docs/`, so Vercel reads `docs/vercel.json` (which didn't exist) and ignored it. Adds `docs/vercel.json` with the same `/install.sh` -> raw bootstrap.sh redirect so it fires. Verified: raw bootstrap.sh is public (200); index serves; only /install.sh was 404. Will confirm live after deploy.