### PR TITLE
ci: security scanning workflows (CodeQL, gitleaks, Scorecard) [DS-20]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: codeql
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly on Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+          - actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,15 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pin the open-source gitleaks CLI to an exact released version. The CLI is
+  # free for all repos; only the gitleaks-action wrapper requires a paid
+  # GITLEAKS_LICENSE for org-owned repos. Running the binary directly avoids
+  # that gate. Bump VERSION and SHA256 together (checksum from the release's
+  # gitleaks_<v>_checksums.txt asset).
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -18,7 +27,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
+          curl -sSfL "$url" -o "$tarball"
+          echo "${GITLEAKS_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xzf "$tarball" gitleaks
+          install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gitleaks git . \
+            --redact=100 \
+            --verbose \
+            --exit-code 1 \
+            --report-format sarif \
+            --report-path gitleaks.sarif
+
+      - name: Upload report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks.sarif
+          if-no-files-found: ignore

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,24 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
+      # OpenSSF Scorecard's publish_results API only accepts an approved step
+      # list and forbids workflow-level write permissions; do not add
+      # non-allowlisted steps or broaden permissions or publish_results breaks.
       - name: Run analysis
         uses: ossf/scorecard-action@v2
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly on Saturdays at 01:30 UTC.
+    - cron: '30 1 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+# gitleaks configuration
+#
+# Purpose: extend the bundled default ruleset and allowlist the intentional
+# fake-secret corpora used by the eval harness. These fixtures plant fake
+# credentials and real public git SHAs by design (e.g. to test the
+# security-auditor's detection, or to pin task base commits). They are not
+# real secrets. Without this allowlist, `gitleaks git .` scans full history
+# and fails every PR on these by-design fixtures.
+#
+# Scope discipline: allowlist ONLY eval fixture corpora, never real-code paths.
+#   - evals/fixtures/**            : per-agent eval fixture corpora (entirely
+#                                    fixture data; safe to allowlist wholesale)
+#   - evals/skill-comparison/tasks/: task corpus (git SHAs misread as api keys);
+#                                    the rest of skill-comparison is real harness
+#                                    code and is deliberately NOT allowlisted.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional fake secrets / public git SHAs in eval fixture corpora - not real credentials"
+paths = [
+  '''evals/fixtures/.*''',
+  '''evals/skill-comparison/tasks/.*''',
+]


### PR DESCRIPTION
Adds three standard GitHub Actions security workflows. References DS-20.

- `codeql.yml` - CodeQL code scanning. Matrix over `javascript-typescript`, `python`, `actions` (the CodeQL-supported languages present in the tree; shell is not a CodeQL language). Triggers: push to main, PR to main, weekly schedule. Pins `github/codeql-action@v4` (latest stable major, v4.36.2).
- `gitleaks.yml` - secret scanning on PR and push to main. Runs the open-source gitleaks CLI directly (pinned to v8.30.1 with SHA256 checksum verification), not `gitleaks/gitleaks-action`, because the Action wrapper requires a paid `GITLEAKS_LICENSE` secret for org-owned repos. The CLI is free for all repos. Full-depth checkout; `gitleaks git . --exit-code 1` fails the job on findings and uploads a SARIF report artifact.
- `scorecard.yml` - OpenSSF Scorecard via `ossf/scorecard-action@v2` (latest stable, v2.4.3) on weekly schedule + push to main, with `security-events: write`, `id-token: write`, `contents: read`; uploads SARIF to code scanning; `publish_results: true`. No `pull_request` trigger (experimental + fork-unsupported per scorecard docs).

Note: the new Scorecard scan will report a lower Pinned-Dependencies score because first-party actions use floating-major tags by repo convention - expected, not a regression.

Validated with actionlint 1.7.12 (clean). No existing workflows modified. DCO-signed.
