### PR TITLE
chore: scrub client email from current files (DS-24)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,6 +9,5 @@
 
 Tyson Hummel <tyhummel@gmail.com> <admin@fullmetalblanket.com>
 Tyson Hummel <tyhummel@gmail.com> <tyson@solara6.com>
-Tyson Hummel <tyhummel@gmail.com> <thummel@crocs.com>
 Tyson Hummel <tyhummel@gmail.com> <thummelbiz@gmail.com>
 Tyson Hummel <tyhummel@gmail.com> tysonhummel <tyhummel@gmail.com>


### PR DESCRIPTION
Removes the Crocs client email (`thummel@crocs.com`) from current tracked files. Only `.mailmap` contained it; one mapping line removed.

- Scrubs the client email from current tracked files only. `git grep` at HEAD now returns zero hits.
- A full history rewrite was intentionally declined as disproportionate. The address remains in historical commit metadata.
- Side effect: removing the `.mailmap` mapping means the ~31 old commits previously authored under that address now display their raw historical email in `git shortlog` / `git log --use-mailmap` rather than the canonicalized identity. Expected, since we are not rewriting history.

Refs DS-24.