### PR TITLE
docs: add MAINTAINERS (DS-23)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# Maintainers
+
+This file lists the people who maintain DinoStack.
+
+| Maintainer | Handle | Role |
+| --- | --- | --- |
+| Tyson Hummel | `tysonhummel` | Lead maintainer |
+
+The list will grow as the project grows and contributors are added. See [GOVERNANCE.md](GOVERNANCE.md) for how maintainers are chosen and what the role involves.


### PR DESCRIPTION
Adds a minimal `MAINTAINERS.md` at the repo root (DS-23).

- Lists the sole current maintainer: Tyson Hummel (`tysonhummel`, lead maintainer).
- Notes the list will grow as contributors are added.
- Links to GOVERNANCE.md for how maintainers are chosen; handle matches the lead maintainer named there.

Out of scope: TRADEMARKS.md (deferred). No other files touched.

AI-assisted: content reviewed; right to submit under the project license. DCO signed.