### PR TITLE
chore(ci): enforce docs/planning gitignore via tracked-file guard

### DIFF
--- a/.github/workflows/no-planning-docs.yml
+++ b/.github/workflows/no-planning-docs.yml
@@ -1,0 +1,20 @@
+name: no-planning-docs
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  check-no-planning-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Guard - docs/planning must not be tracked
+        run: |
+          tracked=$(git ls-files docs/planning/)
+          if [ -n "$tracked" ]; then
+            echo "::error::docs/planning/ files are tracked in git. Briefs, Plans, and working docs must stay local (docs/planning/ is gitignored by design). Remove with: git rm --cached docs/planning/<file>"
+            echo "$tracked"
+            exit 1
+          fi
+          echo "OK: no docs/planning/ files are tracked."


### PR DESCRIPTION
Adds a CI workflow that actively enforces the existing `docs/planning/` gitignore rule.

`.gitignore` only gates untracked files - a `git add -f` silently bypasses it (as happened in PR #228). This guard runs `git ls-files docs/planning/` on every PR and push to main, and fails with an actionable error if any planning files are tracked.

Fix when it trips: `git rm --cached docs/planning/<file>`.

Matches existing workflow conventions (`actions/checkout@v6`, `pull_request` + `push: branches: [main]`, `::error::` annotation). Skeptic-reviewed: no Critical/Major findings.