### PR TITLE
chore(ci): push changelog via CHANGELOG_PUSH_TOKEN to clear main ruleset

### DIFF
--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -11,6 +11,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.CHANGELOG_PUSH_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: '22'


### PR DESCRIPTION
Follow-up to #257. The daily changelog workflow pushed with the built-in `GITHUB_TOKEN`, which can't write to the ruleset-protected `main`. This points `actions/checkout` at the `CHANGELOG_PUSH_TOKEN` PAT (Contents: write, owned by a repo-admin bypass actor), so the persisted credential authenticates the final `git push origin HEAD:main` as the admin and clears the ruleset.

Two-line change to the checkout step; no trigger/permission/cron changes. Reviewed: token reaches the push, nothing overrides it, secret name matches, scope is exactly one file.