### PR TITLE
fix(comparison): restore DinoStack cyan tint + stack Table C status notes

### DIFF
--- a/docs/agentic-engineering-comparison.html
+++ b/docs/agentic-engineering-comparison.html
@@ -280,11 +280,11 @@
   thead th:first-child, thead th.ae { z-index: 3; } /* corner cells: both axes */
   /* DinoStack anchor column = 2nd column (1st data col) */
   th.ae, td.ae {
-    background: #0c1322;
+    background: #0B2536;
     border-left: 2px solid var(--gold);
     border-right: 1px solid var(--border-faint);
   }
-  thead th.ae { background: #111b2e; color: var(--gold); }
+  thead th.ae { background: #0F394D; color: var(--gold); }
   tbody th[scope="row"] + td.ae { font-weight: 500; color: var(--text-primary); }
 
   /* Pills for capability table */

--- a/docs/agentic-engineering-comparison.html
+++ b/docs/agentic-engineering-comparison.html
@@ -291,6 +291,7 @@
   .pill {
     display: inline-flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
     font-size: 13px;
     line-height: 1.4;
@@ -305,7 +306,7 @@
   .pill.partial .dot { background: var(--status-partial); color: var(--status-partial); }
   .pill.dash .dot { background: var(--status-no); color: var(--status-no); box-shadow: none; }
   .pill.dash { color: var(--text-muted); }
-  .pill .note { color: var(--text-muted); font-size: 12.5px; }
+  .pill .note { color: var(--text-muted); font-size: 12.5px; flex-basis: 100%; margin-top: 1px; }
 
   .legend {
     display: flex;


### PR DESCRIPTION
Two visual follow-ups to the frozen-columns work on `docs/agentic-engineering-comparison.html`:

- **Restore the DinoStack column tint.** Making the column opaque for the sticky freeze had flattened its cyan tint to near-neutral. Replaced with faithful opaque blends of the original glow: body `#0B2536`, header `#0F394D` - so the anchor column reads distinctly cyan again while staying opaque (no scroll bleed-through).
- **Stack Table C status notes.** The Yes/No/Partial label and its parenthetical note now stack (label on top, note below) instead of sitting inline: `.pill` gets `flex-wrap: wrap` and `.note` gets `flex-basis: 100%`. Scoped to Table C; legend pills and no-note cells are unaffected.

CSS-only, single file.