### PR TITLE
fix(install): guard identity.sh pipelines so set -e abort no longer silently kills the installer

### DIFF
--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -72,7 +72,7 @@ _ae_setup_identity() {
   local show_out
   show_out="$(agentic-identity show --scope effective 2>/dev/null)" || show_out=""
   local existing_handle
-  existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')"
+  existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')" || existing_handle=""
   if [[ -n "$existing_handle" ]]; then
     if echo "$show_out" | grep -q 'provisional:'; then
       echo "  = identity already set to '$existing_handle' (provisional - run 'agentic-identity confirm' to lock it in)"

--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -128,10 +128,16 @@ _ae_setup_identity() {
   # Branch 7: gh absent or unauthenticated - prompt manually
   echo "  Developer identity links telemetry to your handle across sessions."
   local typed_handle=""
+  local raw_handle=""
   read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
+  raw_handle="$typed_handle"
   typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')" || typed_handle=""
   if [[ -z "$typed_handle" ]]; then
-    echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    if [[ -n "${raw_handle//[[:space:]]/}" ]]; then
+      echo "  - typed handle could not be parsed, skipping identity setup (run 'agentic-identity init <handle>' later)"
+    else
+      echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
+    fi
     return
   fi
   if ! echo "$typed_handle" | grep -qE '^[a-z0-9._-]{1,64}$'; then

--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -19,7 +19,8 @@
 # Downstream consumers:
 #   .claude/install.sh, .codex/install.sh, .cursor/install.sh,
 #   .gemini/install.sh, .hermes/install.sh, .kimi/install.sh,
-#   .omp/install.sh, .opencode/install.sh, .pi/install.sh
+#   .omp/install.sh, .openclaw/install.sh, .opencode/install.sh,
+#   .pi/install.sh
 #
 # Failure modes:
 #   Never aborts the caller - every agentic-identity call captures rc;
@@ -128,7 +129,7 @@ _ae_setup_identity() {
   echo "  Developer identity links telemetry to your handle across sessions."
   local typed_handle=""
   read -r -p "  GitHub handle [skip]: " typed_handle </dev/tty || typed_handle=""
-  typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')"
+  typed_handle="$(echo "$typed_handle" | xargs | tr '[:upper:]' '[:lower:]')" || typed_handle=""
   if [[ -z "$typed_handle" ]]; then
     echo "  - identity setup skipped (run 'agentic-identity init <handle>' later)"
     return


### PR DESCRIPTION
## Installer silently aborts at "Developer identity..." when no identity is set

`scripts/lib/identity.sh` is sourced by all 10 adapter installers, every one of which runs under `set -euo pipefail`. Two unguarded command substitutions in `_ae_setup_identity` could trip `set -e` and kill the installer mid-function with no error message.

### Symptom

Running `.claude/install.sh` with no developer identity configured printed `Developer identity...` and then returned to the shell - the `Run 'agentic-identity show'` line and every subsequent step (MCP setup, permissions, bin/ symlinking, summary) silently never ran.

### Root cause

- `identity.sh:75` - `grep '^developer_id:'` matches nothing when `agentic-identity show` reports "No identity set" (exit 0, no `developer_id:` line), so grep exits 1. But `awk` (the pipeline's last command) exits 0 - so the abort is only possible under `pipefail`, which surfaces grep's exit 1 as the pipeline's status (without it, awk's 0 would mask grep's failure and the assignment would succeed). Under `pipefail` that non-zero status propagates to the bare assignment and `set -e` aborts. **Fires whenever no identity exists yet** (the common fresh-install case), and only in the installers' `set -euo pipefail` context.
- `identity.sh:131` - the manual-handle prompt's `xargs` pipeline exits 1 on an unmatched quote in user input, aborting the same way and defeating the handle-validation that follows. **Fires on the `gh`-absent fallback path** when a user types a handle containing a stray quote.

### Fix

Append the same `|| var=""` guard already used on the two adjacent substitutions (lines 73, 106). The existing `[[ -n ]]` / `[[ -z ]]` checks handle the empty case gracefully. Restores the module manifest's "Never aborts the caller" contract. Also reconciles the manifest's downstream-consumer list to the actual 10 adapters (adds `.openclaw`).

The manual-prompt path additionally distinguishes a deliberate skip (empty input) from an unparseable handle (the `xargs` guard fired): the latter now prints "typed handle could not be parsed, skipping identity setup" instead of the generic skip message, so a user whose input was silently dropped is told why.

Single shared source - all 10 adapters `source` it directly, so the change covers every adapter.

### Verification

Isolated bash harness under `set -euo pipefail`, function called as a bare statement (matching the real call site at `.claude/install.sh:625`), with a stubbed `agentic-identity`:

- no-identity input → before: aborts (exit 1); after: completes, all follow-up steps run (exit 0)
- malformed-quote handle → before: aborts (exit 1); after: graceful "could not be parsed" skip (exit 0)
- valid / empty / uppercase handles → behave correctly (exit 0), normalization intact

No committed shell regression test added - no shell-test harness sources this lib (the only identity test exercises the Python binary), and scaffolding a new framework for a one-line guard is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYDKXD78xTbNwkYScE5T2x
