### PR TITLE
fix(config): backfill missing template toggles + correct capability_preflight_mode default

### DIFF
--- a/.claude/skills/agentic-engineering/templates/.agentic/config.json
+++ b/.claude/skills/agentic-engineering/templates/.agentic/config.json
@@ -4,8 +4,11 @@
   "qa_default_skip": null,
   "model_profile": "default",
   "auto_merge_on_ci_green": false,
-  "capability_preflight_mode": "advisory",
+  "capability_preflight_mode": "blocking",
   "perceptual_diff_enabled": false,
   "theme_aware": false,
-  "storybook_enabled": false
+  "storybook_enabled": false,
+  "motion_aware": false,
+  "storybook_version": 7,
+  "commit_telemetry": true
 }

--- a/.codex/skill/templates/.agentic/config.json
+++ b/.codex/skill/templates/.agentic/config.json
@@ -4,8 +4,11 @@
   "qa_default_skip": null,
   "model_profile": "default",
   "auto_merge_on_ci_green": false,
-  "capability_preflight_mode": "advisory",
+  "capability_preflight_mode": "blocking",
   "perceptual_diff_enabled": false,
   "theme_aware": false,
-  "storybook_enabled": false
+  "storybook_enabled": false,
+  "motion_aware": false,
+  "storybook_version": 7,
+  "commit_telemetry": true
 }

--- a/.cursor/templates/.agentic/config.json
+++ b/.cursor/templates/.agentic/config.json
@@ -4,8 +4,11 @@
   "qa_default_skip": null,
   "model_profile": "default",
   "auto_merge_on_ci_green": false,
-  "capability_preflight_mode": "advisory",
+  "capability_preflight_mode": "blocking",
   "perceptual_diff_enabled": false,
   "theme_aware": false,
-  "storybook_enabled": false
+  "storybook_enabled": false,
+  "motion_aware": false,
+  "storybook_version": 7,
+  "commit_telemetry": true
 }

--- a/.gemini/templates/.agentic/config.json
+++ b/.gemini/templates/.agentic/config.json
@@ -4,8 +4,11 @@
   "qa_default_skip": null,
   "model_profile": "default",
   "auto_merge_on_ci_green": false,
-  "capability_preflight_mode": "advisory",
+  "capability_preflight_mode": "blocking",
   "perceptual_diff_enabled": false,
   "theme_aware": false,
-  "storybook_enabled": false
+  "storybook_enabled": false,
+  "motion_aware": false,
+  "storybook_version": 7,
+  "commit_telemetry": true
 }

--- a/content/templates/.agentic/config.json
+++ b/content/templates/.agentic/config.json
@@ -4,8 +4,11 @@
   "qa_default_skip": null,
   "model_profile": "default",
   "auto_merge_on_ci_green": false,
-  "capability_preflight_mode": "advisory",
+  "capability_preflight_mode": "blocking",
   "perceptual_diff_enabled": false,
   "theme_aware": false,
-  "storybook_enabled": false
+  "storybook_enabled": false,
+  "motion_aware": false,
+  "storybook_version": 7,
+  "commit_telemetry": true
 }


### PR DESCRIPTION
Aligns the seed `config.json` that `/init-project` writes into new projects with the documented toggle set. Pre-existing intent-debt surfaced during the Graphify work; kept separate from those PRs because it changes scaffolding defaults.

Changes to `content/templates/.agentic/config.json`:
- `capability_preflight_mode`: `"advisory"` -> `"blocking"` (the documented P2 default; template was stale)
- `motion_aware`: added (`false`)
- `storybook_version`: added (`7`)
- `commit_telemetry`: added (`true`)

Result: 12 keys (scaffolding_version + 11 documented toggles), matching the set documented in `content/rules/conventions.md` and `content/sections/04-risk-classification.md`. Absent keys already fell back to these defaults at runtime, so this is a completeness/correctness fix to the seed, not a behavior change for existing projects. Adapter copies regenerated; no `content/sections/` touched so the drift baseline is unchanged.