### PR TITLE
fix(ci): pin ossf/scorecard-action to v2.4.3 SHA (bare @v2 tag does not exist)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
       # list and forbids workflow-level write permissions; do not add
       # non-allowlisted steps or broaden permissions or publish_results breaks.
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The `ossf/scorecard-action@v2` floating tag does not exist on the action repo - only specific `v2.4.x` tags are published. This caused the "Prepare all required actions" step to fail with "unable to find version 'v2'".

Pinned to the commit SHA for v2.4.3 (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`), matching OpenSSF's recommended pinning style.