### PR TITLE
feat(hooks): in-session capture-gap nudge via PostToolUse(Task)

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -523,6 +523,43 @@ else:
     print("  + Added PreToolUse orchestrator-singularity enforcement hook")
     print("    (To disable: set AE_SINGULARITY_GUARD_DISABLE=1 and restart Claude Code)")
 
+# ---- PostToolUse capture-nudge hook -----------------------------------------
+# Surfaces an in-session capture-gap nudge when a Task spawn launches and the
+# session has a learning-worthy event with no learning captured yet. Matcher
+# "Task"; find-or-create idempotent, identical pattern to the PreToolUse Task
+# blocks above. Claude-Code-only (consistent with the deferred-wrap hooks).
+CAPTURE_NUDGE_CMD = f"node {repo_dir}/hooks/post-tool-use-capture-nudge.js"
+
+ptu_post_list = hooks.setdefault("PostToolUse", [])
+
+# Find or create a matcher "Task" block.
+ptu_post_task = None
+for block in ptu_post_list:
+    if block.get("matcher") == "Task":
+        ptu_post_task = block
+        break
+
+if ptu_post_task is None:
+    ptu_post_task = {"matcher": "Task", "hooks": []}
+    ptu_post_list.append(ptu_post_task)
+
+ptu_post_task.setdefault("hooks", [])
+
+already_has_capture_nudge = any(
+    "post-tool-use-capture-nudge" in entry.get("command", "")
+    for entry in ptu_post_task["hooks"]
+)
+
+if already_has_capture_nudge:
+    print("  = PostToolUse capture-nudge hook already present")
+else:
+    ptu_post_task["hooks"].append({
+        "type": "command",
+        "command": CAPTURE_NUDGE_CMD,
+        "timeout": 5
+    })
+    print("  + Added PostToolUse capture-nudge hook")
+
 # ---- PreToolUse AskUserQuestion default-enforcement hook --------------------
 ENFORCE_AUQ_CMD = f"python3 {repo_dir}/hooks/enforce-askuserquestion-default.py"
 

--- a/.codex/references/conductor-operating-rules.md
+++ b/.codex/references/conductor-operating-rules.md
@@ -32,6 +32,10 @@ Downstream consumers: content/sections/02-delegation.md (inline pointers from
                       (required reading directive), content/agents/learnings-
                       agent.md (required reading directive), conductor (applies
                       mandatory trigger protocol at each capture gate).
+                      hooks/post-tool-use-capture-nudge.js (the in-session
+                      PostToolUse(Task) capture-gap nudge that mechanically
+                      surfaces the §learnings-agent "spawn autonomously, do not
+                      ask the user" rule mid-session).
 
 Failure modes: Prose reference; does not auto-execute. Permission-blocked
                fallback requires immediate Skeptic on the applied edit -
@@ -166,7 +170,9 @@ When `Capture: MUST` is declared, the conductor spawns `learnings-agent` in the
 background with `run_in_background: true`. Before spawning, check
 `.agentic/learnings-agent.session`; if present and its `session_id` matches the
 current session, the agent is already active - send the event message to the running
-agent rather than re-spawning.
+agent rather than re-spawning. When `Capture: MUST` is declared, the conductor writes
+the entry or spawns `learnings-agent` autonomously - do not ask the user whether to
+capture, do not wait for acknowledgment.
 
 The conductor's message contains: `event_type`, `description`, `resolution`,
 `domain_tag`, `severity` (omit `severity` for KNW-producing event types). The agent

--- a/.cursor/rules/references/conductor-operating-rules.md
+++ b/.cursor/rules/references/conductor-operating-rules.md
@@ -32,6 +32,10 @@ Downstream consumers: content/sections/02-delegation.md (inline pointers from
                       (required reading directive), content/agents/learnings-
                       agent.md (required reading directive), conductor (applies
                       mandatory trigger protocol at each capture gate).
+                      hooks/post-tool-use-capture-nudge.js (the in-session
+                      PostToolUse(Task) capture-gap nudge that mechanically
+                      surfaces the §learnings-agent "spawn autonomously, do not
+                      ask the user" rule mid-session).
 
 Failure modes: Prose reference; does not auto-execute. Permission-blocked
                fallback requires immediate Skeptic on the applied edit -
@@ -166,7 +170,9 @@ When `Capture: MUST` is declared, the conductor spawns `learnings-agent` in the
 background with `run_in_background: true`. Before spawning, check
 `.agentic/learnings-agent.session`; if present and its `session_id` matches the
 current session, the agent is already active - send the event message to the running
-agent rather than re-spawning.
+agent rather than re-spawning. When `Capture: MUST` is declared, the conductor writes
+the entry or spawns `learnings-agent` autonomously - do not ask the user whether to
+capture, do not wait for acknowledgment.
 
 The conductor's message contains: `event_type`, `description`, `resolution`,
 `domain_tag`, `severity` (omit `severity` for KNW-producing event types). The agent

--- a/.gemini/references/conductor-operating-rules.md
+++ b/.gemini/references/conductor-operating-rules.md
@@ -32,6 +32,10 @@ Downstream consumers: content/sections/02-delegation.md (inline pointers from
                       (required reading directive), content/agents/learnings-
                       agent.md (required reading directive), conductor (applies
                       mandatory trigger protocol at each capture gate).
+                      hooks/post-tool-use-capture-nudge.js (the in-session
+                      PostToolUse(Task) capture-gap nudge that mechanically
+                      surfaces the §learnings-agent "spawn autonomously, do not
+                      ask the user" rule mid-session).
 
 Failure modes: Prose reference; does not auto-execute. Permission-blocked
                fallback requires immediate Skeptic on the applied edit -
@@ -166,7 +170,9 @@ When `Capture: MUST` is declared, the conductor spawns `learnings-agent` in the
 background with `run_in_background: true`. Before spawning, check
 `.agentic/learnings-agent.session`; if present and its `session_id` matches the
 current session, the agent is already active - send the event message to the running
-agent rather than re-spawning.
+agent rather than re-spawning. When `Capture: MUST` is declared, the conductor writes
+the entry or spawns `learnings-agent` autonomously - do not ask the user whether to
+capture, do not wait for acknowledgment.
 
 The conductor's message contains: `event_type`, `description`, `resolution`,
 `domain_tag`, `severity` (omit `severity` for KNW-producing event types). The agent

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ content/**/.agentic/
 !content/templates/.agentic/
 !content/templates/.agentic/**
 
+# Local-only scheduling/automation (e.g. DinoStack PR-review launchd job).
+# Machine-specific (resolves local binary paths, pins a GitHub identity) and not
+# part of the shipped methodology — kept local, never committed upstream.
+/automation/
+
 # Pi coding agent generated/project-local state (not adapter-owned)
 .pi/taskplane.json
 .pi/agents/supervisor.md

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -1868,6 +1868,10 @@ Downstream consumers: content/sections/02-delegation.md (inline pointers from
                       (required reading directive), content/agents/learnings-
                       agent.md (required reading directive), conductor (applies
                       mandatory trigger protocol at each capture gate).
+                      hooks/post-tool-use-capture-nudge.js (the in-session
+                      PostToolUse(Task) capture-gap nudge that mechanically
+                      surfaces the §learnings-agent "spawn autonomously, do not
+                      ask the user" rule mid-session).
 
 Failure modes: Prose reference; does not auto-execute. Permission-blocked
                fallback requires immediate Skeptic on the applied edit -
@@ -2002,7 +2006,9 @@ When `Capture: MUST` is declared, the conductor spawns `learnings-agent` in the
 background with `run_in_background: true`. Before spawning, check
 `.agentic/learnings-agent.session`; if present and its `session_id` matches the
 current session, the agent is already active - send the event message to the running
-agent rather than re-spawning.
+agent rather than re-spawning. When `Capture: MUST` is declared, the conductor writes
+the entry or spawns `learnings-agent` autonomously - do not ask the user whether to
+capture, do not wait for acknowledgment.
 
 The conductor's message contains: `event_type`, `description`, `resolution`,
 `domain_tag`, `severity` (omit `severity` for KNW-producing event types). The agent

--- a/content/references/conductor-operating-rules.md
+++ b/content/references/conductor-operating-rules.md
@@ -32,6 +32,10 @@ Downstream consumers: content/sections/02-delegation.md (inline pointers from
                       (required reading directive), content/agents/learnings-
                       agent.md (required reading directive), conductor (applies
                       mandatory trigger protocol at each capture gate).
+                      hooks/post-tool-use-capture-nudge.js (the in-session
+                      PostToolUse(Task) capture-gap nudge that mechanically
+                      surfaces the §learnings-agent "spawn autonomously, do not
+                      ask the user" rule mid-session).
 
 Failure modes: Prose reference; does not auto-execute. Permission-blocked
                fallback requires immediate Skeptic on the applied edit -
@@ -166,7 +170,9 @@ When `Capture: MUST` is declared, the conductor spawns `learnings-agent` in the
 background with `run_in_background: true`. Before spawning, check
 `.agentic/learnings-agent.session`; if present and its `session_id` matches the
 current session, the agent is already active - send the event message to the running
-agent rather than re-spawning.
+agent rather than re-spawning. When `Capture: MUST` is declared, the conductor writes
+the entry or spawns `learnings-agent` autonomously - do not ask the user whether to
+capture, do not wait for acknowledgment.
 
 The conductor's message contains: `event_type`, `description`, `resolution`,
 `domain_tag`, `severity` (omit `severity` for KNW-producing event types). The agent

--- a/hooks/lib/capture-gap.js
+++ b/hooks/lib/capture-gap.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+/**
+ * Purpose: Shared capture-gap detector. Determines whether the current session
+ *          has a learning-worthy event (debugger/investigator root cause,
+ *          skeptic major/critical resolved, or tool-failure workaround) with no
+ *          learning captured yet, so callers can surface a capture nudge. Pure
+ *          read-only detection: reads .agentic/events.jsonl and
+ *          .agentic/learnings.md, runs one git diff subprocess for guardrail
+ *          suppression, and returns a result object. Extracted verbatim from
+ *          hooks/stop-context.js (detectCaptureGap, GUARDRAIL_PATTERNS,
+ *          _tokenize) so the Stop-hook backstop and the in-session
+ *          PostToolUse(Task) nudge share one implementation.
+ *
+ * Public API (CommonJS, all exported on module.exports):
+ *   detectCaptureGap(cwd, sessionId)
+ *     -> { shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }
+ *   GUARDRAIL_PATTERNS - RegExp[] of guardrail-file basename patterns.
+ *   _tokenize(str) -> string[] - domain-proximity tokenizer.
+ *
+ * Upstream deps: Node built-ins only (fs, path, child_process). Reads
+ *                [cwd]/.agentic/events.jsonl (learning-worthy events),
+ *                [cwd]/.agentic/learnings.md (today-dated LRN/KNW suppression),
+ *                [cwd]/.agentic/.capture-gap-last-sweep (pagination cursor, READ
+ *                only - the cursor WRITE stays in stop-context.js's
+ *                appendCaptureGapNoticeToContextMd, the sole cursor writer).
+ *                Runs `git diff --name-only origin/HEAD..HEAD` (primary) /
+ *                `git diff --name-only HEAD~1 HEAD` (fallback) for guardrail
+ *                suppression. No npm dependencies. No writes.
+ *
+ * Downstream consumers: hooks/stop-context.js (Stop-hook backstop that appends a
+ *                        nudge to context.md for the NEXT session) and
+ *                        hooks/post-tool-use-capture-nudge.js (PostToolUse(Task)
+ *                        hook that injects an in-session additionalContext nudge).
+ *
+ * Failure modes: Never throws. All errors are absorbed and return
+ *                { shouldNudge: false, residualOnly: false, lastEventTs: null }.
+ *                A missing events.jsonl, a non-git cwd, a missing learnings.md,
+ *                or a malformed event line are all tolerated silently. The git
+ *                diff subprocess soft-fails (no suppression applied) on any
+ *                error. Pure read-only: no on-disk state is mutated, so the
+ *                function is idempotent and safe to call on every spawn.
+ *
+ * Performance: ~5-20 ms typical; at most one git diff subprocess call (5 s
+ *              timeout, soft-fail) and two synchronous file reads. The git
+ *              subprocess runs ONLY once a learning-worthy event with no captured
+ *              learning is found (conditions (a) and (b) hold), so the common
+ *              no-event case costs a single file read and returns early.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Capture-gap detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Guardrail glob patterns used to detect test / lint / schema files added
+ * during the session. Matched against the basename of each changed path.
+ * @type {RegExp[]}
+ */
+const GUARDRAIL_PATTERNS = [
+  /test/i,
+  /spec/i,
+  /\.eslintrc/i,
+  /\.schema\./i,
+  /ruff\.toml/i,
+  /mypy\.ini/i,
+];
+
+/**
+ * Normalize a string into tokens for domain-proximity matching.
+ * Splits on '/', '.', '-', '_' and lowercases; filters tokens shorter than 4
+ * chars (too generic to carry domain signal).
+ *
+ * @param {string} str
+ * @returns {string[]}
+ */
+function _tokenize(str) {
+  return str.toLowerCase().split(/[\/.\-_]/).filter((t) => t.length >= 4);
+}
+
+/**
+ * Detect whether this session has learning-worthy events with no learnings
+ * captured. Pure function: reads files, runs one git subprocess, returns a
+ * result object. Never throws - all errors are absorbed and return
+ * { shouldNudge: false, residualOnly: false, lastEventTs: null }.
+ *
+ * Three conditions must ALL hold for shouldNudge === true:
+ *   (a) At least one learning-worthy event this session (debugger/investigator
+ *       spawn_complete, skeptic spawn_complete with major/critical resolved, or
+ *       tool_failure_workaround). Events without session_uuid are DELIBERATELY
+ *       EXCLUDED (inverse of scanSessionAggregate which includes absent uuids
+ *       for back-compat). This exclusion prevents false nags from legacy event
+ *       lines whose session cannot be determined. Self-heals after one post-upgrade
+ *       session where emits carry session_uuid.
+ *   (b) No today-dated [LRN- or [KNW- entries in .agentic/learnings.md.
+ *   (c) No domain-proximate guardrail added this session (suppression). The
+ *       suppressor checks git diff --name-only origin/HEAD..HEAD (all session
+ *       commits since branch diverged from upstream - primary) falling back to
+ *       git diff --name-only HEAD~1 HEAD (single-commit fallback when no
+ *       upstream ref exists). If guardrails were added but none are domain-
+ *       proximate with the event domain tokens, residualOnly is set true and
+ *       the nudge still fires with residual-WHY wording.
+ *
+ * lastEventTs is the ts of the most recent learning-worthy event encountered in
+ * the scan, or null when no worthy event was found. Callers use it as the dedup
+ * key for the in-session nudge ((session_id, lastEventTs) tuple) so a single
+ * worthy event nudges at most once per session.
+ *
+ * @param {string} cwd - Project root (absolute, already validated by caller).
+ * @param {string|null} sessionId - Stop / PostToolUse payload session_id (harness uuid).
+ * @returns {{ shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }}
+ */
+function detectCaptureGap(cwd, sessionId) {
+  try {
+    if (!sessionId) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
+
+    // --- (a) Scan events.jsonl for learning-worthy events this session ---
+    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+
+    // Pagination: read only lines after the last sweep cursor.
+    let lastSweepTs = '';
+    try {
+      const cursorPath = path.join(cwd, '.agentic', '.capture-gap-last-sweep');
+      if (fs.existsSync(cursorPath)) {
+        lastSweepTs = fs.readFileSync(cursorPath, 'utf8').trim();
+      }
+    } catch (_) { /* silent */ }
+
+    let rawEvents = '';
+    try {
+      if (fs.existsSync(eventsPath)) {
+        rawEvents = fs.readFileSync(eventsPath, 'utf8');
+      }
+    } catch (_) { return { shouldNudge: false, residualOnly: false, lastEventTs: null }; }
+
+    const eventLines = rawEvents.split('\n');
+    // On cold start (no cursor), cap to the last 100 lines.
+    const linesToScan = lastSweepTs
+      ? eventLines
+      : eventLines.slice(-100);
+
+    const LEARNING_AGENTS = new Set(['debugger', 'investigator']);
+    let hasLearningWorthyEvent = false;
+    let lastWorthyTs = null;
+    const eventDomainTokens = new Set();
+
+    for (const line of linesToScan) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try { obj = JSON.parse(trimmed); } catch (_) { continue; }
+
+      const data = (obj && obj.data) || {};
+
+      // DELIBERATE: lines without data.session_uuid are EXCLUDED here.
+      // This is the inverse of scanSessionAggregate (which includes absent uuids
+      // for back-compat). The backstop must not nag on legacy event lines from
+      // prior sessions that lack session attribution - that would cause false
+      // positives on every session until the file rotates. scanSessionAggregate
+      // keeps absent=include for back-compat; only this backstop uses absent=exclude.
+      if (!data.session_uuid || data.session_uuid !== sessionId) continue;
+
+      // Pagination: skip lines at or before the last sweep timestamp.
+      if (lastSweepTs && obj.ts && obj.ts <= lastSweepTs) continue;
+
+      const ev = obj.event;
+      const agentName = (obj.agent || '').toLowerCase();
+
+      let worthy = false;
+      if (ev === 'tool_failure_workaround') {
+        worthy = true;
+      } else if (ev === 'spawn_complete') {
+        if (LEARNING_AGENTS.has(agentName)) {
+          worthy = true;
+        } else if (agentName === 'skeptic') {
+          const fc = data.findings_count || {};
+          if ((Number(fc.critical) || 0) > 0 || (Number(fc.major) || 0) > 0) {
+            if (data.signed_off) worthy = true;
+          }
+        }
+      }
+
+      if (worthy) {
+        hasLearningWorthyEvent = true;
+        // Track the ts of the most recent learning-worthy event for dedup.
+        // Lines are scanned in file order (oldest -> newest), so the last
+        // assignment wins. Guard against absent ts.
+        if (typeof obj.ts === 'string' && obj.ts) {
+          lastWorthyTs = obj.ts;
+        }
+        // Collect domain tokens from domain_tag and tool references
+        for (const src of [data.domain_tag, data.tool]) {
+          if (typeof src === 'string' && src) {
+            for (const tok of _tokenize(src)) eventDomainTokens.add(tok);
+          }
+        }
+      }
+    }
+
+    if (!hasLearningWorthyEvent) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
+
+    // --- (b) Check .agentic/learnings.md for today-dated entries ---
+    const todayStr = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    try {
+      const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
+      if (fs.existsSync(learningsPath)) {
+        const learningsRaw = fs.readFileSync(learningsPath, 'utf8');
+        // Match [LRN-YYYYMMDD-XXX] or [KNW-YYYYMMDD-XXX] with today's date, OR
+        // a "Discovered: YYYY-MM-DD" line dated today.
+        const dateCompact = todayStr.replace(/-/g, '');
+        const hasToday =
+          learningsRaw.includes(`[LRN-${dateCompact}`) ||
+          learningsRaw.includes(`[KNW-${dateCompact}`) ||
+          learningsRaw.includes(`Discovered: ${todayStr}`);
+        if (hasToday) return { shouldNudge: false, residualOnly: false, lastEventTs: lastWorthyTs };
+      }
+    } catch (_) { /* silent - absent learnings.md means no learning captured */ }
+
+    // --- (c) Guardrail suppression ---
+    // Collect names of guardrail files added this session via git diff.
+    // Primary: git diff --name-only origin/HEAD..HEAD  (all commits since branch diverged)
+    // Fallback: git diff --name-only HEAD~1 HEAD       (last commit only; used when no upstream)
+    let changedPaths = [];
+    try {
+      let diffOutput = '';
+      try {
+        diffOutput = execSync(
+          'git diff --name-only origin/HEAD..HEAD',
+          { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+        );
+      } catch (_primaryErr) {
+        // No upstream ref - fall back to last commit only.
+        try {
+          diffOutput = execSync(
+            'git diff --name-only HEAD~1 HEAD',
+            { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+          );
+        } catch (_) { /* no commits yet or non-git dir; diffOutput stays '' */ }
+      }
+      changedPaths = diffOutput.split('\n').map((p) => p.trim()).filter(Boolean);
+    } catch (_) { /* soft-fail: no suppression applied */ }
+
+    const addedGuardrailPaths = changedPaths.filter((p) => {
+      const base = path.basename(p);
+      if (GUARDRAIL_PATTERNS.some((re) => re.test(base))) return true;
+      // Also match directory segments: tests/, evals/, spec/
+      return /(?:^|\/)(?:tests|evals|spec)\//i.test(p + '/');
+    });
+
+    if (addedGuardrailPaths.length === 0) {
+      // No guardrails added - fire standard nudge.
+      return { shouldNudge: true, residualOnly: false, lastEventTs: lastWorthyTs };
+    }
+
+    // Check domain proximity: does any guardrail path share a >=4-char token
+    // with any event domain token?
+    let domainProximate = false;
+    if (eventDomainTokens.size > 0) {
+      for (const gp of addedGuardrailPaths) {
+        const gpTokens = _tokenize(gp);
+        if (gpTokens.some((t) => eventDomainTokens.has(t))) {
+          domainProximate = true;
+          break;
+        }
+      }
+    }
+
+    if (domainProximate) {
+      // Domain-proximate guardrail added - suppress nudge entirely.
+      return { shouldNudge: false, residualOnly: false, lastEventTs: lastWorthyTs };
+    }
+
+    // Guardrails added but none domain-proximate - fire with residual-WHY text.
+    return { shouldNudge: true, residualOnly: true, lastEventTs: lastWorthyTs };
+  } catch (_) {
+    // Top-level safety net: any unexpected error -> no nudge (never blocks exit).
+    return { shouldNudge: false, residualOnly: false, lastEventTs: null };
+  }
+}
+
+module.exports = {
+  detectCaptureGap,
+  GUARDRAIL_PATTERNS,
+  _tokenize,
+};

--- a/hooks/post-tool-use-capture-nudge.js
+++ b/hooks/post-tool-use-capture-nudge.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * Purpose: Claude Code PostToolUse(Task) hook that surfaces an in-session
+ *          capture-gap nudge. When a Task spawn launches (async_launched) and the
+ *          session has a learning-worthy event with no learning captured yet, the
+ *          hook prints a hookSpecificOutput.additionalContext message so the
+ *          conductor emits its Capture: declaration and spawns learnings-agent
+ *          autonomously - in-session, not waiting for the Stop-hook backstop. This
+ *          closes the gap where free-form (non-/implement-ticket) sessions skip
+ *          mandatory capture or ask the user.
+ *
+ * Public API: run() - invoked immediately at module load via run() call at the
+ *             bottom of the file. Not imported in production; executed as a CLI
+ *             script by the Claude Code PostToolUse(Task) hook. The test loads it
+ *             via a tmp shim that suppresses run() and exercises the body.
+ *
+ * Upstream deps: Node built-ins only (fs, path) plus the local CommonJS module
+ *                hooks/lib/capture-gap.js (detectCaptureGap). No npm dependencies.
+ *                Reads PostToolUse payload from stdin (fd 0); reads
+ *                [cwd]/.agentic/.capture-gap-surfaced (dedup tracker, fail-open);
+ *                detectCaptureGap reads [cwd]/.agentic/events.jsonl,
+ *                [cwd]/.agentic/learnings.md, [cwd]/.agentic/.capture-gap-last-sweep
+ *                (cursor READ only), and runs one git diff subprocess.
+ *                Writes ONLY [cwd]/.agentic/.capture-gap-surfaced (atomic
+ *                tmp+rename). NEVER writes .capture-gap-last-sweep (owned by
+ *                stop-context.js) and NEVER writes learnings.md / context.md.
+ *
+ * Downstream consumers: Claude Code PostToolUse(Task) hook (wired by
+ *                        .claude/install.sh; matcher "Task"). The conductor reads
+ *                        the additionalContext message next to the Task tool result.
+ *
+ * Failure modes: Fully soft-fail. The entire body is wrapped in try/catch and
+ *                always process.exit(0) - the hook NEVER blocks a spawn, never
+ *                writes to stderr, never emits non-JSON to stdout. Malformed
+ *                stdin, a non-Task tool, a non-async_launched response, an absent
+ *                dedup tracker, a detector error, or a tracker-write failure all
+ *                resolve to a silent exit 0. The dedup tracker is fail-open: a
+ *                missing or unreadable tracker is treated as "not yet surfaced"
+ *                so the nudge fires (a duplicate nudge is cheaper than a missed
+ *                one). The (session_id, lastEventTs) tuple keys the dedup so a
+ *                single worthy event nudges at most once per session.
+ *
+ * Performance: ~5-20 ms typical; detectCaptureGap's git subprocess (5 s timeout)
+ *              runs only once a worthy event is found, so the common no-event
+ *              spawn costs a single events.jsonl read and returns early.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { detectCaptureGap } = require('./lib/capture-gap.js');
+
+// Verbatim nudge texts (handoff section 3). The standard variant fires when no
+// guardrail was added this session; the residualOnly variant fires when a
+// guardrail was added but is not domain-proximate to the learning-worthy event.
+const NUDGE_STANDARD =
+  'CAPTURE-NUDGE: a learning-worthy event occurred this session (debugger/investigator root '
+  + 'cause, skeptic major/critical resolved, or tool-failure workaround) but no learning has '
+  + 'been captured yet. Emit your Capture: declaration now. If Capture: MUST, spawn '
+  + 'learnings-agent autonomously - do not ask the user whether to capture.';
+
+const NUDGE_RESIDUAL =
+  'CAPTURE-NUDGE: a related guardrail was added this session but is not domain-proximate to '
+  + 'the learning-worthy event. Emit your Capture: declaration now for any residual WHY or '
+  + 'dead-end reasoning. If Capture: MUST, spawn learnings-agent autonomously.';
+
+/**
+ * Read the dedup tracker and return true if this (session_id, lastEventTs) tuple
+ * was already surfaced this session. Fail-open: a missing or unreadable tracker
+ * returns false (treat as "not surfaced" so the nudge fires).
+ *
+ * Tracker format: one JSON object per line, { session_id, last_event_ts }.
+ *
+ * @param {string} cwd - Project root.
+ * @param {string} sessionId
+ * @param {string|null} lastEventTs
+ * @returns {boolean}
+ */
+function alreadySurfaced(cwd, sessionId, lastEventTs) {
+  try {
+    const trackerPath = path.join(cwd, '.agentic', '.capture-gap-surfaced');
+    if (!fs.existsSync(trackerPath)) return false;
+    const raw = fs.readFileSync(trackerPath, 'utf8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try { obj = JSON.parse(trimmed); } catch (_) { continue; }
+      if (obj && obj.session_id === sessionId && obj.last_event_ts === lastEventTs) {
+        return true;
+      }
+    }
+    return false;
+  } catch (_) {
+    // Fail-open: on any read error, treat as not surfaced (fire the nudge).
+    return false;
+  }
+}
+
+/**
+ * Append a dedup entry for this (session_id, lastEventTs) tuple. Atomic via
+ * read-existing + tmp-write + rename so a concurrent reader never sees a partial
+ * file. Silent failure - a missed write at worst re-nudges next spawn.
+ *
+ * @param {string} cwd - Project root.
+ * @param {string} sessionId
+ * @param {string|null} lastEventTs
+ */
+function recordSurfaced(cwd, sessionId, lastEventTs) {
+  const agenticDir = path.join(cwd, '.agentic');
+  const trackerPath = path.join(agenticDir, '.capture-gap-surfaced');
+  fs.mkdirSync(agenticDir, { recursive: true });
+
+  let existing = '';
+  try {
+    if (fs.existsSync(trackerPath)) existing = fs.readFileSync(trackerPath, 'utf8');
+  } catch (_) { /* fall through with empty existing */ }
+
+  const entry = JSON.stringify({ session_id: sessionId, last_event_ts: lastEventTs });
+  const body = (existing && !existing.endsWith('\n')) ? existing + '\n' : existing;
+  const next = body + entry + '\n';
+
+  const tmpPath = trackerPath + '.tmp';
+  fs.writeFileSync(tmpPath, next, 'utf8');
+  fs.renameSync(tmpPath, trackerPath);
+}
+
+function run() {
+  try {
+    // --- 1. Read + parse stdin ---
+    let raw = '';
+    try {
+      raw = fs.readFileSync(0, 'utf8');
+    } catch (_) {
+      process.exit(0);
+    }
+    if (!raw.trim()) process.exit(0);
+
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch (_) {
+      process.exit(0);
+    }
+
+    // --- 2. Gate on tool_name === "Task" && tool_response.status === "async_launched" ---
+    // Background Task spawns (which this methodology mandates) fire PostToolUse at
+    // LAUNCH with status "async_launched"; the subagent output is not yet available,
+    // so the signal source is events.jsonl via detectCaptureGap, not tool_response.
+    const toolName = payload && payload.tool_name;
+    const toolResponse = (payload && payload.tool_response) || {};
+    if (toolName !== 'Task') process.exit(0);
+    if (toolResponse.status !== 'async_launched') process.exit(0);
+
+    // --- 3. Resolve cwd + session_id (top-level fields on the PostToolUse payload) ---
+    const cwd = (typeof payload.cwd === 'string' && payload.cwd.trim())
+      ? payload.cwd.trim()
+      : null;
+    if (!cwd) process.exit(0);
+
+    const sessionId = (typeof payload.session_id === 'string' && payload.session_id.trim())
+      ? payload.session_id.trim()
+      : null;
+    if (!sessionId) process.exit(0);
+
+    // --- 4. Detect capture gap (shared detector; pure read-only) ---
+    const gap = detectCaptureGap(cwd, sessionId);
+    if (!gap || gap.shouldNudge !== true) process.exit(0);
+
+    // --- 5. Dedup on (session_id, lastEventTs) ---
+    if (alreadySurfaced(cwd, sessionId, gap.lastEventTs)) process.exit(0);
+
+    // --- 6. Record + emit ---
+    try {
+      recordSurfaced(cwd, sessionId, gap.lastEventTs);
+    } catch (_) {
+      // Tracker write failed - still emit the nudge once; a missed dedup record
+      // at worst re-nudges on the next spawn, which is acceptable.
+    }
+
+    const additionalContext = gap.residualOnly ? NUDGE_RESIDUAL : NUDGE_STANDARD;
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext,
+      },
+      suppressOutput: true,
+    }));
+    process.exit(0);
+  } catch (_) {
+    // Soft-fail: any unexpected error -> silent exit 0. Never block a spawn.
+    process.exit(0);
+  }
+}
+
+run();

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -21,7 +21,6 @@
  *             writeSessionLogGlobal(identity, sessionId, data),
  *             writePendingBuffer(cwd, sessionId),
  *             appendIdentityNudgeToContextMd(repoRoot),
- *             detectCaptureGap(cwd, sessionId),
  *             appendCaptureGapNoticeToContextMd(cwd, residualOnly),
  *             wrapLockHeld(cwd) (thin alias to wrap-marker lib),
  *             appendSpilloverRecord(cwd, record),
@@ -32,10 +31,13 @@
  *             stagePending, touchHeartbeat, etc.) now live in
  *             hooks/lib/wrap-marker.js, the single source of truth.
  *
- * Upstream deps: Node built-ins only (fs, path, os, child_process) plus the
- *                local CommonJS module hooks/lib/wrap-marker.js (the deferred-/wrap
+ * Upstream deps: Node built-ins only (fs, path, os, child_process) plus two
+ *                local CommonJS modules: hooks/lib/wrap-marker.js (the deferred-/wrap
  *                marker single source of truth - lock gate, per-session staging,
- *                heartbeat). No npm dependencies. Reads from stdin (fd 0).
+ *                heartbeat) and hooks/lib/capture-gap.js (the shared capture-gap
+ *                detector - detectCaptureGap, GUARDRAIL_PATTERNS, _tokenize,
+ *                extracted so the in-session PostToolUse nudge reuses it).
+ *                No npm dependencies. Reads from stdin (fd 0).
  *                Reads/writes
  *                ~/.claude/projects/[hash]/context.md,
  *                [cwd]/.agentic/loop-state.json,
@@ -172,6 +174,14 @@ const { execSync } = require('child_process');
 // delegated to this lib so stop-context.js, the SessionEnd hook, and the daemon
 // share one atomic, fail-open implementation.
 const wrapMarker = require('./lib/wrap-marker.js');
+
+// Shared capture-gap detector extracted to hooks/lib/capture-gap.js so the
+// Stop-hook backstop below and the in-session PostToolUse(Task) nudge
+// (hooks/post-tool-use-capture-nudge.js) share one implementation. Only
+// detectCaptureGap is used here; GUARDRAIL_PATTERNS and _tokenize remain
+// exported by the lib for test-capture-gap.js. appendCaptureGapNoticeToContextMd
+// (the sole writer of the .capture-gap-last-sweep cursor) stays in this file.
+const { detectCaptureGap } = require('./lib/capture-gap.js');
 
 /**
  * Read the `deferred_wrap_daemon` toggle from [cwd]/.agentic/config.json.
@@ -799,220 +809,10 @@ function stageWrapPending(cwd, sessionId, scan) {
 // ---------------------------------------------------------------------------
 // Capture-gap backstop helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Guardrail glob patterns used to detect test / lint / schema files added
- * during the session. Matched against the basename of each changed path.
- * @type {RegExp[]}
- */
-const GUARDRAIL_PATTERNS = [
-  /test/i,
-  /spec/i,
-  /\.eslintrc/i,
-  /\.schema\./i,
-  /ruff\.toml/i,
-  /mypy\.ini/i,
-];
-
-/**
- * Normalize a string into tokens for domain-proximity matching.
- * Splits on '/', '.', '-', '_' and lowercases; filters tokens shorter than 4
- * chars (too generic to carry domain signal).
- *
- * @param {string} str
- * @returns {string[]}
- */
-function _tokenize(str) {
-  return str.toLowerCase().split(/[\/.\-_]/).filter((t) => t.length >= 4);
-}
-
-/**
- * Detect whether this session has learning-worthy events with no learnings
- * captured. Pure function: reads files, runs one git subprocess, returns a
- * result object. Never throws - all errors are absorbed and return
- * { shouldNudge: false }.
- *
- * Three conditions must ALL hold for shouldNudge === true:
- *   (a) At least one learning-worthy event this session (debugger/investigator
- *       spawn_complete, skeptic spawn_complete with major/critical resolved, or
- *       tool_failure_workaround). Events without session_uuid are DELIBERATELY
- *       EXCLUDED (inverse of scanSessionAggregate which includes absent uuids
- *       for back-compat). This exclusion prevents false nags from legacy event
- *       lines whose session cannot be determined. Self-heals after one post-upgrade
- *       session where emits carry session_uuid.
- *   (b) No today-dated [LRN- or [KNW- entries in .agentic/learnings.md.
- *   (c) No domain-proximate guardrail added this session (suppression). The
- *       suppressor checks git diff --name-only origin/HEAD..HEAD (all session
- *       commits since branch diverged from upstream - primary) falling back to
- *       git diff --name-only HEAD~1 HEAD (single-commit fallback when no
- *       upstream ref exists). If guardrails were added but none are domain-
- *       proximate with the event domain tokens, residualOnly is set true and
- *       the nudge still fires with residual-WHY wording.
- *
- * @param {string} cwd - Project root (absolute, already validated by run()).
- * @param {string|null} sessionId - Stop payload session_id (harness uuid).
- * @returns {{ shouldNudge: boolean, residualOnly: boolean }}
- */
-function detectCaptureGap(cwd, sessionId) {
-  try {
-    if (!sessionId) return { shouldNudge: false, residualOnly: false };
-
-    // --- (a) Scan events.jsonl for learning-worthy events this session ---
-    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
-
-    // Pagination: read only lines after the last sweep cursor.
-    let lastSweepTs = '';
-    try {
-      const cursorPath = path.join(cwd, '.agentic', '.capture-gap-last-sweep');
-      if (fs.existsSync(cursorPath)) {
-        lastSweepTs = fs.readFileSync(cursorPath, 'utf8').trim();
-      }
-    } catch (_) { /* silent */ }
-
-    let rawEvents = '';
-    try {
-      if (fs.existsSync(eventsPath)) {
-        rawEvents = fs.readFileSync(eventsPath, 'utf8');
-      }
-    } catch (_) { return { shouldNudge: false, residualOnly: false }; }
-
-    const eventLines = rawEvents.split('\n');
-    // On cold start (no cursor), cap to the last 100 lines.
-    const linesToScan = lastSweepTs
-      ? eventLines
-      : eventLines.slice(-100);
-
-    const LEARNING_AGENTS = new Set(['debugger', 'investigator']);
-    let hasLearningWorthyEvent = false;
-    const eventDomainTokens = new Set();
-
-    for (const line of linesToScan) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      let obj;
-      try { obj = JSON.parse(trimmed); } catch (_) { continue; }
-
-      const data = (obj && obj.data) || {};
-
-      // DELIBERATE: lines without data.session_uuid are EXCLUDED here.
-      // This is the inverse of scanSessionAggregate (which includes absent uuids
-      // for back-compat). The backstop must not nag on legacy event lines from
-      // prior sessions that lack session attribution - that would cause false
-      // positives on every session until the file rotates. scanSessionAggregate
-      // keeps absent=include for back-compat; only this backstop uses absent=exclude.
-      if (!data.session_uuid || data.session_uuid !== sessionId) continue;
-
-      // Pagination: skip lines at or before the last sweep timestamp.
-      if (lastSweepTs && obj.ts && obj.ts <= lastSweepTs) continue;
-
-      const ev = obj.event;
-      const agentName = (obj.agent || '').toLowerCase();
-
-      let worthy = false;
-      if (ev === 'tool_failure_workaround') {
-        worthy = true;
-      } else if (ev === 'spawn_complete') {
-        if (LEARNING_AGENTS.has(agentName)) {
-          worthy = true;
-        } else if (agentName === 'skeptic') {
-          const fc = data.findings_count || {};
-          if ((Number(fc.critical) || 0) > 0 || (Number(fc.major) || 0) > 0) {
-            if (data.signed_off) worthy = true;
-          }
-        }
-      }
-
-      if (worthy) {
-        hasLearningWorthyEvent = true;
-        // Collect domain tokens from domain_tag and tool references
-        for (const src of [data.domain_tag, data.tool]) {
-          if (typeof src === 'string' && src) {
-            for (const tok of _tokenize(src)) eventDomainTokens.add(tok);
-          }
-        }
-      }
-    }
-
-    if (!hasLearningWorthyEvent) return { shouldNudge: false, residualOnly: false };
-
-    // --- (b) Check .agentic/learnings.md for today-dated entries ---
-    const todayStr = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    try {
-      const learningsPath = path.join(cwd, '.agentic', 'learnings.md');
-      if (fs.existsSync(learningsPath)) {
-        const learningsRaw = fs.readFileSync(learningsPath, 'utf8');
-        // Match [LRN-YYYYMMDD-XXX] or [KNW-YYYYMMDD-XXX] with today's date, OR
-        // a "Discovered: YYYY-MM-DD" line dated today.
-        const dateCompact = todayStr.replace(/-/g, '');
-        const hasToday =
-          learningsRaw.includes(`[LRN-${dateCompact}`) ||
-          learningsRaw.includes(`[KNW-${dateCompact}`) ||
-          learningsRaw.includes(`Discovered: ${todayStr}`);
-        if (hasToday) return { shouldNudge: false, residualOnly: false };
-      }
-    } catch (_) { /* silent - absent learnings.md means no learning captured */ }
-
-    // --- (c) Guardrail suppression ---
-    // Collect names of guardrail files added this session via git diff.
-    // Primary: git diff --name-only origin/HEAD..HEAD  (all commits since branch diverged)
-    // Fallback: git diff --name-only HEAD~1 HEAD       (last commit only; used when no upstream)
-    let changedPaths = [];
-    try {
-      let diffOutput = '';
-      try {
-        diffOutput = execSync(
-          'git diff --name-only origin/HEAD..HEAD',
-          { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
-        );
-      } catch (_primaryErr) {
-        // No upstream ref - fall back to last commit only.
-        try {
-          diffOutput = execSync(
-            'git diff --name-only HEAD~1 HEAD',
-            { cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
-          );
-        } catch (_) { /* no commits yet or non-git dir; diffOutput stays '' */ }
-      }
-      changedPaths = diffOutput.split('\n').map((p) => p.trim()).filter(Boolean);
-    } catch (_) { /* soft-fail: no suppression applied */ }
-
-    const addedGuardrailPaths = changedPaths.filter((p) => {
-      const base = path.basename(p);
-      if (GUARDRAIL_PATTERNS.some((re) => re.test(base))) return true;
-      // Also match directory segments: tests/, evals/, spec/
-      return /(?:^|\/)(?:tests|evals|spec)\//i.test(p + '/');
-    });
-
-    if (addedGuardrailPaths.length === 0) {
-      // No guardrails added - fire standard nudge.
-      return { shouldNudge: true, residualOnly: false };
-    }
-
-    // Check domain proximity: does any guardrail path share a >=4-char token
-    // with any event domain token?
-    let domainProximate = false;
-    if (eventDomainTokens.size > 0) {
-      for (const gp of addedGuardrailPaths) {
-        const gpTokens = _tokenize(gp);
-        if (gpTokens.some((t) => eventDomainTokens.has(t))) {
-          domainProximate = true;
-          break;
-        }
-      }
-    }
-
-    if (domainProximate) {
-      // Domain-proximate guardrail added - suppress nudge entirely.
-      return { shouldNudge: false, residualOnly: false };
-    }
-
-    // Guardrails added but none domain-proximate - fire with residual-WHY text.
-    return { shouldNudge: true, residualOnly: true };
-  } catch (_) {
-    // Top-level safety net: any unexpected error -> no nudge (never blocks exit).
-    return { shouldNudge: false, residualOnly: false };
-  }
-}
+// detectCaptureGap, GUARDRAIL_PATTERNS, and _tokenize now live in
+// hooks/lib/capture-gap.js (required at the top of this file) so the in-session
+// PostToolUse(Task) nudge shares the detector. appendCaptureGapNoticeToContextMd
+// below - the sole writer of the .capture-gap-last-sweep cursor - stays here.
 
 /**
  * Append a capture-gap nudge to .agentic/context.md. Sentinel-gated per session

--- a/hooks/tests/test-capture-gap.js
+++ b/hooks/tests/test-capture-gap.js
@@ -68,6 +68,7 @@ const hookSource = fs.readFileSync(hookPath, 'utf8');
 // path to the REAL hooks/lib/wrap-marker.js before writing the shim, so the
 // shimmed copy still loads the real lib (no behavior change, just resolution).
 const libMarkerAbs = path.resolve(__dirname, '..', 'lib', 'wrap-marker.js');
+const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
 const shimmedSource = hookSource
   // Replace the final bare `run();` call so the hook doesn't try to read stdin.
   .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
@@ -78,14 +79,24 @@ const shimmedSource = hookSource
     /require\(['"]\.\/lib\/wrap-marker\.js['"]\)/,
     `require(${JSON.stringify(libMarkerAbs)})`
   )
+  // Second re-anchor: stop-context.js now requires the shared capture-gap
+  // detector via ./lib/capture-gap.js. Anchor it to the real lib too so the
+  // /tmp shim resolves both relative lib requires.
+  .replace(
+    /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
+    `require(${JSON.stringify(libCaptureGapAbs)})`
+  )
   + `\n
 // Expose helpers for unit tests via a module-level export shim.
-// This block is appended by the test loader.
+// This block is appended by the test loader. detectCaptureGap and
+// appendCaptureGapNoticeToContextMd live in stop-context.js's scope;
+// _tokenize is now owned by hooks/lib/capture-gap.js (stop-context.js no longer
+// imports it), so pull it straight from the lib rather than module scope.
 if (typeof module !== 'undefined') {
   module.exports = {
     detectCaptureGap,
     appendCaptureGapNoticeToContextMd,
-    _tokenize,
+    _tokenize: require(${JSON.stringify(libCaptureGapAbs)})._tokenize,
   };
 }
 `;

--- a/hooks/tests/test-post-tool-use-capture-nudge.js
+++ b/hooks/tests/test-post-tool-use-capture-nudge.js
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: post-tool-use-capture-nudge.js PostToolUse(Task) in-session nudge.
+ *
+ * The hook is a stdin-driven CLI script (run() reads fd 0 and process.exit(0)s),
+ * so each behavioral case drives the REAL hook as a subprocess with a controlled
+ * payload on stdin and a temporary .agentic/ fixture, then asserts on the hook's
+ * stdout (the hookSpecificOutput JSON) and the .capture-gap-surfaced tracker.
+ *
+ * In addition, a tmp-shim load (same technique as test-capture-gap.js's loader)
+ * suppresses run() and re-anchors the relative ./lib/capture-gap.js require to an
+ * absolute path, proving the hook's lib require resolves from /tmp - the
+ * fragility guard mirrors test-capture-gap.js so a changed require form fails loud.
+ *
+ * Test cases:
+ *   1. fires-when-worthy-event:       debugger spawn_complete -> additionalContext emitted
+ *   2. dedup-suppresses-repeat:       second identical spawn -> no second emit
+ *   3. no-fire-when-no-worthy-event:  empty events.jsonl -> no emit
+ *   4. no-fire-when-wrong-tool:       tool_name !== "Task" -> no emit
+ *   5. no-fire-when-not-async-launched: status !== "async_launched" -> no emit
+ *   6. soft-fail-on-malformed-stdin:  non-JSON stdin -> exit 0, no emit, no throw
+ *   7. residualOnly-wording:          unrelated guardrail -> residual nudge text
+ *
+ * Run with: node hooks/tests/test-post-tool-use-capture-nudge.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const hookPath = path.resolve(__dirname, '..', 'post-tool-use-capture-nudge.js');
+
+// ---------------------------------------------------------------------------
+// Tmp-shim load (mirrors test-capture-gap.js): suppress run(), re-anchor the
+// relative ./lib/capture-gap.js require to an absolute path so the /tmp shim can
+// resolve it. We do not export helpers (the hook's surface is run() over stdin);
+// this load only proves the require rewrite + fragility guard hold.
+// ---------------------------------------------------------------------------
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
+const shimmedSource = hookSource
+  // Suppress the trailing bare run() call so requiring the shim does not read stdin.
+  .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
+  // Re-anchor the relative lib require to an absolute path to the real lib.
+  .replace(
+    /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
+    `require(${JSON.stringify(libCaptureGapAbs)})`
+  );
+
+// Fail loud if the re-anchor did not fire (require text changed form).
+if (/require\(['"]\.\/lib\//.test(shimmedSource)) {
+  console.error(
+    '  FATAL: a relative ./lib/ require survived the shim re-anchor - update the '
+    + 'rewrite in test-post-tool-use-capture-nudge.js so the /tmp shim can resolve it.'
+  );
+  process.exit(1);
+}
+
+const tmpShimPath = path.join(os.tmpdir(), `post-tool-use-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+try {
+  require(tmpShimPath); // must load without reading stdin or throwing
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTempProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-ptu-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+function makeEvent(sessionId, event, agent, extra = {}) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'test',
+    event,
+    agent: agent || null,
+    task_id: null,
+    data: Object.assign({ session_uuid: sessionId }, extra),
+  });
+}
+
+/**
+ * Drive the real hook as a subprocess with the given payload on stdin.
+ * Returns { stdout, status }. spawnSync (not execSync) so a clean exit 0 with
+ * empty stdout is captured rather than treated as an error.
+ *
+ * @param {object} payload
+ * @param {string} cwd
+ * @param {string|null} rawOverride - raw stdin string (bypasses JSON.stringify)
+ * @returns {{ stdout: string, status: number }}
+ */
+function runHook(payload, cwd, rawOverride) {
+  const input = rawOverride !== undefined ? rawOverride : JSON.stringify(payload);
+  const res = spawnSync('node', [hookPath], {
+    input, cwd, timeout: 10000, encoding: 'utf8',
+  });
+  return { stdout: res.stdout || '', status: res.status };
+}
+
+function taskPayload(cwd, sessionId, overrides = {}) {
+  return Object.assign({
+    cwd,
+    session_id: sessionId,
+    tool_name: 'Task',
+    tool_response: { status: 'async_launched' },
+  }, overrides);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: fires-when-worthy-event
+// ---------------------------------------------------------------------------
+console.log('\nTest 1: fires-when-worthy-event');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-001';
+  fs.writeFileSync(
+    path.join(cwd, '.agentic', 'events.jsonl'),
+    makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8'
+  );
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  let out = null;
+  try { out = JSON.parse(stdout); } catch (_) { /* leave null */ }
+  assert(out !== null, 'hook emitted parseable JSON');
+  assert(
+    out && out.hookSpecificOutput && out.hookSpecificOutput.hookEventName === 'PostToolUse',
+    'hookEventName is PostToolUse'
+  );
+  assert(
+    out && out.hookSpecificOutput
+    && out.hookSpecificOutput.additionalContext.includes('CAPTURE-NUDGE')
+    && out.hookSpecificOutput.additionalContext.includes('learning-worthy event occurred'),
+    'additionalContext carries the standard CAPTURE-NUDGE text'
+  );
+  assert(out && out.suppressOutput === true, 'suppressOutput is true');
+  // Tracker was written.
+  const trackerPath = path.join(cwd, '.agentic', '.capture-gap-surfaced');
+  assert(fs.existsSync(trackerPath), 'dedup tracker written after firing');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: dedup-suppresses-repeat
+// ---------------------------------------------------------------------------
+console.log('\nTest 2: dedup-suppresses-repeat');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-002';
+  // A fixed-ts event so both spawns see the SAME lastEventTs tuple.
+  const fixedEvent = JSON.stringify({
+    ts: '2026-06-24T10:00:00.000Z',
+    phase: 'test',
+    event: 'spawn_complete',
+    agent: 'debugger',
+    task_id: null,
+    data: { session_uuid: sessionId },
+  });
+  fs.writeFileSync(path.join(cwd, '.agentic', 'events.jsonl'), fixedEvent + '\n', 'utf8');
+
+  const first = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(first.stdout.includes('CAPTURE-NUDGE'), 'first spawn emits nudge');
+
+  const second = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(second.status === 0, 'second spawn exits 0');
+  assert(second.stdout.trim() === '', 'second spawn (same tuple) emits nothing - dedup');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: no-fire-when-no-worthy-event
+// ---------------------------------------------------------------------------
+console.log('\nTest 3: no-fire-when-no-worthy-event');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-003';
+  // events.jsonl absent -> no worthy event.
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge emitted when no worthy event');
+  assert(
+    !fs.existsSync(path.join(cwd, '.agentic', '.capture-gap-surfaced')),
+    'no tracker written when no worthy event'
+  );
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: no-fire-when-wrong-tool
+// ---------------------------------------------------------------------------
+console.log('\nTest 4: no-fire-when-wrong-tool');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-004';
+  fs.writeFileSync(
+    path.join(cwd, '.agentic', 'events.jsonl'),
+    makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8'
+  );
+  // tool_name is Bash, not Task - must not fire even though a worthy event exists.
+  const payload = taskPayload(cwd, sessionId, { tool_name: 'Bash' });
+  const { stdout, status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge emitted for non-Task tool');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: no-fire-when-not-async-launched
+// ---------------------------------------------------------------------------
+console.log('\nTest 5: no-fire-when-not-async-launched');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-005';
+  fs.writeFileSync(
+    path.join(cwd, '.agentic', 'events.jsonl'),
+    makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8'
+  );
+  // tool_response.status is "completed" (foreground), not "async_launched".
+  const payload = taskPayload(cwd, sessionId, { tool_response: { status: 'completed' } });
+  const { stdout, status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge emitted when status !== async_launched');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: soft-fail-on-malformed-stdin
+// ---------------------------------------------------------------------------
+console.log('\nTest 6: soft-fail-on-malformed-stdin');
+{
+  const cwd = makeTempProject();
+  const { stdout, status } = runHook(null, cwd, '{ this is not json');
+  assert(status === 0, 'hook exits 0 on malformed stdin (soft-fail)');
+  assert(stdout.trim() === '', 'no output on malformed stdin');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: residualOnly-wording
+// A guardrail file is added but is NOT domain-proximate to the event, so the
+// detector returns residualOnly=true and the hook must emit the residual text.
+// ---------------------------------------------------------------------------
+console.log('\nTest 7: residualOnly-wording');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-007';
+  let ok = true;
+  try {
+    execSync('git init -b main', { cwd, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd, stdio: 'pipe' });
+    fs.writeFileSync(path.join(cwd, 'README.md'), 'initial\n');
+    execSync('git add README.md', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd, stdio: 'pipe' });
+
+    // Unrelated guardrail (payments domain), event domain is git -> no overlap.
+    fs.mkdirSync(path.join(cwd, 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'tests', 'test-stripe-checkout.js'), '// test\n');
+    execSync('git add tests/test-stripe-checkout.js', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "add unrelated test"', { cwd, stdio: 'pipe' });
+
+    fs.writeFileSync(
+      path.join(cwd, '.agentic', 'events.jsonl'),
+      makeEvent(sessionId, 'tool_failure_workaround', null, {
+        domain_tag: 'git', tool: 'git-push',
+      }) + '\n', 'utf8'
+    );
+  } catch (e) {
+    ok = false;
+    console.log(`  SKIP: git fixture setup failed (${(e.message || '').split('\n')[0]})`);
+  }
+
+  if (ok) {
+    const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+    assert(status === 0, 'hook exits 0');
+    let out = null;
+    try { out = JSON.parse(stdout); } catch (_) { /* leave null */ }
+    assert(out !== null, 'hook emitted parseable JSON (residual case)');
+    const ctx = out && out.hookSpecificOutput ? out.hookSpecificOutput.additionalContext : '';
+    assert(
+      ctx.includes('CAPTURE-NUDGE') && ctx.includes('related guardrail was added this session'),
+      'residual case emits the residual CAPTURE-NUDGE wording'
+    );
+    assert(
+      !ctx.includes('learning-worthy event occurred this session'),
+      'residual case does NOT use the standard wording'
+    );
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Makes the mandatory learnings/decisions capture protocol fire autonomously during any session, not just `/implement-ticket` phases. Previously the only mechanical catch outside `/implement-ticket` was the Stop hook's passive `context.md` nudge for the next session, so free-form sessions skipped capture or asked the user.

- Extract `detectCaptureGap` + `GUARDRAIL_PATTERNS` + `_tokenize` into shared `hooks/lib/capture-gap.js`; add a `lastEventTs` return field for in-session dedup keying.
- New `hooks/post-tool-use-capture-nudge.js`: PostToolUse(Task) hook gated on `tool_response.status=async_launched`. On a learning-worthy event with nothing captured it injects a `hookSpecificOutput.additionalContext` nudge, deduped on `(session_id, lastEventTs)`. Fully soft-fail (never blocks a spawn); never writes `learnings.md`/`context.md` or the `.capture-gap-last-sweep` cursor.
- `stop-context.js` requires the shared lib; externally-observable output is byte-for-byte unchanged (proved by `test-capture-gap.js`, 29/29).
- New `test-post-tool-use-capture-nudge.js` (22 assertions). `install.sh` wires the hook idempotently. `conductor-operating-rules.md` §learnings-agent states the spawn-autonomously rule the hook surfaces.

Claude-Code-only, consistent with the deferred-wrap hooks. Plan was architect-authored + Skeptic-reviewed; the code diff was independently Skeptic-reviewed (sign-off, no Critical/Major).

Verification: `node hooks/tests/test-post-tool-use-capture-nudge.js`, `node hooks/tests/test-capture-gap.js`, full hooks suite green, 10-adapter build clean.