### PR TITLE
fix(gemini): emit agent frontmatter matching gemini-cli 0.47 schema

### DIFF
--- a/.gemini/agents/adr-drift-detector.md
+++ b/.gemini/agents/adr-drift-detector.md
@@ -1,8 +1,7 @@
 ---
 name: adr-drift-detector
-description: Audits codebase compliance against Architecture Decision Records (ADRs). Invoke when the user mentions ADR compliance, architecture drift, "does code match ADRs", architectural audit, or wants to verify decisions are being followed. Automatically finds ADRs, extracts decisions, searches code for evidence, and produces a structured drift report.
-tools: Read, Bash, Grep, Glob
-disallowedTools: [Edit, Write, Task]
+description: "Audits codebase compliance against Architecture Decision Records (ADRs). Invoke when the user mentions ADR compliance, architecture drift, \"does code match ADRs\", architectural audit, or wants to verify decisions are being followed. Automatically finds ADRs, extracts decisions, searches code for evidence, and produces a structured drift report."
+tools: [read_file, run_shell_command, grep_search, glob]
 kind: local
 ---
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task. Exception: this is a read-only agent, hard-locked against `Edit`/`Write`/`Task` by the `disallowedTools` frontmatter above - the `Edit`/`Write` examples in this note do not apply to it.

--- a/.gemini/agents/adr-generator.md
+++ b/.gemini/agents/adr-generator.md
@@ -1,7 +1,7 @@
 ---
 name: adr-generator
-description: Expert agent for creating comprehensive Architectural Decision Records (ADRs) with structured formatting optimized for AI consumption and human readability.
-tools: Read, Bash, Grep, Glob, Edit, Write
+description: "Expert agent for creating comprehensive Architectural Decision Records (ADRs) with structured formatting optimized for AI consumption and human readability."
+tools: [read_file, run_shell_command, grep_search, glob, replace, write_file]
 kind: local
 ---
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -1,8 +1,7 @@
 ---
 name: architect
-description: Pre-implementation technical design agent. Spawn when you need a structured technical plan before writing code. Reads the codebase, identifies patterns and constraints, evaluates approaches, and produces a concrete plan a Worker can execute directly. Never writes or modifies files.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Pre-implementation technical design agent. Spawn when you need a structured technical plan before writing code. Reads the codebase, identifies patterns and constraints, evaluates approaches, and produces a concrete plan a Worker can execute directly. Never writes or modifies files."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/debugger.md
+++ b/.gemini/agents/debugger.md
@@ -1,8 +1,7 @@
 ---
 name: debugger
-description: Root cause analysis agent. Spawn when a test is failing, a stack trace needs investigation, or a bug needs diagnosis. Investigates the codebase, forms and tests hypotheses, and returns a diagnosis plus a fix brief. Does NOT implement the fix.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Root cause analysis agent. Spawn when a test is failing, a stack trace needs investigation, or a bug needs diagnosis. Investigates the codebase, forms and tests hypotheses, and returns a diagnosis plus a fix brief. Does NOT implement the fix."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/dependency-auditor.md
+++ b/.gemini/agents/dependency-auditor.md
@@ -1,8 +1,7 @@
 ---
 name: dependency-auditor
-description: Supply-chain review specialist. Spawn when the user says "audit our dependencies", "is this upgrade safe", "any CVEs in our lockfile", "check license compliance", "review this new dependency", "do we have vulnerable packages", or "check our supply chain". Triages lockfiles, runs ecosystem vulnerability tools, flags license risks, assesses maintenance signals, and produces a structured findings report for engineer to execute. Does NOT audit application code for OWASP patterns - that is security-auditor's job.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Supply-chain review specialist. Spawn when the user says \"audit our dependencies\", \"is this upgrade safe\", \"any CVEs in our lockfile\", \"check license compliance\", \"review this new dependency\", \"do we have vulnerable packages\", or \"check our supply chain\". Triages lockfiles, runs ecosystem vulnerability tools, flags license risks, assesses maintenance signals, and produces a structured findings report for engineer to execute. Does NOT audit application code for OWASP patterns - that is security-auditor's job."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/engineer.md
+++ b/.gemini/agents/engineer.md
@@ -1,7 +1,7 @@
 ---
 name: engineer
-description: General-purpose implementation agent. Spawn for any code change: new features, bug fixes, refactors, configuration changes, or script writing. Reads the codebase to understand conventions, implements the change, runs quality gates, and returns a clear summary of what was done. This is the standard Worker for all Elevated-risk implementation tasks.
-tools: Read, Glob, Grep, Bash, Write, Edit
+description: "General-purpose implementation agent. Spawn for any code change: new features, bug fixes, refactors, configuration changes, or script writing. Reads the codebase to understand conventions, implements the change, runs quality gates, and returns a clear summary of what was done. This is the standard Worker for all Elevated-risk implementation tasks."
+tools: [read_file, glob, grep_search, run_shell_command, write_file, replace]
 kind: local
 ---
 

--- a/.gemini/agents/investigator.md
+++ b/.gemini/agents/investigator.md
@@ -1,8 +1,7 @@
 ---
 name: investigator
-description: Codebase investigation agent. Spawn when you need to understand code before deciding how to change it - tracing data flow, mapping blast radius, understanding feature behavior without a stack trace, or exploring an unfamiliar area. Returns a structured investigation brief the conductor can hand directly to architect or engineer. Does NOT implement changes or write to disk.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Codebase investigation agent. Spawn when you need to understand code before deciding how to change it - tracing data flow, mapping blast radius, understanding feature behavior without a stack trace, or exploring an unfamiliar area. Returns a structured investigation brief the conductor can hand directly to architect or engineer. Does NOT implement changes or write to disk."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/learning-extractor.md
+++ b/.gemini/agents/learning-extractor.md
@@ -1,7 +1,7 @@
 ---
 name: learning-extractor
-description: Per-ticket learning extraction agent. Spawned by /implement-ticket Phase 6 clean exit. Reads the resolved findings_log and extracts durable fix-pattern LRN (bug-fix) learnings to .agentic/learnings.md. Emits LRN entries ONLY - KNW (knowledge) capture is learnings-agent's responsibility via mandatory triggers. Tier 1 leaf agent, 30s timeout, soft-fail. Does not touch MEMORY.md, decisions.md, AGENTS.md, or any source/config files.
-tools: Read, Glob, Edit, Write
+description: "Per-ticket learning extraction agent. Spawned by /implement-ticket Phase 6 clean exit. Reads the resolved findings_log and extracts durable fix-pattern LRN (bug-fix) learnings to .agentic/learnings.md. Emits LRN entries ONLY - KNW (knowledge) capture is learnings-agent's responsibility via mandatory triggers. Tier 1 leaf agent, 30s timeout, soft-fail. Does not touch MEMORY.md, decisions.md, AGENTS.md, or any source/config files."
+tools: [read_file, glob, replace, write_file]
 kind: local
 ---
 

--- a/.gemini/agents/learnings-agent.md
+++ b/.gemini/agents/learnings-agent.md
@@ -1,7 +1,7 @@
 ---
 name: learnings-agent
-description: Session-scoped background learnings capture. Spawned by the conductor when the first mandatory capture trigger fires in a session. Receives learning events as messages, writes structured LRN (bug-fix) or KNW (knowledge) entries to .agentic/learnings.md and optionally to MEMORY.md. Uses dedup, caps, and soft-fail discipline. Does not touch decisions.md, AGENTS.md, findings.md, qa.md, tasks.jsonl, loop-state.json, batch-state.json, context.md, or any source/config files.
-tools: Read, Glob, Grep, Edit, Write
+description: "Session-scoped background learnings capture. Spawned by the conductor when the first mandatory capture trigger fires in a session. Receives learning events as messages, writes structured LRN (bug-fix) or KNW (knowledge) entries to .agentic/learnings.md and optionally to MEMORY.md. Uses dedup, caps, and soft-fail discipline. Does not touch decisions.md, AGENTS.md, findings.md, qa.md, tasks.jsonl, loop-state.json, batch-state.json, context.md, or any source/config files."
+tools: [read_file, glob, grep_search, replace, write_file]
 kind: local
 ---
 

--- a/.gemini/agents/orchestration-planner.md
+++ b/.gemini/agents/orchestration-planner.md
@@ -1,8 +1,7 @@
 ---
 name: orchestration-planner
-description: Agent team composition planner. Spawn when you have a complex goal or task and need to determine the optimal combination of agents, their sequencing, handoff points, and parallelization strategy before executing. Use when the right agent team is not obvious, when multiple phases are involved, when a high-level requirement needs decomposing into a concrete execution plan, or when you want to avoid costly mid-task reclassification. Returns a structured orchestration plan the conductor can execute directly. Does not implement anything - planning only.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Agent team composition planner. Spawn when you have a complex goal or task and need to determine the optimal combination of agents, their sequencing, handoff points, and parallelization strategy before executing. Use when the right agent team is not obvious, when multiple phases are involved, when a high-level requirement needs decomposing into a concrete execution plan, or when you want to avoid costly mid-task reclassification. Returns a structured orchestration plan the conductor can execute directly. Does not implement anything - planning only."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/perf-analyst.md
+++ b/.gemini/agents/perf-analyst.md
@@ -1,8 +1,7 @@
 ---
 name: perf-analyst
-description: Performance analysis specialist. Spawn when a feature is slow, investigating a performance regression, benchmarking before/after a change, profiling CPU or memory hotspots, measuring latency or throughput against a budget, or hunting memory leaks. Distinct from debugger (correctness failures, stack traces) and qa-engineer (acceptance criteria, browser verification). Profiles, benchmarks, and bisects to find where time or memory is spent — then produces a measured findings brief the engineer can execute. Does NOT implement fixes.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Performance analysis specialist. Spawn when a feature is slow, investigating a performance regression, benchmarking before/after a change, profiling CPU or memory hotspots, measuring latency or throughput against a budget, or hunting memory leaks. Distinct from debugger (correctness failures, stack traces) and qa-engineer (acceptance criteria, browser verification). Profiles, benchmarks, and bisects to find where time or memory is spent — then produces a measured findings brief the engineer can execute. Does NOT implement fixes."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/product-discovery.md
+++ b/.gemini/agents/product-discovery.md
@@ -1,7 +1,7 @@
 ---
 name: product-discovery
-description: Facilitated product discovery before any architecture or implementation work. Spawn when someone arrives with a product or feature idea that is not yet scoped - "I want to build...", "we should add...", "thinking about a tool that...", "here's an idea for..." - or when a project has no vision/requirements docs yet and work is about to start. Also spawn when the user asks to scope a feature, write a PRD, frame a problem, identify target users, run a competitive scan, or draft a product brief or PRFAQ. Decides WHAT to build and WHY, then stages a proposed vision.md and requirements.md for the operator to confirm. Stages proposals to docs/overview/_proposed/ only; never writes the canonical docs/overview/ files. Prefer this over jumping straight to design or code when the underlying problem, users, or scope are still fuzzy.
-tools: Read, Glob, Grep, Bash, Write, Edit
+description: "Facilitated product discovery before any architecture or implementation work. Spawn when someone arrives with a product or feature idea that is not yet scoped - \"I want to build...\", \"we should add...\", \"thinking about a tool that...\", \"here's an idea for...\" - or when a project has no vision/requirements docs yet and work is about to start. Also spawn when the user asks to scope a feature, write a PRD, frame a problem, identify target users, run a competitive scan, or draft a product brief or PRFAQ. Decides WHAT to build and WHY, then stages a proposed vision.md and requirements.md for the operator to confirm. Stages proposals to docs/overview/_proposed/ only; never writes the canonical docs/overview/ files. Prefer this over jumping straight to design or code when the underlying problem, users, or scope are still fuzzy."
+tools: [read_file, glob, grep_search, run_shell_command, write_file, replace]
 kind: local
 ---
 

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -1,8 +1,7 @@
 ---
 name: qa-engineer
-description: Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says "run QA", "verify in the browser", "check the feature works", "test the acceptance criteria", or "does it work". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Dynamic verification agent for runtime testing. Spawn after Skeptic review, before merge, for any change with visible UI or behavioral output. Also invoked when the user says \"run QA\", \"verify in the browser\", \"check the feature works\", \"test the acceptance criteria\", or \"does it work\". Verifies changes work in a real browser, runs test suites, validates against acceptance criteria and design specs. Supports scenario methods: browser, api, runtime-required, visual_conformance, accessibility (WCAG via axe-core), perceptual_diff (pixel regression via pixelmatch), and motion (prefers-reduced-motion via Playwright CDP). Iterates all applicable scenarios across each declared viewport. Returns a structured pass/fail report with evidence. Does not fix issues. Appends learned project-specific quirks to .agentic/qa.md for future runs."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/release-orchestrator.md
+++ b/.gemini/agents/release-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: release-orchestrator
-description: End-to-end release sequencing agent. Spawn when you need to cut a release, ship this to production, bump version and tag, deploy to production, or roll back the last release. Owns the full sequence from pre-flight through post-deploy verification. Refuses to proceed when any gate fails. Does not write feature code. Hands failures to the debugger.
-tools: Read, Glob, Grep, Bash, Write, Edit
+description: "End-to-end release sequencing agent. Spawn when you need to cut a release, ship this to production, bump version and tag, deploy to production, or roll back the last release. Owns the full sequence from pre-flight through post-deploy verification. Refuses to proceed when any gate fails. Does not write feature code. Hands failures to the debugger."
+tools: [read_file, glob, grep_search, run_shell_command, write_file, replace]
 kind: local
 ---
 

--- a/.gemini/agents/security-auditor.md
+++ b/.gemini/agents/security-auditor.md
@@ -1,8 +1,7 @@
 ---
 name: security-auditor
-description: Specialized security reviewer. Spawn when a deep, threat-model-driven security audit is needed on code changes. Applies OWASP Top 10 and CWE-category analysis systematically, assumes a capable attacker, and produces a structured findings report with severity ratings, specific code locations, and remediation guidance. The spawn prompt provides the files or code to audit, the security domain, and any known prior mitigations.
-tools: Read, Glob, Grep, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Specialized security reviewer. Spawn when a deep, threat-model-driven security audit is needed on code changes. Applies OWASP Top 10 and CWE-category analysis systematically, assumes a capable attacker, and produces a structured findings report with severity ratings, specific code locations, and remediation guidance. The spawn prompt provides the files or code to audit, the security domain, and any known prior mitigations."
+tools: [read_file, glob, grep_search, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -1,8 +1,7 @@
 ---
 name: skeptic
-description: Adversarial code reviewer. Spawn when conducting Skeptic Protocol review of Worker output. Evaluates implementation against an adversarial brief, classifies findings as Critical/Major/Minor, and produces a structured sign-off. The spawn prompt must contain four things: (1) the adversarial brief defining the attack surface to probe, (2) Worker output as inline text or file paths, (3) a resolved-issues preflight listing findings addressed in prior rounds, and (4) a Global-context input set (a "## Global-context inputs" block containing the architect plan path, Brief/Plan artifact path, qa_criteria block, per-consumer impact table, related files list, and diff under review). See content/references/skeptic-protocol.md Section 4.5 for the canonical block format.
-tools: Read, Grep, Glob, Bash
-disallowedTools: [Edit, Write, Task]
+description: "Adversarial code reviewer. Spawn when conducting Skeptic Protocol review of Worker output. Evaluates implementation against an adversarial brief, classifies findings as Critical/Major/Minor, and produces a structured sign-off. The spawn prompt must contain four things: (1) the adversarial brief defining the attack surface to probe, (2) Worker output as inline text or file paths, (3) a resolved-issues preflight listing findings addressed in prior rounds, and (4) a Global-context input set (a \"## Global-context inputs\" block containing the architect plan path, Brief/Plan artifact path, qa_criteria block, per-consumer impact table, related files list, and diff under review). See content/references/skeptic-protocol.md Section 4.5 for the canonical block format."
+tools: [read_file, grep_search, glob, run_shell_command]
 kind: local
 ---
 

--- a/.gemini/agents/wrap-ticket.md
+++ b/.gemini/agents/wrap-ticket.md
@@ -1,7 +1,7 @@
 ---
 name: wrap-ticket
-description: Per-ticket learnings capture invoked at /implement-ticket Phase 11b. Constrained subset of /wrap that fires automatically on every PR opened. Reads the ticket's findings_log, qa.md diff, merged diff, and conversation summary; appends durable learnings to MEMORY.md, decisions.md, and .agentic/context.md (## Recent Focus only). Does not touch AGENTS.md, qa.md, findings.md, tasks.jsonl, loop-state.json, batch-state.json, or any source/config files. Soft-fails on any error - never blocks Phase 12 or PR completion.
-tools: Read, Glob, Grep, Edit, Write
+description: "Per-ticket learnings capture invoked at /implement-ticket Phase 11b. Constrained subset of /wrap that fires automatically on every PR opened. Reads the ticket's findings_log, qa.md diff, merged diff, and conversation summary; appends durable learnings to MEMORY.md, decisions.md, and .agentic/context.md (## Recent Focus only). Does not touch AGENTS.md, qa.md, findings.md, tasks.jsonl, loop-state.json, batch-state.json, or any source/config files. Soft-fails on any error - never blocks Phase 12 or PR completion."
+tools: [read_file, glob, grep_search, replace, write_file]
 kind: local
 ---
 > **Note on `tools`:** The `tools:` field lists the minimum/typical toolset this agent uses. Subagents inherit the parent's full toolset regardless of this list. Use additional tools (browser, WriteFile, Edit, etc.) as needed for the task.

--- a/.gemini/build.sh
+++ b/.gemini/build.sh
@@ -306,6 +306,54 @@ for src in "$CONTENT/agents/"*.md; do
       if [[ "$line" == model:* ]] || [[ "$line" == "model: "* ]]; then
         continue
       fi
+      # Skip disallowedTools: lines (redundant in gemini-cli 0.47+; tools is an allowlist)
+      if [[ "$line" == disallowedTools:* ]] || [[ "$line" == "disallowedTools: "* ]]; then
+        continue
+      fi
+      # Transform tools: comma-string -> YAML flow array with gemini tool names
+      # gemini-cli 0.47 requires an array and only accepts its own tool name identifiers.
+      # Map Claude Code tool names to gemini equivalents:
+      #   Read  -> read_file        Glob -> glob        Grep -> grep_search
+      #   Bash  -> run_shell_command  Write -> write_file  Edit -> replace
+      #   Task  -> invoke_agent
+      if [[ "$line" == tools:* ]]; then
+        val="${line#tools:}"
+        val="${val# }"  # strip leading space
+        if [[ "$val" != "["* ]]; then
+          # Split on commas, trim whitespace, map names, build [item1, item2, ...] flow array
+          IFS=',' read -ra items <<< "$val"
+          arr="["
+          for item in "${items[@]}"; do
+            trimmed="${item#"${item%%[![:space:]]*}"}"  # ltrim
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"  # rtrim
+            # Map Claude Code tool names -> gemini tool names
+            case "$trimmed" in
+              Read)  trimmed="read_file" ;;
+              Glob)  trimmed="glob" ;;
+              Grep)  trimmed="grep_search" ;;
+              Bash)  trimmed="run_shell_command" ;;
+              Write) trimmed="write_file" ;;
+              Edit)  trimmed="replace" ;;
+              Task)  trimmed="invoke_agent" ;;
+            esac
+            arr+="$trimmed, "
+          done
+          arr="${arr%, }]"  # remove trailing ", " and close
+          line="tools: $arr"
+        fi
+      fi
+      # Quote description: values to prevent YAML misparse of colon-space sequences
+      if [[ "$line" == description:* ]]; then
+        val="${line#description:}"
+        val="${val# }"  # strip leading space
+        # Only quote if not already double-quoted
+        if [[ "$val" != '"'* ]]; then
+          # Escape backslashes then double-quotes in value
+          val="${val//\\/\\\\}"
+          val="${val//\"/\\\"}"
+          line="description: \"$val\""
+        fi
+      fi
       # Track if kind: is already present
       if [[ "$line" == kind:* ]] || [[ "$line" == "kind: "* ]]; then
         has_kind=1


### PR DESCRIPTION
gemini-cli 0.47.0 tightened the local-agent frontmatter schema; every generated `.gemini/agents/*.md` failed to load (`tools: Expected array, received string`, `Unrecognized key disallowedTools`, and YAML indent errors from colon-space in descriptions).

Fix in `.gemini/build.sh` Step 4 frontmatter generation:
- `tools:` comma-string -> YAML flow array, with Claude->gemini tool-name mapping (Read->read_file, Glob->glob, Grep->grep_search, Bash->run_shell_command, Write->write_file, Edit->replace, Task->invoke_agent) verified against the gemini bundle's builtin-tool constants
- drop `disallowedTools:` (no longer accepted; `tools` array is the allowlist)
- quote `description:` to neutralize colon-space

Regenerated all 17 agent files. Headless `gemini -p` run: 17 Agent-loading-errors -> 0. No read-only agent gained write/invoke capability. content/ untouched (adapter-sync + methodology-baseline stay green). Skeptic signed off (no findings).

Assignee: Tyson