### PR TITLE
fix(hooks): restore three enforcement hooks killed by the Task→Agent tool rename

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -494,33 +494,35 @@ for spawn_matcher in ("Task", "Agent"):
     )
 
 # ---- PostToolUse capture-nudge hook -----------------------------------------
-# Surfaces an in-session capture-gap nudge when a Task spawn launches and the
-# session has a learning-worthy event with no learning captured yet. Matcher
-# "Task"; find-or-create idempotent, identical pattern to the PreToolUse Task
-# blocks above. Claude-Code-only (consistent with the deferred-wrap hooks).
+# Surfaces an in-session capture-gap nudge when a subagent spawn launches and the
+# session has a learning-worthy event with no learning captured yet. Claude Code
+# renamed the spawn tool from "Task" to "Agent", so we wire BOTH matcher names
+# (same dual Task/Agent block pattern as the PreToolUse hooks above), each
+# find-or-create idempotent. Claude-Code-only (consistent with deferred-wrap hooks).
 CAPTURE_NUDGE_CMD = f"node {repo_dir}/hooks/post-tool-use-capture-nudge.js"
 
 ptu_post_list = hooks.setdefault("PostToolUse", [])
 
-# Find or create a matcher "Task" block.
-ptu_post_task = None
-for block in ptu_post_list:
-    if block.get("matcher") == "Task":
-        ptu_post_task = block
-        break
+for spawn_matcher in ("Task", "Agent"):
+    # Find or create a matcher block for this tool name.
+    ptu_post_block = None
+    for block in ptu_post_list:
+        if block.get("matcher") == spawn_matcher:
+            ptu_post_block = block
+            break
 
-if ptu_post_task is None:
-    ptu_post_task = {"matcher": "Task", "hooks": []}
-    ptu_post_list.append(ptu_post_task)
+    if ptu_post_block is None:
+        ptu_post_block = {"matcher": spawn_matcher, "hooks": []}
+        ptu_post_list.append(ptu_post_block)
 
-ptu_post_task.setdefault("hooks", [])
+    ptu_post_block.setdefault("hooks", [])
 
-upsert_hook(
-    ptu_post_task["hooks"],
-    "post-tool-use-capture-nudge.js",
-    {"type": "command", "command": CAPTURE_NUDGE_CMD, "timeout": 5},
-    "PostToolUse capture-nudge hook",
-)
+    upsert_hook(
+        ptu_post_block["hooks"],
+        "post-tool-use-capture-nudge.js",
+        {"type": "command", "command": CAPTURE_NUDGE_CMD, "timeout": 5},
+        f"PostToolUse({spawn_matcher}) capture-nudge hook",
+    )
 
 # ---- PreToolUse AskUserQuestion default-enforcement hook --------------------
 ENFORCE_AUQ_CMD = f"python3 {repo_dir}/hooks/enforce-askuserquestion-default.py"

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -451,43 +451,47 @@ upsert_hook(
     "SessionStart deferred-wrap hook",
 )
 
-# ---- PreToolUse background-spawn enforcement hook ---------------------------
+# ---- PreToolUse background-spawn + orchestrator-singularity hooks -----------
+# NOTE - Task/Agent rename: Claude Code renamed the subagent-spawn tool from
+# "Task" to "Agent". We wire BOTH matcher names so the hooks fire under either
+# CC version. The hooks themselves also guard on both names internally for
+# belt-and-suspenders coverage. Two PreToolUse blocks are created: one for
+# "Task" (legacy) and one for "Agent" (current), each containing both hooks.
 ENFORCE_BG_CMD = f"python3 {repo_dir}/hooks/enforce-background-spawn.py"
+ENFORCE_SINGULARITY_CMD = f"python3 {repo_dir}/hooks/enforce-orchestrator-singularity.py"
 
 ptu_list = hooks.setdefault("PreToolUse", [])
 
-# Find or create a matcher "Task" block
-ptu_task = None
-for block in ptu_list:
-    if block.get("matcher") == "Task":
-        ptu_task = block
-        break
+for spawn_matcher in ("Task", "Agent"):
+    # Find or create a matcher block for this tool name.
+    ptu_block = None
+    for block in ptu_list:
+        if block.get("matcher") == spawn_matcher:
+            ptu_block = block
+            break
 
-if ptu_task is None:
-    ptu_task = {"matcher": "Task", "hooks": []}
-    ptu_list.append(ptu_task)
+    if ptu_block is None:
+        ptu_block = {"matcher": spawn_matcher, "hooks": []}
+        ptu_list.append(ptu_block)
 
-ptu_task.setdefault("hooks", [])
+    ptu_block.setdefault("hooks", [])
 
-upsert_hook(
-    ptu_task["hooks"],
-    "enforce-background-spawn.py",
-    {"type": "command", "command": ENFORCE_BG_CMD, "timeout": 5},
-    "PreToolUse background-spawn enforcement hook",
-)
+    upsert_hook(
+        ptu_block["hooks"],
+        "enforce-background-spawn.py",
+        {"type": "command", "command": ENFORCE_BG_CMD, "timeout": 5},
+        f"PreToolUse({spawn_matcher}) background-spawn enforcement hook",
+    )
 
-# ---- PreToolUse orchestrator-singularity enforcement hook -------------------
-# Denies Task spawns issued from inside a subagent context (detected via the
-# top-level agent_id field). To disable: set AE_SINGULARITY_GUARD_DISABLE=1
-# in the environment that launches Claude Code, then restart.
-ENFORCE_SINGULARITY_CMD = f"python3 {repo_dir}/hooks/enforce-orchestrator-singularity.py"
-
-upsert_hook(
-    ptu_task["hooks"],
-    "enforce-orchestrator-singularity.py",
-    {"type": "command", "command": ENFORCE_SINGULARITY_CMD, "timeout": 5},
-    "PreToolUse orchestrator-singularity enforcement hook",
-)
+    # Denies spawns issued from inside a subagent context (detected via the
+    # top-level agent_id field). To disable: set AE_SINGULARITY_GUARD_DISABLE=1
+    # in the environment that launches Claude Code, then restart.
+    upsert_hook(
+        ptu_block["hooks"],
+        "enforce-orchestrator-singularity.py",
+        {"type": "command", "command": ENFORCE_SINGULARITY_CMD, "timeout": 5},
+        f"PreToolUse({spawn_matcher}) orchestrator-singularity enforcement hook",
+    )
 
 # ---- PostToolUse capture-nudge hook -----------------------------------------
 # Surfaces an in-session capture-gap nudge when a Task spawn launches and the

--- a/hooks/enforce-background-spawn.py
+++ b/hooks/enforce-background-spawn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Purpose: PreToolUse hook that enforces the METHODOLOGY §Delegation background-by-default
-         rule by denying any Task (subagent spawn) tool call that lacks
+         rule by denying any subagent spawn tool call that lacks
          run_in_background: true. Converts a prose advisory into a hard gate on
          Claude Code. Feeds the deny reason back to the model so it can re-issue
          the call correctly. Documented foreground-exempt agents (see
@@ -11,13 +11,23 @@ Purpose: PreToolUse hook that enforces the METHODOLOGY §Delegation background-b
          release). The hook fails open on parse error, so older builds degrade
          to no-enforcement rather than breaking.
 
-Public API: Run as a Claude Code PreToolUse hook. Reads JSON from stdin,
-            writes hookSpecificOutput JSON to stdout when denying, exits 0 always.
+         NOTE - Task/Agent rename: Claude Code renamed the subagent-spawn tool
+         from "Task" to "Agent" in a recent release. This hook guards on BOTH
+         names (`tool_name in ("Task", "Agent")`) for backward compatibility
+         across Claude Code versions. The settings.json matcher is also wired
+         for both names by install.sh (two PreToolUse blocks: one for "Task",
+         one for "Agent"). The hook fires under either name; the internal guard
+         is defensive belt-and-suspenders.
+
+Public API: Run as a Claude Code PreToolUse hook (matcher: "Task" or "Agent").
+            Reads JSON from stdin, writes hookSpecificOutput JSON to stdout when
+            denying, exits 0 always.
 
 Upstream deps: Python 3 stdlib only (json, sys). No external dependencies.
 
-Downstream consumers: Claude Code hook runner (PreToolUse event for the Task tool).
-                      Wired via ~/.claude/settings.json by .claude/install.sh.
+Downstream consumers: Claude Code hook runner (PreToolUse event for the Task /
+                      Agent tool). Wired via ~/.claude/settings.json by
+                      .claude/install.sh (two matcher blocks: "Task" and "Agent").
 
 Failure modes:
     - Malformed stdin: fail-open (exit 0, no deny). A hook bug must never brick
@@ -25,7 +35,8 @@ Failure modes:
     - Null or non-dict tool_input: fail-open (exit 0). Same contract - any parse
       or logic error exits 0 so enforcement gaps are never converted to blanket
       blocks.
-    - Non-Task tool_name: passthrough (exit 0). This hook is scoped to Task only.
+    - Non-Task/Agent tool_name: passthrough (exit 0). This hook is scoped to
+      Task/Agent only.
     - run_in_background absent, false, or non-boolean: deny with reason fed back
       to model. Only boolean True is accepted as the allow signal.
     - Foreground-exempt subagent_type (FOREGROUND_EXEMPT): allow regardless of
@@ -58,10 +69,12 @@ def main() -> None:
         except Exception:
             sys.exit(0)
 
-        # Only enforce on Task (subagent spawn). All direct-action tools
-        # (Read, Bash, Write, Edit, Glob, Grep, etc.) never use Task, so
-        # there are no false positives from a blanket Task-scoped deny.
-        if data.get("tool_name") != "Task":
+        # Only enforce on Task/Agent (subagent spawn). Claude Code renamed
+        # this tool from "Task" to "Agent"; guard on both names so the hook
+        # works across CC versions. All direct-action tools (Read, Bash,
+        # Write, Edit, Glob, Grep, etc.) never use Task/Agent, so there
+        # are no false positives from this scoped deny.
+        if data.get("tool_name") not in ("Task", "Agent"):
             sys.exit(0)
 
         # tool_input may be null/missing. Null means no structured params -
@@ -83,17 +96,18 @@ def main() -> None:
 
         # Deny foreground spawns and feed back a clear, actionable reason
         # so the conductor re-issues with run_in_background: true.
+        tool_name = data.get("tool_name", "Task/Agent")
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
                 "permissionDecisionReason": (
-                    "Task spawn blocked: run_in_background is missing or false. "
+                    tool_name + " spawn blocked: run_in_background is missing or false. "
                     "All delegated subagent spawns MUST set run_in_background: true "
-                    "(METHODOLOGY.md §Delegation). Re-issue the Task call with "
+                    "(METHODOLOGY.md §Delegation). Re-issue the " + tool_name + " call with "
                     "run_in_background: true. Direct-action cases (reads, memory "
-                    "answers, synthesis) do not use Task at all - use the appropriate "
-                    "dedicated tool instead."
+                    "answers, synthesis) do not use " + tool_name + " at all - use the "
+                    "appropriate dedicated tool instead."
                 )
             }
         }))

--- a/hooks/enforce-orchestrator-singularity.py
+++ b/hooks/enforce-orchestrator-singularity.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
 """
 Purpose: PreToolUse hook that enforces the METHODOLOGY §Delegation
-         orchestrator-singularity invariant by denying any Task (subagent
-         spawn) issued from inside a subagent context. Only the main conductor
+         orchestrator-singularity invariant by denying any subagent spawn
+         issued from inside a subagent context. Only the main conductor
          session may spawn subagents; workers must return BLOCKED when they
          would otherwise try to delegate further. This converts a prose
          advisory into a hard gate on Claude Code.
 
-Public API: Run as a Claude Code PreToolUse hook (matcher: "Task"). Reads
-            JSON from stdin, writes hookSpecificOutput JSON to stdout when
+         NOTE - Task/Agent rename: Claude Code renamed the subagent-spawn tool
+         from "Task" to "Agent" in a recent release. This hook guards on BOTH
+         names (`tool_name in ("Task", "Agent")`) for backward compatibility
+         across Claude Code versions. The settings.json matcher is also wired
+         for both names by install.sh (two PreToolUse blocks: one for "Task",
+         one for "Agent"). The hook fires under either name; the internal guard
+         is defensive belt-and-suspenders.
+
+Public API: Run as a Claude Code PreToolUse hook (matcher: "Task" or "Agent").
+            Reads JSON from stdin, writes hookSpecificOutput JSON to stdout when
             denying, exits 0 always.
 
 Upstream deps: Python 3 stdlib only (os, sys, json). No external dependencies.
 
-Downstream consumers: Claude Code hook runner (PreToolUse event for the Task
-                      tool). Wired via ~/.claude/settings.json by
-                      .claude/install.sh.
+Downstream consumers: Claude Code hook runner (PreToolUse event for the Task /
+                      Agent tool). Wired via ~/.claude/settings.json by
+                      .claude/install.sh (two matcher blocks: "Task" and "Agent").
 
 Failure modes:
     - Malformed stdin: fail-open (exit 0, no deny). A hook bug must never
@@ -27,7 +35,7 @@ Failure modes:
       (exit 0) before reading stdin. To disable: set
       AE_SINGULARITY_GUARD_DISABLE=1 in the shell that launches Claude Code,
       or remove the hook entry from ~/.claude/settings.json and restart.
-    - Non-Task tool_name: passthrough (exit 0). Scoped to Task only.
+    - Non-Task/Agent tool_name: passthrough (exit 0). Scoped to Task/Agent only.
     - Older Claude Code versions: if permissionDecision: deny is not
       honoured, switch to exit 2 with the reason on stderr as fallback.
 
@@ -67,8 +75,11 @@ def main() -> None:
         except Exception:
             sys.exit(0)
 
-        # Only enforce on Task (subagent spawn).
-        if data.get("tool_name") != "Task":
+        # Only enforce on Task/Agent (subagent spawn). Claude Code renamed
+        # this tool from "Task" to "Agent"; guard on both names so the hook
+        # works across CC versions. install.sh wires two matcher blocks
+        # ("Task" and "Agent") for belt-and-suspenders coverage.
+        if data.get("tool_name") not in ("Task", "Agent"):
             sys.exit(0)
 
         # Read agent_id from the TOP LEVEL of the payload (not tool_input).
@@ -79,12 +90,13 @@ def main() -> None:
             sys.exit(0)
 
         # Deny: a subagent attempted to spawn a nested subagent.
+        tool_name = data.get("tool_name", "Task/Agent")
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
                 "permissionDecisionReason": (
-                    "Task spawn blocked: a subagent (agent_id="
+                    tool_name + " spawn blocked: a subagent (agent_id="
                     + repr(agent_id)
                     + ") attempted to spawn a nested subagent. "
                     "The AE invariant is that the main conductor is the sole "

--- a/hooks/post-tool-use-capture-nudge.js
+++ b/hooks/post-tool-use-capture-nudge.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Purpose: Claude Code PostToolUse(Task) hook that surfaces an in-session
- *          capture-gap nudge. When a Task spawn launches (async_launched) and the
+ * Purpose: Claude Code PostToolUse(Task/Agent) hook that surfaces an in-session
+ *          capture-gap nudge. When a subagent spawn launches (async_launched) and the
  *          session has a learning-worthy event with no learning captured yet, the
  *          hook prints a hookSpecificOutput.additionalContext message so the
  *          conductor emits its Capture: declaration and spawns learnings-agent
@@ -12,8 +12,8 @@
  *
  * Public API: run() - invoked immediately at module load via run() call at the
  *             bottom of the file. Not imported in production; executed as a CLI
- *             script by the Claude Code PostToolUse(Task) hook. The test loads it
- *             via a tmp shim that suppresses run() and exercises the body.
+ *             script by the Claude Code PostToolUse(Task/Agent) hook. The test loads
+ *             it via a tmp shim that suppresses run() and exercises the body.
  *
  * Upstream deps: Node built-ins only (fs, path) plus the local CommonJS module
  *                hooks/lib/capture-gap.js (detectCaptureGap). No npm dependencies.
@@ -26,14 +26,15 @@
  *                tmp+rename). NEVER writes .capture-gap-last-sweep (owned by
  *                stop-context.js) and NEVER writes learnings.md / context.md.
  *
- * Downstream consumers: Claude Code PostToolUse(Task) hook (wired by
- *                        .claude/install.sh; matcher "Task"). The conductor reads
- *                        the additionalContext message next to the Task tool result.
+ * Downstream consumers: Claude Code PostToolUse(Task/Agent) hook (wired by
+ *                        .claude/install.sh; matchers "Task" and "Agent"). The
+ *                        conductor reads the additionalContext message next to the
+ *                        spawn tool result.
  *
  * Failure modes: Fully soft-fail. The entire body is wrapped in try/catch and
  *                always process.exit(0) - the hook NEVER blocks a spawn, never
  *                writes to stderr, never emits non-JSON to stdout. Malformed
- *                stdin, a non-Task tool, a non-async_launched response, an absent
+ *                stdin, a non-Task/Agent tool, a non-async_launched response, an absent
  *                dedup tracker, a detector error, or a tracker-write failure all
  *                resolve to a silent exit 0. The dedup tracker is fail-open: a
  *                missing or unreadable tracker is treated as "not yet surfaced"
@@ -145,13 +146,15 @@ function run() {
       process.exit(0);
     }
 
-    // --- 2. Gate on tool_name === "Task" && tool_response.status === "async_launched" ---
-    // Background Task spawns (which this methodology mandates) fire PostToolUse at
+    // --- 2. Gate on tool_name in {"Task","Agent"} && tool_response.status === "async_launched" ---
+    // Background subagent spawns (which this methodology mandates) fire PostToolUse at
     // LAUNCH with status "async_launched"; the subagent output is not yet available,
     // so the signal source is events.jsonl via detectCaptureGap, not tool_response.
+    // Claude Code renamed the spawn tool from "Task" to "Agent"; accept both names so
+    // the nudge keeps firing across CC versions (install.sh wires both matchers).
     const toolName = payload && payload.tool_name;
     const toolResponse = (payload && payload.tool_response) || {};
-    if (toolName !== 'Task') process.exit(0);
+    if (toolName !== 'Task' && toolName !== 'Agent') process.exit(0);
     if (toolResponse.status !== 'async_launched') process.exit(0);
 
     // --- 3. Resolve cwd + session_id (top-level fields on the PostToolUse payload) ---

--- a/hooks/tests/test-enforce-background-spawn.py
+++ b/hooks/tests/test-enforce-background-spawn.py
@@ -1,0 +1,173 @@
+# Run with: python3 hooks/tests/test-enforce-background-spawn.py
+"""
+Unit tests for hooks/enforce-background-spawn.py.
+
+Each case pipes a JSON payload (or malformed string) into the hook via stdin
+and asserts ALLOW (exit 0, no deny output) or DENY (exit 0, deny in stdout).
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+HOOK_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "enforce-background-spawn.py"
+)
+
+
+def run_hook(payload: str) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, HOOK_PATH],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def is_allow(returncode: int, stdout: str) -> bool:
+    """ALLOW: exit 0 and no deny decision in stdout."""
+    if returncode != 0:
+        return False
+    if not stdout.strip():
+        return True
+    try:
+        obj = json.loads(stdout)
+        decision = (
+            obj.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        )
+        return decision != "deny"
+    except Exception:
+        return True  # unparseable output -> not a deny
+
+
+def is_deny(returncode: int, stdout: str) -> bool:
+    """DENY: exit 0 and permissionDecision == deny in stdout."""
+    if returncode != 0:
+        return False
+    try:
+        obj = json.loads(stdout)
+        decision = (
+            obj.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        )
+        return decision == "deny"
+    except Exception:
+        return False
+
+
+cases = [
+    # (label, payload_str, expected)
+    # --- Legacy tool_name="Task" cases ---
+    (
+        "Task: run_in_background=true - ALLOW",
+        json.dumps({"tool_name": "Task", "tool_input": {"run_in_background": True}}),
+        "ALLOW",
+    ),
+    (
+        "Task: run_in_background=false - DENY",
+        json.dumps({"tool_name": "Task", "tool_input": {"run_in_background": False}}),
+        "DENY",
+    ),
+    (
+        "Task: run_in_background absent - DENY",
+        json.dumps({"tool_name": "Task", "tool_input": {}}),
+        "DENY",
+    ),
+    (
+        "Task: run_in_background=null - DENY",
+        json.dumps({"tool_name": "Task", "tool_input": {"run_in_background": None}}),
+        "DENY",
+    ),
+    (
+        "Task: run_in_background string 'true' - DENY (only boolean True accepted)",
+        json.dumps({"tool_name": "Task", "tool_input": {"run_in_background": "true"}}),
+        "DENY",
+    ),
+    (
+        "Task: foreground-exempt wrap-ticket - ALLOW",
+        json.dumps({
+            "tool_name": "Task",
+            "tool_input": {"subagent_type": "wrap-ticket", "run_in_background": False},
+        }),
+        "ALLOW",
+    ),
+    # --- Regression tests: tool_name="Agent" (CC rename, was failing silently) ---
+    # Against the buggy guard (tool_name != "Task" -> sys.exit(0)), all of
+    # these would incorrectly ALLOW. After the fix they must enforce normally.
+    (
+        "Agent: run_in_background=true - ALLOW (regression: was silently ALLOW)",
+        json.dumps({"tool_name": "Agent", "tool_input": {"run_in_background": True}}),
+        "ALLOW",
+    ),
+    (
+        "Agent: run_in_background=false - DENY (regression: was silently ALLOW)",
+        json.dumps({"tool_name": "Agent", "tool_input": {"run_in_background": False}}),
+        "DENY",
+    ),
+    (
+        "Agent: run_in_background absent - DENY (regression: was silently ALLOW)",
+        json.dumps({"tool_name": "Agent", "tool_input": {}}),
+        "DENY",
+    ),
+    (
+        "Agent: run_in_background=null - DENY (regression: was silently ALLOW)",
+        json.dumps({"tool_name": "Agent", "tool_input": {"run_in_background": None}}),
+        "DENY",
+    ),
+    (
+        "Agent: foreground-exempt wrap-ticket - ALLOW",
+        json.dumps({
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "wrap-ticket", "run_in_background": False},
+        }),
+        "ALLOW",
+    ),
+    # --- Other tool passthrough ---
+    (
+        "non-Task/Agent tool (passthrough) - ALLOW",
+        json.dumps({"tool_name": "Read", "tool_input": {}}),
+        "ALLOW",
+    ),
+    (
+        "malformed json - ALLOW (fail-open)",
+        "not-json",
+        "ALLOW",
+    ),
+    (
+        "null tool_input - ALLOW (fail-open)",
+        json.dumps({"tool_name": "Task", "tool_input": None}),
+        "ALLOW",
+    ),
+    (
+        "Agent: null tool_input - ALLOW (fail-open)",
+        json.dumps({"tool_name": "Agent", "tool_input": None}),
+        "ALLOW",
+    ),
+]
+
+failed = 0
+for label, payload, expected in cases:
+    rc, stdout, stderr = run_hook(payload)
+    if expected == "ALLOW":
+        ok = is_allow(rc, stdout)
+    else:
+        ok = is_deny(rc, stdout)
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] {label}")
+    if not ok:
+        print(f"         payload:  {payload}")
+        print(f"         rc:       {rc}")
+        print(f"         stdout:   {stdout!r}")
+        print(f"         stderr:   {stderr!r}")
+        print(f"         expected: {expected}")
+
+print()
+if failed == 0:
+    print(f"All {len(cases)} tests passed.")
+    sys.exit(0)
+else:
+    print(f"{failed}/{len(cases)} tests FAILED.")
+    sys.exit(1)

--- a/hooks/tests/test-enforce-orchestrator-singularity.py
+++ b/hooks/tests/test-enforce-orchestrator-singularity.py
@@ -63,26 +63,27 @@ def is_deny(returncode: int, stdout: str) -> bool:
 
 cases = [
     # (label, payload_str, expected, extra_env)
+    # --- Legacy tool_name="Task" cases ---
     (
-        "absent agent_id",
+        "Task: absent agent_id",
         json.dumps({"tool_name": "Task", "tool_input": {}}),
         "ALLOW",
         None,
     ),
     (
-        "null agent_id",
+        "Task: null agent_id",
         json.dumps({"tool_name": "Task", "agent_id": None}),
         "ALLOW",
         None,
     ),
     (
-        "empty-string agent_id",
+        "Task: empty-string agent_id",
         json.dumps({"tool_name": "Task", "agent_id": ""}),
         "ALLOW",
         None,
     ),
     (
-        "non-empty agent_id",
+        "Task: non-empty agent_id",
         json.dumps({
             "tool_name": "Task",
             "agent_id": "abc-123",
@@ -92,7 +93,59 @@ cases = [
         None,
     ),
     (
-        "non-Task tool (passthrough)",
+        "Task: kill-switch (AE_SINGULARITY_GUARD_DISABLE=1)",
+        json.dumps({
+            "tool_name": "Task",
+            "agent_id": "abc-123",
+            "agent_type": "engineer",
+        }),
+        "ALLOW",
+        {"AE_SINGULARITY_GUARD_DISABLE": "1"},
+    ),
+    # --- Regression tests: tool_name="Agent" (CC rename, was failing silently) ---
+    # These cases MUST deny under the fixed hook. Against the buggy guard
+    # (tool_name != "Task" -> sys.exit(0)), they would all incorrectly ALLOW.
+    (
+        "Agent: non-empty agent_id - DENY (regression: was silently ALLOW)",
+        json.dumps({
+            "tool_name": "Agent",
+            "agent_id": "abc-123",
+            "agent_type": "engineer",
+        }),
+        "DENY",
+        None,
+    ),
+    (
+        "Agent: absent agent_id - ALLOW (conductor has no agent_id)",
+        json.dumps({"tool_name": "Agent", "tool_input": {}}),
+        "ALLOW",
+        None,
+    ),
+    (
+        "Agent: null agent_id - ALLOW",
+        json.dumps({"tool_name": "Agent", "agent_id": None}),
+        "ALLOW",
+        None,
+    ),
+    (
+        "Agent: empty-string agent_id - ALLOW",
+        json.dumps({"tool_name": "Agent", "agent_id": ""}),
+        "ALLOW",
+        None,
+    ),
+    (
+        "Agent: kill-switch disables guard",
+        json.dumps({
+            "tool_name": "Agent",
+            "agent_id": "abc-123",
+            "agent_type": "engineer",
+        }),
+        "ALLOW",
+        {"AE_SINGULARITY_GUARD_DISABLE": "1"},
+    ),
+    # --- Other tool passthrough ---
+    (
+        "non-Task/Agent tool (passthrough)",
         json.dumps({"tool_name": "Read", "agent_id": "abc-123"}),
         "ALLOW",
         None,
@@ -102,16 +155,6 @@ cases = [
         "not-json",
         "ALLOW",
         None,
-    ),
-    (
-        "kill-switch (AE_SINGULARITY_GUARD_DISABLE=1)",
-        json.dumps({
-            "tool_name": "Task",
-            "agent_id": "abc-123",
-            "agent_type": "engineer",
-        }),
-        "ALLOW",
-        {"AE_SINGULARITY_GUARD_DISABLE": "1"},
     ),
 ]
 

--- a/hooks/tests/test-post-tool-use-capture-nudge.js
+++ b/hooks/tests/test-post-tool-use-capture-nudge.js
@@ -16,10 +16,14 @@
  *   1. fires-when-worthy-event:       debugger spawn_complete -> additionalContext emitted
  *   2. dedup-suppresses-repeat:       second identical spawn -> no second emit
  *   3. no-fire-when-no-worthy-event:  empty events.jsonl -> no emit
- *   4. no-fire-when-wrong-tool:       tool_name !== "Task" -> no emit
+ *   4. no-fire-when-wrong-tool:       tool_name is a non-spawn tool (Bash) -> no emit
  *   5. no-fire-when-not-async-launched: status !== "async_launched" -> no emit
  *   6. soft-fail-on-malformed-stdin:  non-JSON stdin -> exit 0, no emit, no throw
  *   7. residualOnly-wording:          unrelated guardrail -> residual nudge text
+ *   8. fires-when-tool-name-Agent:    REGRESSION (CC Task->Agent rename) -
+ *                                     tool_name "Agent" -> nudge fires. Under the
+ *                                     old `!== 'Task'` guard this early-exited
+ *                                     and the nudge was silently disabled.
  *
  * Run with: node hooks/tests/test-post-tool-use-capture-nudge.js
  */
@@ -312,6 +316,42 @@ console.log('\nTest 7: residualOnly-wording');
       'residual case does NOT use the standard wording'
     );
   }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: fires-when-tool-name-Agent (REGRESSION: CC Task->Agent rename)
+// Identical to Test 1 but with tool_name "Agent". Under the pre-fix guard
+// (`if (toolName !== 'Task') process.exit(0)`) this early-exited and emitted
+// nothing - the nudge was silently disabled for every Agent spawn. The fixed
+// guard (`toolName !== 'Task' && toolName !== 'Agent'`) must let it fire.
+// ---------------------------------------------------------------------------
+console.log('\nTest 8: fires-when-tool-name-Agent (regression)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-008';
+  fs.writeFileSync(
+    path.join(cwd, '.agentic', 'events.jsonl'),
+    makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8'
+  );
+
+  // tool_name is "Agent" (post-rename) - a worthy event exists, so the nudge
+  // MUST fire. This asserts the dual Task/Agent guard.
+  const payload = taskPayload(cwd, sessionId, { tool_name: 'Agent' });
+  const { stdout, status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  let out = null;
+  try { out = JSON.parse(stdout); } catch (_) { /* leave null */ }
+  assert(out !== null, 'Agent spawn emits parseable JSON (regression guard)');
+  assert(
+    out && out.hookSpecificOutput
+    && out.hookSpecificOutput.additionalContext.includes('CAPTURE-NUDGE'),
+    'Agent spawn emits the CAPTURE-NUDGE text (would have been silent pre-fix)'
+  );
+  assert(
+    fs.existsSync(path.join(cwd, '.agentic', '.capture-gap-surfaced')),
+    'dedup tracker written after Agent spawn fires'
+  );
   cleanup(cwd);
 }
 


### PR DESCRIPTION
Claude Code renamed the subagent-spawn tool `Task` → `Agent`. Three PreToolUse/PostToolUse hooks gated on the literal string `"Task"` and silently failed open on every spawn, disabling the governance they enforce. Confirmed empirically: a subagent's spawn payload now arrives as `{"tool_name":"Agent","agent_id":"<id>",...}` and the old `!= "Task"` guards bail before their logic.

Restored hooks:
- `enforce-orchestrator-singularity.py` - nested-spawn denial (was off)
- `enforce-background-spawn.py` - background-spawn enforcement (was off)
- `post-tool-use-capture-nudge.js` - in-session capture-gap nudge (was off)

Each guard now accepts both names (`not in ("Task","Agent")` / `!== 'Task' && !== 'Agent'`). `install.sh` wires both `Task` and `Agent` matcher blocks for all three (idempotent). The `AskUserQuestion` hook was unaffected (that tool name didn't change).

Regression tests added that fail against the old guard and pass now: 5 cases (singularity), 15 (background-spawn, new file), Test 8 (capture-nudge). Full `hooks/tests/` suite green (13 files).

Reviewed by two Skeptic passes (full + narrow-delta), 0 Critical / 0 Major.