### PR TITLE
feat(scripts): add repo-dir.sh canonical resolver lib

### DIFF
--- a/scripts/lib/repo-dir.sh
+++ b/scripts/lib/repo-dir.sh
@@ -1,0 +1,120 @@
+# shellcheck shell=bash
+# ---------------------------------------------------------------------------
+# Purpose: Canonical repo_dir resolver for the agentic-engineering install.
+#          Centralises the resolution logic previously duplicated inline in
+#          .claude/install.sh, hooks/lib/version-check-core.sh, bootstrap.sh,
+#          and content/commands/update-agentic-engineering.md Step 0a.
+#
+# Public API:
+#   resolve_repo_dir [--quiet]   - Resolve AE_REPO_DIR from config or fallback.
+#                                  Sets AE_REPO_DIR in the caller's env.
+#                                  Returns 0 on a valid git repo, 1 otherwise.
+#                                  --quiet suppresses the "using fallback" warning.
+#   validate_repo_dir <path>     - Returns 0 if <path> is a valid git repo,
+#                                  1 otherwise. Prints nothing.
+#   assert_canonical_match <session_root> - Canonicalize <session_root> and
+#                                  $AE_REPO_DIR via pwd -P; return 0 if equal,
+#                                  print a message to stderr and return 2 if not.
+#
+# Upstream dependencies:
+#   $HOME/.agentic/agentic-engineering-config.json (repo_dir key, optional),
+#   python3 (JSON parsing, matching existing codebase pattern),
+#   git (rev-parse --git-dir for repo validation).
+#
+# Downstream consumers (planned migrators):
+#   .claude/install.sh, hooks/lib/version-check-core.sh, bootstrap.sh,
+#   content/commands/update-agentic-engineering.md Step 0a.
+#
+# Failure modes:
+#   - Config absent or missing repo_dir key: falls back to $HOME/DinoStack.
+#   - Fallback path is not a git repo: resolve_repo_dir returns 1; AE_REPO_DIR
+#     is still set to the fallback so callers can print actionable messages.
+#   - python3 absent: config read silently fails, fallback applies.
+#   - Non-existent <path> passed to validate_repo_dir: returns 1.
+#   - assert_canonical_match: returns 2 (not 1) so callers can distinguish
+#     "bad path" (validate_repo_dir returns 1) from "wrong repo" (returns 2).
+#   Safe to source under set -euo pipefail; no top-level side effects beyond
+#   function definitions.
+#
+# Performance: standard - one git rev-parse per call; python3 JSON read only
+#              when the config file exists.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# validate_repo_dir <path>
+#   Returns 0 if <path> is the root of a valid git repository, 1 otherwise.
+#   Prints nothing.
+# ---------------------------------------------------------------------------
+validate_repo_dir() {
+  local path="$1"
+  local rc=0
+  git -C "$path" rev-parse --git-dir >/dev/null 2>&1 || rc=$?
+  # git returns 128 for "not a git repo" and 1 for other errors; normalise both to 1
+  [[ "$rc" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# resolve_repo_dir [--quiet]
+#   Resolution order:
+#     1. repo_dir key from $HOME/.agentic/agentic-engineering-config.json
+#     2. Fallback: $HOME/DinoStack
+#   Sets AE_REPO_DIR in the caller's environment.
+#   Returns 0 if AE_REPO_DIR is a valid git repo, 1 otherwise.
+#   --quiet suppresses the "using fallback" warning printed to stderr.
+# ---------------------------------------------------------------------------
+resolve_repo_dir() {
+  local quiet=false
+  if [[ "${1:-}" == "--quiet" ]]; then
+    quiet=true
+  fi
+
+  local ae_config="$HOME/.agentic/agentic-engineering-config.json"
+  AE_REPO_DIR=""
+
+  if [[ -f "$ae_config" ]]; then
+    AE_REPO_DIR="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$ae_config" 2>/dev/null)" || AE_REPO_DIR=""
+  fi
+
+  if [[ -z "$AE_REPO_DIR" ]] || ! validate_repo_dir "$AE_REPO_DIR"; then
+    if [[ -n "$AE_REPO_DIR" ]] && [[ "$quiet" == "false" ]]; then
+      echo "agentic-engineering: repo_dir '$AE_REPO_DIR' is not a valid git repo - using fallback \$HOME/DinoStack" >&2
+    fi
+    AE_REPO_DIR="$HOME/DinoStack"
+    if [[ "$quiet" == "false" ]] && [[ ! -d "$AE_REPO_DIR" ]]; then
+      echo "agentic-engineering: fallback \$HOME/DinoStack does not exist" >&2
+    fi
+  fi
+
+  export AE_REPO_DIR
+  validate_repo_dir "$AE_REPO_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# assert_canonical_match <session_root>
+#   Canonicalize <session_root> and $AE_REPO_DIR via pwd -P, then compare.
+#   Returns 0 if they resolve to the same path.
+#   Prints a message to stderr and returns 2 if they differ.
+#   Mirrors the Step 0a pattern from update-agentic-engineering.md.
+# ---------------------------------------------------------------------------
+assert_canonical_match() {
+  local session_root="$1"
+
+  local ae_real=""
+  local session_real=""
+  ae_real="$(cd "$AE_REPO_DIR" 2>/dev/null && pwd -P || true)"
+  session_real="$(cd "$session_root" 2>/dev/null && pwd -P || true)"
+
+  if [[ -n "$session_real" ]] && [[ "$session_real" == "$ae_real" ]]; then
+    return 0
+  fi
+
+  echo "agentic-engineering: session root '$session_real' does not match AE_REPO_DIR '$ae_real'" >&2
+  return 2
+}

--- a/scripts/test/repo-dir.test.sh
+++ b/scripts/test/repo-dir.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# scripts/test/repo-dir.test.sh
+# Unit tests for scripts/lib/repo-dir.sh
+#
+# Usage: bash scripts/test/repo-dir.test.sh
+# Must pass with zero failures. Uses a temp HOME to avoid touching real ~/.agentic.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../lib" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+
+# Source the lib under test (must have no top-level side effects)
+# shellcheck source=../lib/repo-dir.sh
+source "$LIB_DIR/repo-dir.sh"
+
+# ---------------------------------------------------------------------------
+# Minimal test harness
+# ---------------------------------------------------------------------------
+_pass=0
+_fail=0
+
+pass() { echo "  PASS: $*"; (( _pass++ )) || true; }
+fail() { echo "  FAIL: $*"; (( _fail++ )) || true; }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$desc"
+  else
+    fail "$desc (expected='$expected' got='$actual')"
+  fi
+}
+
+assert_rc() {
+  local desc="$1" expected_rc="$2"
+  shift 2
+  local actual_rc=0
+  "$@" || actual_rc=$?
+  if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+    pass "$desc"
+  else
+    fail "$desc (expected rc=$expected_rc got rc=$actual_rc)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# (a) validate_repo_dir
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (a) validate_repo_dir ==="
+
+assert_rc "valid git repo (repo root)" 0 validate_repo_dir "$REPO_ROOT"
+assert_rc "non-git dir (/tmp) returns non-0" 1 validate_repo_dir "/tmp"
+# note: validate_repo_dir normalises all non-0 git exit codes to 1
+assert_rc "nonexistent path returns non-0" 1 validate_repo_dir "/nonexistent/path/that/does/not/exist"
+
+# ---------------------------------------------------------------------------
+# (b) resolve_repo_dir with temp HOME + temp config
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (b) resolve_repo_dir ==="
+
+ORIG_HOME="$HOME"
+TEMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TEMP_HOME"' EXIT
+
+# b1: config points at the real repo root (valid git repo)
+mkdir -p "$TEMP_HOME/.agentic"
+printf '{"repo_dir": "%s"}\n' "$REPO_ROOT" > "$TEMP_HOME/.agentic/agentic-engineering-config.json"
+
+# resolve_repo_dir runs in the same shell so AE_REPO_DIR is visible after the call
+AE_REPO_DIR=""
+HOME="$TEMP_HOME" resolve_repo_dir --quiet
+assert_eq "AE_REPO_DIR set from config" "$REPO_ROOT" "$AE_REPO_DIR"
+
+# also verify the rc is 0 in an isolated subshell
+assert_rc "resolve_repo_dir returns 0 for valid repo (config-driven)" 0 \
+  env HOME="$TEMP_HOME" bash -c "
+    source '$LIB_DIR/repo-dir.sh'
+    resolve_repo_dir --quiet
+  "
+
+# b2: config missing - falls back to \$HOME/DinoStack which does not exist; returns 1
+rm "$TEMP_HOME/.agentic/agentic-engineering-config.json"
+FALLBACK_RC=0
+env HOME="$TEMP_HOME" bash -c "
+  source '$LIB_DIR/repo-dir.sh'
+  resolve_repo_dir --quiet
+" || FALLBACK_RC=$?
+assert_eq "resolve_repo_dir returns 1 when fallback is not a git repo" "1" "$FALLBACK_RC"
+
+# b3: config present but repo_dir missing - should also fall back
+printf '{"other_key": "irrelevant"}\n' > "$TEMP_HOME/.agentic/agentic-engineering-config.json"
+MISSING_KEY_RC=0
+env HOME="$TEMP_HOME" bash -c "
+  source '$LIB_DIR/repo-dir.sh'
+  resolve_repo_dir --quiet
+" || MISSING_KEY_RC=$?
+assert_eq "resolve_repo_dir returns 1 when config has no repo_dir key" "1" "$MISSING_KEY_RC"
+
+# b4: config points at an invalid path - falls back, returns 1
+printf '{"repo_dir": "/nonexistent/path"}\n' > "$TEMP_HOME/.agentic/agentic-engineering-config.json"
+INVALID_PATH_RC=0
+env HOME="$TEMP_HOME" bash -c "
+  source '$LIB_DIR/repo-dir.sh'
+  resolve_repo_dir --quiet
+" || INVALID_PATH_RC=$?
+assert_eq "resolve_repo_dir returns 1 when config path is not a git repo" "1" "$INVALID_PATH_RC"
+
+HOME="$ORIG_HOME"
+
+# ---------------------------------------------------------------------------
+# (c) assert_canonical_match
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (c) assert_canonical_match ==="
+
+# Set AE_REPO_DIR to the real repo root for these tests
+AE_REPO_DIR="$REPO_ROOT"
+
+assert_rc "assert_canonical_match returns 0 for matching paths" 0 \
+  assert_canonical_match "$REPO_ROOT"
+
+# Test with a symlinked path that resolves to the same canonical dir
+MATCH_RC=0
+assert_canonical_match "$REPO_ROOT/" || MATCH_RC=$?
+assert_eq "assert_canonical_match returns 0 for trailing-slash variant" "0" "$MATCH_RC"
+
+# Mismatch: session root differs from AE_REPO_DIR
+MISMATCH_RC=0
+assert_canonical_match "/tmp" 2>/dev/null || MISMATCH_RC=$?
+assert_eq "assert_canonical_match returns 2 for mismatched paths" "2" "$MISMATCH_RC"
+
+# Mismatch: nonexistent session root (cd fails - session_real is empty)
+NONEXIST_RC=0
+assert_canonical_match "/nonexistent/path" 2>/dev/null || NONEXIST_RC=$?
+assert_eq "assert_canonical_match returns 2 for nonexistent session root" "2" "$NONEXIST_RC"
+
+# ---------------------------------------------------------------------------
+# (d) verify sourcing has no top-level side effects
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (d) no top-level side effects ==="
+
+SIDE_EFFECT_OUT="$(bash -c "
+  set -euo pipefail
+  source '$LIB_DIR/repo-dir.sh'
+  echo 'sourced-ok'
+")"
+assert_eq "sourcing repo-dir.sh under set -euo pipefail produces no output" "sourced-ok" "$SIDE_EFFECT_OUT"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $_pass passed, $_fail failed"
+if [[ "$_fail" -gt 0 ]]; then
+  exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
Adds `scripts/lib/repo-dir.sh` - the single canonical `repo_dir` resolver, currently duplicated inline in `.claude/install.sh`, `hooks/lib/version-check-core.sh`, `bootstrap.sh`, and `update-agentic-engineering` Step 0a. Foundation for the converging-installer + doctor work; callers are migrated in later units.

- `resolve_repo_dir [--quiet]` (config repo_dir → fallback `~/DinoStack`, sets `AE_REPO_DIR`, 0/1 on valid git repo), `validate_repo_dir <path>`, `assert_canonical_match <session_root>` (`pwd -P` compare, returns 2 on mismatch, mirrors Step 0a).
- No top-level side effects (safe to source under `set -euo pipefail`). Manifest header. 13-case test under a temp HOME (never touches real `~/.agentic`).

Skeptic: sign-off, 0 Critical/Major. One Minor noted: `validate_repo_dir ""` returns 0 (git uses cwd) - no current caller passes empty; future guard.

Part of the install/update self-heal effort (Wave-1).