### PR TITLE
feat(bin): add agentic-doctor install-health check with --fix

### DIFF
--- a/bin/agentic-doctor
+++ b/bin/agentic-doctor
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""
+Purpose: Inspect global agentic-engineering install health and (with --fix)
+         converge drift. Checks that managed symlinks under ~/.claude resolve
+         into the canonical repo_dir, that ~/.local/bin/ wrappers exist for
+         each bin/agentic-* script, that hook commands in ~/.claude/settings.json
+         point into repo_dir, and that the repo_dir pre-commit hook is wired.
+         With --fix, re-points ours-to-own broken/stale symlinks and rewrites
+         hook paths in settings.json (atomic read-merge-write). Never invokes
+         install.sh, never touches real files or foreign symlinks.
+
+Public API: agentic-doctor [--fix] [--dry-run]
+            Prints one status line per check:
+              OK <kind>: <detail>
+              FAIL <kind>: <detail>
+              FIX symlink: <dst> : <old/broken target> -> <new target>
+              SKIP <kind>: <dst> (reason)
+            Exits 0 (all pass / --fix resolved all), 1 (findings in read-only
+            or dry-run mode), 2 (--fix ran but one or more items could not be
+            fixed).
+
+Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, sys, tempfile).
+               Reads ~/.agentic/agentic-engineering-config.json (repo_dir source),
+               ~/.claude/settings.json (hook inspection/repair),
+               ~/.claude/agents/, ~/.claude/commands/, ~/.claude/skills/.
+               Reads <repo_dir>/bin/agentic-* (bin wrapper check).
+               Reads <repo_dir>/.git/hooks/pre-commit (pre-commit check).
+
+Downstream consumers: developers diagnosing broken installs after cloning to a
+                      new path; bootstrap guard advisory for two-clone setups.
+
+Failure modes: missing config -> falls back to ~/DinoStack; no crash. Missing
+               ~/.claude/settings.json -> check (c) skipped with SKIP output.
+               All file errors swallowed; a failing check is counted as FAIL.
+               Never modifies files unless --fix is passed (without --dry-run).
+
+Performance: O(small). Linear scan of a few directories + one JSON parse.
+             <100 ms on any modern machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def _home() -> Path:
+    """Current HOME directory (re-evaluated each call so tests can override HOME)."""
+    return Path(os.path.expanduser("~"))
+
+
+def _config_path() -> Path:
+    return _home() / ".agentic" / "agentic-engineering-config.json"
+
+
+def _settings_path() -> Path:
+    return _home() / ".claude" / "settings.json"
+
+
+def _local_bin() -> Path:
+    return _home() / ".local" / "bin"
+
+
+def _managed_link_dirs() -> list[Path]:
+    """Managed symlink trees under ~/.claude. Re-evaluated each call."""
+    h = _home()
+    return [
+        h / ".claude" / "agents",
+        h / ".claude" / "commands",
+        h / ".claude" / "skills" / "agentic-engineering",
+    ]
+
+# Basenames of hook scripts that live in <repo_dir>/hooks/.
+MANAGED_HOOK_BASENAMES: frozenset[str] = frozenset([
+    "enforce-askuserquestion-default.py",
+    "enforce-background-spawn.py",
+    "enforce-orchestrator-singularity.py",
+    "post-tool-use-capture-nudge.js",
+    "session-end-wrap.js",
+    "session-start-version-check.sh",
+    "session-start-wrap.sh",
+    "skill-auto-load-check.sh",
+    "stop-context.js",
+    "wrap-daemon.js",
+])
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_repo_dir() -> Path:
+    """Read repo_dir from config, falling back to ~/DinoStack.
+
+    Always returns a realpath (os.path.realpath) so comparisons with other
+    realpath'd paths work correctly on macOS where /var is a symlink to
+    /private/var.
+    """
+    fallback = Path(os.path.realpath(str(_home() / "DinoStack")))
+    try:
+        config = _config_path()
+        if config.is_file():
+            data = json.loads(config.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and data.get("repo_dir"):
+                raw = Path(str(data["repo_dir"])).expanduser()
+                return Path(os.path.realpath(str(raw)))
+    except Exception:
+        pass
+    return fallback
+
+
+def _is_git_repo(path: Path) -> bool:
+    """Return True if path contains a .git directory or file."""
+    try:
+        return (path / ".git").exists()
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _realpath(p: Path) -> Path:
+    """os.path.realpath resolving symlinks and /private/var -> /var on macOS."""
+    return Path(os.path.realpath(str(p)))
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    """Path.is_relative_to polyfill for Python < 3.9.
+
+    For broken symlinks, os.path.realpath follows the link to its (non-existent)
+    target, so we must NOT use realpath on the child directly - instead, we
+    realpath the child's parent directory (which does exist) and re-attach the
+    final name. This correctly handles cases where child is a symlink (broken or
+    otherwise) that lives in a real directory.
+
+    For regular files/dirs and non-symlink paths, both approaches are equivalent.
+    """
+    # Resolve parent normally
+    parent_r = Path(os.path.realpath(str(parent)))
+    # For child: resolve its parent dir, then re-attach the name.
+    # This avoids following the symlink itself.
+    child_parent_r = Path(os.path.realpath(str(child.parent)))
+    child_r = child_parent_r / child.name
+    try:
+        child_r.relative_to(parent_r)
+        return True
+    except ValueError:
+        return False
+
+
+def _readlink_resolved(dst: Path) -> tuple[str, Path | None]:
+    """Return (raw_target_str, realpath_or_None_if_broken).
+
+    Uses os.path.realpath (not Path.resolve) so /private/var and /var
+    compare correctly on macOS.
+    """
+    try:
+        raw = os.readlink(str(dst))
+        candidate = Path(raw) if Path(raw).is_absolute() else dst.parent / raw
+        real = Path(os.path.realpath(str(candidate)))
+        return raw, real if real.exists() else None
+    except Exception:
+        return "(unreadable)", None
+
+
+# ---------------------------------------------------------------------------
+# Ownership predicate
+# ---------------------------------------------------------------------------
+
+
+def _is_ours(dst: Path, repo_dir: Path) -> bool:
+    """Return True if we own this symlink and may re-point it.
+
+    Owned iff ALL of:
+    - dst is under ~/.claude/{agents,commands,skills/agentic-engineering}
+      OR under <repo_dir>/.git/hooks OR under LOCAL_BIN
+    - dst is a symlink (not a real file)
+    - current target is either already under some DinoStack-looking repo_dir
+      OR broken (target does not exist)
+    """
+    if not os.path.islink(str(dst)):
+        return False
+
+    in_managed = any(_is_relative_to(dst, d) for d in _managed_link_dirs())
+    in_git_hooks = _is_relative_to(dst, repo_dir / ".git" / "hooks")
+    in_local_bin = _is_relative_to(dst, _local_bin())
+
+    if not (in_managed or in_git_hooks or in_local_bin):
+        return False
+
+    _raw, resolved = _readlink_resolved(dst)
+
+    # Broken symlink - target does not exist -> we can reclaim it
+    if resolved is None:
+        return True
+
+    # Target exists under repo_dir -> clearly ours
+    if _is_relative_to(resolved, repo_dir):
+        return True
+
+    # Target exists under another DinoStack clone (name heuristic).
+    # Match any path component that IS "DinoStack" or ENDS WITH "-DinoStack"
+    # (e.g. "old-DinoStack", "backup-DinoStack").
+    for part in resolved.parts:
+        if part == "DinoStack" or part.endswith("-DinoStack"):
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Finding accumulator
+# ---------------------------------------------------------------------------
+
+
+class Doctor:
+    def __init__(self, repo_dir: Path, fix: bool) -> None:
+        self.repo_dir = repo_dir
+        self.fix = fix  # True only when --fix passed AND --dry-run NOT passed
+        self.findings: list[tuple[str, str]] = []
+        self.unfixable: list[str] = []
+
+    def _emit(self, status: str, message: str) -> None:
+        self.findings.append((status, message))
+        print(f"{status} {message}")
+
+    def ok(self, kind: str, detail: str) -> None:
+        self._emit("OK", f"{kind}: {detail}")
+
+    def fail(self, kind: str, detail: str) -> None:
+        self._emit("FAIL", f"{kind}: {detail}")
+
+    def skip(self, kind: str, dst_or_detail: object, reason: str) -> None:
+        self._emit("SKIP", f"{kind}: {dst_or_detail} ({reason})")
+
+    def repoint_symlink(self, kind: str, dst: Path, old: str, new: Path) -> None:
+        """Announce and (if fix mode) perform a symlink re-point.
+
+        Prints: FIX symlink: <dst> : <old/broken target> -> <new target>
+        In read-only/dry-run mode, the FIX line is informational only and
+        counts as a finding (exit 1). In live fix mode, performs the re-point.
+        """
+        self._emit("FIX", f"symlink: {dst} : {old} -> {new}")
+        if self.fix:
+            try:
+                if os.path.islink(str(dst)):
+                    os.remove(str(dst))
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(str(new), str(dst))
+            except Exception as exc:
+                self.fail(kind, f"could not re-point {dst}: {exc}")
+                self.unfixable.append(str(dst))
+
+    def has_unresolved_findings(self) -> bool:
+        """Return True if there are FAIL or FIX lines in the output.
+
+        In live fix mode, FIX lines represent completed repairs (not failures),
+        so only FAIL lines count. In read-only/dry-run mode, both FAIL and FIX
+        lines count as findings requiring action.
+        """
+        if self.fix:
+            # Fix mode: only unfixed items (FAIL lines) matter
+            return any(s == "FAIL" for s, _ in self.findings)
+        else:
+            # Read-only/dry-run: FAIL or FIX both indicate drift
+            return any(s in ("FAIL", "FIX") for s, _ in self.findings)
+
+    def has_unfixable(self) -> bool:
+        return bool(self.unfixable)
+
+
+# ---------------------------------------------------------------------------
+# Check (a): repo_dir is a valid git repo
+# ---------------------------------------------------------------------------
+
+
+def check_repo_dir(doc: Doctor) -> None:
+    if not doc.repo_dir.exists():
+        doc.fail(
+            "repo_dir",
+            f"{doc.repo_dir} does not exist; re-run bootstrap or set repo_dir in {_config_path()}",
+        )
+        return
+    if not _is_git_repo(doc.repo_dir):
+        doc.fail(
+            "repo_dir",
+            f"{doc.repo_dir} exists but is not a git repo; re-run bootstrap or set repo_dir in {_config_path()}",
+        )
+        return
+    doc.ok("repo_dir", f"{doc.repo_dir} is a valid git repo")
+
+
+# ---------------------------------------------------------------------------
+# Check (b): managed ~/.claude symlinks resolve into repo_dir
+# ---------------------------------------------------------------------------
+
+
+def check_managed_symlinks(doc: Doctor) -> None:
+    """Check all entries under the managed ~/.claude dirs resolve into repo_dir."""
+    for root in _managed_link_dirs():
+        # If the root itself is a symlink (e.g. skills/agentic-engineering)
+        if os.path.islink(str(root)):
+            _check_one_link(doc, root, "managed_links")
+            continue
+
+        if not root.exists():
+            doc.skip("managed_links", root, "directory does not exist")
+            continue
+
+        try:
+            entries = sorted(root.iterdir())
+        except Exception:
+            doc.skip("managed_links", root, "could not read directory")
+            continue
+
+        for entry in entries:
+            if os.path.islink(str(entry)):
+                _check_one_link(doc, entry, "managed_links")
+            else:
+                # Real file in a managed dir: skip, do not touch
+                doc.skip("managed_links", entry, "real file, not a symlink")
+
+
+def _check_one_link(doc: Doctor, dst: Path, kind: str) -> None:
+    """Verify one symlink resolves into repo_dir; fix or skip as appropriate."""
+    raw, resolved = _readlink_resolved(dst)
+
+    if resolved is not None and _is_relative_to(resolved, doc.repo_dir):
+        doc.ok(kind, f"{dst} -> {raw}")
+        return
+
+    expected = _expected_target_in_repo(dst, doc.repo_dir)
+
+    if not _is_ours(dst, doc.repo_dir):
+        t_display = raw if resolved is None else str(resolved)
+        doc.skip(kind, dst, f"not ours - target {t_display} exists outside repo_dir")
+        return
+
+    # Broken or wrong target - we own it
+    old_display = f"{raw} (broken)" if resolved is None else raw
+
+    if expected is not None:
+        doc.repoint_symlink(kind, dst, old_display, expected)
+    else:
+        doc.fail(kind, f"{dst}: target {old_display} is wrong; could not determine repair target")
+        if doc.fix:
+            doc.unfixable.append(str(dst))
+
+
+def _expected_target_in_repo(dst: Path, repo_dir: Path) -> Path | None:
+    """Compute where dst should point within repo_dir.
+
+    Agents/commands: ~/.claude/agents/foo.md -> <repo_dir>/.claude/agents/foo.md
+    Skills dir:      ~/.claude/skills/agentic-engineering ->
+                     <repo_dir>/.claude/skills/agentic-engineering
+
+    Uses parent-realpath to avoid following symlinks on dst itself (which would
+    resolve to the broken/stale target, not the symlink's location).
+    """
+    claude_dir = _home() / ".claude"
+    # Build the realpath of dst's location (not its target) for comparison
+    dst_resolved = Path(os.path.realpath(str(dst.parent))) / dst.name
+    claude_dir_r = Path(os.path.realpath(str(claude_dir)))
+    try:
+        rel = dst_resolved.relative_to(claude_dir_r)
+        return repo_dir / ".claude" / rel
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Check (c): hook commands in settings.json embed paths under repo_dir
+# ---------------------------------------------------------------------------
+
+
+def check_hook_paths(doc: Doctor) -> None:
+    settings_path = _settings_path()
+    if not settings_path.exists():
+        doc.skip("hooks", settings_path, "settings.json not found")
+        return
+
+    try:
+        raw_text = settings_path.read_text(encoding="utf-8")
+        data = json.loads(raw_text)
+    except Exception as exc:
+        doc.fail("hooks", f"could not parse {settings_path}: {exc}")
+        return
+
+    drift: list[tuple[str, str]] = []  # (old_cmd, new_cmd)
+
+    def _walk(obj: object) -> None:
+        if isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+        elif isinstance(obj, dict):
+            cmd = obj.get("command")
+            if isinstance(cmd, str):
+                replacement = _hook_replacement(cmd, doc.repo_dir)
+                if replacement is not None:
+                    drift.append((cmd, replacement))
+            for v in obj.values():
+                if isinstance(v, (dict, list)):
+                    _walk(v)
+
+    _walk(data)
+
+    if not drift:
+        doc.ok("hooks", f"{settings_path}: all managed hook paths reference repo_dir")
+        return
+
+    for old_cmd, new_cmd in drift:
+        doc.repoint_symlink("hooks", settings_path, old_cmd, Path(new_cmd))
+
+    if doc.fix:
+        _atomic_patch_settings(doc, settings_path, data, {old: new for old, new in drift})
+
+
+def _hook_replacement(cmd: str, repo_dir: Path) -> str | None:
+    """If cmd references a managed hook at the wrong path, return the fixed cmd."""
+    for basename in MANAGED_HOOK_BASENAMES:
+        if basename not in cmd:
+            continue
+        tokens = cmd.split()
+        for token in tokens:
+            if basename not in token:
+                continue
+            token_path = Path(token)
+            expected = repo_dir / "hooks" / basename
+            if _is_relative_to(token_path, repo_dir):
+                return None  # already correct
+            # Only fix paths that look like a DinoStack install
+            if any(p == "DinoStack" or p.endswith("-DinoStack") for p in token_path.parts):
+                return cmd.replace(str(token_path), str(expected), 1)
+        break
+    return None
+
+
+def _atomic_patch_settings(
+    doc: Doctor, settings_path: Path, data: dict, replacements: dict[str, str]
+) -> None:
+    """Atomic read-merge-write: fix only the matched hook command strings."""
+
+    def _patch(obj: object) -> object:
+        if isinstance(obj, list):
+            return [_patch(item) for item in obj]
+        elif isinstance(obj, dict):
+            return {
+                k: (
+                    replacements[v]
+                    if k == "command" and isinstance(v, str) and v in replacements
+                    else _patch(v)
+                )
+                for k, v in obj.items()
+            }
+        return obj
+
+    try:
+        patched = _patch(data)
+        new_text = json.dumps(patched, indent=2) + "\n"
+        dir_ = str(settings_path.parent)
+        fd, tmp_path = tempfile.mkstemp(dir=dir_, prefix=".settings-tmp-")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(new_text)
+            os.replace(tmp_path, str(settings_path))
+            doc.ok("hooks", f"{settings_path}: hook paths repaired (atomic rewrite)")
+        except Exception as exc:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+            doc.fail("hooks", f"could not write {settings_path}: {exc}")
+            doc.unfixable.append(str(settings_path))
+    except Exception as exc:
+        doc.fail("hooks", f"patch failed: {exc}")
+        doc.unfixable.append(str(settings_path))
+
+
+# ---------------------------------------------------------------------------
+# Check (d): ~/.local/bin/<name> symlinks for each bin/agentic-* script
+# ---------------------------------------------------------------------------
+
+
+def check_local_bin_symlinks(doc: Doctor) -> None:
+    bin_dir = doc.repo_dir / "bin"
+    if not bin_dir.is_dir():
+        doc.skip("local_bin", bin_dir, "repo_dir/bin does not exist")
+        return
+
+    try:
+        scripts = sorted(
+            p for p in bin_dir.iterdir()
+            if p.name.startswith("agentic-") and p.is_file()
+        )
+    except Exception:
+        doc.skip("local_bin", bin_dir, "could not read bin/")
+        return
+
+    if not scripts:
+        doc.skip("local_bin", bin_dir, "no agentic-* scripts found in repo_dir/bin")
+        return
+
+    local_bin = _local_bin()
+    for script in scripts:
+        link = local_bin / script.name
+        _check_bin_link(doc, link, script)
+
+
+def _check_bin_link(doc: Doctor, link: Path, expected_target: Path) -> None:
+    """Verify or fix one ~/.local/bin/<name> symlink."""
+    link_exists = link.exists() or os.path.islink(str(link))
+
+    if not link_exists:
+        doc.repoint_symlink("local_bin", link, "(missing)", expected_target)
+        return
+
+    if not os.path.islink(str(link)):
+        doc.skip("local_bin", link, "real file, not a symlink")
+        return
+
+    raw, resolved = _readlink_resolved(link)
+
+    if resolved is not None and resolved == _realpath(expected_target):
+        doc.ok("local_bin", f"{link} -> {raw}")
+        return
+
+    if _is_ours(link, doc.repo_dir):
+        old = raw if resolved is not None else f"{raw} (broken)"
+        doc.repoint_symlink("local_bin", link, old, expected_target)
+    else:
+        t = str(resolved) if resolved else f"{raw} (broken)"
+        doc.skip("local_bin", link, f"not ours - target {t} exists outside repo_dir")
+
+
+# ---------------------------------------------------------------------------
+# Check (e): <repo_dir>/.git/hooks/pre-commit -> <repo_dir>/hooks/pre-commit
+# ---------------------------------------------------------------------------
+
+
+def check_git_precommit(doc: Doctor) -> None:
+    expected_src = doc.repo_dir / "hooks" / "pre-commit"
+    git_hook = doc.repo_dir / ".git" / "hooks" / "pre-commit"
+
+    if not expected_src.exists():
+        doc.skip("git_precommit", git_hook, f"managed pre-commit not found at {expected_src}")
+        return
+
+    hook_exists = git_hook.exists() or os.path.islink(str(git_hook))
+
+    if not hook_exists:
+        doc.repoint_symlink("git_precommit", git_hook, "(missing)", expected_src)
+        return
+
+    if not os.path.islink(str(git_hook)):
+        doc.skip("git_precommit", git_hook, "real file, not a symlink - not managed by us")
+        return
+
+    raw, resolved = _readlink_resolved(git_hook)
+
+    if resolved is not None and resolved == _realpath(expected_src):
+        doc.ok("git_precommit", f"{git_hook} -> {raw}")
+        return
+
+    if _is_ours(git_hook, doc.repo_dir):
+        old = raw if resolved is not None else f"{raw} (broken)"
+        doc.repoint_symlink("git_precommit", git_hook, old, expected_src)
+    else:
+        t = str(resolved) if resolved else f"{raw} (broken)"
+        doc.skip("git_precommit", git_hook, f"not ours - target {t} exists outside repo_dir")
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="agentic-doctor",
+        description=(
+            "Inspect global agentic-engineering install health. "
+            "With --fix, re-points drifted symlinks toward the canonical repo_dir "
+            "and repairs hook paths in ~/.claude/settings.json. "
+            "NEVER invokes install.sh or rebuilds adapters. "
+            "Note: with two DinoStack clones, --fix re-points links toward the "
+            "canonical repo_dir (from ~/.agentic/agentic-engineering-config.json); "
+            "prevention is the bootstrap guard."
+        ),
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Re-point ours-to-own drifted symlinks and repair hook paths in settings.json.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help=(
+            "Enumerate findings and planned re-points without changing anything. "
+            "Same as no-flag mode (read-only scan)."
+        ),
+    )
+    args = parser.parse_args()
+
+    # --dry-run takes priority; --fix alone is the live-fix mode
+    actually_fix = args.fix and not args.dry_run
+
+    repo_dir = _load_repo_dir()
+    doc = Doctor(repo_dir=repo_dir, fix=actually_fix)
+
+    # (a) repo_dir validity
+    check_repo_dir(doc)
+
+    # (b) managed ~/.claude symlinks
+    check_managed_symlinks(doc)
+
+    # (c) hook paths in settings.json
+    check_hook_paths(doc)
+
+    # (d) ~/.local/bin wrappers
+    check_local_bin_symlinks(doc)
+
+    # (e) git pre-commit hook
+    check_git_precommit(doc)
+
+    # Exit codes
+    if actually_fix:
+        return 2 if doc.has_unfixable() else 0
+
+    # Read-only mode (no --fix, or --dry-run): exit 1 if any FAIL or FIX
+    return 1 if doc.has_unresolved_findings() else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/tests/test_agentic_doctor.sh
+++ b/bin/tests/test_agentic_doctor.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# Purpose: Regression and smoke tests for bin/agentic-doctor.
+#
+# Public API: ./bin/tests/test_agentic_doctor.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, mktemp.
+#
+# Downstream consumers: developer running locally before commit; can be
+#                       wired into CI.
+#
+# Failure modes: any test failure prints the failing assertion and exits 1.
+#                Tests use isolated TEMP_HOME dirs with a fake ~/.claude
+#                and fake ~/.agentic to avoid touching real user state.
+#                NEVER points at the real ~/.claude.
+#
+# Performance: <2 s wall time on a developer machine.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DOCTOR="$SCRIPT_DIR/agentic-doctor"
+
+if [[ ! -x "$DOCTOR" ]]; then
+  echo "FAIL: $DOCTOR not executable" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Test fixture setup
+# ---------------------------------------------------------------------------
+# Build a TEMP_HOME with:
+#   - TEMP_HOME/.agentic/agentic-engineering-config.json  pointing at FAKE_REPO
+#   - FAKE_REPO/   (a fake git repo with .claude/agents/ tree)
+#   - TEMP_HOME/.claude/agents/correct.md -> FAKE_REPO/.claude/agents/correct.md  [OK]
+#   - TEMP_HOME/.claude/agents/stale.md  -> OLD_REPO/.claude/agents/stale.md      [FAIL/ours]
+#   - TEMP_HOME/.claude/agents/broken.md -> /nonexistent/broken.md                 [FAIL/ours]
+#   - TEMP_HOME/.claude/agents/realfile.md  (a real file, not a symlink)            [SKIP]
+#   - TEMP_HOME/.claude/agents/foreign.md -> EXTERNAL_FILE                         [SKIP/not-ours]
+#
+# The "ours" heuristic requires the existing target to contain "DinoStack" in
+# its path, or be broken. For stale.md we point at a path under a sibling
+# DinoStack clone; for foreign.md we point at an external file that exists
+# outside any DinoStack path, which must NOT be touched.
+
+setup_fixture() {
+  TEMP_HOME="$(mktemp -d)"
+  FAKE_REPO="$TEMP_HOME/fake-DinoStack"
+  OLD_REPO="$TEMP_HOME/old-DinoStack"
+  EXTERNAL_DIR="$TEMP_HOME/external"
+  # Resolve via realpath so comparisons work on macOS where /var -> /private/var
+  REAL_FAKE_REPO="$(python3 -c "import os; print(os.path.realpath('$TEMP_HOME/fake-DinoStack'))")"
+
+  # Create fake git repos
+  mkdir -p "$FAKE_REPO/.git" "$FAKE_REPO/.claude/agents"
+  mkdir -p "$OLD_REPO/.git"
+  mkdir -p "$EXTERNAL_DIR"
+
+  # Populate repo targets so correct.md link resolves
+  echo "correct" > "$FAKE_REPO/.claude/agents/correct.md"
+  echo "stale"   > "$OLD_REPO/stale-target.md"
+
+  # External file (exists, outside any DinoStack path)
+  echo "foreign" > "$EXTERNAL_DIR/foreign.md"
+
+  # ~/.agentic config pointing at FAKE_REPO
+  mkdir -p "$TEMP_HOME/.agentic"
+  cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "$FAKE_REPO"
+}
+EOF
+
+  # ~/.claude/agents/
+  mkdir -p "$TEMP_HOME/.claude/agents"
+
+  # [OK] correct link
+  ln -s "$FAKE_REPO/.claude/agents/correct.md" "$TEMP_HOME/.claude/agents/correct.md"
+
+  # [FAIL/ours] stale link - points at old DinoStack clone (target exists, ours by name)
+  ln -s "$OLD_REPO/stale-target.md" "$TEMP_HOME/.claude/agents/stale.md"
+
+  # [FAIL/ours] broken link
+  ln -s "/nonexistent/path/broken.md" "$TEMP_HOME/.claude/agents/broken.md"
+
+  # [SKIP] real file - must never be touched
+  echo "real content" > "$TEMP_HOME/.claude/agents/realfile.md"
+
+  # [SKIP] foreign symlink - target exists outside DinoStack; must not be touched
+  ln -s "$EXTERNAL_DIR/foreign.md" "$TEMP_HOME/.claude/agents/foreign.md"
+
+  # No settings.json (skip hooks check)
+  # No local/bin (skip local_bin check - no bin/ in FAKE_REPO either,
+  # we just confirm FAKE_REPO/.git exists so check(a) passes)
+}
+
+invoke_doctor() {
+  # Run agentic-doctor with HOME and FAKE_REPO via config; capture output + exit
+  (
+    HOME="$TEMP_HOME"
+    export HOME
+    python3 "$DOCTOR" "$@"
+  ) > "$TEMP_HOME/.out" 2>&1
+  echo $? > "$TEMP_HOME/.exit"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: read-only mode reports correct OK/FAIL/SKIP set, exits 1
+# ---------------------------------------------------------------------------
+setup_fixture
+invoke_doctor  # no flags - read-only
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" != "1" ]]; then
+  _fail "T1 read-only exit code: expected 1, got $RC\n$OUT"
+else
+  _pass "T1 read-only: exits 1 (findings present)"
+fi
+
+if echo "$OUT" | grep -q "^OK managed_links:.*correct.md"; then
+  _pass "T1 read-only: correct link reported OK"
+else
+  _fail "T1 read-only: correct link should be OK\n$OUT"
+fi
+
+# stale.md (ours, wrong target) must be a FAIL or FIX
+if echo "$OUT" | grep -q "stale.md"; then
+  _pass "T1 read-only: stale link appears in output"
+else
+  _fail "T1 read-only: stale link not mentioned\n$OUT"
+fi
+
+# broken.md must be a FAIL or FIX
+if echo "$OUT" | grep -qE "(FAIL|FIX).*broken.md"; then
+  _pass "T1 read-only: broken link reported as FAIL or FIX"
+else
+  _fail "T1 read-only: broken link should be FAIL/FIX\n$OUT"
+fi
+
+# realfile.md must be SKIP (real file)
+if echo "$OUT" | grep -q "^SKIP.*realfile.md"; then
+  _pass "T1 read-only: real file is SKIPped"
+else
+  _fail "T1 read-only: real file should be SKIP\n$OUT"
+fi
+
+# foreign.md must be SKIP (not ours)
+if echo "$OUT" | grep -q "^SKIP.*foreign.md"; then
+  _pass "T1 read-only: foreign symlink is SKIPped"
+else
+  _fail "T1 read-only: foreign symlink should be SKIP\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 2: --fix re-points ours-to-own, prints each FIX line, leaves others alone
+# ---------------------------------------------------------------------------
+setup_fixture
+
+# Ensure the expected target exists for stale.md repair
+mkdir -p "$FAKE_REPO/.claude/agents"
+echo "stale repaired" > "$FAKE_REPO/.claude/agents/stale.md"
+# broken.md expected target: FAKE_REPO/.claude/agents/broken.md
+echo "broken repaired" > "$FAKE_REPO/.claude/agents/broken.md"
+
+invoke_doctor --fix
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" || "$RC" == "2" ]]; then
+  _pass "T2 --fix: exits 0 or 2 (fix ran)"
+else
+  _fail "T2 --fix exit code: expected 0 or 2, got $RC\n$OUT"
+fi
+
+# FIX lines must have been printed for stale and broken
+if echo "$OUT" | grep -q "^FIX symlink:.*stale.md"; then
+  _pass "T2 --fix: FIX line printed for stale.md"
+else
+  _fail "T2 --fix: missing FIX line for stale.md\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "^FIX symlink:.*broken.md"; then
+  _pass "T2 --fix: FIX line printed for broken.md"
+else
+  _fail "T2 --fix: missing FIX line for broken.md\n$OUT"
+fi
+
+# stale.md should now resolve into FAKE_REPO (compare against realpath)
+STALE_TARGET="$(readlink "$TEMP_HOME/.claude/agents/stale.md" 2>/dev/null || echo "(not a link)")"
+if [[ "$STALE_TARGET" == "$FAKE_REPO/.claude/agents/stale.md" ]] || [[ "$STALE_TARGET" == "$REAL_FAKE_REPO/.claude/agents/stale.md" ]]; then
+  _pass "T2 --fix: stale.md re-pointed to FAKE_REPO"
+else
+  _fail "T2 --fix: stale.md target is '$STALE_TARGET', expected '$FAKE_REPO/.claude/agents/stale.md' or realpath variant"
+fi
+
+# broken.md should now resolve into FAKE_REPO (compare against realpath)
+BROKEN_TARGET="$(readlink "$TEMP_HOME/.claude/agents/broken.md" 2>/dev/null || echo "(not a link)")"
+if [[ "$BROKEN_TARGET" == "$FAKE_REPO/.claude/agents/broken.md" ]] || [[ "$BROKEN_TARGET" == "$REAL_FAKE_REPO/.claude/agents/broken.md" ]]; then
+  _pass "T2 --fix: broken.md re-pointed to FAKE_REPO"
+else
+  _fail "T2 --fix: broken.md target is '$BROKEN_TARGET', expected '$FAKE_REPO/.claude/agents/broken.md' or realpath variant"
+fi
+
+# realfile.md must still be a real file (not a symlink, not removed)
+if [[ -f "$TEMP_HOME/.claude/agents/realfile.md" ]] && [[ ! -L "$TEMP_HOME/.claude/agents/realfile.md" ]]; then
+  _pass "T2 --fix: realfile.md untouched (still a real file)"
+else
+  _fail "T2 --fix: realfile.md was modified (must never touch real files)"
+fi
+
+# foreign.md must still point at the external target (untouched)
+FOREIGN_TARGET="$(readlink "$TEMP_HOME/.claude/agents/foreign.md" 2>/dev/null || echo "(not a link)")"
+EXTERNAL_FILE="$TEMP_HOME/external/foreign.md"
+if [[ "$FOREIGN_TARGET" == "$EXTERNAL_FILE" ]]; then
+  _pass "T2 --fix: foreign.md untouched (not ours)"
+else
+  _fail "T2 --fix: foreign.md target changed from '$EXTERNAL_FILE' to '$FOREIGN_TARGET'"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 3: idempotent re-run after --fix exits 0
+# ---------------------------------------------------------------------------
+setup_fixture
+
+mkdir -p "$FAKE_REPO/.claude/agents"
+echo "stale repaired" > "$FAKE_REPO/.claude/agents/stale.md"
+echo "broken repaired" > "$FAKE_REPO/.claude/agents/broken.md"
+
+# First --fix pass
+invoke_doctor --fix
+
+# Second --fix pass - should exit 0 (nothing to fix)
+invoke_doctor --fix
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T3 idempotent: second --fix exits 0"
+else
+  _fail "T3 idempotent: second --fix exited $RC (expected 0)\n$OUT"
+fi
+
+# Should be no FAIL lines on second pass (for the managed links we fixed)
+FAIL_LINES=$(echo "$OUT" | grep "^FAIL" | grep -v "not found" || true)
+if [[ -z "$FAIL_LINES" ]]; then
+  _pass "T3 idempotent: no FAIL lines on second pass (for repaired links)"
+else
+  _fail "T3 idempotent: unexpected FAIL lines on second pass:\n$FAIL_LINES"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 4: --dry-run does not change anything
+# ---------------------------------------------------------------------------
+setup_fixture
+
+mkdir -p "$FAKE_REPO/.claude/agents"
+echo "stale content" > "$FAKE_REPO/.claude/agents/stale.md"
+echo "broken content" > "$FAKE_REPO/.claude/agents/broken.md"
+
+# Record original targets
+STALE_ORIG="$(readlink "$TEMP_HOME/.claude/agents/stale.md")"
+BROKEN_ORIG="$(readlink "$TEMP_HOME/.claude/agents/broken.md")"
+
+invoke_doctor --dry-run
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+# Should still exit 1 (findings present, not fixed)
+if [[ "$RC" == "1" ]]; then
+  _pass "T4 --dry-run: exits 1 (not fixed)"
+else
+  _fail "T4 --dry-run: expected exit 1, got $RC\n$OUT"
+fi
+
+# Symlinks must NOT have been changed
+STALE_AFTER="$(readlink "$TEMP_HOME/.claude/agents/stale.md" 2>/dev/null)"
+BROKEN_AFTER="$(readlink "$TEMP_HOME/.claude/agents/broken.md" 2>/dev/null)"
+
+if [[ "$STALE_AFTER" == "$STALE_ORIG" ]]; then
+  _pass "T4 --dry-run: stale.md target unchanged"
+else
+  _fail "T4 --dry-run: stale.md was modified (dry-run must not change files)"
+fi
+
+if [[ "$BROKEN_AFTER" == "$BROKEN_ORIG" ]]; then
+  _pass "T4 --dry-run: broken.md target unchanged"
+else
+  _fail "T4 --dry-run: broken.md was modified (dry-run must not change files)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 5: invalid repo_dir path exits 1 with FAIL repo_dir: line, not a crash
+# ---------------------------------------------------------------------------
+setup_fixture
+
+# Overwrite config to point repo_dir at a path that does not exist
+cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "/nonexistent/path"
+}
+EOF
+
+invoke_doctor
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T5 invalid repo_dir: exits 1 (not a crash)"
+else
+  _fail "T5 invalid repo_dir: expected exit 1, got $RC (possible NameError crash?)\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "^FAIL repo_dir:"; then
+  _pass "T5 invalid repo_dir: FAIL repo_dir: line present"
+else
+  _fail "T5 invalid repo_dir: missing FAIL repo_dir: line\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds `bin/agentic-doctor [--fix] [--dry-run]` - read-only-by-default install health check that detects (and with `--fix` converges) the global-symlink / hook-path drift behind the recent split-brain incident.

Checks: repo_dir validity, managed `~/.claude` symlinks resolve under repo_dir, settings.json hook command paths, `~/.local/bin` wrappers, git pre-commit hook.

Safety (the point of the tool):
- Ownership predicate only ever touches a path that is a symlink (never a real file) whose target is broken or under a `DinoStack` / `-DinoStack` checkout. Skeptic traced it: `MyDinoStackFork` etc. are not false-matched.
- `--fix` prints each re-point individually; patches settings.json via atomic tmp+rename; never invokes install.sh / rebuild / MCP.
- Exit codes: 0 clean / 1 findings / 2 unfixable.

Validation: 20-assertion temp-HOME test (all ownership cases: OK / FIX-ours / SKIP-realfile / SKIP-foreign, idempotent re-fix, invalid-repo_dir). Skeptic also ran it read-only against the real (consolidated) environment: all 54 checks OK. Skeptic Major (a NameError on the invalid-repo_dir path) fixed + covered by Test 5.

Part of the install/update self-heal effort (Wave-1).