### PR TITLE
feat(install): converging symlinks + guarded repo_dir write (self-heal drift)

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1,4 +1,34 @@
 #!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Purpose: One-shot installer for agentic-engineering. Symlinks agents,
+#          commands, and the skill directory into ~/.claude/; wires hooks into
+#          ~/.claude/settings.json; writes activation mode + risk profile;
+#          optionally configures permissions, MCPs, and developer identity;
+#          writes repo_dir to ~/.agentic/agentic-engineering-config.json with
+#          a clobber-guard (never overwrites a valid different repo_dir).
+#
+# Public API:
+#   bash .claude/install.sh [--mode=opt-in|opt-out] [--profile=relaxed|default|strict]
+#                           [--identity=<handle>] [--no-identity] [--dry-run]
+#   --dry-run: print symlink actions and repo_dir write intent without executing
+#              them. Hook wiring, build, and permission phases still execute.
+#
+# Upstream deps: bash 3.2+, python3, git, node (for hooks), ln, readlink.
+#
+# Downstream consumers: bootstrap.sh (calls this), /update-agentic-engineering,
+#   developers running directly.
+#
+# Failure modes:
+#   - Stale symlinks pointing to another methodology checkout are RE-POINTED
+#     (converging / self-healing). Real files at dst are skipped (never touched).
+#   - Symlinks to non-methodology paths are skipped; a warning is printed.
+#   - repo_dir clobber-guard: if ~/.agentic/agentic-engineering-config.json
+#     already holds a valid DIFFERENT repo_dir, a warning is printed and the
+#     existing value is preserved. Only absent/invalid/same values are written.
+#   - All interactive prompts fall back to a default when stdin is not a TTY.
+#
+# Performance: ~5-10 s (one build pass, node/python3 calls for hooks/settings).
+# ---------------------------------------------------------------------------
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -27,6 +57,7 @@ AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
 AE_IDENTITY_FLAG=""
 AE_NO_IDENTITY=false
+AE_DRY_RUN=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -46,6 +77,9 @@ for arg in "$@"; do
       ;;
     --no-identity)
       AE_NO_IDENTITY=true
+      ;;
+    --dry-run)
+      AE_DRY_RUN=true
       ;;
   esac
 done
@@ -205,6 +239,39 @@ SETTINGS="$HOME/.claude/settings.json"
 # Helpers
 # ---------------------------------------------------------------------------
 
+# _ae_is_ours DST
+#   Returns 0 (true) iff DST is "ours to own" - i.e. safe to re-point.
+#   A destination is ours iff:
+#     - it IS a symlink (never touch real files), AND
+#     - its current target is broken OR resolves under a methodology checkout
+#       (path contains a component equal to "DinoStack" or ending with "-DinoStack").
+#   Intentionally more conservative than agentic-doctor on broken symlinks:
+#   agentic-doctor reclaims ALL broken symlinks in managed dirs regardless of
+#   origin, while this predicate only reclaims broken symlinks whose target
+#   string contains a /DinoStack/ or -DinoStack/ component (i.e., was clearly
+#   a methodology path). Non-methodology broken symlinks are left untouched.
+#   Must NOT match "MyDinoStackFork" or similar; only exact-component matches count.
+_ae_is_ours() {
+  local dst="$1"
+  # Not a symlink -> not ours (real file: never touch)
+  [[ -L "$dst" ]] || return 1
+  # Broken symlink pointing to a non-methodology path is still "ours" when
+  # the original target was under a DinoStack checkout. If it's broken and
+  # clearly not a DinoStack path we should not re-point it.
+  local current_target
+  current_target="$(readlink "$dst")"
+  # Broken symlink: if target was under a methodology checkout, ours.
+  # The target string itself encodes the path even when the file is gone.
+  if [[ ! -e "$dst" ]]; then
+    # Broken - check if original target is a methodology path
+    [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+    return 1
+  fi
+  # Live symlink: check if it resolves under a methodology checkout.
+  [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+  return 1
+}
+
 symlink_files() {
   local src_dir="$1"
   local dst_dir="$2"
@@ -229,17 +296,38 @@ symlink_files() {
       if [[ "$current_target" == "$src_file" ]]; then
         echo "  = $name (already linked)"
         continue
+      elif _ae_is_ours "$dst_file"; then
+        # Stale symlink pointing to another methodology checkout - re-point it.
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          echo "  ~ $name (would re-point to repo_dir)"
+        else
+          ln -sfn "$src_file" "$dst_file"
+          echo "  ~ $name (re-pointed to repo_dir)"
+        fi
+        continue
       else
-        echo "  ! $name (symlink points elsewhere: $current_target - skipping)"
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          echo "  ! $name (would skip: symlink points outside methodology checkout: $current_target)"
+        else
+          echo "  ! $name (symlink points elsewhere: $current_target - skipping)"
+        fi
         continue
       fi
     elif [[ -e "$dst_file" ]]; then
-      echo "  ! $name (real file exists at destination - skipping)"
+      if [[ "$AE_DRY_RUN" == "true" ]]; then
+        echo "  ! $name (would skip: real file exists at destination)"
+      else
+        echo "  ! $name (real file exists at destination - skipping)"
+      fi
       continue
     fi
 
-    ln -s "$src_file" "$dst_file"
-    echo "  + $name"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  + $name (would create)"
+    else
+      ln -s "$src_file" "$dst_file"
+      echo "  + $name"
+    fi
   done
 }
 
@@ -269,14 +357,34 @@ if [[ -L "$SKILLS_DST" ]]; then
   current_target="$(readlink "$SKILLS_DST")"
   if [[ "$current_target" == "$SKILLS_SRC" ]]; then
     echo "  = engineering (already linked)"
+  elif _ae_is_ours "$SKILLS_DST"; then
+    # Stale symlink pointing to another methodology checkout - re-point it.
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ engineering (would re-point to repo_dir)"
+    else
+      ln -sfn "$SKILLS_SRC" "$SKILLS_DST"
+      echo "  ~ engineering (re-pointed to repo_dir)"
+    fi
   else
-    echo "  ! engineering (symlink points elsewhere: $current_target - skipping)"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ! engineering (would skip: symlink points outside methodology checkout: $current_target)"
+    else
+      echo "  ! engineering (symlink points elsewhere: $current_target - skipping)"
+    fi
   fi
 elif [[ -e "$SKILLS_DST" ]]; then
-  echo "  ! engineering (real file/directory exists at destination - skipping)"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  ! engineering (would skip: real file/directory exists at destination)"
+  else
+    echo "  ! engineering (real file/directory exists at destination - skipping)"
+  fi
 else
-  ln -s "$SKILLS_SRC" "$SKILLS_DST"
-  echo "  + agentic-engineering"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  + agentic-engineering (would create)"
+  else
+    ln -s "$SKILLS_SRC" "$SKILLS_DST"
+    echo "  + agentic-engineering"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -635,6 +743,122 @@ else:
 PYEOF
 
 # ---------------------------------------------------------------------------
+# Write repo_dir to ~/.agentic/agentic-engineering-config.json (guarded)
+#
+# Persists the canonical checkout path so hooks and /update-agentic-engineering
+# can find it in future sessions (bootstrap.sh does this unconditionally, but
+# standalone `bash .claude/install.sh` runs skip bootstrap, leaving repo_dir
+# unset until now).
+#
+# Clobber-guard: ONLY writes when the config is absent, has no repo_dir key,
+# has an invalid (non-git-repo) repo_dir, or already equals REPO_DIR.
+# A valid DIFFERENT repo_dir is NEVER overwritten - a warning is printed
+# instead. Use agentic-doctor or set repo_dir manually if the intent is to
+# switch canonical checkouts.
+# ---------------------------------------------------------------------------
+
+# Source the lib so we can call validate_repo_dir.
+# Gracefully skip if the lib is not available (e.g. older checkout).
+if [[ -f "$REPO_DIR/scripts/lib/repo-dir.sh" ]]; then
+  # shellcheck source=scripts/lib/repo-dir.sh
+  . "$REPO_DIR/scripts/lib/repo-dir.sh"
+
+  _ae_write_repo_dir() {
+    local target_repo_dir="$1"
+    python3 - "$HOME/.agentic/agentic-engineering-config.json" "$target_repo_dir" <<'PYEOF'
+import json, sys, os
+cfg, repo_dir = sys.argv[1], sys.argv[2]
+os.makedirs(os.path.dirname(cfg), exist_ok=True)
+data = {}
+if os.path.exists(cfg):
+    try:
+        with open(cfg) as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+data["repo_dir"] = repo_dir
+# Atomic: write to tmp then rename
+import tempfile
+tmp = cfg + ".tmp." + str(os.getpid())
+with open(tmp, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+os.replace(tmp, cfg)
+PYEOF
+  }
+
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    # Under --dry-run: determine which branch WOULD run and print intent only.
+    _ae_config="$HOME/.agentic/agentic-engineering-config.json"
+    _existing_repo_dir=""
+    if [[ -f "$_ae_config" ]]; then
+      _existing_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$_ae_config" 2>/dev/null)" || _existing_repo_dir=""
+    fi
+    if [[ -z "$_existing_repo_dir" ]]; then
+      echo "  [dry-run] would write repo_dir=$REPO_DIR to $_ae_config"
+    elif ! validate_repo_dir "$_existing_repo_dir"; then
+      echo "  [dry-run] would update repo_dir=$REPO_DIR (previous '$_existing_repo_dir' was not a valid git repo)"
+    else
+      _existing_real="$(cd "$_existing_repo_dir" 2>/dev/null && pwd -P || echo "$_existing_repo_dir")"
+      _this_real="$(cd "$REPO_DIR" 2>/dev/null && pwd -P || echo "$REPO_DIR")"
+      if [[ "$_existing_real" == "$_this_real" ]]; then
+        echo "  [dry-run] would skip repo_dir (already set to this checkout)"
+      else
+        echo "  [dry-run] would warn: existing repo_dir '$_existing_repo_dir' differs from '$REPO_DIR'; not overwriting"
+      fi
+    fi
+  else
+    _ae_config="$HOME/.agentic/agentic-engineering-config.json"
+    _existing_repo_dir=""
+    if [[ -f "$_ae_config" ]]; then
+      _existing_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$_ae_config" 2>/dev/null)" || _existing_repo_dir=""
+    fi
+
+    if [[ -z "$_existing_repo_dir" ]]; then
+      # No existing repo_dir - write unconditionally.
+      if _ae_write_repo_dir "$REPO_DIR" 2>/dev/null; then
+        echo "  + wrote repo_dir=$REPO_DIR to $_ae_config"
+      else
+        echo "  ! warning: failed to write repo_dir to $_ae_config (non-fatal)" >&2
+      fi
+    elif ! validate_repo_dir "$_existing_repo_dir"; then
+      # Existing value is not a valid git repo - overwrite with current checkout.
+      if _ae_write_repo_dir "$REPO_DIR" 2>/dev/null; then
+        echo "  ~ updated repo_dir=$REPO_DIR (previous '$_existing_repo_dir' was not a valid git repo)"
+      else
+        echo "  ! warning: failed to update repo_dir in $_ae_config (non-fatal)" >&2
+      fi
+    else
+      # Resolve both paths to canonical forms before comparing.
+      _existing_real="$(cd "$_existing_repo_dir" 2>/dev/null && pwd -P || echo "$_existing_repo_dir")"
+      _this_real="$(cd "$REPO_DIR" 2>/dev/null && pwd -P || echo "$REPO_DIR")"
+      if [[ "$_existing_real" == "$_this_real" ]]; then
+        echo "  = repo_dir already set to this checkout (keeping)"
+      else
+        # Valid DIFFERENT repo_dir - do NOT overwrite.
+        echo "  warning: existing canonical repo_dir '$_existing_repo_dir' differs from this checkout '$REPO_DIR'; not overwriting. Run agentic-doctor or set repo_dir manually if this is intended." >&2
+      fi
+    fi
+  fi
+else
+  echo "  [skip] scripts/lib/repo-dir.sh not found - repo_dir write skipped"
+fi
+
+# ---------------------------------------------------------------------------
 # Run initial build
 # ---------------------------------------------------------------------------
 
@@ -655,14 +879,30 @@ if [[ -L "$HOOK_DST" ]]; then
   current_target="$(readlink "$HOOK_DST")"
   if [[ "$current_target" == "$HOOK_SRC" ]]; then
     echo "  = pre-commit hook already linked"
+  elif _ae_is_ours "$HOOK_DST"; then
+    # Stale symlink pointing to another methodology checkout - re-point it.
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ pre-commit hook (would re-point to repo_dir)"
+    else
+      ln -sfn "$HOOK_SRC" "$HOOK_DST"
+      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
+    fi
   else
-    echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
+    else
+      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    fi
   fi
 elif [[ -e "$HOOK_DST" ]]; then
   echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
 else
-  ln -s "$HOOK_SRC" "$HOOK_DST"
-  echo "  + pre-commit hook installed"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  + pre-commit hook (would create)"
+  else
+    ln -s "$HOOK_SRC" "$HOOK_DST"
+    echo "  + pre-commit hook installed"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Purpose: Tests for .claude/install.sh symlink-convergence and guarded
+#          repo_dir write (Changes 1-3 in the converging-symlinks PR).
+#
+# Public API: bash .claude/tests/install-converge.test.sh
+#             Exits 0 on all pass, non-zero on any failure.
+#
+# Upstream deps: bash, python3, git, ln, readlink, mktemp.
+#
+# Downstream consumers: developer running locally; CI.
+#
+# Failure modes: failures print the failing test name and exit 1.
+#                All side effects use TEMP HOME dirs; the real ~/.claude and
+#                ~/.agentic are NEVER touched.
+#
+# Performance: ~10 s wall time (runs install.sh multiple times with fake HOME).
+#
+# Regression coverage:
+#   - Change 1: stale "ours" symlink (target under .../DinoStack/...) is
+#     RE-POINTED rather than skipped.
+#   - Change 1: broken "ours" symlink is re-pointed.
+#   - Change 1: a real file at dst is left untouched (skip).
+#   - Change 1: a symlink pointing outside any methodology checkout is skipped.
+#   - Change 2: --dry-run makes no filesystem changes.
+#   - Change 3: clobber guard - valid DIFFERENT repo_dir is NOT overwritten;
+#     absent/invalid repo_dir IS written.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO_DIR/.claude/install.sh"
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+  echo "FAIL: $INSTALL_SH not found" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAKE_HOME=""
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+_cleanup() {
+  if [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]]; then
+    rm -rf "$FAKE_HOME"
+  fi
+}
+trap _cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: run install.sh with a temp HOME, capturing output.
+# Passes --mode=opt-out --profile=default to suppress interactive prompts.
+# Extra args are passed through.
+# ---------------------------------------------------------------------------
+_run_install() {
+  local fake_home="$1"
+  shift
+  # Ensure the fake HOME has the minimal ~/.agentic dir so repo-dir.sh works.
+  mkdir -p "$fake_home/.agentic"
+  # Run install.sh with fake HOME; stdin is /dev/null to skip TTY prompts.
+  HOME="$fake_home" bash "$INSTALL_SH" --mode=opt-out --profile=default "$@" \
+    < /dev/null > "$fake_home/.install_out" 2>&1
+  return $?
+}
+
+# Source dir that install.sh will symlink FROM (agents dir used as a concrete target).
+AGENTS_SRC="$REPO_DIR/.claude/agents"
+
+# Pick one .md file from agents/ to use as a concrete fixture target.
+_pick_fixture_file() {
+  local f
+  for f in "$AGENTS_SRC"/*.md; do
+    [[ -e "$f" ]] && { echo "$f"; return 0; }
+  done
+  echo ""
+}
+
+FIXTURE_SRC="$(_pick_fixture_file)"
+if [[ -z "$FIXTURE_SRC" ]]; then
+  echo "FAIL: no .md fixture file found in $AGENTS_SRC" >&2
+  exit 1
+fi
+FIXTURE_NAME="$(basename "$FIXTURE_SRC")"
+
+# ===========================================================================
+# Test cases
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Case (a): stale "ours" symlink (target under fake .../DinoStack/...) gets
+#           RE-POINTED to the correct src.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude/agents"
+# Create a fake "other DinoStack checkout" path (doesn't need to exist for
+# the ownership predicate - just needs to match */DinoStack/*).
+FAKE_OTHER="/tmp/other-DinoStack/path/to/$FIXTURE_NAME"
+ln -s "$FAKE_OTHER" "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
+
+_run_install "$FAKE_HOME" || true
+
+# After install, the symlink should now point to the real src.
+if [[ -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
+  actual_target="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+  if [[ "$actual_target" == "$FIXTURE_SRC" ]]; then
+    _pass "case (a): stale 'ours' symlink re-pointed"
+  else
+    _fail "case (a): expected target '$FIXTURE_SRC', got '$actual_target'"
+  fi
+else
+  _fail "case (a): $FIXTURE_NAME is not a symlink after install"
+fi
+
+# Also verify that the install output mentioned re-pointing (~ line).
+if grep -q "~ $FIXTURE_NAME" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (a): install output includes re-point indicator"
+else
+  _fail "case (a): install output did not include '~ $FIXTURE_NAME' indicator"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (b): broken "ours" symlink (target under DinoStack, but file is gone)
+#           gets RE-POINTED.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude/agents"
+# A symlink under a methodology path that does not actually exist.
+ln -s "/nonexistent/DinoStack/path/$FIXTURE_NAME" "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
+
+_run_install "$FAKE_HOME" || true
+
+if [[ -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
+  actual_target="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+  if [[ "$actual_target" == "$FIXTURE_SRC" ]]; then
+    _pass "case (b): broken 'ours' symlink re-pointed"
+  else
+    _fail "case (b): expected target '$FIXTURE_SRC', got '$actual_target'"
+  fi
+else
+  _fail "case (b): $FIXTURE_NAME is not a symlink after install"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (c): a REAL file at dst is left untouched (skip).
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude/agents"
+REAL_FILE_CONTENT="# real user file - must not be clobbered"
+printf '%s\n' "$REAL_FILE_CONTENT" > "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
+
+_run_install "$FAKE_HOME" || true
+
+# Must still be a regular file, not a symlink.
+if [[ -f "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]] && [[ ! -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
+  actual_content="$(cat "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+  if [[ "$actual_content" == "$REAL_FILE_CONTENT" ]]; then
+    _pass "case (c): real file at dst untouched"
+  else
+    _fail "case (c): real file content was altered"
+  fi
+else
+  _fail "case (c): real file was replaced by a symlink"
+fi
+
+# Also check the install output says "skipping" for this file.
+if grep -q "! $FIXTURE_NAME" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (c): install output indicates skip for real file"
+else
+  _fail "case (c): install output did not mention skip for '$FIXTURE_NAME'"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (d): symlink pointing OUTSIDE any methodology checkout is left untouched.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude/agents"
+# Target is outside any DinoStack path (no DinoStack component).
+OUTSIDE_TARGET="/tmp/user/totally-unrelated/$FIXTURE_NAME"
+ln -s "$OUTSIDE_TARGET" "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
+
+_run_install "$FAKE_HOME" || true
+
+# Symlink should still point to the original outside target.
+if [[ -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
+  actual_target="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+  if [[ "$actual_target" == "$OUTSIDE_TARGET" ]]; then
+    _pass "case (d): out-of-checkout symlink untouched"
+  else
+    _fail "case (d): out-of-checkout symlink was changed to '$actual_target'"
+  fi
+else
+  _fail "case (d): $FIXTURE_NAME is no longer a symlink (was clobbered)"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (e): --dry-run changes nothing.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude/agents"
+# Set up a stale "ours" symlink that would normally be re-pointed.
+ln -s "/nonexistent/DinoStack/old/$FIXTURE_NAME" "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
+OLD_TARGET="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+
+_run_install "$FAKE_HOME" --dry-run || true
+
+# Symlink must NOT have been changed.
+if [[ -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
+  actual_target="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
+  if [[ "$actual_target" == "$OLD_TARGET" ]]; then
+    _pass "case (e): --dry-run left symlink unchanged"
+  else
+    _fail "case (e): --dry-run changed symlink to '$actual_target' (expected '$OLD_TARGET')"
+  fi
+else
+  _fail "case (e): $FIXTURE_NAME is no longer a symlink after --dry-run"
+fi
+
+# Dry-run output should mention "would re-point".
+if grep -q "would re-point" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (e): --dry-run output includes 'would re-point'"
+else
+  _fail "case (e): --dry-run output did not include 'would re-point'"
+fi
+
+# The repo_dir config file must NOT be created or modified under --dry-run.
+if [[ ! -f "$FAKE_HOME/.agentic/agentic-engineering-config.json" ]]; then
+  _pass "case (e): --dry-run did not create the repo_dir config file"
+else
+  _fail "case (e): --dry-run created ~/.agentic/agentic-engineering-config.json (must not mutate config)"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (f1): clobber guard - config with a valid DIFFERENT repo_dir is NOT
+#            overwritten; a warning is printed.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.agentic"
+
+# Create a fake "other valid repo" that passes validate_repo_dir (a git repo).
+FAKE_OTHER_REPO="$(mktemp -d)"
+git -C "$FAKE_OTHER_REPO" init -q
+git -C "$FAKE_OTHER_REPO" commit --allow-empty -q -m "init" 2>/dev/null || true
+
+# Write it as the existing repo_dir in the config.
+python3 - "$FAKE_HOME/.agentic/agentic-engineering-config.json" "$FAKE_OTHER_REPO" <<'PYEOF'
+import json, sys, os
+cfg, repo_dir = sys.argv[1], sys.argv[2]
+with open(cfg, "w") as f:
+    json.dump({"repo_dir": repo_dir}, f, indent=2)
+    f.write("\n")
+PYEOF
+
+_run_install "$FAKE_HOME" || true
+
+# Config must still contain the original other repo_dir.
+actual_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$FAKE_HOME/.agentic/agentic-engineering-config.json" 2>/dev/null)"
+
+if [[ "$actual_repo_dir" == "$FAKE_OTHER_REPO" ]]; then
+  _pass "case (f1): valid different repo_dir not overwritten"
+else
+  _fail "case (f1): repo_dir was changed to '$actual_repo_dir' (expected '$FAKE_OTHER_REPO')"
+fi
+
+# Install output (stderr merged into stdout via 2>&1 in _run_install) should
+# contain the warning.
+if grep -q "warning:" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (f1): warning printed for different valid repo_dir"
+else
+  _fail "case (f1): no warning printed for different valid repo_dir"
+fi
+
+rm -rf "$FAKE_OTHER_REPO" "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (f2): absent repo_dir in config IS written.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.agentic"
+# Write config with no repo_dir key.
+python3 - "$FAKE_HOME/.agentic/agentic-engineering-config.json" <<'PYEOF'
+import json, sys
+with open(sys.argv[1], "w") as f:
+    json.dump({"mode": "opt-out"}, f, indent=2)
+    f.write("\n")
+PYEOF
+
+_run_install "$FAKE_HOME" || true
+
+actual_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$FAKE_HOME/.agentic/agentic-engineering-config.json" 2>/dev/null)"
+
+if [[ -n "$actual_repo_dir" ]]; then
+  _pass "case (f2): absent repo_dir was written (value: $actual_repo_dir)"
+else
+  _fail "case (f2): repo_dir was not written when config had no repo_dir key"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (f3): invalid repo_dir in config IS overwritten.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.agentic"
+# Write config with a repo_dir that is not a git repo.
+python3 - "$FAKE_HOME/.agentic/agentic-engineering-config.json" <<'PYEOF'
+import json, sys
+with open(sys.argv[1], "w") as f:
+    json.dump({"repo_dir": "/nonexistent/path/that/is/not/a/git/repo"}, f, indent=2)
+    f.write("\n")
+PYEOF
+
+_run_install "$FAKE_HOME" || true
+
+actual_repo_dir="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('repo_dir', ''))
+except Exception:
+    print('')
+" "$FAKE_HOME/.agentic/agentic-engineering-config.json" 2>/dev/null)"
+
+if [[ -n "$actual_repo_dir" ]] && [[ "$actual_repo_dir" != "/nonexistent/path/that/is/not/a/git/repo" ]]; then
+  _pass "case (f3): invalid repo_dir overwritten (new value: $actual_repo_dir)"
+else
+  _fail "case (f3): invalid repo_dir was not overwritten (got '$actual_repo_dir')"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following flags work for all adapters (`.claude`, `.cursor`, `.codex`, `.gem
 ```
 bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
 bash .claude/install.sh --no-identity          # skip the developer-identity prompt
+bash .claude/install.sh --dry-run             # preview symlink + repo_dir changes; hook, build, and permission phases still execute
 ```
 
 **Changing mode later:** rerun any adapter's installer with `--mode=<value>` to overwrite the config, or edit `~/.claude/agentic-engineering.json` directly.


### PR DESCRIPTION
Makes `.claude/install.sh` self-healing - the root fix for the symlink split-brain. Previously the installer SKIPPED any symlink pointing elsewhere, so it could never reconverge drift.

- **Converging symlinks** (`_ae_is_ours`): a stale managed symlink whose target is broken or under a `DinoStack`/`-DinoStack` checkout is now RE-POINTED via `ln -sfn` (not skipped), in all 3 sites (agents/commands, skill, pre-commit). Real files and symlinks pointing outside any methodology checkout are never touched. Conservative on broken links (narrower than `agentic-doctor` by design).
- **`--dry-run`**: previews the symlink phase and the repo_dir write, mutating nothing. Hook-wiring/build/permission phases still execute (documented in the manifest).
- **Guarded `repo_dir` write**: standalone installs now persist `repo_dir`, but a valid *different* repo_dir is never clobbered (warns and preserves) - closes the Critical clobber vector flagged in review.

Validation: 13-case temp-HOME test (converge, real-file skip, out-of-checkout skip, dry-run no-op incl no-config-write, clobber-guard f1/f2/f3). Skeptic: 2 Majors (dry-run not gating the repo_dir write + stale manifest) and 2 Minors all resolved; clobber-guard, predicate false-positive resistance, and `ln -sfn` safety verified by review.

Completes the install/update self-heal Wave-1 (with #302 saveConfig, #303 repo-dir.sh, #304 agentic-doctor).