### PR TITLE
feat(update): skip adapter rebuild when no adapter-source changed (consumer fast-path)

### DIFF
--- a/scripts/test/update-needsrebuild.test.js
+++ b/scripts/test/update-needsrebuild.test.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the needsRebuild() pure predicate in scripts/update.js.
+ *
+ * Run: node scripts/test/update-needsrebuild.test.js
+ *
+ * Decision table:
+ *   (a) oldHead empty/null    -> always rebuild (first-install safety case)
+ *   (b) old === new           -> skip (already up to date)
+ *   (c) content/ path changed -> rebuild
+ *   (d) bin/ path changed     -> rebuild
+ *   (e) README.md / docs/ only -> skip (doc-only change)
+ *   (f) adapter build.sh changed -> rebuild
+ *   (g) hooks/ changed        -> rebuild
+ */
+
+'use strict';
+
+const path = require('path');
+const { needsRebuild } = require(path.join(__dirname, '..', 'update.js'));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, msg) {
+  if (condition) {
+    console.log(`  PASS  ${msg}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${msg}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Case (a): oldHead empty -> always rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (a): null/empty oldHead -> full rebuild');
+assert(needsRebuild('', 'abc123', []),            'empty string oldHead -> rebuild');
+assert(needsRebuild(null, 'abc123', []),           'null oldHead -> rebuild');
+assert(needsRebuild(undefined, 'abc123', []),      'undefined oldHead -> rebuild');
+assert(needsRebuild('', '', []),                   'both empty oldHead -> rebuild (safety)');
+
+// ---------------------------------------------------------------------------
+// Case (b): old === new -> skip
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (b): old === new -> skip');
+assert(!needsRebuild('abc123', 'abc123', []),                         'identical SHAs -> skip');
+assert(!needsRebuild('abc123', 'abc123', ['README.md']),              'identical SHAs, changed paths ignored -> skip');
+assert(!needsRebuild('abc123', 'abc123', ['content/agents/foo.md']), 'identical SHAs, trigger path ignored -> skip');
+
+// ---------------------------------------------------------------------------
+// Case (c): content/ path changed -> rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (c): content/ changed -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['content/agents/engineer.md']), 'content/agents/... -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['content/commands/brief.md']),  'content/commands/... -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['content/foo.txt']),             'content/foo.txt -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['README.md', 'content/x.md']), 'mixed: content/ among others -> rebuild');
+
+// ---------------------------------------------------------------------------
+// Case (d): bin/ path changed -> rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (d): bin/ changed -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['bin/agentic-doctor']),          'bin/agentic-doctor -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['bin/agentic-cost']),            'bin/agentic-cost -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['README.md', 'bin/new-tool']),   'mixed: bin/ among others -> rebuild');
+
+// ---------------------------------------------------------------------------
+// Case (e): README.md / docs/ only -> skip
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (e): doc-only changes -> skip');
+assert(!needsRebuild('aaa', 'bbb', ['README.md']),                         'README.md only -> skip');
+assert(!needsRebuild('aaa', 'bbb', ['docs/overview/vision.md']),           'docs/overview/... -> skip');
+assert(!needsRebuild('aaa', 'bbb', ['CHANGELOG.md', 'docs/changelog.html']), 'changelog files -> skip');
+assert(!needsRebuild('aaa', 'bbb', ['.gitignore', 'docs/technical/x.md']), 'gitignore + docs -> skip');
+
+// ---------------------------------------------------------------------------
+// Case (f): adapter build.sh (*/build.sh) -> rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (f): adapter build.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['.cursor/build.sh']),  '.cursor/build.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['.claude/build.sh']), '.claude/build.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['.codex/build.sh']),  '.codex/build.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['scripts/build-all.sh']),         'scripts/build-all.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['scripts/build-methodology.sh']), 'scripts/build-methodology.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['scripts/build-slides.sh']),      'scripts/build-slides.sh -> rebuild');
+
+// ---------------------------------------------------------------------------
+// Case (g): hooks/ changed -> rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (g): hooks/ changed -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['hooks/enforce-background-spawn.py']), 'hooks/enforce-*.py -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['hooks/stop-context.js']),             'hooks/stop-context.js -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['README.md', 'hooks/x.sh']),          'mixed: hooks/ among others -> rebuild');
+
+// ---------------------------------------------------------------------------
+// .claude/install.sh specifically -> rebuild
+// ---------------------------------------------------------------------------
+
+console.log('\nExtra: .claude/install.sh -> rebuild');
+assert(needsRebuild('aaa', 'bbb', ['.claude/install.sh']), '.claude/install.sh -> rebuild');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed + failed} test(s): ${passed} passed, ${failed} failed.\n`);
+if (failed > 0) process.exit(1);

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -4,9 +4,14 @@
  * Purpose: Interactive updater for agentic-engineering. Presents a TUI
  *          multi-select menu of adapters, runs git pull --ff-only
  *          origin main, and executes each selected adapter's install.sh.
+ *          Skips adapter rebuilds when no adapter-source paths changed,
+ *          making pure consumer daily updates near-instant.
  *
- * Public API: main() — CLI entry point. Called directly when the file is
- *             executed as a script.
+ * Public API:
+ *   main()        - CLI entry point. Called directly when the file is
+ *                   executed as a script.
+ *   needsRebuild(oldHead, newHead, changedPaths) - pure predicate; exported
+ *                   for unit tests via module.exports when not run directly.
  *
  * Upstream deps: Node built-ins (fs, path, child_process, readline). No
  *                external packages.
@@ -18,7 +23,8 @@
  *                adapter installs and config writes.
  *
  * Performance: Standard. TUI is synchronous; git and install script
- *              operations block until completion.
+ *              operations block until completion. Rebuild-skip path skips
+ *              all adapter install.sh executions and is near-instant.
  *
  * Usage: node scripts/update.js <repo_dir>
  */
@@ -215,6 +221,63 @@ function getDirtyFiles(repoDir) {
     }
   }
   return { staged, unstaged, untracked };
+}
+
+// ---------------------------------------------------------------------------
+// Rebuild decision
+// ---------------------------------------------------------------------------
+
+// Prefixes/paths that require a full adapter rebuild when any changed file
+// starts with one of these strings (after normalising to forward slashes).
+const REBUILD_TRIGGERS = [
+  'content/',
+  'scripts/build-all.sh',
+  'scripts/build-methodology.sh',
+  'scripts/build-slides.sh',
+  'hooks/',
+  '.claude/install.sh',
+  'bin/',
+];
+
+// Returns true if adapter install scripts should be run after a pull.
+//
+// Decision table:
+//   oldHead empty/null/undefined -> true  (first install, never skip)
+//   oldHead === newHead           -> false (already up to date)
+//   any changedPath matches a REBUILD_TRIGGER prefix -> true
+//   otherwise                    -> false (doc-only or unrelated changes)
+//
+// changedPaths: string[] of repo-relative paths as returned by
+//               `git diff --name-only OLD NEW`.
+function needsRebuild(oldHead, newHead, changedPaths) {
+  // Safety case: no prior HEAD means first install - always rebuild.
+  if (!oldHead) return true;
+
+  // No commits pulled - nothing to rebuild.
+  if (oldHead === newHead) return false;
+
+  // Check each changed path against rebuild triggers.
+  for (const p of changedPaths) {
+    // Normalise separators (Windows safety) and strip leading slashes.
+    const normalised = p.replace(/\\/g, '/').replace(/^\//, '');
+    for (const trigger of REBUILD_TRIGGERS) {
+      if (trigger.endsWith('/')) {
+        // Directory prefix: match any file under this directory.
+        if (normalised.startsWith(trigger)) return true;
+      } else if (trigger.includes('/')) {
+        // Exact file path (e.g. 'scripts/build-all.sh').
+        if (normalised === trigger) return true;
+      } else {
+        // Bare glob: any path ending in this filename pattern.
+        // Currently unused but kept for forward compatibility.
+        if (normalised === trigger || normalised.endsWith('/' + trigger)) return true;
+      }
+    }
+    // Any adapter-local build.sh (e.g. '.cursor/build.sh', '.claude/build.sh').
+    if (/\/build\.sh$/.test(normalised) || normalised === 'build.sh') return true;
+  }
+
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -563,6 +626,13 @@ async function main() {
   }
 
   // Git operations
+
+  // Capture HEAD immediately before the pull so we can diff what changed.
+  // The fetch does not move HEAD; capturing here (before fetch) vs. after
+  // fetch produces the same SHA. We go before fetch to be maximally clear
+  // about "the state we started from".
+  const oldHead = git(resolvedRepoDir, 'rev-parse', 'HEAD').stdout || '';
+
   console.log('\n>>> git fetch origin');
   const fetchResult = git(resolvedRepoDir, 'fetch', 'origin');
   if (!fetchResult.success) {
@@ -570,8 +640,6 @@ async function main() {
     console.error(fetchResult.stderr);
     process.exit(1);
   }
-
-  const oldHead = git(resolvedRepoDir, 'rev-parse', 'HEAD').stdout;
 
   console.log('\n>>> git pull --ff-only origin main');
   const pullResult = git(resolvedRepoDir, 'pull', '--ff-only', 'origin', 'main');
@@ -582,9 +650,9 @@ async function main() {
     process.exit(1);
   }
 
-  const newHead = git(resolvedRepoDir, 'rev-parse', 'HEAD').stdout;
+  const newHead = git(resolvedRepoDir, 'rev-parse', 'HEAD').stdout || '';
   let commitsPulled = 0;
-  if (oldHead !== newHead) {
+  if (oldHead && newHead && oldHead !== newHead) {
     const countResult = git(resolvedRepoDir, 'rev-list', '--count', `${oldHead}..${newHead}`);
     commitsPulled = countResult.success ? parseInt(countResult.stdout, 10) : 0;
   }
@@ -594,26 +662,50 @@ async function main() {
   // rather than waiting for the next TTL-gated background refresh.
   resetVersionCheckCache();
 
-  // Run install scripts (fail-fast: stop on first failure)
-  const successes = [];
-
-  for (const adapter of selected) {
-    const result = await runInstallScript(resolvedRepoDir, adapter);
-    if (result.success) {
-      successes.push(result.display);
-    } else {
-      console.error(`\nerror: ${result.display}/install.sh failed (exit ${result.code}).`);
-      console.error('       Fix the failure and re-run ./update.sh.');
-      process.exit(result.code || 1);
+  // Decide whether to run adapter install scripts.
+  let changedPaths = [];
+  if (oldHead && newHead && oldHead !== newHead) {
+    const diffResult = git(resolvedRepoDir, 'diff', '--name-only', oldHead, newHead);
+    if (diffResult.success && diffResult.stdout) {
+      changedPaths = diffResult.stdout.split('\n').filter(Boolean);
     }
   }
 
-  // Save config
+  const rebuild = needsRebuild(oldHead, newHead, changedPaths);
+
+  // Run install scripts (fail-fast: stop on first failure)
+  const successes = [];
+
+  if (!rebuild) {
+    const reason = oldHead === newHead
+      ? 'Already up to date - skipping adapter rebuild.'
+      : 'No adapter-source changes - skipping rebuild.';
+    console.log(`\n${reason}`);
+  } else {
+    for (const adapter of selected) {
+      const result = await runInstallScript(resolvedRepoDir, adapter);
+      if (result.success) {
+        successes.push(result.display);
+      } else {
+        console.error(`\nerror: ${result.display}/install.sh failed (exit ${result.code}).`);
+        console.error('       Fix the failure and re-run ./update.sh.');
+        process.exit(result.code || 1);
+      }
+    }
+  }
+
+  // Save config (always - adapter selection is independent of rebuild)
   saveConfig(selected);
 
   // Summary
   console.log('');
-  if (commitsPulled === 0) {
+  if (!rebuild) {
+    if (commitsPulled === 0) {
+      console.log('Already up to date. Adapter rebuild skipped.');
+    } else {
+      console.log(`Updated: pulled ${commitsPulled} commit(s). Adapter rebuild skipped (no adapter-source changes).`);
+    }
+  } else if (commitsPulled === 0) {
     console.log(`Already up to date. Refreshed ${successes.length} adapter(s): ${successes.join(' ')}.`);
   } else {
     console.log(`Updated: pulled ${commitsPulled} commit(s); refreshed ${successes.length} adapter(s): ${successes.join(' ')}.`);
@@ -641,7 +733,13 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Export pure helpers for unit tests. Guard the main() call so that requiring
+// this file from a test does not launch the interactive TUI.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+} else {
+  module.exports = { needsRebuild };
+}


### PR DESCRIPTION
Makes a pure consumer's daily `./update.sh` near-instant: skip the per-adapter `install.sh` rebuilds when nothing adapter-affecting changed between the pulled commits.

- Captures `OLD_HEAD` before the pull; after pull, `git diff --name-only OLD NEW`.
- New pure `needsRebuild(oldHead, newHead, changedPaths)`: empty/null `oldHead` (first install) → always rebuild; `old === new` → skip; any path under `content/`, `bin/`, `hooks/`, `.claude/install.sh`, the `scripts/build-*.sh`, or any `*/build.sh` → rebuild; else (docs/README/etc.) → skip.
- `saveConfig` + version-cache reset still run unconditionally; only adapter installs are gated.
- 29-assertion unit test (`require.main` guard makes the predicate importable without launching the TUI).

Skeptic: sign-off, no findings (trigger matching has no false-positive/negative; `bin/` included so new binaries get linked; null-HEAD safety verified).

Wave-2 of the install/update self-heal.