### PR TITLE
feat(bootstrap): guard against second-clone split-brain

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 #   - ~/.agentic/agentic-engineering-config.json (written with repo_dir key)
 #
 # Failure modes:
-#   Exit 0: success
+#   Exit 0: success OR rogue-clone guard fired (second-checkout prevented; message on stderr)
 #   Exit 1: preflight failure (missing git/python3, or unwritable AE_DEST_DIR parent)
 #   Exit 2: clone/pull failure (both HTTPS and SSH failed, or dest exists but is
 #            not a git repo)
@@ -82,6 +82,63 @@ if ! mkdir -p "$AE_PARENT" 2>/dev/null; then
   echo "bootstrap.sh: cannot create parent directory '$AE_PARENT' - check write permissions" >&2
   exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# Rogue-clone guard: warn and exit if a valid install already exists elsewhere
+# ---------------------------------------------------------------------------
+# Reads repo_dir from ~/.agentic/agentic-engineering-config.json (inline Python
+# parse - scripts/lib/repo-dir.sh does not exist at bootstrap time since the
+# repo may not be cloned yet). Prints "existing_path|dest_path" to stdout and
+# exits 1 only when a rogue-clone would occur; exits 0 silently otherwise.
+_GUARD_OUT="$(python3 - "$HOME/.agentic/agentic-engineering-config.json" "$AE_DEST_DIR" <<'GUARD_PYEOF'
+import json, os, subprocess, sys
+
+cfg, dest = sys.argv[1], sys.argv[2]
+
+if not os.path.exists(cfg):
+    sys.exit(0)          # no config - first install, proceed
+
+try:
+    with open(cfg) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)          # unreadable / malformed config, proceed
+
+repo_dir = data.get("repo_dir", "")
+if not repo_dir:
+    sys.exit(0)          # no repo_dir key, proceed
+
+# Check it is a live git repo
+rc = subprocess.call(
+    ["git", "-C", repo_dir, "rev-parse", "--git-dir"],
+    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+)
+if rc != 0:
+    sys.exit(0)          # not a valid git repo, proceed
+
+# Canonicalize both paths
+try:
+    canon_existing = os.path.realpath(repo_dir)
+    canon_dest     = os.path.realpath(dest)
+except Exception:
+    sys.exit(0)
+
+if canon_existing == canon_dest:
+    sys.exit(0)          # same path - in-place update, proceed
+
+# Different valid repo exists: signal guard fires via stdout + exit 1
+print(repo_dir + "|" + dest)
+sys.exit(1)
+GUARD_PYEOF
+)" || {
+  _GUARD_EXISTING="${_GUARD_OUT%%|*}"
+  _GUARD_DEST="${_GUARD_OUT##*|}"
+  echo "bootstrap.sh: An existing DinoStack install is at $_GUARD_EXISTING." >&2
+  echo "Running bootstrap from here would create a second clone at $_GUARD_DEST and cause split-brain." >&2
+  echo "To update in place: AE_DEST_DIR=$_GUARD_EXISTING $0, or run $_GUARD_EXISTING/update.sh." >&2
+  echo "Aborting without cloning." >&2
+  exit 0
+}
 
 # ---------------------------------------------------------------------------
 # Clone-or-update logic

--- a/tests/bootstrap-guard.test.sh
+++ b/tests/bootstrap-guard.test.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# tests/bootstrap-guard.test.sh
+#
+# Regression tests for the rogue-clone guard in bootstrap.sh.
+# Uses temp HOME + temp git repos; never touches real ~/.agentic or clones.
+#
+# Cases:
+#   (a) config repo_dir = valid git repo at /path/A, AE_DEST_DIR = /path/B -> warns + exits 0, no clone
+#   (b) AE_DEST_DIR = same as repo_dir -> proceeds past guard (no abort)
+#   (c) absent config -> proceeds past guard
+#   (d) config repo_dir = non-git path -> proceeds past guard
+#
+# For case (a): bootstrap.sh exits 0 immediately (guard fires before clone).
+# For cases (b-d): the guard does not fire; bootstrap.sh continues and will
+#   eventually fail trying to clone (no network) or find install.sh (not in
+#   temp repo). We intercept at the clone step with a git stub for (a) only
+#   (to verify no clone happens) and rely on the absence of guard messages
+#   plus non-early-exit for (b-d). Cases (b-d) may exit non-zero after the
+#   guard for unrelated reasons - we only check guard behavior.
+
+set -euo pipefail
+
+BOOTSTRAP_SH="$(cd "$(dirname "$0")/.." && pwd)/bootstrap.sh"
+if [ ! -f "$BOOTSTRAP_SH" ]; then
+  echo "FATAL: bootstrap.sh not found at $BOOTSTRAP_SH" >&2
+  exit 1
+fi
+
+# Find the real git binary (before any PATH manipulation)
+REAL_GIT="$(command -v git)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PASS=0
+FAIL=0
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+_pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+_fail() { echo "FAIL: $1 - $2"; FAIL=$((FAIL+1)); }
+
+# Create a minimal git repo (valid git dir, no network needed)
+_make_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q 2>/dev/null
+  touch "$dir/.keep"
+  git -C "$dir" add .keep 2>/dev/null
+  git -C "$dir" -c user.email="t@t.com" -c user.name="T" commit -q -m "init" 2>/dev/null || true
+}
+
+# Write a config JSON to a given fake HOME
+_write_config() {
+  local home="$1" repo_dir="$2"
+  mkdir -p "$home/.agentic"
+  python3 -c "
+import json, sys
+data = {'repo_dir': sys.argv[1]}
+print(json.dumps(data, indent=2))
+" "$repo_dir" > "$home/.agentic/agentic-engineering-config.json"
+}
+
+# Git stub for case (a): intercepts 'git clone' (should never be reached),
+# passes everything else to the real git using its absolute path.
+# Uses $REAL_GIT_PATH env var to avoid PATH-based recursion.
+_make_git_stub_no_clone() {
+  local stub_bin="$1"
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/git" <<STUBEOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "clone" ]; then
+  echo "STUB_CLONE_CALLED" >&2
+  exit 0
+fi
+exec "\$REAL_GIT_PATH" "\$@"
+STUBEOF
+  chmod +x "$stub_bin/git"
+}
+
+# ---------------------------------------------------------------------------
+# Case (a): valid different repo_dir -> guard fires, exits 0, no clone
+# ---------------------------------------------------------------------------
+test_case_a() {
+  local tmp="$TMPDIR_BASE/case_a"
+  local fake_home="$tmp/home"
+  local path_a="$tmp/repoA"
+  local path_b="$tmp/repoB"
+
+  _make_git_repo "$path_a"
+  _write_config "$fake_home" "$path_a"
+
+  local stub_bin="$tmp/bin"
+  _make_git_stub_no_clone "$stub_bin"
+
+  local out
+  local rc=0
+  out="$(
+    HOME="$fake_home" \
+    AE_DEST_DIR="$path_b" \
+    AE_HTTPS_URL="NOCLONE" \
+    AE_SSH_URL="NOCLONE" \
+    REAL_GIT_PATH="$REAL_GIT" \
+    PATH="$stub_bin:$PATH" \
+    bash "$BOOTSTRAP_SH" 2>&1
+  )" || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    _fail "case_a" "expected exit 0 from guard, got exit $rc. Output: $out"
+    return
+  fi
+  if ! echo "$out" | grep -q "split-brain"; then
+    _fail "case_a" "expected split-brain warning in output. Got: $out"
+    return
+  fi
+  if echo "$out" | grep -q "STUB_CLONE_CALLED"; then
+    _fail "case_a" "git clone was invoked despite guard"
+    return
+  fi
+  if [ -d "$path_b" ]; then
+    _fail "case_a" "path_b was created despite guard firing"
+    return
+  fi
+  _pass "case_a: guard fires on valid different repo_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Case (b): AE_DEST_DIR == repo_dir (same canonical path) -> proceeds past guard
+# ---------------------------------------------------------------------------
+test_case_b() {
+  local tmp="$TMPDIR_BASE/case_b"
+  local fake_home="$tmp/home"
+  local path_a="$tmp/repoA"
+
+  _make_git_repo "$path_a"
+  _write_config "$fake_home" "$path_a"
+
+  local stub_bin="$tmp/bin"
+  _make_git_stub_no_clone "$stub_bin"
+
+  local out
+  local rc=0
+  # bootstrap.sh will exit non-zero after guard (no install.sh in temp repo);
+  # we only care the guard did NOT fire.
+  out="$(
+    HOME="$fake_home" \
+    AE_DEST_DIR="$path_a" \
+    AE_HTTPS_URL="NOCLONE" \
+    AE_SSH_URL="NOCLONE" \
+    REAL_GIT_PATH="$REAL_GIT" \
+    PATH="$stub_bin:$PATH" \
+    bash "$BOOTSTRAP_SH" 2>&1
+  )" || rc=$?
+
+  if echo "$out" | grep -q "Aborting without cloning"; then
+    _fail "case_b" "guard aborted when AE_DEST_DIR == repo_dir. Output: $out"
+    return
+  fi
+  if echo "$out" | grep -q "split-brain"; then
+    _fail "case_b" "split-brain warning when same path. Output: $out"
+    return
+  fi
+  _pass "case_b: guard skipped when AE_DEST_DIR matches repo_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Case (c): no config file -> proceeds past guard
+# ---------------------------------------------------------------------------
+test_case_c() {
+  local tmp="$TMPDIR_BASE/case_c"
+  local fake_home="$tmp/home"
+  local path_b="$tmp/repoB"
+
+  mkdir -p "$fake_home"
+  # No config written
+
+  local stub_bin="$tmp/bin"
+  _make_git_stub_no_clone "$stub_bin"
+
+  local out
+  local rc=0
+  out="$(
+    HOME="$fake_home" \
+    AE_DEST_DIR="$path_b" \
+    AE_HTTPS_URL="NOCLONE" \
+    AE_SSH_URL="NOCLONE" \
+    REAL_GIT_PATH="$REAL_GIT" \
+    PATH="$stub_bin:$PATH" \
+    bash "$BOOTSTRAP_SH" 2>&1
+  )" || rc=$?
+
+  if echo "$out" | grep -q "Aborting without cloning"; then
+    _fail "case_c" "guard fired with no config. Output: $out"
+    return
+  fi
+  if echo "$out" | grep -q "split-brain"; then
+    _fail "case_c" "split-brain with no config. Output: $out"
+    return
+  fi
+  _pass "case_c: guard skipped when no config present"
+}
+
+# ---------------------------------------------------------------------------
+# Case (d): config repo_dir = non-git directory -> proceeds past guard
+# ---------------------------------------------------------------------------
+test_case_d() {
+  local tmp="$TMPDIR_BASE/case_d"
+  local fake_home="$tmp/home"
+  local non_git="$tmp/not_a_repo"
+  local path_b="$tmp/repoB"
+
+  mkdir -p "$non_git"  # exists, but not a git repo
+  _write_config "$fake_home" "$non_git"
+
+  local stub_bin="$tmp/bin"
+  _make_git_stub_no_clone "$stub_bin"
+
+  local out
+  local rc=0
+  out="$(
+    HOME="$fake_home" \
+    AE_DEST_DIR="$path_b" \
+    AE_HTTPS_URL="NOCLONE" \
+    AE_SSH_URL="NOCLONE" \
+    REAL_GIT_PATH="$REAL_GIT" \
+    PATH="$stub_bin:$PATH" \
+    bash "$BOOTSTRAP_SH" 2>&1
+  )" || rc=$?
+
+  if echo "$out" | grep -q "Aborting without cloning"; then
+    _fail "case_d" "guard fired for non-git repo_dir. Output: $out"
+    return
+  fi
+  if echo "$out" | grep -q "split-brain"; then
+    _fail "case_d" "split-brain warning for non-git repo_dir. Output: $out"
+    return
+  fi
+  _pass "case_d: guard skipped when repo_dir is not a valid git repo"
+}
+
+# ---------------------------------------------------------------------------
+# Run all cases
+# ---------------------------------------------------------------------------
+echo "=== bootstrap-guard tests ==="
+test_case_a
+test_case_b
+test_case_c
+test_case_d
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
`bootstrap.sh` clones to `\$cwd/DinoStack` - run from the wrong directory it creates a second checkout of the same repo and wires global config to it (the split-brain incident). This adds a pre-clone guard.

- Before cloning, reads `repo_dir` from `~/.agentic/agentic-engineering-config.json` (inline Python - no dependency on the not-yet-cloned repo).
- If `repo_dir` is a valid git repo whose canonical path differs from the intended clone target, warns to stderr (with the in-place-update command) and exits 0 **without cloning**.
- Proceeds normally when: config absent, `repo_dir` missing/non-git, or target == existing repo_dir (legitimate in-place update). `realpath` on both sides handles `/var`↔`/private/var`.

4-case temp-HOME test (git stub, no network). Skeptic: sign-off, 0 Critical/Major; one trivial Minor noted (pipe-delimiter parse only affects paths containing a literal `|`).

Wave-2 of the install/update self-heal - prevents the root-cause mistake at the source.