### PR TITLE
feat(adapters): converging symlinks in cursor + opencode install.sh

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -17,6 +17,7 @@ AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
 AE_IDENTITY_FLAG=""
 AE_NO_IDENTITY=false
+AE_DRY_RUN=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out) AE_MODE_FLAG="${arg#--mode=}" ;;
@@ -28,6 +29,9 @@ for arg in "$@"; do
       ;;
     --no-identity)
       AE_NO_IDENTITY=true
+      ;;
+    --dry-run)
+      AE_DRY_RUN=true
       ;;
   esac
 done
@@ -197,6 +201,26 @@ warned_commands=()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+# _ae_is_ours DST
+#   Returns 0 (true) iff DST is "ours to own" - i.e. safe to re-point.
+#   A destination is ours iff:
+#     - it IS a symlink (never touch real files), AND
+#     - its current target is broken OR resolves under a methodology checkout
+#       (path contains a component equal to "DinoStack" or ending with "-DinoStack").
+_ae_is_ours() {
+  local dst="$1"
+  [[ -L "$dst" ]] || return 1
+  local current_target
+  current_target="$(readlink "$dst")"
+  if [[ ! -e "$dst" ]]; then
+    [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+    return 1
+  fi
+  [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+  return 1
+}
+
 array_append() {
   local _arr="$1"
   local _item="$2"
@@ -232,20 +256,38 @@ symlink_files() {
       if [[ "$current_target" == "$src_file" ]]; then
         array_append "$skipped_name" "$name (already linked)"
         continue
-      elif [[ "$current_target" == "$REPO_DIR"* ]]; then
-        array_append "$skipped_name" "$name (already linked to agentic-engineering but different path: $current_target - skipping)"
+      elif _ae_is_ours "$dst_file"; then
+        # Stale symlink pointing to another methodology checkout - re-point it.
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          array_append "$skipped_name" "$name (would re-point to repo_dir)"
+        else
+          ln -sfn "$src_file" "$dst_file"
+          array_append "$installed_name" "$name (re-pointed to repo_dir)"
+        fi
         continue
       else
-        array_append "$warned_name" "$name (symlink points elsewhere: $current_target - skipping)"
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          array_append "$warned_name" "$name (would skip: symlink points outside methodology checkout: $current_target)"
+        else
+          array_append "$warned_name" "$name (symlink points elsewhere: $current_target - skipping)"
+        fi
         continue
       fi
     elif [[ -e "$dst_file" ]]; then
-      array_append "$warned_name" "$name (real file exists at destination - skipping)"
+      if [[ "$AE_DRY_RUN" == "true" ]]; then
+        array_append "$warned_name" "$name (would skip: real file exists at destination)"
+      else
+        array_append "$warned_name" "$name (real file exists at destination - skipping)"
+      fi
       continue
     fi
 
-    ln -s "$src_file" "$dst_file"
-    array_append "$installed_name" "$name"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      array_append "$installed_name" "$name (would create)"
+    else
+      ln -s "$src_file" "$dst_file"
+      array_append "$installed_name" "$name"
+    fi
   done
 }
 
@@ -303,14 +345,30 @@ if [[ -L "$HOOK_DST" ]]; then
   current_target="$(readlink "$HOOK_DST")"
   if [[ "$current_target" == "$HOOK_SRC" ]]; then
     echo "  = pre-commit hook already linked"
+  elif _ae_is_ours "$HOOK_DST"; then
+    # Stale symlink pointing to another methodology checkout - re-point it.
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ pre-commit hook (would re-point to repo_dir)"
+    else
+      ln -sfn "$HOOK_SRC" "$HOOK_DST"
+      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
+    fi
   else
-    echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
+    else
+      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    fi
   fi
 elif [[ -e "$HOOK_DST" ]]; then
   echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
 else
-  ln -s "$HOOK_SRC" "$HOOK_DST"
-  echo "  + pre-commit hook installed"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  + pre-commit hook (would create)"
+  else
+    ln -s "$HOOK_SRC" "$HOOK_DST"
+    echo "  + pre-commit hook installed"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/.cursor/tests/install-converge.test.sh
+++ b/.cursor/tests/install-converge.test.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Purpose: Tests for .cursor/install.sh and .opencode/install.sh
+#          symlink-convergence behaviour (mirrors .claude/tests/install-converge.test.sh).
+#
+# Public API: bash .cursor/tests/install-converge.test.sh
+#             Exits 0 on all pass, non-zero on any failure.
+#
+# Upstream deps: bash, python3, ln, readlink, mktemp.
+#
+# Downstream consumers: developer running locally; CI.
+#
+# Failure modes: each failing test is printed to stderr; exits 1 if any fail.
+#                All side effects use TEMP HOME dirs; the real ~/.cursor,
+#                ~/.config/opencode, and ~/.local/bin are NEVER touched.
+#
+# Performance: ~10 s wall time (runs install.sh multiple times with fake HOME).
+#
+# Regression coverage:
+#   - Stale "ours" symlink (target under .../DinoStack/...) is RE-POINTED.
+#   - Broken "ours" symlink is re-pointed.
+#   - Real file at dst is left untouched (skip).
+#   - Symlink pointing outside any methodology checkout is skipped.
+#   - --dry-run makes no filesystem changes.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CURSOR_INSTALL="$REPO_DIR/.cursor/install.sh"
+OPENCODE_INSTALL="$REPO_DIR/.opencode/install.sh"
+
+PASS=0
+FAIL=0
+FAKE_HOME=""
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+_cleanup() {
+  if [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]]; then
+    rm -rf "$FAKE_HOME"
+  fi
+}
+trap _cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Source for a concrete fixture .mdc file (cursor rules directory).
+# ---------------------------------------------------------------------------
+CURSOR_RULES_SRC="$REPO_DIR/.cursor/rules"
+_pick_cursor_fixture() {
+  local f
+  for f in "$CURSOR_RULES_SRC"/*.mdc; do
+    [[ -e "$f" ]] && { echo "$f"; return 0; }
+  done
+  echo ""
+}
+CURSOR_FIXTURE_SRC="$(_pick_cursor_fixture)"
+if [[ -z "$CURSOR_FIXTURE_SRC" ]]; then
+  echo "SKIP: no .mdc fixture file found in $CURSOR_RULES_SRC - cursor tests skipped"
+  SKIP_CURSOR=true
+else
+  SKIP_CURSOR=false
+  CURSOR_FIXTURE_NAME="$(basename "$CURSOR_FIXTURE_SRC")"
+fi
+
+# ---------------------------------------------------------------------------
+# Source for a concrete fixture .md file (opencode agents directory).
+# Note: opencode/agents is build-generated but we are testing the symlink_files
+# predicate with the pattern; use the agents dir as the fixture source.
+# ---------------------------------------------------------------------------
+OPENCODE_AGENTS_SRC="$REPO_DIR/.opencode/agents"
+_pick_opencode_fixture() {
+  local f
+  for f in "$OPENCODE_AGENTS_SRC"/*.md; do
+    [[ -e "$f" ]] && { echo "$f"; return 0; }
+  done
+  echo ""
+}
+OPENCODE_FIXTURE_SRC="$(_pick_opencode_fixture)"
+if [[ -z "$OPENCODE_FIXTURE_SRC" ]]; then
+  echo "SKIP: no .md fixture in $OPENCODE_AGENTS_SRC - opencode symlink_files test skipped"
+  SKIP_OPENCODE=true
+else
+  SKIP_OPENCODE=false
+  OPENCODE_FIXTURE_NAME="$(basename "$OPENCODE_FIXTURE_SRC")"
+fi
+
+# ---------------------------------------------------------------------------
+# _run_cursor FAKE_HOME [extra args...]
+# Runs .cursor/install.sh with a fake HOME, capturing output.
+# Passes --mode=opt-out --profile=default to suppress interactive prompts.
+# Wires SKIP_IDENTITY so the identity step does not attempt ssh/gh operations.
+# ---------------------------------------------------------------------------
+_run_cursor() {
+  local fake_home="$1"
+  shift
+  mkdir -p "$fake_home/.cursor/rules"
+  mkdir -p "$fake_home/.local/bin"
+  HOME="$fake_home" AE_NO_IDENTITY=true bash "$CURSOR_INSTALL" \
+    --mode=opt-out --profile=default --no-identity "$@" \
+    < /dev/null > "$fake_home/.install_out" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# _run_opencode FAKE_HOME [extra args...]
+# Runs .opencode/install.sh with a fake HOME, capturing output.
+# ---------------------------------------------------------------------------
+_run_opencode() {
+  local fake_home="$1"
+  shift
+  mkdir -p "$fake_home/.config/opencode/agents"
+  mkdir -p "$fake_home/.config/opencode/skills"
+  mkdir -p "$fake_home/.local/bin"
+  HOME="$fake_home" AE_NO_IDENTITY=true bash "$OPENCODE_INSTALL" \
+    --mode=opt-out --profile=default --no-identity "$@" \
+    < /dev/null > "$fake_home/.install_out" 2>&1
+  return $?
+}
+
+# ===========================================================================
+# CURSOR TESTS
+# ===========================================================================
+
+if [[ "$SKIP_CURSOR" != "true" ]]; then
+  echo ""
+  echo "--- cursor symlink_files tests ---"
+
+  # -------------------------------------------------------------------------
+  # Cursor (a): stale "ours" symlink gets re-pointed.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/.cursor/rules"
+  FAKE_OTHER="/tmp/other-DinoStack/path/$CURSOR_FIXTURE_NAME"
+  ln -s "$FAKE_OTHER" "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME"
+
+  _run_cursor "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$CURSOR_FIXTURE_SRC" ]]; then
+      _pass "cursor (a): stale 'ours' symlink re-pointed"
+    else
+      _fail "cursor (a): expected '$CURSOR_FIXTURE_SRC', got '$actual_target'"
+    fi
+  else
+    _fail "cursor (a): $CURSOR_FIXTURE_NAME is not a symlink after install"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # Cursor (b): broken "ours" symlink gets re-pointed.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/.cursor/rules"
+  ln -s "/nonexistent/DinoStack/path/$CURSOR_FIXTURE_NAME" "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME"
+
+  _run_cursor "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$CURSOR_FIXTURE_SRC" ]]; then
+      _pass "cursor (b): broken 'ours' symlink re-pointed"
+    else
+      _fail "cursor (b): expected '$CURSOR_FIXTURE_SRC', got '$actual_target'"
+    fi
+  else
+    _fail "cursor (b): $CURSOR_FIXTURE_NAME is not a symlink after install"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # Cursor (c): real file at dst is left untouched.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/.cursor/rules"
+  REAL_FILE_CONTENT="# real user file - must not be clobbered"
+  printf '%s\n' "$REAL_FILE_CONTENT" > "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME"
+
+  _run_cursor "$FAKE_HOME" || true
+
+  if [[ -f "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]] && \
+     [[ ! -L "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]]; then
+    actual_content="$(cat "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+    if [[ "$actual_content" == "$REAL_FILE_CONTENT" ]]; then
+      _pass "cursor (c): real file at dst untouched"
+    else
+      _fail "cursor (c): real file content was altered"
+    fi
+  else
+    _fail "cursor (c): real file was replaced by a symlink"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # Cursor (d): out-of-checkout symlink is left untouched.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/.cursor/rules"
+  OUTSIDE_TARGET="/tmp/user/unrelated/$CURSOR_FIXTURE_NAME"
+  ln -s "$OUTSIDE_TARGET" "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME"
+
+  _run_cursor "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OUTSIDE_TARGET" ]]; then
+      _pass "cursor (d): out-of-checkout symlink untouched"
+    else
+      _fail "cursor (d): out-of-checkout symlink was changed to '$actual_target'"
+    fi
+  else
+    _fail "cursor (d): $CURSOR_FIXTURE_NAME is no longer a symlink"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # Cursor (e): --dry-run changes nothing.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/.cursor/rules"
+  ln -s "/nonexistent/DinoStack/old/$CURSOR_FIXTURE_NAME" "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME"
+  OLD_TARGET="$(readlink "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+
+  _run_cursor "$FAKE_HOME" --dry-run || true
+
+  if [[ -L "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/.cursor/rules/$CURSOR_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OLD_TARGET" ]]; then
+      _pass "cursor (e): --dry-run left symlink unchanged"
+    else
+      _fail "cursor (e): --dry-run changed symlink to '$actual_target'"
+    fi
+  else
+    _fail "cursor (e): $CURSOR_FIXTURE_NAME is no longer a symlink after --dry-run"
+  fi
+
+  if grep -q "would re-point" "$FAKE_HOME/.install_out" 2>/dev/null; then
+    _pass "cursor (e): --dry-run output includes 'would re-point'"
+  else
+    _fail "cursor (e): --dry-run output missing 'would re-point'"
+  fi
+  rm -rf "$FAKE_HOME"
+fi
+
+# ===========================================================================
+# OPENCODE TESTS
+# ===========================================================================
+
+if [[ "$SKIP_OPENCODE" != "true" ]]; then
+  echo ""
+  echo "--- opencode symlink_files tests ---"
+
+  OPENCODE_AGENTS_DST_SUBPATH=".config/opencode/agents"
+
+  # -------------------------------------------------------------------------
+  # OpenCode (a): stale "ours" symlink gets re-pointed.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH"
+  FAKE_OTHER_OC="/tmp/other-DinoStack/oc/$OPENCODE_FIXTURE_NAME"
+  ln -s "$FAKE_OTHER_OC" "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME"
+
+  _run_opencode "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OPENCODE_FIXTURE_SRC" ]]; then
+      _pass "opencode (a): stale 'ours' symlink re-pointed"
+    else
+      _fail "opencode (a): expected '$OPENCODE_FIXTURE_SRC', got '$actual_target'"
+    fi
+  else
+    _fail "opencode (a): $OPENCODE_FIXTURE_NAME is not a symlink after install"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # OpenCode (b): broken "ours" symlink gets re-pointed.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH"
+  ln -s "/nonexistent/DinoStack/oc/$OPENCODE_FIXTURE_NAME" \
+        "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME"
+
+  _run_opencode "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OPENCODE_FIXTURE_SRC" ]]; then
+      _pass "opencode (b): broken 'ours' symlink re-pointed"
+    else
+      _fail "opencode (b): expected '$OPENCODE_FIXTURE_SRC', got '$actual_target'"
+    fi
+  else
+    _fail "opencode (b): $OPENCODE_FIXTURE_NAME is not a symlink after install"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # OpenCode (c): real file at dst is left untouched.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH"
+  REAL_FILE_CONTENT_OC="# real opencode user file - must not be clobbered"
+  printf '%s\n' "$REAL_FILE_CONTENT_OC" > "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME"
+
+  _run_opencode "$FAKE_HOME" || true
+
+  if [[ -f "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]] && \
+     [[ ! -L "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]]; then
+    actual_content="$(cat "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+    if [[ "$actual_content" == "$REAL_FILE_CONTENT_OC" ]]; then
+      _pass "opencode (c): real file at dst untouched"
+    else
+      _fail "opencode (c): real file content was altered"
+    fi
+  else
+    _fail "opencode (c): real file was replaced by a symlink"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # OpenCode (d): out-of-checkout symlink is left untouched.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH"
+  OUTSIDE_TARGET_OC="/tmp/user/totally-unrelated-oc/$OPENCODE_FIXTURE_NAME"
+  ln -s "$OUTSIDE_TARGET_OC" "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME"
+
+  _run_opencode "$FAKE_HOME" || true
+
+  if [[ -L "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OUTSIDE_TARGET_OC" ]]; then
+      _pass "opencode (d): out-of-checkout symlink untouched"
+    else
+      _fail "opencode (d): out-of-checkout symlink was changed to '$actual_target'"
+    fi
+  else
+    _fail "opencode (d): $OPENCODE_FIXTURE_NAME is no longer a symlink"
+  fi
+  rm -rf "$FAKE_HOME"
+
+  # -------------------------------------------------------------------------
+  # OpenCode (e): --dry-run changes nothing.
+  # -------------------------------------------------------------------------
+  FAKE_HOME="$(mktemp -d)"
+  mkdir -p "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH"
+  ln -s "/nonexistent/DinoStack/old-oc/$OPENCODE_FIXTURE_NAME" \
+        "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME"
+  OLD_TARGET_OC="$(readlink "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+
+  _run_opencode "$FAKE_HOME" --dry-run || true
+
+  if [[ -L "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME" ]]; then
+    actual_target="$(readlink "$FAKE_HOME/$OPENCODE_AGENTS_DST_SUBPATH/$OPENCODE_FIXTURE_NAME")"
+    if [[ "$actual_target" == "$OLD_TARGET_OC" ]]; then
+      _pass "opencode (e): --dry-run left symlink unchanged"
+    else
+      _fail "opencode (e): --dry-run changed symlink to '$actual_target'"
+    fi
+  else
+    _fail "opencode (e): $OPENCODE_FIXTURE_NAME is no longer a symlink after --dry-run"
+  fi
+
+  if grep -q "would re-point" "$FAKE_HOME/.install_out" 2>/dev/null; then
+    _pass "opencode (e): --dry-run output includes 'would re-point'"
+  else
+    _fail "opencode (e): --dry-run output missing 'would re-point'"
+  fi
+  rm -rf "$FAKE_HOME"
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.opencode/install.sh
+++ b/.opencode/install.sh
@@ -24,6 +24,7 @@ AE_MODE_FLAG=""
 AE_PROFILE_FLAG=""
 AE_IDENTITY_FLAG=""
 AE_NO_IDENTITY=false
+AE_DRY_RUN=false
 for arg in "$@"; do
   case "$arg" in
     --mode=opt-in|--mode=opt-out)
@@ -43,6 +44,9 @@ for arg in "$@"; do
       ;;
     --no-identity)
       AE_NO_IDENTITY=true
+      ;;
+    --dry-run)
+      AE_DRY_RUN=true
       ;;
   esac
 done
@@ -193,6 +197,25 @@ fi
 # Helpers
 # ---------------------------------------------------------------------------
 
+# _ae_is_ours DST
+#   Returns 0 (true) iff DST is "ours to own" - i.e. safe to re-point.
+#   A destination is ours iff:
+#     - it IS a symlink (never touch real files), AND
+#     - its current target is broken OR resolves under a methodology checkout
+#       (path contains a component equal to "DinoStack" or ending with "-DinoStack").
+_ae_is_ours() {
+  local dst="$1"
+  [[ -L "$dst" ]] || return 1
+  local current_target
+  current_target="$(readlink "$dst")"
+  if [[ ! -e "$dst" ]]; then
+    [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+    return 1
+  fi
+  [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+  return 1
+}
+
 symlink_files() {
   local src_dir="$1"
   local dst_dir="$2"
@@ -218,17 +241,38 @@ symlink_files() {
       if [[ "$current_target" == "$src_file" ]]; then
         echo "  = $name (already linked)"
         continue
+      elif _ae_is_ours "$dst_file"; then
+        # Stale symlink pointing to another methodology checkout - re-point it.
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          echo "  ~ $name (would re-point to repo_dir)"
+        else
+          ln -sfn "$src_file" "$dst_file"
+          echo "  ~ $name (re-pointed to repo_dir)"
+        fi
+        continue
       else
-        echo "  ! $name (symlink points elsewhere: $current_target - skipping)"
+        if [[ "$AE_DRY_RUN" == "true" ]]; then
+          echo "  ! $name (would skip: symlink points outside methodology checkout: $current_target)"
+        else
+          echo "  ! $name (symlink points elsewhere: $current_target - skipping)"
+        fi
         continue
       fi
     elif [[ -e "$dst_file" ]]; then
-      echo "  ! $name (real file exists at destination - skipping)"
+      if [[ "$AE_DRY_RUN" == "true" ]]; then
+        echo "  ! $name (would skip: real file exists at destination)"
+      else
+        echo "  ! $name (real file exists at destination - skipping)"
+      fi
       continue
     fi
 
-    ln -s "$src_file" "$dst_file"
-    echo "  + $name"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ $name (would create)"
+    else
+      ln -s "$src_file" "$dst_file"
+      echo "  + $name"
+    fi
   done
 }
 
@@ -247,14 +291,30 @@ if [[ -L "$SKILLS_DST" ]]; then
   current_target="$(readlink "$SKILLS_DST")"
   if [[ "$current_target" == "$SKILLS_SRC" ]]; then
     echo "  = agentic-engineering (already linked)"
+  elif _ae_is_ours "$SKILLS_DST"; then
+    # Stale symlink pointing to another methodology checkout - re-point it.
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ agentic-engineering (would re-point to repo_dir)"
+    else
+      ln -sfn "$SKILLS_SRC" "$SKILLS_DST"
+      echo "  ~ agentic-engineering (re-pointed to repo_dir)"
+    fi
   else
-    echo "  ! agentic-engineering (symlink points elsewhere: $current_target - skipping)"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ! agentic-engineering (would skip: symlink points outside methodology checkout: $current_target)"
+    else
+      echo "  ! agentic-engineering (symlink points elsewhere: $current_target - skipping)"
+    fi
   fi
 elif [[ -e "$SKILLS_DST" ]]; then
   echo "  ! agentic-engineering (real file/directory exists at destination - skipping)"
 else
-  ln -s "$SKILLS_SRC" "$SKILLS_DST"
-  echo "  + agentic-engineering"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  + agentic-engineering (would create)"
+  else
+    ln -s "$SKILLS_SRC" "$SKILLS_DST"
+    echo "  + agentic-engineering"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -406,14 +466,30 @@ if [[ -L "$HOOK_DST" ]]; then
   current_target="$(readlink "$HOOK_DST")"
   if [[ "$current_target" == "$HOOK_SRC" ]]; then
     echo "  = pre-commit hook already linked"
+  elif _ae_is_ours "$HOOK_DST"; then
+    # Stale symlink pointing to another methodology checkout - re-point it.
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ~ pre-commit hook (would re-point to repo_dir)"
+    else
+      ln -sfn "$HOOK_SRC" "$HOOK_DST"
+      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
+    fi
   else
-    echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
+    else
+      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+    fi
   fi
 elif [[ -e "$HOOK_DST" ]]; then
   echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
 else
-  ln -s "$HOOK_SRC" "$HOOK_DST"
-  echo "  + pre-commit hook installed"
+  if [[ "$AE_DRY_RUN" == "true" ]]; then
+    echo "  + pre-commit hook (would create)"
+  else
+    ln -s "$HOOK_SRC" "$HOOK_DST"
+    echo "  + pre-commit hook installed"
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Applies the converging-symlink fix (merged for `.claude` in #306) to the only two other adapters with their own `symlink_files()`: `.cursor/install.sh` and `.opencode/install.sh`.

- `_ae_is_ours` predicate (identical to `.claude`: symlink-only; target broken or under a `DinoStack`/`-DinoStack` checkout) - stale "ours" symlinks are re-pointed via `ln -sfn` instead of skipped.
- `--dry-run` added to both (gates symlink writes, print-only).
- All sites converge: `symlink_files()` + pre-commit (both), plus the skill-symlink block (opencode). Real files / out-of-checkout links never touched.

Step-0 verified: both installers are hand-authored source (no build script generates them). 12-case temp-HOME test (both adapters); `.claude` regression intact. Skeptic: sign-off, 0 Critical/Major; one cosmetic Minor (`.opencode` dry-run "would create" prefix).

Completes adapter coverage for the install self-heal (Wave-2).