### PR TITLE
docs: replace stale agent-methodology.md references with current rules structure

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1,7 +1,7 @@
 # What's included
 
 **Rules** (3 files) - the core methodology:
-- Agent methodology - delegation, risk classification, task decomposition, worktree lifecycle
+- Module manifest - required manifest header for non-trivial source files (exports, 50+ LOC, or side-effecting)
 - Code standards - tool discipline, quality gates, package management, browser verification
 - Conventions - writing style, project structure, session context, git workflow
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1001,7 +1001,7 @@
     </div>
   </div>
   <div class="note">
-    <strong>Skill directory layout:</strong> <code>~/DinoStack/.claude/skills/agentic-engineering/rules/</code> (agent-methodology.md, code-standards.md, conventions.md, module-manifest.md) and <code>~/DinoStack/.claude/skills/agentic-engineering/references/</code> (skeptic-protocol.md, subagent-protocol.md, agent-team.md, design-goals.md, regression-test-obligation.md, qa-regression-obligation.md, doc-sync-obligation.md)<br>
+    <strong>Skill directory layout:</strong> <code>~/DinoStack/.claude/skills/agentic-engineering/METHODOLOGY.md</code> (top-level - delegation, risk classification, task decomposition), <code>~/DinoStack/.claude/skills/agentic-engineering/rules/</code> (code-standards.md, conventions.md, module-manifest.md) and <code>~/DinoStack/.claude/skills/agentic-engineering/references/</code> (skeptic-protocol.md, subagent-protocol.md, agent-team.md, design-goals.md, regression-test-obligation.md, qa-regression-obligation.md, doc-sync-obligation.md)<br>
     <strong>Multi-adapter:</strong> The <code>~/DinoStack</code> repo ships adapters for Claude Code (<code>.claude/</code>), Cursor (<code>.cursor/</code>), Codex CLI (<code>.codex/</code>), Gemini CLI (<code>.gemini/</code>), Kimi Code CLI (<code>.kimi/</code>), OpenCode (<code>.opencode/</code>), Pi coding agent (<code>.pi/</code>), oh-my-pi (<code>.omp/</code>), Hermes (<code>.hermes/</code>), and OpenClaw (<code>.openclaw/</code>) - the same methodology in each tool's native format.<br>
     <strong>Per-project override:</strong> Each project has its own root AGENTS.md (~40 lines) + subdirectory AGENTS.md files for deeper context. AGENTS.md files can override any global rule. The global layer provides the foundation; the project layer customizes it.
   </div>
@@ -1037,7 +1037,7 @@
   <div class="two-col">
     <div>
       <div class="rel-card">
-        <h4>agent-methodology.md <span class="load-badge always">always loaded</span></h4>
+        <h4>METHODOLOGY.md <span class="load-badge always">always loaded</span></h4>
         <ul>
           <li>Delegation model: conductor delegates, never implements</li>
           <li>Risk classification: Low vs Elevated</li>


### PR DESCRIPTION
`agent-methodology.md` no longer exists in `content/rules/` (the methodology content moved to top-level `METHODOLOGY.md`; the third rule file is `module-manifest.md`). Three doc surfaces still cited the old name.

- `index.html` (skill-directory layout): `rules/` now lists the 3 real files (code-standards, conventions, module-manifest); `METHODOLOGY.md` shown as a top-level always-loaded doc, not under `rules/`.
- `index.html` (always-loaded card): heading renamed `agent-methodology.md` → `METHODOLOGY.md`; content unchanged.
- `components.md` ("Rules (3 files)"): replaced the nonexistent "Agent methodology" entry with "Module manifest" and its accurate description.

Historical PR titles in `changelog.html` mentioning the old name are left as-is (legitimate history). Surfaced by the Skeptic on PR #300 as out-of-scope drift; split out here.

Draft pending Skeptic review.