### PR TITLE
docs(install): document agentic-doctor health check + install safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ With the global mode set to `opt-out` (the default), a project without any marke
 
 Run `./update.sh` for an interactive TUI updater (arrow keys, space to toggle adapters). For non-interactive or CI use, run `git pull` first then `./install-all.sh`.
 
-Full details - manual update steps, clean-refresh procedure, and agent-driven update prompts: see [docs/updating.md](docs/updating.md).
+If symlinks or hooks have drifted (common after moving the repo), run `agentic-doctor` to diagnose and `agentic-doctor --fix` to repair. Bootstrap is guarded against creating a second clone - if an existing install is detected, it aborts and prints the update-in-place command.
+
+Full details - manual update steps, clean-refresh procedure, health check, safeguards, and agent-driven update prompts: see [docs/updating.md](docs/updating.md).
 
 ## Adapters
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -28,6 +28,44 @@ git pull
 bash .claude/install.sh
 ```
 
+## Health check and repair (`agentic-doctor`)
+
+`agentic-doctor` is a read-only health inspector that verifies your install is wired correctly. Run it any time symlinks feel broken, hooks aren't firing, or you've moved the repo to a new path.
+
+```bash
+agentic-doctor          # read-only scan; exit 0 = healthy, 1 = findings
+agentic-doctor --fix    # re-point drifted symlinks and repair hook paths; exit 0 = all fixed, 2 = some unfixable
+agentic-doctor --dry-run  # same as the default scan - enumerate findings without changing anything
+```
+
+What it checks:
+
+- `repo_dir` in `~/.agentic/agentic-engineering-config.json` points to a valid git repo
+- Every managed symlink under `~/.claude/agents/`, `~/.claude/commands/`, and `~/.claude/skills/agentic-engineering/` resolves into `repo_dir`
+- Every hook command path in `~/.claude/settings.json` points into `repo_dir`
+- `~/.local/bin/agentic-*` wrappers exist and point into `repo_dir/bin/`
+- The git pre-commit hook at `<repo_dir>/.git/hooks/pre-commit` is linked to the managed hook
+
+Real files (not symlinks) and symlinks pointing outside any DinoStack repo are skipped rather than flagged.
+
+`--fix` repairs only links and paths that belong to DinoStack. It never runs `install.sh` or rebuilds adapters. Reach for it after moving the repo or if a partial install left something dangling.
+
+## Safeguards
+
+**Split-brain guard:** bootstrap detects an existing valid install before cloning. If `~/.agentic/agentic-engineering-config.json` already records a live DinoStack git repo at a different path, bootstrap aborts without cloning and prints an update-in-place message like:
+
+```
+To update in place: AE_DEST_DIR=<existing> <bootstrap.sh>, or run <existing>/update.sh.
+```
+
+The exact message echoes how you invoked bootstrap (the `<bootstrap.sh>` token is whatever you actually ran).
+
+This prevents two clones from diverging while adapters and config point at the wrong one.
+
+**Self-heal on reinstall:** re-running an adapter installer (e.g. `bash .claude/install.sh`) repairs drifted symlinks and stale hook paths instead of clobbering your config. `repo_dir` is updated when stale and never clobbered when it already points at another valid clone, so moving the repo and reinstalling is safe.
+
+**Fast-path on `update.sh`:** `./update.sh` skips the adapter rebuild step when no adapter source has changed since the last pull, so routine updates complete faster.
+
 ## Agent-driven update
 
 Ask your coding agent:


### PR DESCRIPTION
Documents the install/update safeguards and health-check tool that shipped (PRs #304, #309, #306, #297, #308, #303, #311) but had no user-facing docs beyond the auto-generated changelog.

- `docs/updating.md`: new "Health check and repair (`agentic-doctor`)" section (read-only scan, `--fix`, `--dry-run`, exit codes, the five checks, SKIP behavior) and a "Safeguards" section (split-brain guard, self-heal on reinstall, fast-path rebuild skip).
- `README.md`: two lines in the Updating section pointing at `agentic-doctor --fix` for drift repair and noting the bootstrap split-brain guard.

Every concrete claim (flags, exit codes, the five checks, guard message, fast-path mechanism) was verified against `bin/agentic-doctor`, `bootstrap.sh`, `.claude/install.sh`, and `scripts/update.js` during Skeptic review. Docs-only; no adapter rebuild.