### PR TITLE
fix(doctor): --fix exits 2 when repo_dir is invalid (was silently 0)

### DIFF
--- a/bin/agentic-doctor
+++ b/bin/agentic-doctor
@@ -290,12 +290,16 @@ def check_repo_dir(doc: Doctor) -> None:
             "repo_dir",
             f"{doc.repo_dir} does not exist; re-run bootstrap or set repo_dir in {_config_path()}",
         )
+        if doc.fix:
+            doc.unfixable.append(str(doc.repo_dir))
         return
     if not _is_git_repo(doc.repo_dir):
         doc.fail(
             "repo_dir",
             f"{doc.repo_dir} exists but is not a git repo; re-run bootstrap or set repo_dir in {_config_path()}",
         )
+        if doc.fix:
+            doc.unfixable.append(str(doc.repo_dir))
         return
     doc.ok("repo_dir", f"{doc.repo_dir} is a valid git repo")
 

--- a/bin/tests/test_agentic_doctor.sh
+++ b/bin/tests/test_agentic_doctor.sh
@@ -343,6 +343,39 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
+# Test 6: --fix exits 2 (not 0) when repo_dir is invalid/missing
+# Regression test for: --fix silently returning 0 when repo_dir FAIL is
+# not appended to doc.unfixable, which caused has_unfixable() to return
+# False and the exit path to return 0 instead of 2.
+# ---------------------------------------------------------------------------
+setup_fixture
+
+# Point repo_dir at a path that does not exist (not auto-fixable by doctor)
+cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "/nonexistent/path"
+}
+EOF
+
+invoke_doctor --fix
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "2" ]]; then
+  _pass "T6 --fix with invalid repo_dir: exits 2 (unfixable)"
+else
+  _fail "T6 --fix with invalid repo_dir: expected exit 2, got $RC (regression: unfixable not recorded)\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "^FAIL repo_dir:"; then
+  _pass "T6 --fix with invalid repo_dir: FAIL repo_dir: line present"
+else
+  _fail "T6 --fix with invalid repo_dir: missing FAIL repo_dir: line\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
`agentic-doctor --fix` returned exit 0 ("all fixed") even when `repo_dir` was invalid/missing, contradicting the documented contract (0=all fixed, 1=read-only findings, 2=unfixable). Surfaced during review of #317.

Cause: `check_repo_dir` raised a FAIL finding but never appended to `doc.unfixable`, so `has_unfixable()` stayed False and `--fix` exited 0.

- `bin/agentic-doctor`: both FAIL branches of `check_repo_dir` now append to `doc.unfixable` under `if doc.fix`, mirroring the canonical `_check_one_link` pattern. An invalid `repo_dir` is not auto-repairable (the doctor can't know the intended path), so it correctly counts as unfixable.
- Read-only and `--dry-run` exit behavior unchanged: invalid `repo_dir` still exits 1.
- `bin/tests/test_agentic_doctor.sh`: added T6 regression test. Verified during review that T6 fails (exit 0) against the pre-fix code and passes (exit 2) after.

Suite: 22/22 pass. Docs-contract from #317 now matches the binary.