### PR TITLE
feat(bin): add agentic-update from-anywhere update command

### DIFF
--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -25,8 +25,8 @@ Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
                 failure / git not found / repo not found)
              2  agentic-doctor --fix exited 2 (unfixable health issues)
 
-Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, subprocess,
-               sys, tempfile, time). Reads
+Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, re,
+               subprocess, sys, tempfile, time). Reads
                ~/.agentic/agentic-engineering-config.json (repo_dir, adapters).
                Invokes: git (fetch, pull, rev-parse, diff, status, etc.),
                bash <adapter>/install.sh, agentic-doctor.
@@ -50,6 +50,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -198,8 +199,10 @@ def _needs_rebuild(old_head: str, new_head: str, changed_paths: list[str]) -> bo
         return False
 
     for p in changed_paths:
-        # Normalise separators (Windows safety) and strip leading slashes.
-        normalised = p.replace("\\", "/").lstrip("/")
+        # Normalise separators (Windows safety) and strip ONE leading slash,
+        # mirroring update.js `replace(/^\//, '')` which removes exactly one
+        # leading slash (not all consecutive, as lstrip would).
+        normalised = re.sub(r'^/', '', p.replace("\\", "/"))
         for trigger in REBUILD_TRIGGERS:
             if trigger.endswith("/"):
                 # Directory prefix: match any file under this directory.
@@ -362,7 +365,19 @@ def main() -> int:
     # ------------------------------------------------------------------
     rc, porcelain_out, _ = _git(repo_dir, "status", "--porcelain")
     if porcelain_out:
-        dirty_files = [line[3:] for line in porcelain_out.splitlines() if line.strip()]
+        dirty_files = []
+        for line in porcelain_out.splitlines():
+            if not line.strip():
+                continue
+            status = line[:2]
+            file_part = line[3:]
+            # Porcelain v1 renames/copies show "old -> new"; extract just the
+            # new path. Mirrors getDirtyFiles() in scripts/update.js.
+            if status[0] in ('R', 'C') or status[1] in ('R', 'C'):
+                m = re.match(r'^(.+?) -> (.+)$', file_part)
+                if m:
+                    file_part = m.group(2)
+            dirty_files.append(file_part)
         print(
             "error: working tree has uncommitted changes; commit or stash first:",
             file=sys.stderr,
@@ -435,7 +450,9 @@ def main() -> int:
         print("No rebuild needed (no adapter source changed).")
         _reset_version_check_cache()
         if not args.no_doctor:
-            return _run_doctor()
+            doctor_rc = _run_doctor()
+            if doctor_rc != 0:
+                return doctor_rc
         print("Done.")
         return 0
 

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -373,7 +373,10 @@ def main() -> int:
             file_part = line[3:]
             # Porcelain v1 renames/copies show "old -> new"; extract just the
             # new path. Mirrors getDirtyFiles() in scripts/update.js.
-            if status[0] in ('R', 'C') or status[1] in ('R', 'C'):
+            # Guard len>=2 before indexing status[1]: real porcelain output is
+            # always "XY path" (>=4 chars), but malformed/short lines must not
+            # crash with IndexError.
+            if len(status) >= 2 and (status[0] in ('R', 'C') or status[1] in ('R', 'C')):
                 m = re.match(r'^(.+?) -> (.+)$', file_part)
                 if m:
                     file_part = m.group(2)

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+Purpose: From-anywhere, non-interactive updater for agentic-engineering
+         (DinoStack). Fetches origin, detects whether adapter sources changed
+         via the same REBUILD_TRIGGERS logic as scripts/update.js, runs the
+         appropriate install.sh scripts, resets the version-check cache, and
+         optionally runs agentic-doctor --fix. Designed for CI, cron jobs,
+         shell aliases, and any non-TTY context where scripts/update.js cannot
+         run (because that script requires a TTY for its TUI).
+
+Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
+             --check        Report how far behind origin/main the local main
+                            branch is, then exit 0. Does NOT pull. Works from
+                            any branch.
+             --no-doctor    Skip the agentic-doctor --fix step after update.
+             --adapters=X   Comma-separated list of adapter dirs to refresh
+                            (e.g. --adapters=.claude,.cursor). .claude is
+                            always prepended (LOCKED_ADAPTERS invariant).
+            Environment:
+             AGENTIC_CONFIG_PATH  Override path to agentic-engineering-config.json
+                                  (useful for tests; default ~/.agentic/...).
+            Exits:
+             0  success (up-to-date or updated)
+             1  fatal error (not on main / dirty tree / pull failure / adapter
+                failure / git not found / repo not found)
+             2  agentic-doctor --fix exited 2 (unfixable health issues)
+
+Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, subprocess,
+               sys, tempfile, time). Reads
+               ~/.agentic/agentic-engineering-config.json (repo_dir, adapters).
+               Invokes: git (fetch, pull, rev-parse, diff, status, etc.),
+               bash <adapter>/install.sh, agentic-doctor.
+
+Downstream consumers: end users running from any cwd; CI pipelines; shell
+                      aliases; any non-TTY automation that cannot launch the
+                      interactive scripts/update.js TUI.
+
+Failure modes: exit 1 on non-main branch, dirty working tree, pull failure,
+               or adapter install failure. exit 2 when agentic-doctor --fix
+               exits 2 (unfixable issues). Cache write (version-check-cache)
+               is non-fatal: failures emit a warning and execution continues.
+               Missing agentic-doctor binary: warning, exit 0.
+
+Performance: network-bound (git fetch); rebuild decision and adapter installs
+             add seconds only when adapter sources changed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Adapters always included regardless of config selection.
+# Mirrors LOCKED_ADAPTERS in scripts/update.js.
+LOCKED_ADAPTERS: tuple[str, ...] = (".claude",)
+
+# Dot-dirs under repo root excluded from adapter discovery.
+SKIP_DIRS: frozenset[str] = frozenset([
+    ".", "..", ".git", ".github", ".vscode", ".idea",
+    ".cache", ".venv", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+])
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _home() -> Path:
+    """Current HOME directory. Re-evaluated each call so tests can override HOME."""
+    return Path(os.path.expanduser("~"))
+
+
+def _config_path() -> Path:
+    override = os.environ.get("AGENTIC_CONFIG_PATH")
+    if override:
+        return Path(override)
+    return _home() / ".agentic" / "agentic-engineering-config.json"
+
+
+def _load_config() -> dict:
+    """Return parsed config dict, or {} on any error."""
+    try:
+        cfg = _config_path()
+        if cfg.is_file():
+            return json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def _load_repo_dir() -> Path:
+    """Resolve repo_dir from config, falling back to ~/DinoStack."""
+    fallback = Path(os.path.realpath(str(_home() / "DinoStack")))
+    try:
+        data = _load_config()
+        if data.get("repo_dir"):
+            raw = Path(str(data["repo_dir"])).expanduser()
+            return Path(os.path.realpath(str(raw)))
+    except Exception:
+        pass
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo_dir: Path, *args: str, capture: bool = True) -> tuple[int, str, str]:
+    """Run git -C repo_dir *args. Return (returncode, stdout.strip, stderr.strip)."""
+    cmd = ["git", "-C", str(repo_dir)] + list(args)
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.PIPE if capture else None,
+            text=True,
+        )
+        stdout = (result.stdout or "").strip() if capture else ""
+        stderr = (result.stderr or "").strip() if capture else ""
+        return result.returncode, stdout, stderr
+    except FileNotFoundError:
+        return 127, "", "git: command not found"
+    except Exception as exc:
+        return 1, "", str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Adapter discovery
+# ---------------------------------------------------------------------------
+
+
+def _discover_adapters(repo_dir: Path) -> list[str]:
+    """Return sorted list of dot-dirs in repo_dir containing install.sh."""
+    adapters: list[str] = []
+    try:
+        for entry in sorted(repo_dir.iterdir()):
+            name = entry.name
+            if not name.startswith("."):
+                continue
+            if name in SKIP_DIRS:
+                continue
+            if not entry.is_dir():
+                continue
+            if (entry / "install.sh").is_file():
+                adapters.append(name)
+    except Exception:
+        pass
+    adapters.sort(key=lambda s: s.lower())
+    return adapters
+
+
+# ---------------------------------------------------------------------------
+# Rebuild decision
+# ---------------------------------------------------------------------------
+
+# Ported from scripts/update.js:252-281 (needsRebuild). Keep in sync -
+# REBUILD_TRIGGERS and the */build.sh catch-all are the source of truth there.
+REBUILD_TRIGGERS: tuple[str, ...] = (
+    "content/",
+    "scripts/build-all.sh",
+    "scripts/build-methodology.sh",
+    "scripts/build-slides.sh",
+    "hooks/",
+    ".claude/install.sh",
+    "bin/",
+)
+
+
+def _needs_rebuild(old_head: str, new_head: str, changed_paths: list[str]) -> bool:
+    """Return True if adapter install scripts should run after a pull.
+
+    Ported from scripts/update.js:252-281 (needsRebuild). Keep in sync -
+    REBUILD_TRIGGERS and the */build.sh catch-all are the source of truth there.
+
+    Decision table:
+      old_head empty/falsy -> True  (first install, never skip)
+      old_head == new_head -> False (already up to date)
+      any changed path matches a REBUILD_TRIGGER -> True
+      otherwise -> False (doc-only or unrelated changes)
+    """
+    # Safety case: no prior HEAD means first install - always rebuild.
+    if not old_head:
+        return True
+
+    # No commits pulled - nothing to rebuild.
+    if old_head == new_head:
+        return False
+
+    for p in changed_paths:
+        # Normalise separators (Windows safety) and strip leading slashes.
+        normalised = p.replace("\\", "/").lstrip("/")
+        for trigger in REBUILD_TRIGGERS:
+            if trigger.endswith("/"):
+                # Directory prefix: match any file under this directory.
+                if normalised.startswith(trigger):
+                    return True
+            elif "/" in trigger:
+                # Exact file path (e.g. 'scripts/build-all.sh').
+                if normalised == trigger:
+                    return True
+            else:
+                # Bare name: any path ending in this filename.
+                # Currently unused but kept for forward compatibility.
+                if normalised == trigger or normalised.endswith("/" + trigger):
+                    return True
+        # Any adapter-local build.sh (e.g. '.cursor/build.sh', '.claude/build.sh').
+        if normalised.endswith("/build.sh") or normalised == "build.sh":
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Version-check cache
+# ---------------------------------------------------------------------------
+
+
+def _reset_version_check_cache() -> None:
+    """Write behind_count: 0 to the version-check cache (atomic tmp+rename).
+
+    Mirrors resetVersionCheckCache() in scripts/update.js.
+    Non-fatal: any error is warned, never raised.
+    """
+    try:
+        cache_dir = _home() / ".agentic"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = cache_dir / "version-check-cache.json"
+        payload = json.dumps({"behind_count": 0, "last_fetch_epoch": int(time.time())}) + "\n"
+        fd, tmp_path = tempfile.mkstemp(dir=str(cache_dir), prefix=".version-cache-tmp-")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+            os.replace(tmp_path, str(cache_path))
+        except Exception as exc:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+            print(f"warning: failed to reset version-check cache: {exc}", file=sys.stderr)
+    except Exception as exc:
+        print(f"warning: failed to reset version-check cache: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="agentic-update",
+        description=(
+            "Non-interactive updater for agentic-engineering (DinoStack). "
+            "Fetches origin, detects adapter-source changes, runs install scripts, "
+            "resets the version-check cache, and optionally runs agentic-doctor --fix. "
+            "Safe for CI and non-TTY contexts."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Report how many commits the local main branch is behind origin/main, "
+            "then exit 0. Does NOT pull. Works from any branch."
+        ),
+    )
+    parser.add_argument(
+        "--no-doctor",
+        action="store_true",
+        dest="no_doctor",
+        help="Skip agentic-doctor --fix after updating.",
+    )
+    parser.add_argument(
+        "--adapters",
+        default="",
+        help=(
+            "Comma-separated list of adapter dirs to refresh "
+            "(e.g. --adapters=.claude,.cursor). "
+            ".claude is always included (LOCKED_ADAPTERS invariant)."
+        ),
+    )
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Step 2: resolve repo_dir
+    # ------------------------------------------------------------------
+    repo_dir = _load_repo_dir()
+
+    if not repo_dir.exists():
+        cfg = _config_path()
+        print(
+            f"error: repo_dir '{repo_dir}' does not exist. "
+            f"Re-run bootstrap or set repo_dir in {cfg}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    rc, _, _ = _git(repo_dir, "rev-parse", "--git-dir")
+    if rc != 0:
+        cfg = _config_path()
+        print(
+            f"error: '{repo_dir}' is not a git repository. "
+            f"Re-run bootstrap or set repo_dir in {cfg}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 3: fetch origin (quiet)
+    # ------------------------------------------------------------------
+    rc, _, stderr = _git(repo_dir, "fetch", "--quiet", "origin")
+    if rc != 0:
+        print(f"error: 'git fetch origin' failed.\n{stderr}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 4: --check mode (branch-independent, no pull)
+    # ------------------------------------------------------------------
+    if args.check:
+        rc, behind_str, _ = _git(
+            repo_dir, "rev-list", "--count", "refs/heads/main..origin/main"
+        )
+        if rc != 0:
+            # refs/heads/main may not exist yet (no local main branch); graceful fallback
+            print("unable to determine behind count (refs/heads/main not found).")
+            return 0
+        try:
+            behind = int(behind_str)
+        except ValueError:
+            behind = 0
+        if behind == 0:
+            print("Up to date.")
+        else:
+            print(f"{behind} commit(s) behind main.")
+        return 0
+
+    # ------------------------------------------------------------------
+    # Step 5: branch check
+    # ------------------------------------------------------------------
+    rc, current_branch, _ = _git(repo_dir, "branch", "--show-current")
+    if current_branch != "main":
+        print(
+            f"error: must be on 'main' to update (currently on '{current_branch}'). "
+            f"Run: git -C {repo_dir} checkout main",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 6: dirty-tree check
+    # ------------------------------------------------------------------
+    rc, porcelain_out, _ = _git(repo_dir, "status", "--porcelain")
+    if porcelain_out:
+        dirty_files = [line[3:] for line in porcelain_out.splitlines() if line.strip()]
+        print(
+            "error: working tree has uncommitted changes; commit or stash first:",
+            file=sys.stderr,
+        )
+        for f in dirty_files:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 7: capture old HEAD
+    # ------------------------------------------------------------------
+    rc, old_head, _ = _git(repo_dir, "rev-parse", "HEAD")
+    if rc != 0:
+        old_head = ""
+
+    # ------------------------------------------------------------------
+    # Step 8: pull
+    # ------------------------------------------------------------------
+    rc, _, pull_stderr = _git(repo_dir, "pull", "--ff-only", "origin", "main")
+    if rc != 0:
+        print(f"error: 'git pull --ff-only origin main' failed.\n{pull_stderr}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 9: capture new HEAD; check if anything changed
+    # ------------------------------------------------------------------
+    rc, new_head, _ = _git(repo_dir, "rev-parse", "HEAD")
+    if rc != 0:
+        new_head = ""
+
+    old_short = old_head[:8] if old_head else "unknown"
+
+    if old_head and new_head and old_head == new_head:
+        print(f"Already up to date ({old_short}).")
+        _reset_version_check_cache()
+        # Skip to doctor
+        if not args.no_doctor:
+            return _run_doctor()
+        return 0
+
+    # ------------------------------------------------------------------
+    # Step 10: compute changed paths
+    # ------------------------------------------------------------------
+    changed_paths: list[str] = []
+    if old_head and new_head and old_head != new_head:
+        rc, diff_out, _ = _git(repo_dir, "diff", "--name-only", old_head, new_head)
+        if rc == 0 and diff_out:
+            changed_paths = [p for p in diff_out.splitlines() if p.strip()]
+
+    # Count commits pulled
+    commits_pulled = 0
+    if old_head and new_head and old_head != new_head:
+        rc, count_str, _ = _git(
+            repo_dir, "rev-list", "--count", f"{old_head}..{new_head}"
+        )
+        if rc == 0:
+            try:
+                commits_pulled = int(count_str)
+            except ValueError:
+                commits_pulled = 0
+
+    new_short = new_head[:8] if new_head else "unknown"
+
+    # ------------------------------------------------------------------
+    # Step 11: needsRebuild check + adapter selection
+    # ------------------------------------------------------------------
+    rebuild = _needs_rebuild(old_head, new_head, changed_paths)
+
+    if not rebuild:
+        print("No rebuild needed (no adapter source changed).")
+        _reset_version_check_cache()
+        if not args.no_doctor:
+            return _run_doctor()
+        print("Done.")
+        return 0
+
+    # Determine which adapter paths triggered the rebuild
+    triggering_paths = [
+        p for p in changed_paths
+        if _needs_rebuild(old_head, new_head, [p])
+    ]
+    print(
+        f"Updated {old_short}..{new_short} ({commits_pulled} commit(s)). "
+        f"Rebuild triggered by: {', '.join(triggering_paths) or '(unknown)'}."
+    )
+
+    # ------------------------------------------------------------------
+    # Step 12: adapter selection + install
+    # ------------------------------------------------------------------
+    config = _load_config()
+
+    if args.adapters.strip():
+        # Explicit --adapters flag
+        user_adapters = [a.strip() for a in args.adapters.split(",") if a.strip()]
+        adapters_to_run = list(LOCKED_ADAPTERS) + [
+            a for a in user_adapters if a not in LOCKED_ADAPTERS
+        ]
+    elif config.get("adapters"):
+        # Config has saved adapter selection
+        saved = config["adapters"]
+        enabled = [a for a, v in saved.items() if v]
+        adapters_to_run = list(LOCKED_ADAPTERS) + [
+            a for a in enabled if a not in LOCKED_ADAPTERS
+        ]
+    else:
+        # No saved selection: default to all discovered adapters
+        discovered = _discover_adapters(repo_dir)
+        print(
+            "note: no saved adapter selection; refreshing all discovered adapters. "
+            "Run ./update.sh to choose a subset."
+        )
+        adapters_to_run = list(LOCKED_ADAPTERS) + [
+            a for a in discovered if a not in LOCKED_ADAPTERS
+        ]
+
+    failures: list[str] = []
+    for adapter in adapters_to_run:
+        install_sh = repo_dir / adapter / "install.sh"
+        if not install_sh.is_file():
+            print(f"warning: {install_sh} not found, skipping.", file=sys.stderr)
+            continue
+        print(f">>> bash {install_sh}")
+        rc = subprocess.call(["bash", str(install_sh)], cwd=str(repo_dir))
+        if rc != 0:
+            failures.append(f"{adapter}/install.sh (exit {rc})")
+
+    if failures:
+        print("error: the following adapters failed to install:", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 13: write version-check cache
+    # ------------------------------------------------------------------
+    _reset_version_check_cache()
+
+    # ------------------------------------------------------------------
+    # Step 14: doctor
+    # ------------------------------------------------------------------
+    if not args.no_doctor:
+        doctor_rc = _run_doctor()
+        if doctor_rc != 0:
+            return doctor_rc
+
+    print("Done.")
+    return 0
+
+
+def _run_doctor() -> int:
+    """Run agentic-doctor --fix. Return 0 on success, 2 on unfixable, 0 on other errors."""
+    try:
+        result = subprocess.run(
+            ["agentic-doctor", "--fix"],
+            # Inherit stdio so doctor output flows to the terminal
+        )
+        if result.returncode == 2:
+            print(
+                "WARNING: health check found issues that could not be auto-fixed; "
+                "run 'agentic-doctor' for details",
+                file=sys.stderr,
+            )
+            return 2
+        if result.returncode != 0:
+            print(
+                f"warning: agentic-doctor --fix exited {result.returncode}; "
+                "continuing (non-critical).",
+                file=sys.stderr,
+            )
+    except FileNotFoundError:
+        print(
+            "warning: agentic-doctor not found on PATH; skipping health check.",
+            file=sys.stderr,
+        )
+    except Exception as exc:
+        print(f"warning: agentic-doctor failed: {exc}; continuing.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# Purpose: Regression and smoke tests for bin/agentic-update.
+#
+# Public API: ./bin/tests/test_agentic_update.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, git, mktemp.
+#
+# Downstream consumers: developer running locally before commit; can be
+#                       wired into CI.
+#
+# Failure modes: any test failure prints the failing assertion and exits 1.
+#                Tests use isolated TEMP_HOME dirs with a fake config and
+#                fake git repos. NEVER touches the real ~/.agentic or pulls
+#                from the network.
+#
+# Performance: <5 s wall time on a developer machine (all local git ops).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+UPDATER="$SCRIPT_DIR/agentic-update"
+
+if [[ ! -x "$UPDATER" ]]; then
+  echo "FAIL: $UPDATER not executable" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a minimal bare-clone pair for push/fetch tests.
+#
+# Returns (via globals):
+#   FAKE_REMOTE   - a bare git repo that acts as "origin"
+#   FAKE_REPO     - a working clone of FAKE_REMOTE, on branch main
+#   TEMP_HOME     - isolated HOME with config pointing at FAKE_REPO
+# ---------------------------------------------------------------------------
+setup_git_fixture() {
+  TEMP_HOME="$(mktemp -d)"
+  FAKE_REMOTE="$TEMP_HOME/remote.git"
+  FAKE_REPO="$TEMP_HOME/repo"
+
+  # Create bare remote
+  git init --bare --initial-branch=main "$FAKE_REMOTE" -q 2>/dev/null \
+    || git init --bare "$FAKE_REMOTE" -q
+
+  # Clone into working repo
+  git clone --quiet "$FAKE_REMOTE" "$FAKE_REPO" 2>/dev/null
+
+  # Bootstrap: commit at least one file on main so rev-parse works
+  (
+    cd "$FAKE_REPO"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "init" > README.md
+    git add README.md
+    git commit -m "init" -q
+    git push -q origin main 2>/dev/null
+  )
+
+  # Write config pointing at FAKE_REPO
+  mkdir -p "$TEMP_HOME/.agentic"
+  cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "$FAKE_REPO"
+}
+EOF
+}
+
+invoke_updater() {
+  # Run agentic-update with AGENTIC_CONFIG_PATH pointing at our temp config.
+  # We also override HOME so the version-check cache writes go to TEMP_HOME.
+  local config_path="$TEMP_HOME/.agentic/agentic-engineering-config.json"
+  (
+    HOME="$TEMP_HOME"
+    export HOME
+    AGENTIC_CONFIG_PATH="$config_path"
+    export AGENTIC_CONFIG_PATH
+    python3 "$UPDATER" "$@"
+  ) > "$TEMP_HOME/.out" 2>&1
+  echo $? > "$TEMP_HOME/.exit"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: --check resolves repo from an arbitrary cwd and exits 0
+# Re-creates the "run from /tmp with config pointing at temp git repo" scenario
+# from the spec. The script must NOT fail with "repo not found" when invoked
+# from an unrelated directory.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+# Run from /tmp (unrelated directory - config is resolved via AGENTIC_CONFIG_PATH)
+(
+  HOME="$TEMP_HOME"
+  export HOME
+  AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
+  export AGENTIC_CONFIG_PATH
+  python3 "$UPDATER" --check
+) > "$TEMP_HOME/.out" 2>&1
+echo $? > "$TEMP_HOME/.exit"
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T1 --check from arbitrary cwd: exits 0"
+else
+  _fail "T1 --check from arbitrary cwd: expected exit 0, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -qE "(Up to date|commit\(s\) behind)"; then
+  _pass "T1 --check: output contains status message"
+else
+  _fail "T1 --check: unexpected output: $OUT"
+fi
+
+# Also confirm HEAD is unchanged after --check
+HEAD_BEFORE="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+(
+  HOME="$TEMP_HOME"
+  export HOME
+  AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
+  export AGENTIC_CONFIG_PATH
+  python3 "$UPDATER" --check
+) > /dev/null 2>&1
+HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+
+if [[ "$HEAD_BEFORE" == "$HEAD_AFTER" ]]; then
+  _pass "T1 --check: HEAD unchanged (no pull performed)"
+else
+  _fail "T1 --check: HEAD changed ($HEAD_BEFORE -> $HEAD_AFTER); --check must not pull"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 2: Non-main branch exits 1, output contains "main"
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+# Detach to a non-main branch in the repo
+(
+  cd "$FAKE_REPO"
+  git checkout -b other-branch -q
+)
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T2 non-main branch: exits 1"
+else
+  _fail "T2 non-main branch: expected exit 1, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -qi "main"; then
+  _pass "T2 non-main branch: output mentions 'main'"
+else
+  _fail "T2 non-main branch: output does not mention 'main'\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 3: Dirty working tree exits 1 and lists the dirty file in output
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+# Create an untracked file to make the tree dirty
+DIRTY_FILE="$FAKE_REPO/dirty_file.txt"
+echo "dirty" > "$DIRTY_FILE"
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T3 dirty tree: exits 1"
+else
+  _fail "T3 dirty tree: expected exit 1, got $RC\n$OUT"
+fi
+
+# The dirty file name must appear in the output
+if echo "$OUT" | grep -q "dirty_file.txt"; then
+  _pass "T3 dirty tree: dirty file listed in output"
+else
+  _fail "T3 dirty tree: dirty file not listed in output\n$OUT"
+fi
+
+# Cleanup
+rm -f "$DIRTY_FILE"
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 4: --check does not pull (up-to-date repo, HEAD unchanged)
+# This is the authoritative "check does not pull" guard.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+HEAD_BEFORE="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+invoke_updater --check
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T4 --check up-to-date: exits 0"
+else
+  _fail "T4 --check up-to-date: expected exit 0, got $RC\n$OUT"
+fi
+
+HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+if [[ "$HEAD_BEFORE" == "$HEAD_AFTER" ]]; then
+  _pass "T4 --check: HEAD unchanged"
+else
+  _fail "T4 --check: HEAD changed from $HEAD_BEFORE to $HEAD_AFTER (should not pull)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 5: Invalid repo_dir exits 1 with actionable message
+# ---------------------------------------------------------------------------
+TEMP_HOME="$(mktemp -d)"
+mkdir -p "$TEMP_HOME/.agentic"
+cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "/nonexistent/path/that/does/not/exist"
+}
+EOF
+
+(
+  HOME="$TEMP_HOME"
+  export HOME
+  AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
+  export AGENTIC_CONFIG_PATH
+  python3 "$UPDATER" --check
+) > "$TEMP_HOME/.out" 2>&1
+echo $? > "$TEMP_HOME/.exit"
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T5 invalid repo_dir: exits 1"
+else
+  _fail "T5 invalid repo_dir: expected exit 1, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -qi "does not exist\|not a git\|not found"; then
+  _pass "T5 invalid repo_dir: actionable message in output"
+else
+  _fail "T5 invalid repo_dir: missing actionable message\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 6: Already up-to-date update exits 0 (no adapter run, no doctor)
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T6 up-to-date update: exits 0"
+else
+  _fail "T6 up-to-date update: expected exit 0, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -qiE "(Already up to date|No rebuild needed)"; then
+  _pass "T6 up-to-date update: reports up-to-date or no rebuild"
+else
+  _fail "T6 up-to-date update: unexpected output\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -11,10 +11,10 @@
 #
 # Failure modes: any test failure prints the failing assertion and exits 1.
 #                Tests use isolated TEMP_HOME dirs with a fake config and
-#                fake git repos. NEVER touches the real ~/.agentic or pulls
-#                from the network.
+#                fake local-only git repos. Never touches the real ~/.agentic
+#                or network; all git operations use local bare remotes.
 #
-# Performance: <5 s wall time on a developer machine (all local git ops).
+# Performance: <10 s wall time on a developer machine.
 
 set -u
 
@@ -40,13 +40,14 @@ _pass() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: create a minimal bare-clone pair for push/fetch tests.
-#
-# Returns (via globals):
-#   FAKE_REMOTE   - a bare git repo that acts as "origin"
-#   FAKE_REPO     - a working clone of FAKE_REMOTE, on branch main
-#   TEMP_HOME     - isolated HOME with config pointing at FAKE_REPO
+# Fixture helpers
 # ---------------------------------------------------------------------------
+
+# setup_git_fixture: create a TEMP_HOME with an isolated local-only git
+# setup. Sets globals:
+#   TEMP_HOME     - isolated HOME; also holds the config
+#   FAKE_REMOTE   - bare git repo acting as "origin"
+#   FAKE_REPO     - working clone of FAKE_REMOTE, on branch main
 setup_git_fixture() {
   TEMP_HOME="$(mktemp -d)"
   FAKE_REMOTE="$TEMP_HOME/remote.git"
@@ -59,7 +60,7 @@ setup_git_fixture() {
   # Clone into working repo
   git clone --quiet "$FAKE_REMOTE" "$FAKE_REPO" 2>/dev/null
 
-  # Bootstrap: commit at least one file on main so rev-parse works
+  # Bootstrap: one commit on main so rev-parse + refs/heads/main exist
   (
     cd "$FAKE_REPO"
     git config user.email "test@test.com"
@@ -79,9 +80,33 @@ setup_git_fixture() {
 EOF
 }
 
+# push_ahead_commit: add a commit to FAKE_REMOTE after FAKE_REPO was cloned,
+# making local main genuinely 1 behind origin/main.
+# Creates a no-op .claude/install.sh in the commit so the real update path
+# can run its adapter-install step without side effects when .claude/install.sh
+# (an exact-path REBUILD_TRIGGER) appears in the changed files.
+# Must be called after setup_git_fixture.
+push_ahead_commit() {
+  local pusher_dir="$TEMP_HOME/pusher"
+  git clone --quiet "$FAKE_REMOTE" "$pusher_dir" 2>/dev/null
+  (
+    cd "$pusher_dir"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    mkdir -p .claude
+    printf '#!/usr/bin/env bash\nexit 0\n' > .claude/install.sh
+    chmod +x .claude/install.sh
+    git add .claude/install.sh
+    git commit -m "add no-op .claude/install.sh" -q
+    git push -q origin main 2>/dev/null
+  )
+  rm -rf "$pusher_dir"
+}
+
+# invoke_updater: run agentic-update with AGENTIC_CONFIG_PATH pointing at
+# the temp config. HOME is also overridden so version-check-cache writes
+# go to TEMP_HOME rather than the real user home.
 invoke_updater() {
-  # Run agentic-update with AGENTIC_CONFIG_PATH pointing at our temp config.
-  # We also override HOME so the version-check cache writes go to TEMP_HOME.
   local config_path="$TEMP_HOME/.agentic/agentic-engineering-config.json"
   (
     HOME="$TEMP_HOME"
@@ -94,19 +119,19 @@ invoke_updater() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 1: --check resolves repo from an arbitrary cwd and exits 0
-# Re-creates the "run from /tmp with config pointing at temp git repo" scenario
-# from the spec. The script must NOT fail with "repo not found" when invoked
-# from an unrelated directory.
+# Test 1: --check resolves repo from arbitrary cwd, exits 0 with a message
+# Scenario: run from /tmp with config pointing at a temp git repo.
+# Must NOT fail with "repo not found" because resolution uses the config,
+# not cwd.
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
-# Run from /tmp (unrelated directory - config is resolved via AGENTIC_CONFIG_PATH)
 (
   HOME="$TEMP_HOME"
   export HOME
   AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
   export AGENTIC_CONFIG_PATH
+  cd /tmp
   python3 "$UPDATER" --check
 ) > "$TEMP_HOME/.out" 2>&1
 echo $? > "$TEMP_HOME/.exit"
@@ -115,32 +140,15 @@ RC=$(cat "$TEMP_HOME/.exit")
 OUT=$(cat "$TEMP_HOME/.out")
 
 if [[ "$RC" == "0" ]]; then
-  _pass "T1 --check from arbitrary cwd: exits 0"
+  _pass "T1 --check from /tmp: exits 0"
 else
-  _fail "T1 --check from arbitrary cwd: expected exit 0, got $RC\n$OUT"
+  _fail "T1 --check from /tmp: expected exit 0, got $RC (output: $OUT)"
 fi
 
 if echo "$OUT" | grep -qE "(Up to date|commit\(s\) behind)"; then
   _pass "T1 --check: output contains status message"
 else
   _fail "T1 --check: unexpected output: $OUT"
-fi
-
-# Also confirm HEAD is unchanged after --check
-HEAD_BEFORE="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
-(
-  HOME="$TEMP_HOME"
-  export HOME
-  AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
-  export AGENTIC_CONFIG_PATH
-  python3 "$UPDATER" --check
-) > /dev/null 2>&1
-HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
-
-if [[ "$HEAD_BEFORE" == "$HEAD_AFTER" ]]; then
-  _pass "T1 --check: HEAD unchanged (no pull performed)"
-else
-  _fail "T1 --check: HEAD changed ($HEAD_BEFORE -> $HEAD_AFTER); --check must not pull"
 fi
 
 rm -rf "$TEMP_HOME"
@@ -150,7 +158,6 @@ rm -rf "$TEMP_HOME"
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
-# Detach to a non-main branch in the repo
 (
   cd "$FAKE_REPO"
   git checkout -b other-branch -q
@@ -164,13 +171,13 @@ OUT=$(cat "$TEMP_HOME/.out")
 if [[ "$RC" == "1" ]]; then
   _pass "T2 non-main branch: exits 1"
 else
-  _fail "T2 non-main branch: expected exit 1, got $RC\n$OUT"
+  _fail "T2 non-main branch: expected exit 1, got $RC"
 fi
 
 if echo "$OUT" | grep -qi "main"; then
   _pass "T2 non-main branch: output mentions 'main'"
 else
-  _fail "T2 non-main branch: output does not mention 'main'\n$OUT"
+  _fail "T2 non-main branch: output does not mention 'main' (got: $OUT)"
 fi
 
 rm -rf "$TEMP_HOME"
@@ -180,7 +187,6 @@ rm -rf "$TEMP_HOME"
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
-# Create an untracked file to make the tree dirty
 DIRTY_FILE="$FAKE_REPO/dirty_file.txt"
 echo "dirty" > "$DIRTY_FILE"
 
@@ -192,23 +198,21 @@ OUT=$(cat "$TEMP_HOME/.out")
 if [[ "$RC" == "1" ]]; then
   _pass "T3 dirty tree: exits 1"
 else
-  _fail "T3 dirty tree: expected exit 1, got $RC\n$OUT"
+  _fail "T3 dirty tree: expected exit 1, got $RC"
 fi
 
-# The dirty file name must appear in the output
 if echo "$OUT" | grep -q "dirty_file.txt"; then
   _pass "T3 dirty tree: dirty file listed in output"
 else
-  _fail "T3 dirty tree: dirty file not listed in output\n$OUT"
+  _fail "T3 dirty tree: dirty file not listed in output (got: $OUT)"
 fi
 
-# Cleanup
 rm -f "$DIRTY_FILE"
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
-# Test 4: --check does not pull (up-to-date repo, HEAD unchanged)
-# This is the authoritative "check does not pull" guard.
+# Test 4: --check on up-to-date repo - HEAD unchanged (smoke test)
+# Note: T7 provides the falsifiable version of this assertion (remote ahead).
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
@@ -221,14 +225,14 @@ OUT=$(cat "$TEMP_HOME/.out")
 if [[ "$RC" == "0" ]]; then
   _pass "T4 --check up-to-date: exits 0"
 else
-  _fail "T4 --check up-to-date: expected exit 0, got $RC\n$OUT"
+  _fail "T4 --check up-to-date: expected exit 0, got $RC"
 fi
 
 HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
 if [[ "$HEAD_BEFORE" == "$HEAD_AFTER" ]]; then
   _pass "T4 --check: HEAD unchanged"
 else
-  _fail "T4 --check: HEAD changed from $HEAD_BEFORE to $HEAD_AFTER (should not pull)"
+  _fail "T4 --check: HEAD changed ($HEAD_BEFORE -> $HEAD_AFTER)"
 fi
 
 rm -rf "$TEMP_HOME"
@@ -259,19 +263,19 @@ OUT=$(cat "$TEMP_HOME/.out")
 if [[ "$RC" == "1" ]]; then
   _pass "T5 invalid repo_dir: exits 1"
 else
-  _fail "T5 invalid repo_dir: expected exit 1, got $RC\n$OUT"
+  _fail "T5 invalid repo_dir: expected exit 1, got $RC"
 fi
 
 if echo "$OUT" | grep -qi "does not exist\|not a git\|not found"; then
   _pass "T5 invalid repo_dir: actionable message in output"
 else
-  _fail "T5 invalid repo_dir: missing actionable message\n$OUT"
+  _fail "T5 invalid repo_dir: missing actionable message (got: $OUT)"
 fi
 
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
-# Test 6: Already up-to-date update exits 0 (no adapter run, no doctor)
+# Test 6: Already up-to-date update exits 0
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
@@ -283,13 +287,205 @@ OUT=$(cat "$TEMP_HOME/.out")
 if [[ "$RC" == "0" ]]; then
   _pass "T6 up-to-date update: exits 0"
 else
-  _fail "T6 up-to-date update: expected exit 0, got $RC\n$OUT"
+  _fail "T6 up-to-date update: expected exit 0, got $RC"
 fi
 
-if echo "$OUT" | grep -qiE "(Already up to date|No rebuild needed)"; then
-  _pass "T6 up-to-date update: reports up-to-date or no rebuild"
+if echo "$OUT" | grep -qiE "Already up to date"; then
+  _pass "T6 up-to-date update: reports 'Already up to date'"
 else
-  _fail "T6 up-to-date update: unexpected output\n$OUT"
+  _fail "T6 up-to-date update: unexpected output (got: $OUT)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 7 (MAJOR fix): --check reports behind count when local is behind origin
+#
+# This test is falsifiable: if --check accidentally pulled, HEAD would move
+# to the new commit and the HEAD-unchanged assertion below would FAIL.
+# The prior fixture always had origin == local so --check could vacuously
+# pass even if it pulled. This fixture sets origin 1 commit ahead first.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_commit   # remote now 1 ahead; FAKE_REPO has NOT pulled yet
+
+HEAD_BEFORE="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+invoke_updater --check
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T7 --check behind: exits 0"
+else
+  _fail "T7 --check behind: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -q "1 commit(s) behind"; then
+  _pass "T7 --check behind: reports '1 commit(s) behind'"
+else
+  _fail "T7 --check behind: expected '1 commit(s) behind' (got: $OUT)"
+fi
+
+# Falsifiable no-pull assertion: HEAD must NOT move after --check
+HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+if [[ "$HEAD_BEFORE" == "$HEAD_AFTER" ]]; then
+  _pass "T7 --check behind: HEAD unchanged (--check did not pull)"
+else
+  _fail "T7 --check behind: HEAD changed $HEAD_BEFORE -> $HEAD_AFTER (--check must not pull)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 8 (MAJOR fix): Real update moves HEAD and runs adapter when local
+# is behind origin.
+#
+# push_ahead_commit adds .claude/install.sh (an exact REBUILD_TRIGGER),
+# so _needs_rebuild must return True, the adapter must run (no-op exit 0),
+# and HEAD must advance. This exercises the full update path including
+# needsRebuild, adapter selection, install, cache reset, and Done. output.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_commit   # remote 1 ahead; commit contains .claude/install.sh
+
+HEAD_BEFORE="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T8 real update: exits 0"
+else
+  _fail "T8 real update: expected exit 0, got $RC (output: $OUT)"
+fi
+
+HEAD_AFTER="$(git -C "$FAKE_REPO" rev-parse HEAD 2>/dev/null)"
+if [[ "$HEAD_BEFORE" != "$HEAD_AFTER" ]]; then
+  _pass "T8 real update: HEAD moved (pull happened)"
+else
+  _fail "T8 real update: HEAD unchanged ($HEAD_BEFORE); pull did not advance HEAD"
+fi
+
+# .claude/install.sh is an exact REBUILD_TRIGGER -> rebuild must fire
+if echo "$OUT" | grep -q "Rebuild triggered by"; then
+  _pass "T8 real update: rebuild triggered (.claude/install.sh is a REBUILD_TRIGGER)"
+else
+  _fail "T8 real update: 'Rebuild triggered by' not in output (got: $OUT)"
+fi
+
+# Done. must appear at the end of a successful update (tests the fixed
+# output-symmetry between rebuild and no-rebuild branches)
+if echo "$OUT" | grep -q "Done\."; then
+  _pass "T8 real update: 'Done.' printed at end"
+else
+  _fail "T8 real update: 'Done.' missing from output (got: $OUT)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 9 (MAJOR fix): Direct _needs_rebuild unit test via importlib
+#
+# Loads bin/agentic-update as a Python module (no .py extension).
+# importlib.util.spec_from_file_location sets module __name__ to the spec
+# name ("agentic_update"), NOT "__main__", so the guard at the bottom of
+# the script (`if __name__ == "__main__": sys.exit(main())`) does not fire.
+# This gives direct access to _needs_rebuild without spawning the CLI.
+#
+# Cases covered:
+#   content/x.md          -> rebuild (directory-prefix trigger)
+#   .cursor/build.sh      -> rebuild (*/build.sh catch-all)
+#   docs/x.md             -> NO rebuild (not a trigger)
+#   bin/agentic-update    -> rebuild (bin/ directory-prefix trigger)
+#   empty old_head        -> always rebuild (safety case)
+#   same old_head==new    -> never rebuild
+# ---------------------------------------------------------------------------
+python3 - "$UPDATER" > /tmp/t9_agentic_update_out.$$ 2>&1 <<'PYEOF'
+import importlib.util, importlib.machinery, sys
+
+updater_path = sys.argv[1]
+# spec_from_file_location cannot infer the loader for extensionless files;
+# supply SourceFileLoader explicitly so Python treats it as a .py source.
+loader = importlib.machinery.SourceFileLoader("agentic_update", updater_path)
+spec = importlib.util.spec_from_file_location("agentic_update", updater_path, loader=loader)
+mod = importlib.util.module_from_spec(spec)
+# __name__ is "agentic_update" when exec_module runs, so the
+# `if __name__ == "__main__"` guard at the bottom does NOT invoke main().
+spec.loader.exec_module(mod)
+
+nr = mod._needs_rebuild
+old = "abc123"
+new = "def456"
+failures = []
+
+if not nr(old, new, ["content/x.md"]):
+    failures.append("content/x.md should trigger rebuild (content/ prefix)")
+if not nr(old, new, [".cursor/build.sh"]):
+    failures.append(".cursor/build.sh should trigger rebuild (*/build.sh catch-all)")
+if nr(old, new, ["docs/x.md"]):
+    failures.append("docs/x.md should NOT trigger rebuild")
+if not nr(old, new, ["bin/agentic-update"]):
+    failures.append("bin/agentic-update should trigger rebuild (bin/ prefix)")
+if not nr("", new, ["docs/x.md"]):
+    failures.append("empty old_head should always rebuild")
+if nr(old, old, ["content/x.md"]):
+    failures.append("same old_head==new_head should NOT rebuild")
+
+if failures:
+    for f in failures:
+        print("FAIL:", f)
+    sys.exit(1)
+print("all cases ok")
+sys.exit(0)
+PYEOF
+NR_RC=$?
+NR_OUT=$(cat /tmp/t9_agentic_update_out.$$ 2>/dev/null)
+rm -f /tmp/t9_agentic_update_out.$$
+
+if [[ "$NR_RC" == "0" ]]; then
+  _pass "T9 _needs_rebuild: content/ prefix triggers rebuild"
+  _pass "T9 _needs_rebuild: */build.sh catch-all triggers rebuild"
+  _pass "T9 _needs_rebuild: docs/ does not trigger rebuild"
+  _pass "T9 _needs_rebuild: bin/ prefix triggers rebuild"
+  _pass "T9 _needs_rebuild: empty old_head always rebuilds"
+  _pass "T9 _needs_rebuild: same heads never rebuild"
+else
+  _fail "T9 _needs_rebuild: one or more cases wrong: $NR_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10 (MINOR m5): --check on a non-main branch exits 0
+#
+# Verifies that --check uses refs/heads/main..origin/main (branch-independent)
+# not HEAD..origin/main (which would error on a non-main branch with no
+# upstream tracking ref).
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_commit   # remote 1 ahead so there is actually something to count
+
+# Switch FAKE_REPO to a non-main branch
+(
+  cd "$FAKE_REPO"
+  git checkout -b some-feature -q
+)
+
+invoke_updater --check
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T10 --check on non-main branch: exits 0 (branch-independent)"
+else
+  _fail "T10 --check on non-main branch: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -qE "(commit\(s\) behind|Up to date)"; then
+  _pass "T10 --check on non-main branch: output has status message"
+else
+  _fail "T10 --check on non-main branch: unexpected output: $OUT"
 fi
 
 rm -rf "$TEMP_HOME"

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -458,9 +458,13 @@ fi
 # ---------------------------------------------------------------------------
 # Test 10 (MINOR m5): --check on a non-main branch exits 0
 #
-# Verifies that --check uses refs/heads/main..origin/main (branch-independent)
-# not HEAD..origin/main (which would error on a non-main branch with no
-# upstream tracking ref).
+# Proves --check is reachable and exits 0 from a non-main branch.
+# `some-feature` is branched from local main with no divergent commit, so
+# HEAD == local main; both HEAD..origin/main and refs/heads/main..origin/main
+# yield the same count. This test cannot distinguish which ref-range the code
+# uses - that is verified by reading the implementation. What it does assert:
+# --check does not hard-error or refuse to run when the current branch is not
+# main (only the non-check update path enforces the branch guard).
 # ---------------------------------------------------------------------------
 setup_git_fixture
 push_ahead_commit   # remote 1 ahead so there is actually something to count


### PR DESCRIPTION
The recurring action is updating, not installing - this adds the missing one-command path.

`agentic-update` runs from any directory (no cd into the repo, no TTY): resolves the repo via the canonical resolver, `git pull --ff-only`, rebuilds only the adapters whose source changed (full `needsRebuild` port from scripts/update.js, incl. the `*/build.sh` catch-all), resets the version-check cache, then runs `agentic-doctor --fix`.

- Flags: `--check` (report behind-count without pulling, branch-independent), `--no-doctor`, `--adapters=a,b`.
- Safety: refuses non-`main` and dirty trees with actionable messages; `--ff-only` only; `--check` performs no mutation. agentic-doctor exit 2 (unfixable) propagates.
- Installs onto PATH via the existing `ae_install_bins` symlink loop on the next `.claude/install.sh` run.
- Tests: bin/tests/test_agentic_update.sh - 27 assertions incl. real origin-ahead fixture exercising the pull+rebuild path and a direct `_needs_rebuild` test. Doctor suite stays green (22).

Stands alone; the nudge-message and docs PRs reference it and merge after this.