### PR TITLE
fix(hooks): point version-check nudge at agentic-update + /pull-and-install

### DIFF
--- a/hooks/lib/version-check-core.sh
+++ b/hooks/lib/version-check-core.sh
@@ -142,7 +142,7 @@ mkdir -p "$HOME/.agentic" >/dev/null 2>&1 || true
 maybe_refresh
 
 if [[ "$behind_count" =~ ^[0-9]+$ ]] && [[ "$behind_count" -gt 0 ]]; then
-  echo "⚠️ agentic-engineering: newer version available. Update with /update-agentic-engineering (in session) or ${ae_repo_dir}/update.sh (shell)."
+  echo "⚠️ agentic-engineering: newer version available. Run: agentic-update (shell) or /pull-and-install (in session). No PATH? ${ae_repo_dir}/update.sh"
 fi
 
 exit 0


### PR DESCRIPTION
The session-start "newer version available" nudge pointed at `/update-agentic-engineering` (the methodology author push tool, wrong for consumers).

Repointed to the consumer paths: `agentic-update` (shell, from anywhere - landed in #321) and `/pull-and-install` (in-session), keeping `${ae_repo_dir}/update.sh` as an absolute failsafe for users without `~/.local/bin` on PATH.

One line changed in `hooks/lib/version-check-core.sh`. Not generated from content/, so no adapter rebuild.