### PR TITLE
docs: lead with updating; add agentic-update across README, updating.md, and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ This system is designed to evolve. As AI tooling matures and teams discover bett
 
 **Live docs:** https://docs.dinostack.ai/
 
+## Updating
+
+Run `agentic-update` from anywhere, no arguments.
+
+| Path | Command | When |
+|---|---|---|
+| Shell (recommended) | `agentic-update` | Default; from any directory, no TTY |
+| In-session | `/pull-and-install` | Inside Claude Code, any project |
+| TUI | `./update.sh` | Interactive adapter selection |
+| CI / scripts | `git pull && ./install-all.sh` | Non-interactive |
+| Repair drift | `agentic-doctor --fix` | Fix broken symlinks/hooks (e.g. after moving the repo) |
+
+Bootstrap is guarded against creating a second clone - if an existing install is detected it aborts and prints the update-in-place command.
+
+Full details: [docs/updating.md](docs/updating.md).
+
 ## Getting started
 
 ### One-liner install (quickest)
@@ -140,14 +156,6 @@ agentic-engineering: opt-out
 Matching is case-insensitive. A leading `- ` (markdown list) is allowed. If both markers appear, the one appearing first wins and a warning is printed.
 
 With the global mode set to `opt-out` (the default), a project without any marker still runs the methodology. With `opt-in` mode, a project must have the `opt-in` marker or the methodology stays dormant.
-
-## Updating
-
-Run `./update.sh` for an interactive TUI updater (arrow keys, space to toggle adapters). For non-interactive or CI use, run `git pull` first then `./install-all.sh`.
-
-If symlinks or hooks have drifted (common after moving the repo), run `agentic-doctor` to diagnose and `agentic-doctor --fix` to repair. Bootstrap is guarded against creating a second clone - if an existing install is detected, it aborts and prints the update-in-place command.
-
-Full details - manual update steps, clean-refresh procedure, health check, safeguards, and agent-driven update prompts: see [docs/updating.md](docs/updating.md).
 
 ## Adapters
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -874,6 +874,7 @@
   <a href="#decks"><span class="nav-dot" style="background: var(--text-muted);"></span> Slide Decks</a>
   <a href="#infographics"><span class="nav-dot" style="background: var(--gold);"></span> Infographics</a>
   <a href="#signals"><span class="nav-dot" style="background: var(--gold);"></span> Is It Working?</a>
+  <a href="#updating"><span class="nav-dot" style="background: var(--cyan);"></span> Updating</a>
   <a href="#config"><span class="nav-dot" style="background: var(--cyan);"></span> Configuration</a>
   <a href="#protocols"><span class="nav-dot" style="background: var(--violet);"></span> Protocol Rules</a>
   <a href="#protocol-deep-dive"><span class="nav-dot" style="background: var(--violet);"></span> Protocol Deep Dive</a>
@@ -975,6 +976,49 @@
   <div class="note" style="margin-top: 12px;">
     <strong>Tuning Skeptic overhead:</strong> the default profile works for most projects. Add <code>agentic-engineering-profile: relaxed</code> to a project's <code>AGENTS.md</code> for faster iteration with less review, or <code>strict</code> when correctness is paramount. See <a href="#profiles">Risk Profiles</a> for the full breakdown.
   </div>
+</div>
+
+<!-- ═══ UPDATING: Keep DinoStack current ═══ -->
+<div id="updating" class="section config-layer">
+  <div class="section-title"><h2>Updating</h2><h3>Keep DinoStack current with one command.</h3></div>
+  <p class="desc">Run <code>agentic-update</code> from any directory, no arguments. It pulls the latest <code>main</code>, rebuilds adapters only when something changed under <code>content/</code>, <code>hooks/</code>, <code>bin/</code>, or the build scripts, resets the version-check cache, and runs <code>agentic-doctor --fix</code> to repair drifted symlinks or hooks. No TTY required.</p>
+  <table style="width: 100%; border-collapse: collapse; font-size: 14.5px; margin: 16px 0;">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border-subtle);">
+        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 22%;">Path</th>
+        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 42%;">Command</th>
+        <th style="text-align: left; padding: 10px 12px; color: var(--text-muted); width: 36%;">When</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">Shell <span style="color: var(--text-muted); font-size: 0.85em;">(recommended)</span></td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-update</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Default; from any directory, no TTY</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">In-session</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>/pull-and-install</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Inside Claude Code, any project</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">TUI</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>./update.sh</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Interactive adapter selection</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">CI / scripts</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>git pull &amp;&amp; ./install-all.sh</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Non-interactive</td>
+      </tr>
+      <tr>
+        <td style="padding: 10px 12px; vertical-align: top;">Repair drift</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-doctor --fix</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Fix broken symlinks/hooks (e.g. after moving the repo)</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="desc">Full details: <a href="updating.md">updating.md</a></p>
 </div>
 
 <!-- ═══ LAYER 1: Configuration Files ═══ -->

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,5 +1,19 @@
 # Updating
 
+## Quick update (recommended)
+
+Run `agentic-update` from any directory, no arguments.
+
+What it does: pulls the latest `main`, rebuilds adapters only if something changed under `content/`, `hooks/`, `bin/`, or the build scripts, resets the version-check cache, and runs `agentic-doctor --fix` to repair drifted symlinks or hooks. No TTY required.
+
+Flags:
+
+- `--check` - report how many commits behind you are without pulling
+- `--no-doctor` - skip the `agentic-doctor --fix` repair step
+- `--adapters=cursor,codex` - rebuild only the specified adapters
+
+First time? `agentic-update` installs itself to `~/.local/bin/` on your next `./update.sh` or `/pull-and-install` run; after that it works from anywhere.
+
 ## TUI updater (`./update.sh`)
 
 Run `./update.sh` for an interactive update. It pulls the latest `main` branch and refreshes selected adapters. Uses a native Node.js TUI - arrow keys to navigate, space to toggle adapters, enter to confirm. The `.claude` adapter is always-on (locked, non-toggleable); the TUI is for selecting ADDITIONAL adapters to refresh. Your selections are saved to `~/.agentic/agentic-engineering-config.json` for future runs. Warnings are shown (but non-blocking) if you're not on `main` or have a dirty working tree. Failed adapter installs are reported at the end without aborting the others.


### PR DESCRIPTION
Users install once but update many times; the docs over-weighted install. This rebalances toward updating.

- README: `## Updating` now leads (before Getting started) with a path table - `agentic-update` (recommended), `/pull-and-install`, `./update.sh`, CI, and the `agentic-doctor --fix` repair row. Retains the split-brain-guard sentence. Install content is condensed below, unchanged.
- docs/updating.md: new `## Quick update (recommended)` headline section for `agentic-update`.
- docs/index.html: adds the update section + nav entry the site was missing entirely.

Docs-only; auto-deploys on merge.