### PR TITLE
docs: clarify per-project opt-in/opt-out depends on the install --mode global mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ agentic-engineering: opt-out
 
 Matching is case-insensitive. A leading `- ` (markdown list) is allowed. If both markers appear, the one appearing first wins and a warning is printed.
 
-With the global mode set to `opt-out` (the default), a project without any marker still runs the methodology. With `opt-in` mode, a project must have the `opt-in` marker or the methodology stays dormant.
+The per-project marker only has effect in combination with the global activation mode set at install (the `--mode` flag). See [Installation modes](#installation-modes).
+
+- **Global `opt-out` (default):** every project is active unless it contains `agentic-engineering: opt-out`. Adding `opt-in` to a project has no effect - the project is already active.
+- **Global `opt-in`:** every project is dormant unless it contains `agentic-engineering: opt-in`. Adding `opt-out` to a project has no effect - the project is already dormant.
 
 ## Adapters
 


### PR DESCRIPTION
The "Initialize a project" section introduced the per-project `agentic-engineering: opt-in`/`opt-out` marker without making clear its effect depends on the global mode set at install (`--mode`). A reader could read the markers as standalone switches.

Replaces the terse closing line with an explicit dependency statement, a cross-reference to Installation modes, and two bullets spelling out both combinations:
- Global opt-out (default): active unless a project has `opt-out`; `opt-in` marker is a no-op.
- Global opt-in: dormant unless a project has `opt-in`; `opt-out` marker is redundant.

Matrix verified against content/sections/01-activation-preflight.md Step 4 (all 6 mode x marker cells). README only.