### PR TITLE
test(bin): add tests for agentic-memory + 4 untested CLIs (#259)

### DIFF
--- a/bin/tests/test_agentic_calibrate.py
+++ b/bin/tests/test_agentic_calibrate.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-calibrate: Skeptic calibration rollup CLI.
+
+Subcommands: density [--since ISO8601] [--task task_id]
+             divergence [--since ISO8601]
+             help
+
+Exit codes: 0 success; 1 missing events log; 2 malformed input.
+
+Run with: python3 bin/tests/test_agentic_calibrate.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from io import StringIO
+from pathlib import Path
+
+_BIN_PATH = Path(__file__).parent.parent / "agentic-calibrate"
+_loader = importlib.machinery.SourceFileLoader("agentic_calibrate", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_calibrate", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-calibrate from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+def _make_skeptic_spawn_complete(
+    task_id: str,
+    ts: str,
+    findings_count: dict,
+    diff_lines: int,
+    signed_off: bool = True,
+    iteration: int = 1,
+) -> str:
+    return json.dumps({
+        "ts": ts,
+        "phase": "skeptic",
+        "event": "spawn_complete",
+        "agent": "skeptic",
+        "task_id": task_id,
+        "data": {
+            "findings_count": findings_count,
+            "diff_lines": diff_lines,
+            "signed_off": signed_off,
+            "iteration": iteration,
+        },
+    })
+
+
+def _make_meta_review_complete(
+    task_id: str,
+    ts: str,
+    critical_missed: list,
+    major_missed: list,
+    minor_missed: list,
+    agreement: bool,
+) -> str:
+    return json.dumps({
+        "ts": ts,
+        "phase": "meta_review",
+        "event": "meta_review_complete",
+        "agent": None,
+        "task_id": task_id,
+        "data": {
+            "original_task_id": task_id,
+            "agreement": agreement,
+            "divergence": {
+                "critical_missed": critical_missed,
+                "major_missed": major_missed,
+                "minor_missed": minor_missed,
+            },
+        },
+    })
+
+
+def _capture_cmd(cmd_fn, args_ns, events_path: Path) -> tuple[int, str, str]:
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    out_cap = StringIO()
+    err_cap = StringIO()
+    sys.stdout = out_cap
+    sys.stderr = err_cap
+    try:
+        old_env = os.environ.get("AGENTIC_DIR")
+        os.environ["AGENTIC_DIR"] = str(events_path.parent)
+        try:
+            rc = cmd_fn(args_ns)
+        finally:
+            if old_env is None:
+                os.environ.pop("AGENTIC_DIR", None)
+            else:
+                os.environ["AGENTIC_DIR"] = old_env
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    return rc, out_cap.getvalue(), err_cap.getvalue()
+
+
+def test_density_missing_events_exits_one():
+    """density with no events.jsonl -> exit 1."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"  # does not exist
+        args = types.SimpleNamespace(since=None, task=None)
+        # sys.exit is called inside; catch it
+        try:
+            rc, _, err = _capture_cmd(_mod.cmd_density, args, events_path)
+            assert False, "Expected SystemExit(1)"
+        except SystemExit as e:
+            assert e.code == 1, f"Expected exit code 1, got {e.code}"
+    print("PASS test_density_missing_events_exits_one")
+
+
+def test_density_empty_events_warming_up():
+    """density with no qualifying spawn_complete events -> warming-up message."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        # Write an event that is NOT a skeptic spawn_complete
+        events_path.write_text(
+            json.dumps({"ts": "2026-05-01T10:00:00Z", "event": "conductor_direct",
+                        "agent": None, "task_id": None, "data": {}}) + "\n"
+        )
+        args = types.SimpleNamespace(since=None, task=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "warming up" in out, f"Expected 'warming up' in output: {out!r}"
+    print("PASS test_density_empty_events_warming_up")
+
+
+def test_density_renders_table_rows():
+    """density renders one row per qualifying spawn_complete."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        lines = [
+            _make_skeptic_spawn_complete(
+                f"T-{i}", f"2026-05-{i+1:02d}T10:00:00Z",
+                {"critical": 0, "major": 1, "minor": 0}, diff_lines=50,
+            )
+            for i in range(3)
+        ]
+        events_path.write_text("\n".join(lines) + "\n")
+        args = types.SimpleNamespace(since=None, task=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "T-0" in out or "T-1" in out or "T-2" in out, (
+            f"Expected task IDs in output: {out!r}"
+        )
+        assert "warming up" in out, "Only 3 spawns; still warming up"
+    print("PASS test_density_renders_table_rows")
+
+
+def test_density_aggregate_above_threshold():
+    """density shows aggregate line when >= WARMING_UP_THRESHOLD qualifying spawns."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        n = _mod.WARMING_UP_THRESHOLD
+        lines = [
+            _make_skeptic_spawn_complete(
+                f"T-{i}", f"2026-05-01T{10+i:02d}:00:00Z",
+                {"critical": 0, "major": 1, "minor": 1}, diff_lines=100,
+            )
+            for i in range(n)
+        ]
+        events_path.write_text("\n".join(lines) + "\n")
+        args = types.SimpleNamespace(since=None, task=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "Aggregate" in out, f"Expected 'Aggregate' line above threshold: {out!r}"
+        assert "warming up" not in out, f"Should not show warming-up above threshold: {out!r}"
+    print("PASS test_density_aggregate_above_threshold")
+
+
+def test_density_task_filter():
+    """--task filters density rows to a specific task_id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        events_path.write_text(
+            _make_skeptic_spawn_complete("TASK-A", "2026-05-01T10:00:00Z",
+                                         {"critical": 1, "major": 0, "minor": 0}, 80) + "\n"
+            + _make_skeptic_spawn_complete("TASK-B", "2026-05-01T10:01:00Z",
+                                            {"critical": 0, "major": 0, "minor": 1}, 40) + "\n"
+        )
+        args = types.SimpleNamespace(since=None, task="TASK-A")
+        rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)
+        assert rc == 0
+        assert "TASK-A" in out, f"Expected TASK-A in filtered output: {out!r}"
+        # TASK-B should not appear in the data rows (it's filtered out)
+        data_lines = [l for l in out.splitlines() if "TASK-B" in l]
+        assert not data_lines, f"TASK-B should be filtered out: {out!r}"
+    print("PASS test_density_task_filter")
+
+
+def test_density_since_filter():
+    """--since filters events before the given timestamp."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        events_path.write_text(
+            _make_skeptic_spawn_complete("OLD", "2026-01-01T10:00:00Z",
+                                         {"critical": 0, "major": 0, "minor": 1}, 10) + "\n"
+            + _make_skeptic_spawn_complete("NEW", "2026-06-01T10:00:00Z",
+                                            {"critical": 0, "major": 1, "minor": 0}, 20) + "\n"
+        )
+        args = types.SimpleNamespace(since="2026-05-01T00:00:00Z", task=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)
+        assert rc == 0
+        assert "NEW" in out, f"Expected NEW task in post-since output: {out!r}"
+        old_rows = [l for l in out.splitlines() if "OLD" in l]
+        assert not old_rows, f"OLD task should be filtered by --since: {out!r}"
+    print("PASS test_density_since_filter")
+
+
+def test_density_malformed_since_exits_two():
+    """--since with invalid ISO8601 -> exit 2."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        events_path.write_text("")
+        args = types.SimpleNamespace(since="not-a-date", task=None)
+        try:
+            _capture_cmd(_mod.cmd_density, args, events_path)
+            assert False, "Expected SystemExit(2)"
+        except SystemExit as e:
+            assert e.code == 2, f"Expected exit 2 for malformed since, got {e.code}"
+    print("PASS test_density_malformed_since_exits_two")
+
+
+def test_divergence_no_meta_events():
+    """divergence with no meta_review_complete events -> informational message."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        events_path.write_text(
+            json.dumps({"ts": "2026-05-01T10:00:00Z", "event": "spawn_complete",
+                        "agent": "engineer", "task_id": "T-1", "data": {}}) + "\n"
+        )
+        args = types.SimpleNamespace(since=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_divergence, args, events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "No meta_review_complete" in out, f"Expected empty-data message: {out!r}"
+    print("PASS test_divergence_no_meta_events")
+
+
+def test_divergence_renders_table():
+    """divergence renders rate table from meta_review_complete events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events_path = agentic / "events.jsonl"
+        events_path.write_text(
+            _make_meta_review_complete("T-1", "2026-05-01T10:00:00Z",
+                                       ["missing-critical"], [], [], False) + "\n"
+            + _make_meta_review_complete("T-2", "2026-05-02T10:00:00Z",
+                                          [], [], [], True) + "\n"
+        )
+        args = types.SimpleNamespace(since=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_divergence, args, events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "Sampled spawns: 2" in out, f"Expected 2 samples: {out!r}"
+        assert "T-1" in out, f"Expected T-1 in output: {out!r}"
+        assert "T-2" in out, f"Expected T-2 in output: {out!r}"
+        assert "Full agreement" in out, f"Expected agreement rate: {out!r}"
+    print("PASS test_divergence_renders_table")
+
+
+def test_help_subcommand_exits_zero():
+    """help subcommand prints help and exits 0."""
+    args = types.SimpleNamespace()
+    old_stdout = sys.stdout
+    captured = StringIO()
+    sys.stdout = captured
+    try:
+        rc = _mod.cmd_help(args)
+    finally:
+        sys.stdout = old_stdout
+    assert rc == 0, f"Expected rc=0, got {rc}"
+    out = captured.getvalue()
+    assert "density" in out and "divergence" in out, (
+        f"Expected subcommand names in help: {out!r}"
+    )
+    print("PASS test_help_subcommand_exits_zero")
+
+
+def test_is_skeptic_spawn_complete():
+    """_is_skeptic_spawn_complete identifies correct events."""
+    yes = {"event": "spawn_complete", "agent": "skeptic"}
+    no1 = {"event": "spawn_complete", "agent": "engineer"}
+    no2 = {"event": "spawn_start", "agent": "skeptic"}
+    assert _mod._is_skeptic_spawn_complete(yes) is True
+    assert _mod._is_skeptic_spawn_complete(no1) is False
+    assert _mod._is_skeptic_spawn_complete(no2) is False
+    print("PASS test_is_skeptic_spawn_complete")
+
+
+def test_is_meta_review_complete():
+    """_is_meta_review_complete identifies correct events."""
+    yes = {"event": "meta_review_complete"}
+    no = {"event": "spawn_complete"}
+    assert _mod._is_meta_review_complete(yes) is True
+    assert _mod._is_meta_review_complete(no) is False
+    print("PASS test_is_meta_review_complete")
+
+
+if __name__ == "__main__":
+    test_density_missing_events_exits_one()
+    test_density_empty_events_warming_up()
+    test_density_renders_table_rows()
+    test_density_aggregate_above_threshold()
+    test_density_task_filter()
+    test_density_since_filter()
+    test_density_malformed_since_exits_two()
+    test_divergence_no_meta_events()
+    test_divergence_renders_table()
+    test_help_subcommand_exits_zero()
+    test_is_skeptic_spawn_complete()
+    test_is_meta_review_complete()
+    print("All agentic-calibrate tests passed.")

--- a/bin/tests/test_agentic_cost_subcommands.py
+++ b/bin/tests/test_agentic_cost_subcommands.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-cost session/task/project/operator subcommands.
+(retro and team are covered by test_agentic_cost_retro.py and
+test_agentic_cost_team.py respectively.)
+
+Run with: python3 bin/tests/test_agentic_cost_subcommands.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from io import StringIO
+from pathlib import Path
+
+_COST_PATH = Path(__file__).parent.parent / "agentic-cost"
+loader = importlib.machinery.SourceFileLoader("agentic_cost", str(_COST_PATH))
+spec = importlib.util.spec_from_loader("agentic_cost", loader)
+if spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-cost from {_COST_PATH}")
+_mod = importlib.util.module_from_spec(spec)
+loader.exec_module(_mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_spawn_complete(
+    agent: str,
+    task_id: str | None,
+    session_uuid: str | None,
+    ts: str,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    wall_seconds: float = 10.0,
+    model: str = "claude-sonnet",
+) -> str:
+    return json.dumps({
+        "ts": ts,
+        "phase": "test",
+        "event": "spawn_complete",
+        "agent": agent,
+        "task_id": task_id,
+        "data": {
+            "session_uuid": session_uuid,
+            "model": model,
+            "wall_seconds": wall_seconds,
+            "tokens": {
+                "input": input_tokens,
+                "output": output_tokens,
+                "cache_creation": 0,
+                "cache_read": 0,
+            },
+        },
+    })
+
+
+def _make_session_line(
+    developer_id: str,
+    session_uuid: str,
+    project_slug: str,
+    ts: str,
+    wall: float = 60.0,
+    input_tokens: int = 1000,
+    output_tokens: int = 500,
+) -> str:
+    return json.dumps({
+        "ts": ts,
+        "phase": "session_end",
+        "event": "session_total",
+        "agent": None,
+        "task_id": None,
+        "developer_id": developer_id,
+        "session_uuid": session_uuid,
+        "project_slug": project_slug,
+        "branch": "main",
+        "data": {
+            "wall_seconds": wall,
+            "tokens": {
+                "input": input_tokens,
+                "output": output_tokens,
+                "cache_creation": 0,
+                "cache_read": 0,
+            },
+            "spawn_count": 1,
+            "by_agent": {},
+        },
+    })
+
+
+def _capture_cmd(cmd_fn, args_ns, events_path: Path | None = None,
+                 session_log_dir: Path | None = None,
+                 global_log_dir: Path | None = None) -> tuple[int, str, str]:
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    out_cap = StringIO()
+    err_cap = StringIO()
+    sys.stdout = out_cap
+    sys.stderr = err_cap
+
+    orig_events = _mod.EVENTS_PATH
+    orig_session = _mod.SESSION_LOG_DIR
+    orig_global = _mod.GLOBAL_SESSION_LOG_DIR
+
+    if events_path is not None:
+        _mod.EVENTS_PATH = events_path
+    if session_log_dir is not None:
+        _mod.SESSION_LOG_DIR = session_log_dir
+    if global_log_dir is not None:
+        _mod.GLOBAL_SESSION_LOG_DIR = global_log_dir
+
+    try:
+        rc = cmd_fn(args_ns)
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        _mod.EVENTS_PATH = orig_events
+        _mod.SESSION_LOG_DIR = orig_session
+        _mod.GLOBAL_SESSION_LOG_DIR = orig_global
+
+    return rc, out_cap.getvalue(), err_cap.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# cmd_session tests
+# ---------------------------------------------------------------------------
+
+def test_session_no_events_empty_table():
+    """session with missing events.jsonl -> exit 0, TOTAL row at zero."""
+    with tempfile.TemporaryDirectory() as tmp:
+        nonexistent = Path(tmp) / "events.jsonl"
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=nonexistent)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "TOTAL" in out, f"Expected TOTAL row even with no events: {out!r}"
+    print("PASS test_session_no_events_empty_table")
+
+
+def test_session_all_events_aggregated():
+    """session with no UUID filter aggregates all spawn_complete events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "T-1", "uuid-A", "2026-05-01T10:00:00Z",
+                                  input_tokens=200, output_tokens=100) + "\n"
+            + _make_spawn_complete("skeptic", "T-1", "uuid-A", "2026-05-01T10:01:00Z",
+                                   input_tokens=150, output_tokens=80) + "\n"
+        )
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "engineer" in out, f"Expected engineer row: {out!r}"
+        assert "skeptic" in out, f"Expected skeptic row: {out!r}"
+        assert "TOTAL" in out
+    print("PASS test_session_all_events_aggregated")
+
+
+def test_session_uuid_filter():
+    """session with UUID filter shows only matching events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "T-1", "uuid-A", "2026-05-01T10:00:00Z",
+                                  input_tokens=500) + "\n"
+            + _make_spawn_complete("engineer", "T-2", "uuid-B", "2026-05-01T10:01:00Z",
+                                   input_tokens=300) + "\n"
+        )
+        args = types.SimpleNamespace(session_uuid="uuid-A")
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "engineer" in out
+        # uuid-B had 300 input tokens; uuid-A had 500. TOTAL should reflect only uuid-A
+        assert "500" in out, f"Expected 500 tokens from uuid-A: {out!r}"
+    print("PASS test_session_uuid_filter")
+
+
+def test_session_v1_footer_present():
+    """session output always includes the V1 disclosure footer."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text("")
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0
+        assert _mod.V1_FOOTER in out, f"V1 footer missing from session output: {out!r}"
+    print("PASS test_session_v1_footer_present")
+
+
+# ---------------------------------------------------------------------------
+# cmd_task tests
+# ---------------------------------------------------------------------------
+
+def test_task_filters_by_task_id():
+    """task subcommand shows only events with the specified task_id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "TASK-A", None, "2026-05-01T10:00:00Z",
+                                  input_tokens=400) + "\n"
+            + _make_spawn_complete("engineer", "TASK-B", None, "2026-05-01T10:01:00Z",
+                                   input_tokens=200) + "\n"
+        )
+        args = types.SimpleNamespace(task_id="TASK-A")
+        rc, out, _ = _capture_cmd(_mod.cmd_task, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "400" in out, f"Expected 400 tokens for TASK-A: {out!r}"
+        assert "200" not in out or "TASK-B" not in out, (
+            f"TASK-B tokens should not appear: {out!r}"
+        )
+    print("PASS test_task_filters_by_task_id")
+
+
+def test_task_no_matching_events_empty_table():
+    """task with non-existent task_id -> exit 0, TOTAL row at zero."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "TASK-X", None, "2026-05-01T10:00:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(task_id="NO-SUCH-TASK")
+        rc, out, _ = _capture_cmd(_mod.cmd_task, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "TOTAL" in out
+    print("PASS test_task_no_matching_events_empty_table")
+
+
+def test_task_v1_footer_present():
+    """task output always includes the V1 disclosure footer."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text("")
+        args = types.SimpleNamespace(task_id="T-1")
+        rc, out, _ = _capture_cmd(_mod.cmd_task, args, events_path=events_path)
+        assert rc == 0
+        assert _mod.V1_FOOTER in out, f"V1 footer missing: {out!r}"
+    print("PASS test_task_v1_footer_present")
+
+
+# ---------------------------------------------------------------------------
+# cmd_project tests
+# ---------------------------------------------------------------------------
+
+def test_project_all_events_no_since():
+    """project with no --since shows all events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "T-1", None, "2026-01-01T10:00:00Z",
+                                  input_tokens=999) + "\n"
+        )
+        args = types.SimpleNamespace(since=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_project, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "999" in out, f"Expected 999 tokens in output: {out!r}"
+    print("PASS test_project_all_events_no_since")
+
+
+def test_project_since_filter():
+    """project --since filters old events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text(
+            _make_spawn_complete("engineer", "OLD", None, "2026-01-01T10:00:00Z",
+                                  input_tokens=777) + "\n"
+            + _make_spawn_complete("skeptic", "NEW", None, "2026-06-01T10:00:00Z",
+                                   input_tokens=333) + "\n"
+        )
+        args = types.SimpleNamespace(since="2026-05-01")
+        rc, out, _ = _capture_cmd(_mod.cmd_project, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "333" in out, f"Expected 333 tokens (NEW event): {out!r}"
+        assert "777" not in out, f"777 should be filtered by --since: {out!r}"
+    print("PASS test_project_since_filter")
+
+
+def test_project_invalid_since_returns_two():
+    """project with invalid --since date -> exit 2."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text("")
+        args = types.SimpleNamespace(since="not-a-date")
+        rc, _, err = _capture_cmd(_mod.cmd_project, args, events_path=events_path)
+        assert rc == 2, f"Expected rc=2 for invalid date, got {rc}"
+        assert "invalid" in err.lower(), f"Expected error message in stderr: {err!r}"
+    print("PASS test_project_invalid_since_returns_two")
+
+
+def test_project_v1_footer_present():
+    """project output always includes the V1 disclosure footer."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        events_path.write_text("")
+        args = types.SimpleNamespace(since=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_project, args, events_path=events_path)
+        assert rc == 0
+        assert _mod.V1_FOOTER in out, f"V1 footer missing: {out!r}"
+    print("PASS test_project_v1_footer_present")
+
+
+# ---------------------------------------------------------------------------
+# cmd_operator tests
+# ---------------------------------------------------------------------------
+
+def test_operator_no_data_guidance_message():
+    """operator with empty global log dir -> exit 0, guidance message."""
+    with tempfile.TemporaryDirectory() as tmp:
+        global_log = Path(tmp) / "session-log"
+        global_log.mkdir()
+        args = types.SimpleNamespace(since=None, json=False)
+        rc, out, _ = _capture_cmd(_mod.cmd_operator, args, global_log_dir=global_log)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "No operator session data" in out, (
+            f"Expected guidance message: {out!r}"
+        )
+    print("PASS test_operator_no_data_guidance_message")
+
+
+def test_operator_aggregates_by_developer_and_project():
+    """operator aggregates (developer_id, project_slug) across global session logs."""
+    with tempfile.TemporaryDirectory() as tmp:
+        global_log = Path(tmp) / "session-log"
+        global_log.mkdir()
+        (global_log / "alice.jsonl").write_text(
+            _make_session_line("alice", "uuid-1", "proj-alpha", "2026-05-01T10:00:00Z",
+                                input_tokens=1000) + "\n"
+            + _make_session_line("alice", "uuid-2", "proj-beta", "2026-05-02T10:00:00Z",
+                                  input_tokens=500) + "\n"
+        )
+        (global_log / "bob.jsonl").write_text(
+            _make_session_line("bob", "uuid-3", "proj-alpha", "2026-05-03T10:00:00Z",
+                                input_tokens=800) + "\n"
+        )
+        args = types.SimpleNamespace(since=None, json=False)
+        rc, out, _ = _capture_cmd(_mod.cmd_operator, args, global_log_dir=global_log)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "alice" in out, f"Expected alice in output: {out!r}"
+        assert "bob" in out, f"Expected bob in output: {out!r}"
+        assert "proj-alpha" in out, f"Expected proj-alpha in output: {out!r}"
+        assert "proj-beta" in out, f"Expected proj-beta in output: {out!r}"
+    print("PASS test_operator_aggregates_by_developer_and_project")
+
+
+def test_operator_json_mode():
+    """operator --json produces valid JSON keyed by developer."""
+    with tempfile.TemporaryDirectory() as tmp:
+        global_log = Path(tmp) / "session-log"
+        global_log.mkdir()
+        (global_log / "alice.jsonl").write_text(
+            _make_session_line("alice", "uuid-1", "proj-x", "2026-05-01T10:00:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(since=None, json=True)
+        rc, out, _ = _capture_cmd(_mod.cmd_operator, args, global_log_dir=global_log)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        data = json.loads(out)
+        assert "alice" in data, f"Expected 'alice' in JSON output: {data}"
+        assert "proj-x" in data["alice"], f"Expected 'proj-x' in alice's projects: {data}"
+    print("PASS test_operator_json_mode")
+
+
+def test_operator_since_filter():
+    """operator --since filters records before cutoff."""
+    with tempfile.TemporaryDirectory() as tmp:
+        global_log = Path(tmp) / "session-log"
+        global_log.mkdir()
+        (global_log / "alice.jsonl").write_text(
+            _make_session_line("alice", "old", "old-proj", "2026-01-01T10:00:00Z",
+                                input_tokens=9999) + "\n"
+            + _make_session_line("alice", "new", "new-proj", "2026-06-01T10:00:00Z",
+                                  input_tokens=111) + "\n"
+        )
+        args = types.SimpleNamespace(since="2026-05-01", json=False)
+        rc, out, _ = _capture_cmd(_mod.cmd_operator, args, global_log_dir=global_log)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "new-proj" in out, f"Expected new-proj in filtered output: {out!r}"
+        assert "old-proj" not in out, f"old-proj should be filtered: {out!r}"
+    print("PASS test_operator_since_filter")
+
+
+def test_operator_since_filters_all_returns_guidance():
+    """operator --since that filters everything -> guidance message, exit 0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        global_log = Path(tmp) / "session-log"
+        global_log.mkdir()
+        (global_log / "alice.jsonl").write_text(
+            _make_session_line("alice", "old", "old-proj", "2026-01-01T10:00:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(since="2030-01-01", json=False)
+        rc, out, _ = _capture_cmd(_mod.cmd_operator, args, global_log_dir=global_log)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "No operator session data" in out, (
+            f"Expected guidance message when all filtered: {out!r}"
+        )
+    print("PASS test_operator_since_filters_all_returns_guidance")
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_operator unit tests
+# ---------------------------------------------------------------------------
+
+def test_aggregate_operator_groups_by_dev_and_project():
+    """_aggregate_operator groups by (developer_id, project_slug)."""
+    records = [
+        {"developer_id": "alice", "project_slug": "proj-a",
+         "data": {"wall_seconds": 10.0, "tokens": {"input": 100, "output": 50,
+                                                     "cache_creation": 0, "cache_read": 0}}},
+        {"developer_id": "alice", "project_slug": "proj-a",
+         "data": {"wall_seconds": 20.0, "tokens": {"input": 200, "output": 100,
+                                                     "cache_creation": 0, "cache_read": 0}}},
+        {"developer_id": "alice", "project_slug": "proj-b",
+         "data": {"wall_seconds": 5.0, "tokens": {"input": 50, "output": 25,
+                                                    "cache_creation": 0, "cache_read": 0}}},
+    ]
+    agg = _mod._aggregate_operator(records)
+    key_aa = ("alice", "proj-a")
+    key_ab = ("alice", "proj-b")
+    assert key_aa in agg, f"Expected key {key_aa} in agg"
+    assert key_ab in agg, f"Expected key {key_ab} in agg"
+    assert agg[key_aa]["sessions"] == 2
+    assert agg[key_aa]["tokens"]["input"] == 300
+    assert agg[key_ab]["sessions"] == 1
+    assert agg[key_ab]["tokens"]["input"] == 50
+    print("PASS test_aggregate_operator_groups_by_dev_and_project")
+
+
+def test_aggregate_operator_skips_missing_developer_id():
+    """_aggregate_operator skips records without developer_id."""
+    records = [
+        {"project_slug": "proj-x",
+         "data": {"wall_seconds": 5.0, "tokens": {"input": 100, "output": 50,
+                                                    "cache_creation": 0, "cache_read": 0}}},
+        {"developer_id": "bob", "project_slug": "proj-y",
+         "data": {"wall_seconds": 10.0, "tokens": {"input": 200, "output": 80,
+                                                     "cache_creation": 0, "cache_read": 0}}},
+    ]
+    agg = _mod._aggregate_operator(records)
+    assert len(agg) == 1, f"Expected 1 bucket (no-dev record skipped), got {len(agg)}"
+    assert ("bob", "proj-y") in agg
+    print("PASS test_aggregate_operator_skips_missing_developer_id")
+
+
+def test_filter_records_since():
+    """_filter_records_since drops records before cutoff."""
+    records = [
+        {"ts": "2026-01-01T00:00:00Z", "developer_id": "alice"},
+        {"ts": "2026-06-01T00:00:00Z", "developer_id": "bob"},
+    ]
+    filtered = _mod._filter_records_since(records, "2026-05-01")
+    assert len(filtered) == 1, f"Expected 1 record after since filter, got {len(filtered)}"
+    assert filtered[0]["developer_id"] == "bob"
+    print("PASS test_filter_records_since")
+
+
+if __name__ == "__main__":
+    # session
+    test_session_no_events_empty_table()
+    test_session_all_events_aggregated()
+    test_session_uuid_filter()
+    test_session_v1_footer_present()
+    # task
+    test_task_filters_by_task_id()
+    test_task_no_matching_events_empty_table()
+    test_task_v1_footer_present()
+    # project
+    test_project_all_events_no_since()
+    test_project_since_filter()
+    test_project_invalid_since_returns_two()
+    test_project_v1_footer_present()
+    # operator
+    test_operator_no_data_guidance_message()
+    test_operator_aggregates_by_developer_and_project()
+    test_operator_json_mode()
+    test_operator_since_filter()
+    test_operator_since_filters_all_returns_guidance()
+    # unit helpers
+    test_aggregate_operator_groups_by_dev_and_project()
+    test_aggregate_operator_skips_missing_developer_id()
+    test_filter_records_since()
+    print("All agentic-cost session/task/project/operator tests passed.")

--- a/bin/tests/test_agentic_help.py
+++ b/bin/tests/test_agentic_help.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-help: static help text CLI.
+
+agentic-help prints a fixed HELP_TEXT block to stdout and always exits 0.
+No subcommands, no flags.
+
+Run with: python3 bin/tests/test_agentic_help.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from io import StringIO
+from pathlib import Path
+
+_BIN_PATH = Path(__file__).parent.parent / "agentic-help"
+_loader = importlib.machinery.SourceFileLoader("agentic_help", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_help", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-help from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+def _capture_main(argv: list[str]) -> tuple[int, str]:
+    old_stdout = sys.stdout
+    captured = StringIO()
+    sys.stdout = captured
+    try:
+        rc = _mod.main(argv)
+    finally:
+        sys.stdout = old_stdout
+    return rc, captured.getvalue()
+
+
+def test_exits_zero():
+    """main() always returns 0."""
+    rc, _ = _capture_main(["agentic-help"])
+    assert rc == 0, f"Expected rc=0, got {rc}"
+    print("PASS test_exits_zero")
+
+
+def test_prints_help_text():
+    """Output equals the module-level HELP_TEXT constant."""
+    rc, out = _capture_main(["agentic-help"])
+    assert rc == 0
+    assert out == _mod.HELP_TEXT, (
+        f"Output does not match HELP_TEXT.\nGot:\n{out}\nExpected:\n{_mod.HELP_TEXT}"
+    )
+    print("PASS test_prints_help_text")
+
+
+def test_known_commands_listed():
+    """Core slash commands appear in the output."""
+    _, out = _capture_main(["agentic-help"])
+    for cmd in ("/agentic-status", "/implement-ticket", "/brief", "/agentic-cost"):
+        assert cmd in out, f"Expected {cmd!r} in help output"
+    print("PASS test_known_commands_listed")
+
+
+def test_no_args_same_as_any_args():
+    """main() ignores argv beyond the first element (no flags)."""
+    _, out1 = _capture_main(["agentic-help"])
+    _, out2 = _capture_main(["agentic-help", "--ignored", "extra"])
+    assert out1 == out2, "Output should be identical regardless of args"
+    print("PASS test_no_args_same_as_any_args")
+
+
+def test_help_text_not_empty():
+    """HELP_TEXT constant is non-empty."""
+    assert _mod.HELP_TEXT and len(_mod.HELP_TEXT) > 100, "HELP_TEXT should be non-trivial"
+    print("PASS test_help_text_not_empty")
+
+
+if __name__ == "__main__":
+    test_exits_zero()
+    test_prints_help_text()
+    test_known_commands_listed()
+    test_no_args_same_as_any_args()
+    test_help_text_not_empty()
+    print("All agentic-help tests passed.")

--- a/bin/tests/test_agentic_memory.py
+++ b/bin/tests/test_agentic_memory.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-memory: memory retrieval CLI.
+
+Subcommands: query [keyword] [--since] [--until] [--type] [--agent]
+             [--last N] [--source ...] [--topic]
+             turns --last N
+
+Run with: python3 bin/tests/test_agentic_memory.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from io import StringIO
+from pathlib import Path
+
+_BIN_PATH = Path(__file__).parent.parent / "agentic-memory"
+_loader = importlib.machinery.SourceFileLoader("agentic_memory", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_memory", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-memory from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+def _make_event(event: str, ts: str, agent: str | None = None, task_id: str | None = None, data: dict | None = None) -> str:
+    return json.dumps({
+        "ts": ts,
+        "phase": "test",
+        "event": event,
+        "agent": agent,
+        "task_id": task_id,
+        "data": data or {},
+    })
+
+
+def _capture_query(args_ns: types.SimpleNamespace, cwd: str) -> tuple[int, str, str]:
+    old_cwd = os.getcwd()
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    out_cap = StringIO()
+    err_cap = StringIO()
+    sys.stdout = out_cap
+    sys.stderr = err_cap
+    try:
+        os.chdir(cwd)
+        rc = _mod.cmd_query(args_ns)
+    finally:
+        os.chdir(old_cwd)
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    return rc, out_cap.getvalue(), err_cap.getvalue()
+
+
+def _capture_turns(args_ns: types.SimpleNamespace, cwd: str) -> tuple[int, str, str]:
+    old_cwd = os.getcwd()
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    out_cap = StringIO()
+    err_cap = StringIO()
+    sys.stdout = out_cap
+    sys.stderr = err_cap
+    try:
+        os.chdir(cwd)
+        rc = _mod.cmd_turns(args_ns)
+    finally:
+        os.chdir(old_cwd)
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    return rc, out_cap.getvalue(), err_cap.getvalue()
+
+
+def _make_query_args(**kwargs) -> types.SimpleNamespace:
+    defaults = {
+        "keyword": None,
+        "since": None,
+        "until": None,
+        "type": None,
+        "agent": None,
+        "last": None,
+        "source": None,
+        "topic": None,
+    }
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+
+def test_query_no_sources_returns_zero():
+    """query with no source files -> exit 0, 'No results found'."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rc, out, _ = _capture_query(_make_query_args(), tmp)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "No results found" in out, f"Expected 'No results found', got: {out!r}"
+    print("PASS test_query_no_sources_returns_zero")
+
+
+def test_query_events_jsonl_keyword_match():
+    """query with keyword finds matching events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        events.write_text(
+            _make_event("spawn_start", "2026-05-01T10:00:00Z", agent="engineer", task_id="T-1") + "\n"
+            + _make_event("spawn_complete", "2026-05-01T10:01:00Z", agent="skeptic") + "\n"
+        )
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(_make_query_args(keyword="engineer", source="events.jsonl"), tmp)
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "engineer" in out, f"Expected 'engineer' in output: {out!r}"
+        assert "spawn_complete" not in out or "skeptic" not in out, (
+            "Skeptic-only event should not match 'engineer' keyword"
+        )
+    print("PASS test_query_events_jsonl_keyword_match")
+
+
+def test_query_events_date_filter():
+    """--since and --until filter events by timestamp."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        events.write_text(
+            _make_event("old_event", "2026-01-01T00:00:00Z") + "\n"
+            + _make_event("new_event", "2026-06-01T00:00:00Z") + "\n"
+        )
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(source="events.jsonl", since="2026-05-01", until="2026-07-01"),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        assert "new_event" in out, f"Expected 'new_event' in output: {out!r}"
+        assert "old_event" not in out, f"old_event should be filtered out: {out!r}"
+    print("PASS test_query_events_date_filter")
+
+
+def test_query_events_agent_filter():
+    """--agent filters events by agent name."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        events.write_text(
+            _make_event("spawn_complete", "2026-05-01T10:00:00Z", agent="engineer") + "\n"
+            + _make_event("spawn_complete", "2026-05-01T10:01:00Z", agent="skeptic") + "\n"
+        )
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(source="events.jsonl", agent="engineer"),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        assert "engineer" in out
+        # The skeptic line should not appear
+        result_lines = [l for l in out.splitlines() if "skeptic" in l]
+        assert not result_lines, f"skeptic should not appear in agent-filtered output: {out!r}"
+    print("PASS test_query_events_agent_filter")
+
+
+def test_query_events_last_filter():
+    """--last N returns only the last N events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        lines = [_make_event(f"ev_{i}", f"2026-05-{i+1:02d}T10:00:00Z") for i in range(5)]
+        events.write_text("\n".join(lines) + "\n")
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(source="events.jsonl", last=2),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        # Should contain ev_3 and ev_4 (last 2), not ev_0
+        assert "ev_3" in out or "ev_4" in out, f"Expected last 2 events: {out!r}"
+        assert "ev_0" not in out, f"ev_0 should not appear with --last 2: {out!r}"
+    print("PASS test_query_events_last_filter")
+
+
+def test_query_memory_md_keyword():
+    """query searches MEMORY.md for keyword in section heading/body."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory = Path(tmp) / "MEMORY.md"
+        memory.write_text(
+            "## Architecture\nWe use Python for all CLIs.\n\n"
+            "## Deployment\nUsing Railway for hosting.\n"
+        )
+
+        old_paths = _mod.MEMORY_PATHS
+        _mod.MEMORY_PATHS = [memory]
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(keyword="python", source="MEMORY.md"),
+                tmp,
+            )
+        finally:
+            _mod.MEMORY_PATHS = old_paths
+
+        assert rc == 0
+        assert "Architecture" in out, f"Expected 'Architecture' section: {out!r}"
+        assert "Deployment" not in out, f"Deployment section should be filtered: {out!r}"
+    print("PASS test_query_memory_md_keyword")
+
+
+def test_query_memory_md_topic():
+    """--topic filters MEMORY.md by section heading."""
+    with tempfile.TemporaryDirectory() as tmp:
+        memory = Path(tmp) / "MEMORY.md"
+        memory.write_text(
+            "## Git Workflow\nAlways commit with -s for DCO.\n\n"
+            "## Testing\nRun python3 bin/tests/*.py\n"
+        )
+
+        old_paths = _mod.MEMORY_PATHS
+        _mod.MEMORY_PATHS = [memory]
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(topic="git", source="MEMORY.md"),
+                tmp,
+            )
+        finally:
+            _mod.MEMORY_PATHS = old_paths
+
+        assert rc == 0
+        assert "Git Workflow" in out, f"Expected 'Git Workflow' section: {out!r}"
+        assert "Testing" not in out, f"Testing section should not appear: {out!r}"
+    print("PASS test_query_memory_md_topic")
+
+
+def test_query_missing_source_warning_on_stderr():
+    """Missing source files produce a warning on stderr, not a crash."""
+    with tempfile.TemporaryDirectory() as tmp:
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = Path(tmp) / "nonexistent.jsonl"
+        try:
+            rc, out, err = _capture_query(
+                _make_query_args(source="events.jsonl"),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0, f"Expected rc=0 for missing source, got {rc}"
+        assert "Warning" in err or "not found" in err, (
+            f"Expected warning on stderr: {err!r}"
+        )
+    print("PASS test_query_missing_source_warning_on_stderr")
+
+
+def test_query_malformed_jsonl_skipped():
+    """Malformed JSONL lines are skipped; valid lines still returned."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        events.write_text(
+            "NOT_VALID_JSON\n"
+            + _make_event("good_event", "2026-05-01T10:00:00Z") + "\n"
+        )
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, err = _capture_query(
+                _make_query_args(source="events.jsonl"),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        assert "good_event" in out, f"Expected valid event in output: {out!r}"
+        assert "Warning" in err or "malformed" in err, (
+            f"Expected malformed line warning on stderr: {err!r}"
+        )
+    print("PASS test_query_malformed_jsonl_skipped")
+
+
+def test_turns_no_context_returns_zero():
+    """turns with no context.md -> exit 0, 'No results found'."""
+    with tempfile.TemporaryDirectory() as tmp:
+        old_ctx = _mod.CONTEXT_PATH
+        _mod.CONTEXT_PATH = Path(tmp) / "nonexistent.md"
+        try:
+            args = types.SimpleNamespace(last=5)
+            rc, out, _ = _capture_turns(args, tmp)
+        finally:
+            _mod.CONTEXT_PATH = old_ctx
+
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "No results found" in out, f"Expected 'No results found': {out!r}"
+    print("PASS test_turns_no_context_returns_zero")
+
+
+def test_turns_with_heading_markers():
+    """turns parses ## Turn headings from context.md."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = Path(tmp) / "context.md"
+        ctx.write_text(
+            "## Turn 1\nUser asked something.\n"
+            "## Turn 2\nAgent responded.\n"
+            "## Turn 3\nUser confirmed.\n"
+        )
+
+        old_ctx = _mod.CONTEXT_PATH
+        _mod.CONTEXT_PATH = ctx
+        try:
+            args = types.SimpleNamespace(last=2)
+            rc, out, _ = _capture_turns(args, tmp)
+        finally:
+            _mod.CONTEXT_PATH = old_ctx
+
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        # last=2: the formatter labels sequentially (Turn 1, Turn 2) but content
+        # comes from source turns 2 and 3. Check body content instead.
+        assert "Agent responded" in out, f"Expected Turn 2 body in output: {out!r}"
+        assert "User confirmed" in out, f"Expected Turn 3 body in output: {out!r}"
+        assert "User asked something" not in out, f"Turn 1 body should be excluded with last=2: {out!r}"
+    print("PASS test_turns_with_heading_markers")
+
+
+def test_split_turns_separator_heuristic():
+    """_split_turns uses '---' separators when no ## Turn headings exist."""
+    text = "First block\nline2\n---\nSecond block\n---\nThird block"
+    turns = _mod._split_turns(text)
+    assert len(turns) == 3, f"Expected 3 turns from --- separators, got {len(turns)}"
+    print("PASS test_split_turns_separator_heuristic")
+
+
+def test_split_turns_blank_line_heuristic():
+    """_split_turns falls back to blank-line separation."""
+    text = "Block one\nline2\n\nBlock two\n\nBlock three"
+    turns = _mod._split_turns(text)
+    assert len(turns) == 3, f"Expected 3 turns from blank lines, got {len(turns)}"
+    print("PASS test_split_turns_blank_line_heuristic")
+
+
+def test_event_to_date_parses_iso():
+    """_event_to_date parses standard ISO timestamps."""
+    d = _mod._event_to_date("2026-05-15T10:00:00Z")
+    assert d is not None, "Expected a date object"
+    assert d.year == 2026 and d.month == 5 and d.day == 15, f"Unexpected date: {d}"
+    print("PASS test_event_to_date_parses_iso")
+
+
+def test_event_to_date_bad_input_returns_none():
+    """_event_to_date returns None for invalid string timestamps."""
+    # The function accepts str; None is not a valid call per the type annotation.
+    assert _mod._event_to_date("not-a-date") is None
+    assert _mod._event_to_date("") is None
+    print("PASS test_event_to_date_bad_input_returns_none")
+
+
+if __name__ == "__main__":
+    test_query_no_sources_returns_zero()
+    test_query_events_jsonl_keyword_match()
+    test_query_events_date_filter()
+    test_query_events_agent_filter()
+    test_query_events_last_filter()
+    test_query_memory_md_keyword()
+    test_query_memory_md_topic()
+    test_query_missing_source_warning_on_stderr()
+    test_query_malformed_jsonl_skipped()
+    test_turns_no_context_returns_zero()
+    test_turns_with_heading_markers()
+    test_split_turns_separator_heuristic()
+    test_split_turns_blank_line_heuristic()
+    test_event_to_date_parses_iso()
+    test_event_to_date_bad_input_returns_none()
+    print("All agentic-memory tests passed.")

--- a/bin/tests/test_agentic_parse_subagent_usage.py
+++ b/bin/tests/test_agentic_parse_subagent_usage.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-parse-subagent-usage: subagent transcript parser.
+
+Public API: main([prog, session_uuid, agent_id])
+  - Resolves transcript from ~/.claude/projects/<hash>/<session_uuid>/subagents/agent-<agent_id>.jsonl
+  - Falls back to glob across all project hashes
+  - Prints compact JSON {tokens, model, wall_seconds}
+  - Always exits 0; errors via {"error": "..."} envelope
+
+Run with: python3 bin/tests/test_agentic_parse_subagent_usage.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+
+_BIN_PATH = Path(__file__).parent.parent / "agentic-parse-subagent-usage"
+_loader = importlib.machinery.SourceFileLoader("agentic_parse_subagent_usage", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_parse_subagent_usage", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-parse-subagent-usage from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+def _capture_main(argv: list[str]) -> tuple[int, str]:
+    old_stdout = sys.stdout
+    captured = StringIO()
+    sys.stdout = captured
+    try:
+        rc = _mod.main(argv)
+    finally:
+        sys.stdout = old_stdout
+    return rc, captured.getvalue()
+
+
+def _make_assistant_turn(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+    timestamp: str = "2026-05-01T10:00:00Z",
+) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "timestamp": timestamp,
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": cache_creation,
+                "cache_read_input_tokens": cache_read,
+            },
+        },
+    })
+
+
+def _make_non_assistant_turn(ts: str = "2026-05-01T09:59:00Z") -> str:
+    return json.dumps({"type": "user", "timestamp": ts, "content": "hello"})
+
+
+def test_missing_args_returns_error_json():
+    """Too few args -> exit 0 with {"error": "usage"}."""
+    rc, out = _capture_main(["agentic-parse-subagent-usage"])
+    assert rc == 0, f"Expected rc=0, got {rc}"
+    data = json.loads(out)
+    assert data.get("error") == "usage", f"Expected error='usage', got {data}"
+    print("PASS test_missing_args_returns_error_json")
+
+
+def test_transcript_not_found_returns_error_json():
+    """Non-existent transcript -> exit 0 with {"error": "transcript_not_found"}."""
+    rc, out = _capture_main(["agentic-parse-subagent-usage", "no-such-uuid", "deadbeef"])
+    assert rc == 0, f"Expected rc=0, got {rc}"
+    data = json.loads(out)
+    assert data.get("error") == "transcript_not_found", (
+        f"Expected error='transcript_not_found', got {data}"
+    )
+    print("PASS test_transcript_not_found_returns_error_json")
+
+
+def test_parse_file_sums_tokens():
+    """_parse_file sums tokens across all assistant turns."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(_make_assistant_turn("claude-3", 100, 50, 10, 5,
+                                     "2026-05-01T10:00:00Z") + "\n")
+        f.write(_make_assistant_turn("claude-3", 200, 80, 20, 15,
+                                     "2026-05-01T10:01:00Z") + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    assert result["tokens"]["input"] == 300, (
+        f"Expected 300 input tokens, got {result['tokens']['input']}"
+    )
+    assert result["tokens"]["output"] == 130, (
+        f"Expected 130 output tokens, got {result['tokens']['output']}"
+    )
+    assert result["tokens"]["cache_creation"] == 30, (
+        f"Expected 30 cache_creation, got {result['tokens']['cache_creation']}"
+    )
+    assert result["tokens"]["cache_read"] == 20, (
+        f"Expected 20 cache_read, got {result['tokens']['cache_read']}"
+    )
+    print("PASS test_parse_file_sums_tokens")
+
+
+def test_parse_file_captures_model():
+    """_parse_file captures model from first assistant turn."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(_make_assistant_turn("claude-sonnet-4", 10, 5) + "\n")
+        f.write(_make_assistant_turn("claude-opus-4", 20, 10) + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    assert result["model"] == "claude-sonnet-4", (
+        f"Expected first model 'claude-sonnet-4', got {result['model']}"
+    )
+    print("PASS test_parse_file_captures_model")
+
+
+def test_parse_file_wall_seconds():
+    """_parse_file computes wall_seconds from first to last timestamp."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(_make_assistant_turn("claude-3", 10, 5,
+                                     timestamp="2026-05-01T10:00:00Z") + "\n")
+        f.write(_make_non_assistant_turn("2026-05-01T10:00:30Z") + "\n")
+        f.write(_make_assistant_turn("claude-3", 20, 8,
+                                     timestamp="2026-05-01T10:01:00Z") + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    # wall = 10:01:00 - 10:00:00 = 60 seconds
+    assert result["wall_seconds"] == 60.0, (
+        f"Expected wall_seconds=60.0, got {result['wall_seconds']}"
+    )
+    print("PASS test_parse_file_wall_seconds")
+
+
+def test_parse_file_single_turn_zero_wall():
+    """Single turn -> wall_seconds == 0.0 (no interval)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(_make_assistant_turn("claude-3", 50, 25,
+                                     timestamp="2026-05-01T10:00:00Z") + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    assert result["wall_seconds"] == 0.0, (
+        f"Expected wall_seconds=0.0 for single turn, got {result['wall_seconds']}"
+    )
+    print("PASS test_parse_file_single_turn_zero_wall")
+
+
+def test_parse_file_skips_non_assistant_turns():
+    """Non-assistant turns are ignored for token counting."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(_make_non_assistant_turn() + "\n")
+        f.write(_make_assistant_turn("claude-3", 100, 50) + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    assert result["tokens"]["input"] == 100, (
+        f"Expected exactly 100 input tokens (user turn ignored), got {result['tokens']['input']}"
+    )
+    print("PASS test_parse_file_skips_non_assistant_turns")
+
+
+def test_parse_file_skips_malformed_lines():
+    """Malformed JSONL lines are silently skipped."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write("NOT_VALID_JSON\n")
+        f.write(_make_assistant_turn("claude-3", 10, 5) + "\n")
+        path = f.name
+
+    result = _mod._parse_file(path)
+    assert result["tokens"]["input"] == 10, (
+        f"Expected 10 input tokens after skipping malformed line, got {result['tokens']['input']}"
+    )
+    print("PASS test_parse_file_skips_malformed_lines")
+
+
+def test_parse_file_empty_file():
+    """Empty transcript -> zero tokens, None model, 0.0 wall."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        path = f.name  # empty file
+
+    result = _mod._parse_file(path)
+    assert result["tokens"]["input"] == 0
+    assert result["tokens"]["output"] == 0
+    assert result["model"] is None
+    assert result["wall_seconds"] == 0.0
+    print("PASS test_parse_file_empty_file")
+
+
+def test_project_hash_from_cwd_substitution():
+    """_project_hash_from_cwd replaces '/' with '-'."""
+    import os
+    old_cwd = os.getcwd()
+    try:
+        # The function uses os.getcwd(), so we can test by checking the pattern
+        h = _mod._project_hash_from_cwd()
+        assert "/" not in h, f"Expected no '/' in hash, got: {h!r}"
+        assert h.startswith("-") or h[0] != "/", "hash should start with '-' for absolute paths"
+    finally:
+        os.chdir(old_cwd)
+    print("PASS test_project_hash_from_cwd_substitution")
+
+
+def test_parse_iso_valid_timestamps():
+    """_parse_iso parses valid ISO timestamps including Z suffix."""
+    ts1 = _mod._parse_iso("2026-05-01T10:00:00Z")
+    ts2 = _mod._parse_iso("2026-05-01T10:00:00+00:00")
+    assert ts1 is not None, "Expected datetime for Z-suffixed timestamp"
+    assert ts2 is not None, "Expected datetime for +00:00 timestamp"
+    print("PASS test_parse_iso_valid_timestamps")
+
+
+def test_parse_iso_invalid_returns_none():
+    """_parse_iso returns None for invalid/empty input."""
+    assert _mod._parse_iso("not-a-date") is None
+    assert _mod._parse_iso("") is None
+    assert _mod._parse_iso(None) is None
+    print("PASS test_parse_iso_invalid_returns_none")
+
+
+def test_resolve_transcript_primary_path(tmp_path: Path | None = None):
+    """_resolve_transcript finds transcript at the primary path when it exists."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_p = Path(tmp)
+        import os
+        # Build path matching primary resolution: ~/<hash>/<uuid>/subagents/agent-<id>.jsonl
+        # We patch HOME to the tmp dir so _project_hash_from_cwd uses tmp
+        session_uuid = "test-session-abc"
+        agent_id = "test-agent-xyz"
+        cwd_hash = os.getcwd().replace("/", "-")
+        subagent_dir = tmp_p / ".claude" / "projects" / cwd_hash / session_uuid / "subagents"
+        subagent_dir.mkdir(parents=True)
+        transcript = subagent_dir / f"agent-{agent_id}.jsonl"
+        transcript.write_text(_make_assistant_turn("claude-3", 5, 2) + "\n")
+
+        # Patch HOME so Path("~").expanduser() resolves to tmp_p
+        old_home = os.environ.get("HOME")
+        os.environ["HOME"] = tmp
+        try:
+            result = _mod._resolve_transcript(session_uuid, agent_id)
+        finally:
+            if old_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = old_home
+
+        assert result is not None, "Expected transcript to be found at primary path"
+        assert result == str(transcript), f"Unexpected path: {result}"
+    print("PASS test_resolve_transcript_primary_path")
+
+
+if __name__ == "__main__":
+    test_missing_args_returns_error_json()
+    test_transcript_not_found_returns_error_json()
+    test_parse_file_sums_tokens()
+    test_parse_file_captures_model()
+    test_parse_file_wall_seconds()
+    test_parse_file_single_turn_zero_wall()
+    test_parse_file_skips_non_assistant_turns()
+    test_parse_file_skips_malformed_lines()
+    test_parse_file_empty_file()
+    test_project_hash_from_cwd_substitution()
+    test_parse_iso_valid_timestamps()
+    test_parse_iso_invalid_returns_none()
+    test_resolve_transcript_primary_path()
+    print("All agentic-parse-subagent-usage tests passed.")


### PR DESCRIPTION
> **Audit batch #258** — independent PR, no merge-order dependency. Merge any time after review.

Adds standalone Python tests for 5 previously-untested `bin/` CLIs and the 4 untested `agentic-cost` subcommands. Closes #259.

- `test_agentic_help.py` (5), `test_agentic_memory.py` (15), `test_agentic_calibrate.py` (12), `test_agentic_parse_subagent_usage.py` (13), `test_agentic_cost_subcommands.py` (19) — 64 tests, all green.
- Run as `python3 bin/tests/test_<name>.py` (no pytest), matching the existing `SourceFileLoader` pattern. No conftest/pyproject introduced.
- `agentic-cost` coverage now includes session, task, project, operator subcommands.
- `agentic-emit` excluded: it is a bash script (`#!/usr/bin/env bash`), no importable Python surface — out of the importlib pattern by construction.

Note: `test_agentic_cost_retro.py` fails on `main` independently of this branch (git-log date range in CI env); not introduced here, not touched.
