### PR TITLE
docs(bin,hooks): author bin/AGENTS.md and hooks/AGENTS.md (#261)

### DIFF
--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,6 +1,6 @@
 # bin/
 
-Thirteen CLI entry points (12 Python, 1 Node) that the agentic-engineering
+Thirteen CLI entry points (11 Python, 1 Bash, 1 Node) that the agentic-engineering
 methodology exposes as PATH-wired commands. Each binary ships with a
 module-manifest docstring (Purpose / Public API / Upstream deps / Downstream
 consumers / Failure modes / Performance) that is the authoritative description

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,0 +1,47 @@
+# bin/
+
+Thirteen CLI entry points (12 Python, 1 Node) that the agentic-engineering
+methodology exposes as PATH-wired commands. Each binary ships with a
+module-manifest docstring (Purpose / Public API / Upstream deps / Downstream
+consumers / Failure modes / Performance) that is the authoritative description
+of that command. Read the binary itself for full detail; this file is the
+module-group map, not a duplicate of those manifests.
+
+## Entry points
+
+| Command | Lang | One-line role |
+|---|---|---|
+| `agentic-calibrate` | Python | Render Skeptic calibration rollups (findings density, meta-Skeptic divergence rate) from `.agentic/events.jsonl`. |
+| `agentic-cost` | Python | Token / wall-time / dollar rollups per agent, session, task, and developer team from `.agentic/events.jsonl` and session logs. |
+| `agentic-disable` | Python | Append the opt-out marker to `AGENTS.md`; optionally update the global config. |
+| `agentic-doctor` | Python | Inspect and repair global install health (symlinks, bin wrappers, hook paths in `settings.json`). |
+| `agentic-emit` | Bash | Append one structured JSON event to `.agentic/events.jsonl` at orchestration boundaries. |
+| `agentic-help` | Python | Print the static slash-command reference to stdout. Zero file I/O; never fails. |
+| `agentic-identity` | Python | Manage per-developer identity files used by the Stop hook for session telemetry attribution. |
+| `agentic-memory` | Python | Query `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md`; return compact Markdown summaries. |
+| `agentic-migrate` | Python | Apply additive project scaffolding migrations (`check` / `apply` / `diff` subcommands). |
+| `agentic-parse-subagent-usage` | Python | Parse a Claude Code subagent transcript JSONL and emit `{tokens, model, wall_seconds}` for `spawn_complete` events. |
+| `agentic-status` | Python | Read-only dump of the activation resolver state with provenance and plain-English explainer. |
+| `agentic-update` | Python | Non-interactive updater: fetch origin, rebuild adapters, reset version-check cache, run `agentic-doctor --fix`. |
+| `agentic-wrap-release-lock` | Node | Release the `/wrap` directory lock (`.agentic/wrap/lock`) safely where `rm -rf` is permission-denied. |
+
+## Upstream dependencies
+
+- Python 3 stdlib only - no third-party installs required for any Python binary.
+- `agentic-wrap-release-lock` requires Node; loads `hooks/lib/wrap-marker.js` via `__dirname`-relative path (not `cwd`).
+- `agentic-emit` shells out to `python3` and `date` for safe JSON assembly.
+- `agentic-cost` soft-depends on `pyyaml` for `~/.agentic/pricing.yml`; absent = token-only output.
+- `agentic-update` shells out to `git` and `bash <adapter>/install.sh`.
+- `agentic-parse-subagent-usage` reads `~/.claude/projects/` transcript files.
+
+## Downstream consumers
+
+`content/commands/` slash-command specs; adapter install scripts (`.claude/install.sh`, `.codex/install.sh`, etc.) that symlink these onto `PATH`; `hooks/stop-context.js` for `agentic-identity` helpers; Activation preflight Step 6 for `agentic-migrate`.
+
+## Failure-mode discipline
+
+Every binary is fail-open: unexpected input, missing files, and permission
+errors are swallowed and surfaced via non-zero exit codes or stderr lines,
+never uncaught exceptions. Exit-code conventions are per-command in each
+binary's `Public API` block. Conductors must not treat a non-zero exit as a
+session-fatal error.

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -1,11 +1,13 @@
 # hooks/
 
 Claude Code lifecycle hooks that enforce methodology rules at the harness
-level and write session telemetry to disk. Ten scripts total: 4 Python
-PreToolUse/Stop enforcers, 4 Node lifecycle handlers, and 2 Bash SessionStart
-helpers. `lib/` holds shared Node utilities consumed by the JS hooks.
-Each script ships with a module-manifest docstring; read the script for full
-detail. This file is the module-group map.
+level and write session telemetry to disk. Eleven scripts in the table below
+(4 Python PreToolUse/Stop enforcers, 4 Node lifecycle handlers, 3 Bash helpers).
+`pre-commit` is also present but is a git hook, not a Claude Code lifecycle
+hook, and is out of scope for this table. `lib/` holds shared utilities
+consumed by the JS hooks and one bin script. Each script ships with a
+module-manifest docstring; read the script for full detail. This file is the
+module-group map.
 
 ## Entry points
 
@@ -28,6 +30,7 @@ detail. This file is the module-group map.
 | File | Role |
 |---|---|
 | `lib/capture-gap.js` | Detect learning-worthy sessions with no captured learning; used by `post-tool-use-capture-nudge.js` and `stop-context.js`. |
+| `lib/version-check-core.sh` | Adapter-neutral core for the "newer version available" SessionStart notice: resolves clone dir, reads behind-count cache, kicks off throttled detached git-fetch refresh; used by `session-start-version-check.sh` and `session-start-wrap.sh`. |
 | `lib/wrap-marker.js` | Single source of truth for all deferred-`/wrap` marker reads, transitions, lock acquire/release, and PID helpers; used by `session-end-wrap.js`, `session-start-wrap.sh`, `stop-context.js`, `wrap-daemon.js`, and `bin/agentic-wrap-release-lock`. |
 
 ## Upstream dependencies

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -1,0 +1,54 @@
+# hooks/
+
+Claude Code lifecycle hooks that enforce methodology rules at the harness
+level and write session telemetry to disk. Ten scripts total: 4 Python
+PreToolUse/Stop enforcers, 4 Node lifecycle handlers, and 2 Bash SessionStart
+helpers. `lib/` holds shared Node utilities consumed by the JS hooks.
+Each script ships with a module-manifest docstring; read the script for full
+detail. This file is the module-group map.
+
+## Entry points
+
+| Script | Lang | Hook event | One-line role |
+|---|---|---|---|
+| `enforce-askuserquestion-default.py` | Python | PreToolUse (AskUserQuestion) | Deny co-equal-ballot `AskUserQuestion` calls lacking a `(Recommended)` label. |
+| `enforce-background-spawn.py` | Python | PreToolUse (Task/Agent) | Deny subagent spawns missing `run_in_background: true`; allow documented foreground-exempt agents. |
+| `enforce-no-abdication.py` | Python | Stop (main session only) | Block turns that end with permission-seeking interrogatives; inject a "proceed" directive. |
+| `enforce-orchestrator-singularity.py` | Python | PreToolUse (Task/Agent) | Deny subagent spawns issued from inside a subagent context (no nested orchestration). |
+| `post-tool-use-capture-nudge.js` | Node | PostToolUse (Task/Agent) | Surface an in-session capture-gap nudge when a learning-worthy event has no captured learning. |
+| `session-end-wrap.js` | Node | SessionEnd | Finalize the deferred-`/wrap` pending-to-ready marker transition and optionally launch `wrap-daemon.js` detached. |
+| `session-start-version-check.sh` | Bash | (sub-script, not wired directly) | Emit a "newer version available" `systemMessage` via the version-check core; called by `session-start-wrap.sh`. |
+| `session-start-wrap.sh` | Bash | SessionStart | Compose version notice, auth-failure notice, artifact migration, and guarded daemon launch into one fail-open handler. |
+| `skill-auto-load-check.sh` | Bash | UserPromptSubmit / BeforeAgent / SessionStart | Emit the skill-load instruction when `skill_auto_load=true` in the global config. |
+| `stop-context.js` | Node | Stop | Write session context to `.agentic/context.md`, mark active loops interrupted, write per-developer telemetry, run capture-gap backstop. |
+| `wrap-daemon.js` | Node | (launched detached by SessionEnd/SessionStart) | Background daemon that drains the deferred-`/wrap` ready-marker queue by headlessly resuming forgotten sessions. |
+
+## Shared library (`lib/`)
+
+| File | Role |
+|---|---|
+| `lib/capture-gap.js` | Detect learning-worthy sessions with no captured learning; used by `post-tool-use-capture-nudge.js` and `stop-context.js`. |
+| `lib/wrap-marker.js` | Single source of truth for all deferred-`/wrap` marker reads, transitions, lock acquire/release, and PID helpers; used by `session-end-wrap.js`, `session-start-wrap.sh`, `stop-context.js`, `wrap-daemon.js`, and `bin/agentic-wrap-release-lock`. |
+
+## Upstream dependencies
+
+- Python hooks: Python 3 stdlib only (`json`, `sys`, `os`).
+- Node hooks: Node built-ins only (`fs`, `path`, `child_process`) plus `lib/wrap-marker.js` and `lib/capture-gap.js` (no npm packages).
+- Bash hooks: `bash`, `python3` (for JSON escaping), `jq` (with grep/sed fallback), `node`.
+- All hooks read `[cwd]/.agentic/` state files; none read outside the project root except identity files at `~/.agentic/`.
+
+## Downstream consumers
+
+`~/.claude/settings.json` wired by `.claude/install.sh`; equivalent adapter
+configs for Codex, Gemini, and Kimi. `bin/agentic-wrap-release-lock` depends
+on `lib/wrap-marker.js`. `content/sections/` methodology prose documents the
+rules these hooks enforce.
+
+## Failure-mode discipline
+
+Every hook is fail-open: parse errors, missing files, and unexpected payloads
+exit 0 without denying the triggering action. Enforcement gaps are preferable
+to blanket blocks. Hooks never raise to the Claude Code harness; non-fatal
+errors are swallowed or written to stderr. The only intentional side effects
+are append-only writes to `.agentic/` files and deny decisions on clearly
+violating tool calls.


### PR DESCRIPTION
> **Audit batch #258** — independent PR, no merge-order dependency. Merge any time after review.

Adds depth-1 `bin/AGENTS.md` and `hooks/AGENTS.md` per the co-located module-map convention. Closes #261.

- `bin/AGENTS.md` — 13 CLI entry points (11 Python, 1 Bash `agentic-emit`, 1 Node `agentic-wrap-release-lock`); role table, upstream/downstream deps, fail-open discipline.
- `hooks/AGENTS.md` — 11 lifecycle scripts (4 Python, 4 Node, 3 Bash) + `lib/` shared-util table (3 files); `pre-commit` explicitly scoped out as a git hook.
- Each entry summarizes role and points to the source file; no module-docstring duplication.

Inventory verified against the live filesystem: header counts == table rows == `ls`. Both files under the ~60-line budget.
