### PR TITLE
perf(identity): single-read dedup in flushPendingBuffer, O(M*N) -> O(M+N) (#268) [bin-stack 1/3]

### DIFF
--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -41,12 +41,17 @@ Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                30s timeout via LOCK_NB+sleep loop (SIGALRM avoided for portability);
                on timeout prints stderr warning and returns without data loss.
                flushPendingBuffer dedup: global log is read ONCE before the
-               per-pending-file loop into a set of seen session_uuid values
-               (O(M+N) total instead of O(M*N)). On OSError the set is empty
-               and all pending files are flushed (same fallback as before).
-               Membership check uses substring scan of the raw log text split
-               by lines, preserving exact dedup precision of the prior
-               `session_uuid in full_text` check (no precision change).
+               per-pending-file loop; each line is JSON-parsed and the
+               session_uuid field is collected into a set (O(M+N) total
+               instead of O(M*N)). Per-pending membership check is O(1).
+               Malformed (non-JSON) lines contribute nothing to the set; at
+               most one self-healing re-flush is possible, and because the
+               re-written line is well-formed JSON it dedups on the next run.
+               This is marginally STRICTER than the prior `session_uuid in
+               full_text` substring check (no false-positive skips on
+               substring coincidences in other fields), never looser.
+               On OSError the set is empty and all pending files are flushed
+               (same fallback as before).
                flushPendingBuffer with repo_root_filter: records whose repo_root
                does not match the filter are skipped (left in the buffer, not
                unlinked); records with no/empty repo_root are also skipped under
@@ -239,9 +244,8 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
                         if _uuid:
                             seen_uuids.add(_uuid)
                     except (json.JSONDecodeError, AttributeError):
-                        # Malformed line: fall back to substring scan so we
-                        # never become LESS strict than the old `in text` check.
-                        # Extract any 36-char UUID-shaped token as a best effort.
+                        # Malformed line: contributes no uuid. Worst case one
+                        # self-healing re-flush (next run's well-formed line dedups it).
                         pass
             except OSError:
                 pass  # Empty set -> flush everything (fallback preserved).

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -227,9 +227,9 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
         # Dedup: read global log ONCE before the per-pending-file loop.
         # Build a set of session_uuid strings seen in the log so each
         # per-file check is O(1) instead of re-reading the whole file.
-        # Precision: split on newlines then substring-scan each line,
-        # which is at least as precise as the prior full-text `in` check
-        # (a uuid that spans a line boundary would be missed by both).
+        # Precision: each line is JSON-parsed and its session_uuid field collected,
+        # stricter than the prior full-text `in` check (no substring-coincidence
+        # false-positive skips). Malformed lines contribute nothing.
         # On OSError the set is empty -> nothing is treated as already-flushed
         # -> all pending files flush (same fallback semantics as before).
         global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -40,6 +40,13 @@ Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                flushPendingBuffer: serialized via fcntl.flock on .flush.lock;
                30s timeout via LOCK_NB+sleep loop (SIGALRM avoided for portability);
                on timeout prints stderr warning and returns without data loss.
+               flushPendingBuffer dedup: global log is read ONCE before the
+               per-pending-file loop into a set of seen session_uuid values
+               (O(M+N) total instead of O(M*N)). On OSError the set is empty
+               and all pending files are flushed (same fallback as before).
+               Membership check uses substring scan of the raw log text split
+               by lines, preserving exact dedup precision of the prior
+               `session_uuid in full_text` check (no precision change).
                flushPendingBuffer with repo_root_filter: records whose repo_root
                does not match the filter are skipped (left in the buffer, not
                unlinked); records with no/empty repo_root are also skipped under
@@ -212,6 +219,33 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
         pending_files = sorted(glob.glob(pending_pattern))
         flushed = 0
 
+        # Dedup: read global log ONCE before the per-pending-file loop.
+        # Build a set of session_uuid strings seen in the log so each
+        # per-file check is O(1) instead of re-reading the whole file.
+        # Precision: split on newlines then substring-scan each line,
+        # which is at least as precise as the prior full-text `in` check
+        # (a uuid that spans a line boundary would be missed by both).
+        # On OSError the set is empty -> nothing is treated as already-flushed
+        # -> all pending files flush (same fallback semantics as before).
+        global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"
+        seen_uuids: set[str] = set()
+        if global_log.is_file():
+            try:
+                log_text = global_log.read_text(encoding="utf-8")
+                for _line in log_text.splitlines():
+                    try:
+                        _row = json.loads(_line)
+                        _uuid = _row.get("session_uuid", "")
+                        if _uuid:
+                            seen_uuids.add(_uuid)
+                    except (json.JSONDecodeError, AttributeError):
+                        # Malformed line: fall back to substring scan so we
+                        # never become LESS strict than the old `in text` check.
+                        # Extract any 36-char UUID-shaped token as a best effort.
+                        pass
+            except OSError:
+                pass  # Empty set -> flush everything (fallback preserved).
+
         for pending_path in pending_files:
             # Parse pending record.
             try:
@@ -229,15 +263,8 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
 
             session_uuid = record.get("session_uuid", "")
 
-            # Dedup: scan global log for this session_uuid.
-            global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"
-            already_flushed = False
-            if session_uuid and global_log.is_file():
-                try:
-                    if session_uuid in global_log.read_text(encoding="utf-8"):
-                        already_flushed = True
-                except OSError:
-                    pass
+            # O(1) dedup check against the pre-built set.
+            already_flushed = bool(session_uuid and session_uuid in seen_uuids)
 
             if already_flushed:
                 try:

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -319,6 +319,185 @@ def test_global_scope_flush_unaffected():
         print("PASS test_global_scope_flush_unaffected")
 
 
+# ---------------------------------------------------------------------------
+# Tests (F-H): O(M+N) dedup regression suite (#268)
+# ---------------------------------------------------------------------------
+
+def test_dedup_skips_already_flushed_uuid():
+    """(F) pending file whose session_uuid is already in global log is skipped+unlinked."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        dev_id = "dedup-dev"
+        already_present_uuid = "uuid-already-in-log"
+
+        # Pre-populate global log with that uuid.
+        global_log = global_log_dir / f"{dev_id}.jsonl"
+        existing_line = json.dumps({
+            "session_uuid": already_present_uuid,
+            "developer_id": dev_id,
+            "phase": "session_end",
+            "event": "session_total",
+            "agent": None,
+            "task_id": None,
+        })
+        global_log.write_text(existing_line + "\n", encoding="utf-8")
+
+        # Write a pending file with the same uuid.
+        pending_record = {
+            "session_uuid": already_present_uuid,
+            "ts": "2026-06-10T00:00:00.000Z",
+            "project_slug": "my-proj",
+            "repo_root": "/repo/my-proj",
+            "branch": "main",
+            "data": {},
+        }
+        pending_path = _write_pending(pending_dir, pending_record)
+
+        count = flushPendingBuffer(dev_id)
+        assert count == 0, f"Expected 0 flushed (already deduped), got {count}"
+
+        # Pending file must be unlinked (dedup path removes it).
+        assert not pending_path.exists(), \
+            "Pending file with already-flushed uuid must be unlinked"
+
+        # Global log must still have exactly 1 line (no duplicate appended).
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1, f"Global log must remain 1 line, got {len(lines)}"
+
+        print("PASS test_dedup_skips_already_flushed_uuid")
+
+
+def test_dedup_flushes_new_uuid_not_in_log():
+    """(G) pending file whose uuid is NOT in the global log is flushed normally."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        dev_id = "dedup-dev2"
+        existing_uuid = "uuid-existing"
+        new_uuid = "uuid-brand-new"
+
+        # Pre-populate global log with a DIFFERENT uuid.
+        global_log = global_log_dir / f"{dev_id}.jsonl"
+        existing_line = json.dumps({
+            "session_uuid": existing_uuid,
+            "developer_id": dev_id,
+            "phase": "session_end",
+            "event": "session_total",
+            "agent": None,
+            "task_id": None,
+        })
+        global_log.write_text(existing_line + "\n", encoding="utf-8")
+
+        # Write pending file with a new uuid.
+        pending_record = {
+            "session_uuid": new_uuid,
+            "ts": "2026-06-10T00:01:00.000Z",
+            "project_slug": "my-proj",
+            "repo_root": "/repo/my-proj",
+            "branch": "main",
+            "data": {},
+        }
+        pending_path = _write_pending(pending_dir, pending_record)
+
+        count = flushPendingBuffer(dev_id)
+        assert count == 1, f"Expected 1 flushed, got {count}"
+
+        assert not pending_path.exists(), "Flushed pending file must be unlinked"
+
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 2, f"Expected 2 lines in global log, got {len(lines)}"
+        uuids_in_log = {json.loads(l)["session_uuid"] for l in lines}
+        assert new_uuid in uuids_in_log, f"{new_uuid!r} must appear in global log"
+
+        print("PASS test_dedup_flushes_new_uuid_not_in_log")
+
+
+def test_dedup_unreadable_global_log_flushes_all():
+    """(H) unreadable/missing global log still flushes all pending files (fallback preserved)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        dev_id = "dedup-dev3"
+
+        # Do NOT create the global log -> is_file() returns False -> seen_uuids empty.
+        record1 = {
+            "session_uuid": "uuid-fallback-1",
+            "ts": "2026-06-10T00:00:00.000Z",
+            "project_slug": "proj",
+            "repo_root": "/repo/proj",
+            "branch": "main",
+            "data": {},
+        }
+        record2 = {
+            "session_uuid": "uuid-fallback-2",
+            "ts": "2026-06-10T00:01:00.000Z",
+            "project_slug": "proj",
+            "repo_root": "/repo/proj",
+            "branch": "main",
+            "data": {},
+        }
+        _write_pending(pending_dir, record1)
+        _write_pending(pending_dir, record2)
+
+        count = flushPendingBuffer(dev_id)
+        assert count == 2, f"Expected 2 flushed (no prior log), got {count}"
+
+        global_log = global_log_dir / f"{dev_id}.jsonl"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 2, f"Expected 2 lines, got {len(lines)}"
+        uuids_in_log = {json.loads(l)["session_uuid"] for l in lines}
+        assert uuids_in_log == {"uuid-fallback-1", "uuid-fallback-2"}
+
+        print("PASS test_dedup_unreadable_global_log_flushes_all")
+
+
+def test_dedup_multi_pending_correct_across_several():
+    """(H2) multi-pending: already-flushed uuids skipped, new uuids flushed — all in one pass."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        dev_id = "dedup-dev4"
+        known_uuids = {"uuid-known-1", "uuid-known-2"}
+        new_uuids = {"uuid-new-1", "uuid-new-2"}
+
+        # Pre-populate global log with the known uuids.
+        global_log = global_log_dir / f"{dev_id}.jsonl"
+        lines_to_write = [
+            json.dumps({"session_uuid": u, "developer_id": dev_id,
+                        "phase": "session_end", "event": "session_total",
+                        "agent": None, "task_id": None})
+            for u in sorted(known_uuids)
+        ]
+        global_log.write_text("\n".join(lines_to_write) + "\n", encoding="utf-8")
+
+        # Write 4 pending files: 2 known (should be skipped), 2 new (should flush).
+        for u in known_uuids | new_uuids:
+            _write_pending(pending_dir, {
+                "session_uuid": u,
+                "ts": "2026-06-10T00:00:00.000Z",
+                "project_slug": "proj",
+                "repo_root": "/repo/proj",
+                "branch": "main",
+                "data": {},
+            })
+
+        count = flushPendingBuffer(dev_id)
+        assert count == 2, f"Expected 2 flushed (only new uuids), got {count}"
+
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 4, f"Expected 4 lines total (2 old + 2 new), got {len(lines)}"
+        uuids_in_log = {json.loads(l)["session_uuid"] for l in lines}
+        assert uuids_in_log == known_uuids | new_uuids, \
+            f"Unexpected uuids in log: {uuids_in_log}"
+
+        print("PASS test_dedup_multi_pending_correct_across_several")
+
+
 if __name__ == "__main__":
     test_flushed_line_canonical_shape()
     test_project_scope_flush_does_not_touch_other_repo_records()
@@ -326,4 +505,8 @@ if __name__ == "__main__":
     test_project_confirmed_beats_confirmed_global()
     test_no_repo_root_record_skipped_by_filter()
     test_global_scope_flush_unaffected()
+    test_dedup_skips_already_flushed_uuid()
+    test_dedup_flushes_new_uuid_not_in_log()
+    test_dedup_unreadable_global_log_flushes_all()
+    test_dedup_multi_pending_correct_across_several()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -415,8 +415,8 @@ def test_dedup_flushes_new_uuid_not_in_log():
         print("PASS test_dedup_flushes_new_uuid_not_in_log")
 
 
-def test_dedup_unreadable_global_log_flushes_all():
-    """(H) unreadable/missing global log still flushes all pending files (fallback preserved)."""
+def test_dedup_missing_global_log_flushes_all():
+    """(H) missing global log (is_file() False) still flushes all pending files (fallback preserved)."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
@@ -452,7 +452,7 @@ def test_dedup_unreadable_global_log_flushes_all():
         uuids_in_log = {json.loads(l)["session_uuid"] for l in lines}
         assert uuids_in_log == {"uuid-fallback-1", "uuid-fallback-2"}
 
-        print("PASS test_dedup_unreadable_global_log_flushes_all")
+        print("PASS test_dedup_missing_global_log_flushes_all")
 
 
 def test_dedup_multi_pending_correct_across_several():
@@ -507,6 +507,6 @@ if __name__ == "__main__":
     test_global_scope_flush_unaffected()
     test_dedup_skips_already_flushed_uuid()
     test_dedup_flushes_new_uuid_not_in_log()
-    test_dedup_unreadable_global_log_flushes_all()
+    test_dedup_missing_global_log_flushes_all()
     test_dedup_multi_pending_correct_across_several()
     print("All tests passed.")


### PR DESCRIPTION
> **Audit batch #258 — bin-stack 1/3.** Merge order: **#331 → #332 → #333** (all touch `bin/agentic-identity` / `bin/agentic-migrate`). This is the base of the stack — merge first. #332 and #333 rebase onto `main` if this squash-merges (SHA changes).

Fixes the O(M*N) dedup scan in `flushPendingBuffer`. Closes #268.

- Global session log is read **once** before the per-pending-file loop into a `seen_uuids` set; per-file dedup is now O(1) membership instead of a `read_text()` + substring scan per file. Total O(M+N).
- `fcntl.flock` scope unchanged — the read sits inside the existing lock (no TOCTOU).
- Dedup is now JSON-field-extraction (`session_uuid` per line) rather than raw substring match: marginally stricter (no false-positive skips on substring coincidences), never looser. Malformed lines contribute nothing; worst case one self-healing re-flush (the re-written line is well-formed and dedups on the next run).
- Fallback preserved: unreadable/missing global log → empty set → everything flushes.

Tests: 4 new dedup regression tests (skip-already-flushed, flush-new, missing-log fallback, multi-pending correctness); full file green (`python3 bin/tests/test_agentic_identity.py`).
