### PR TITLE
fix(migrate): add path-containment guard on manifest writes (#269) [bin-stack 2/3]

### DIFF
--- a/bin/agentic-migrate
+++ b/bin/agentic-migrate
@@ -13,7 +13,8 @@
 #   0 = success / no-op
 #   1 = drift detected (check subcommand only)
 #   2 = manifest not found / parse error
-#   3 = partial apply (some rules errored)
+#   3 = partial apply (some rules errored; also raised when a manifest entry's
+#       path resolves outside project_root - path-traversal guard)
 
 from __future__ import annotations
 
@@ -462,9 +463,17 @@ def cmd_apply(args: argparse.Namespace) -> int:
                 errored = True
 
         # --- file rules ---
+        resolved_root = project_root.resolve()
         for entry in manifest.get("files", []):
             try:
                 target = project_root / entry["path"]
+                if not target.resolve().is_relative_to(resolved_root):
+                    print(
+                        f"agentic-migrate: skipping out-of-root path: {entry['path']!r}",
+                        file=sys.stderr,
+                    )
+                    errored = True
+                    continue
                 if not target.exists():
                     seed_path = manifest_dir / entry["seed"]
                     if seed_path.is_file():

--- a/bin/tests/test_agentic_migrate.py
+++ b/bin/tests/test_agentic_migrate.py
@@ -430,5 +430,79 @@ markers: []
         # 4. No crash (result.returncode already checked above)
 
 
+class TestPathTraversalGuard(unittest.TestCase):
+    """Manifest entries with traversal paths must not write outside project_root; exit 3."""
+
+    def _make_fixture(self):
+        """Return (tmp, project, manifest_dir) with a minimal project scaffold."""
+        tmp = tempfile.mkdtemp()
+        project = Path(tmp) / "project"
+        project.mkdir()
+        agentic = project / ".agentic"
+        agentic.mkdir()
+        (agentic / "config.json").write_text(json.dumps({"debugger_on_failure": False}) + "\n")
+        (project / ".gitignore").write_text("")
+        manifest_dir = Path(tmp)
+        (manifest_dir / "innocent.json").write_text("{}\n")
+        return tmp, project, manifest_dir
+
+    def test_relative_traversal_blocked(self):
+        """../escape.txt must not be written outside project_root."""
+        tmp, project, manifest_dir = self._make_fixture()
+
+        manifest_text = """
+scaffolding_version: 1
+gitignore: []
+files:
+  - path: "../escape.txt"
+    seed: "innocent.json"
+    purpose: "relative traversal attempt"
+markers: []
+"""
+        manifest_path = manifest_dir / "traversal-manifest.yml"
+        manifest_path.write_text(manifest_text)
+
+        result = run(
+            ["apply", "--manifest", str(manifest_path), "--project-root", str(project)],
+        )
+
+        self.assertEqual(result.returncode, 3, msg=f"Expected exit 3, got {result.returncode}\n{result.stderr}")
+        escaped = project.parent / "escape.txt"
+        self.assertFalse(escaped.exists(), "Traversal target must not be written outside project_root")
+        self.assertIn("escape.txt", result.stderr, "stderr must mention the offending path")
+
+    def test_absolute_path_blocked(self):
+        """An absolute path outside project_root must not be written."""
+        tmp, project, manifest_dir = self._make_fixture()
+
+        # Use a predictable temp path that is clearly outside project
+        import tempfile as _tf
+        target_dir = Path(_tf.mkdtemp())
+        absolute_target = str(target_dir / "agentic-escape-test.txt")
+
+        manifest_text = f"""
+scaffolding_version: 1
+gitignore: []
+files:
+  - path: "{absolute_target}"
+    seed: "innocent.json"
+    purpose: "absolute path attack"
+markers: []
+"""
+        manifest_path = manifest_dir / "absolute-manifest.yml"
+        manifest_path.write_text(manifest_text)
+
+        result = run(
+            ["apply", "--manifest", str(manifest_path), "--project-root", str(project)],
+        )
+
+        self.assertEqual(result.returncode, 3, msg=f"Expected exit 3, got {result.returncode}\n{result.stderr}")
+        self.assertFalse(
+            Path(absolute_target).exists(),
+            "Absolute out-of-root target must not be written",
+        )
+        self.assertIn("agentic-escape-test.txt", result.stderr, "stderr must mention the offending path")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> **Audit batch #258 — bin-stack 2/3.** Merge order: #331 → **#332** → #333. Merge **after #331**. Already rebased onto current `main`; re-rebase if #331 squash-merges.

Adds a path-containment guard to `agentic-migrate` manifest writes. Closes #269.

- Before any manifest-derived write in `cmd_apply`, checks `target.resolve().is_relative_to(project_root.resolve())`. Out-of-root entries set `errored=True`, print a stderr warning, and `continue` (skip) — the `continue` precedes `mkdir`/`copy2`, so no directory or file is created outside root.
- Catches relative (`../`), absolute (`/etc/...` — pathlib absolute-reset), and symlink-escape paths. The gitignore loop writes a fixed path (pattern is content, not a path) and is not an attack surface; no other `entry["path"]`-derived write exists.
- Exit code 3 (existing partial-apply path); other valid entries still process. Module docstring updated.

Tests: `TestPathTraversalGuard` — relative + absolute traversal cases, each asserting exit 3, the out-of-root file is NOT created, and stderr names the path. Mutation-checked (guard removed → test fails). 15/15 pass, rebased onto current main (keeps #256's test additions).
