### PR TITLE
refactor(bin): extract shared atomic_write + acquire_exclusive_lock to _lib.py (#265) [bin-stack 3/3]

### DIFF
--- a/bin/_lib.py
+++ b/bin/_lib.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Internal shared helpers for agentic-engineering bin/ CLIs.
+NOT a public CLI - do not invoke directly.
+
+Purpose: Provide two cross-process primitives reused by multiple CLIs:
+  1. acquire_exclusive_lock - fcntl.LOCK_EX context manager with sleep-retry
+     until timeout; used for multi-process coordination (e.g. flush lock).
+  2. atomic_write - write content to <path>.tmp then rename; cleans up .tmp on
+     failure; optional chmod mode.
+
+Public API:
+  acquire_exclusive_lock(lock_path, timeout=30.0)
+    Context manager. Opens lock_path as a Python file object (buffered), acquires
+    fcntl.LOCK_EX | LOCK_NB via a 0.1s sleep-retry loop until timeout, yields the
+    file object, releases (LOCK_UN) and closes on exit. Raises RuntimeError on
+    timeout so callers can distinguish "another holder" from a filesystem error.
+    Caller is responsible for ensuring lock_path and its parent exist before entry.
+
+  atomic_write(path, content, mode=0o600)
+    Writes str content to path.with_suffix('<ext>.tmp') then renames into place.
+    When mode is not None, applies os.chmod to the tmp file before rename.
+    On any exception, unlinks the tmp file (missing_ok) and re-raises.
+    path must be a pathlib.Path.
+
+Upstream deps: Python 3 stdlib only (contextlib, fcntl, os, time, pathlib).
+
+Downstream consumers: bin/agentic-identity (both helpers),
+                      bin/agentic-migrate (atomic_write).
+
+Failure modes:
+  acquire_exclusive_lock: raises RuntimeError("lock timeout") after timeout seconds
+    with no lock held; the underlying fd is always closed before raising.
+    OS errors opening the lock file propagate to the caller unchanged (the file
+    must exist before calling; existence is the caller's responsibility).
+  atomic_write: on any write/chmod/rename failure, removes the .tmp file
+    (missing_ok semantics) and re-raises the original exception. The destination
+    file is never partially written. The .tmp suffix is appended to the full
+    filename (e.g. identity.yml -> identity.yml.tmp) to stay in the same
+    directory and on the same filesystem as the destination.
+
+Performance: Standard. acquire_exclusive_lock sleeps 0.1s per retry (~300 retries
+  over 30s); atomic_write is a single write + fsync-less rename (same filesystem).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+
+@contextmanager
+def acquire_exclusive_lock(
+    lock_path: Path,
+    timeout: float = 30.0,
+) -> Generator[object, None, None]:
+    """Context manager: acquire fcntl.LOCK_EX on lock_path.
+
+    Opens lock_path as a Python file object ('r' mode - the file must already
+    exist), retries with 0.1s sleep until timeout, yields the file object,
+    then releases LOCK_UN and closes on exit.
+
+    Raises RuntimeError on timeout (lock not acquired; fd is closed before
+    raising). OS errors on open propagate unchanged.
+
+    Usage:
+        with acquire_exclusive_lock(lock_path) as fd:
+            # critical section
+            ...
+    """
+    fd = open(lock_path, "r")  # noqa: SIM115 - intentional: file stays open for flock
+    try:
+        deadline = time.monotonic() + timeout
+        acquired = False
+        while time.monotonic() < deadline:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError:
+                time.sleep(0.1)
+
+        if not acquired:
+            fd.close()
+            raise RuntimeError(f"acquire_exclusive_lock: timeout after {timeout}s on {lock_path}")
+
+        try:
+            yield fd
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            fd.close()
+
+    except RuntimeError:
+        raise
+    except BaseException:
+        # Covers exceptions from open() after fd is assigned but before acquired.
+        # If fd was opened but flock not yet attempted (shouldn't happen in normal
+        # flow but guard anyway), close it.
+        try:
+            fd.close()
+        except Exception:
+            pass
+        raise
+
+
+def atomic_write(path: Path, content: str, mode: int | None = 0o600) -> None:
+    """Write content to path atomically via a .tmp sibling.
+
+    Steps:
+      1. Write content to <path>.tmp (text, utf-8).
+      2. If mode is not None, chmod <path>.tmp to mode.
+      3. Rename <path>.tmp -> path.
+
+    On any failure, unlinks <path>.tmp (missing_ok) and re-raises. The
+    destination file is never partially overwritten.
+
+    path.parent must already exist (no mkdir here - callers handle that).
+    """
+    tmp = path.parent / (path.name + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        if mode is not None:
+            os.chmod(tmp, mode)
+        tmp.rename(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -81,13 +81,18 @@ import importlib.util as _ilu
 import importlib.machinery as _ilm
 
 _LIB_PATH = Path(__file__).parent / "_lib.py"
-_loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
-_spec = _ilu.spec_from_loader("_lib", _loader)
-_lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
-_loader.exec_module(_lib_mod)
+if "_lib" in _sys.modules:
+    _lib_mod = _sys.modules["_lib"]
+else:
+    _loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+    _spec = _ilu.spec_from_loader("_lib", _loader)
+    _lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+    _loader.exec_module(_lib_mod)
+    _sys.modules["_lib"] = _lib_mod
+    del _loader, _spec
 acquire_exclusive_lock = _lib_mod.acquire_exclusive_lock
 atomic_write = _lib_mod.atomic_write
-del _sys, _ilu, _ilm, _loader, _spec, _lib_mod
+del _sys, _ilu, _ilm, _lib_mod
 
 IDENTITY_PATH = Path(os.path.expanduser("~/.agentic/identity.yml"))
 PENDING_DIR = Path(os.path.expanduser("~/.agentic/session-log/.pending"))
@@ -206,15 +211,9 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
     FLUSH_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
     FLUSH_LOCK_PATH.touch(exist_ok=True)
 
-    try:
-        ctx = acquire_exclusive_lock(FLUSH_LOCK_PATH, timeout=30.0)
-    except OSError as exc:
-        print(f"agentic-identity confirm: cannot open lock file: {exc}", file=sys.stderr)
-        return 0
-
     flushed = 0
     try:
-        with ctx:
+        with acquire_exclusive_lock(FLUSH_LOCK_PATH, timeout=30.0):
             pending_pattern = str(PENDING_DIR / "*.json")
             pending_files = sorted(glob.glob(pending_pattern))
 
@@ -344,12 +343,11 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
                         pass
                     flushed += 1
 
+    except OSError as exc:
+        print(f"agentic-identity confirm: cannot open lock file: {exc}", file=sys.stderr)
+        return 0
     except RuntimeError:
-        # acquire_exclusive_lock raises RuntimeError on timeout.
-        print(
-            "agentic-identity confirm: lock timeout after 30s; retry.",
-            file=sys.stderr,
-        )
+        print("agentic-identity confirm: lock timeout after 30s; retry.", file=sys.stderr)
         return 0
 
     if flushed > 0:

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -28,18 +28,21 @@ Data model:
   Internal keys _scope ("project"/"global") and _confirmed (bool) are tagged
     on resolved-identity dicts; never written to any file or log.
 
-Upstream deps: Python 3 stdlib only (argparse, fcntl, glob, json, os, re, signal,
+Upstream deps: Python 3 stdlib only (argparse, glob, json, os, re, signal,
                subprocess, sys, datetime, pathlib, time).
+               Shared helpers: bin/_lib (acquire_exclusive_lock, atomic_write).
 
 Downstream consumers: hooks/stop-context.js (reads identity files);
                       bin/agentic-cost team (reads .agentic/session-log/ written
                       after identity is set).
 
 Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
-               Never writes partial files (write to temp, rename).
-               flushPendingBuffer: serialized via fcntl.flock on .flush.lock;
-               30s timeout via LOCK_NB+sleep loop (SIGALRM avoided for portability);
-               on timeout prints stderr warning and returns without data loss.
+               Never writes partial files (atomic_write from _lib: write to temp,
+               chmod, rename; tmp cleaned up on failure).
+               flushPendingBuffer: serialized via fcntl.flock on .flush.lock via
+               acquire_exclusive_lock from _lib; 30s timeout via LOCK_NB+sleep
+               loop (SIGALRM avoided for portability); on timeout prints stderr
+               warning and returns without data loss.
                flushPendingBuffer dedup: global log is read ONCE before the
                per-pending-file loop; each line is JSON-parsed and the
                session_uuid field is collected into a set (O(M+N) total
@@ -63,16 +66,28 @@ Performance: Standard. File I/O only; subprocess for gh CLI in auto subcommand.
 from __future__ import annotations
 
 import argparse
-import fcntl
 import glob
 import json
 import os
 import re
 import subprocess
 import sys
-import time
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+import sys as _sys
+import importlib.util as _ilu
+import importlib.machinery as _ilm
+
+_LIB_PATH = Path(__file__).parent / "_lib.py"
+_loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+_spec = _ilu.spec_from_loader("_lib", _loader)
+_lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+_loader.exec_module(_lib_mod)
+acquire_exclusive_lock = _lib_mod.acquire_exclusive_lock
+atomic_write = _lib_mod.atomic_write
+del _sys, _ilu, _ilm, _loader, _spec, _lib_mod
 
 IDENTITY_PATH = Path(os.path.expanduser("~/.agentic/identity.yml"))
 PENDING_DIR = Path(os.path.expanduser("~/.agentic/session-log/.pending"))
@@ -159,18 +174,15 @@ def _write_identity(lines: list[str], target_path: Path | None = None) -> int:
 
     When target_path is None, writes to global IDENTITY_PATH (default, unchanged
     for all existing callers). When provided, writes to that path (mkdir -p parent).
+    Uses atomic_write from _lib (write to .tmp, chmod 0o600, rename; .tmp cleaned on failure).
     """
     dest = target_path if target_path is not None else IDENTITY_PATH
     content = "\n".join(lines) + "\n"
     dest.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    tmp = dest.with_suffix(".yml.tmp")
     try:
-        tmp.write_text(content, encoding="utf-8")
-        os.chmod(tmp, 0o600)
-        tmp.rename(dest)
+        atomic_write(dest, content, mode=0o600)
     except Exception as exc:
         print(f"agentic-identity: write failed: {exc}", file=sys.stderr)
-        tmp.unlink(missing_ok=True)
         return 1
     return 0
 
@@ -195,164 +207,150 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
     FLUSH_LOCK_PATH.touch(exist_ok=True)
 
     try:
-        fd = open(FLUSH_LOCK_PATH, 'r')
+        ctx = acquire_exclusive_lock(FLUSH_LOCK_PATH, timeout=30.0)
     except OSError as exc:
         print(f"agentic-identity confirm: cannot open lock file: {exc}", file=sys.stderr)
         return 0
 
-    # LOCK_NB + sleep loop, 30s total.
-    deadline = time.monotonic() + 30.0
-    acquired = False
-    while time.monotonic() < deadline:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            acquired = True
-            break
-        except BlockingIOError:
-            time.sleep(0.1)
+    flushed = 0
+    try:
+        with ctx:
+            pending_pattern = str(PENDING_DIR / "*.json")
+            pending_files = sorted(glob.glob(pending_pattern))
 
-    if not acquired:
-        fd.close()
+            # Dedup: read global log ONCE before the per-pending-file loop.
+            # Build a set of session_uuid strings seen in the log so each
+            # per-file check is O(1) instead of re-reading the whole file.
+            # Precision: each line is JSON-parsed and its session_uuid field collected,
+            # stricter than the prior full-text `in` check (no substring-coincidence
+            # false-positive skips). Malformed lines contribute nothing.
+            # On OSError the set is empty -> nothing is treated as already-flushed
+            # -> all pending files flush (same fallback semantics as before).
+            global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"
+            seen_uuids: set[str] = set()
+            if global_log.is_file():
+                try:
+                    log_text = global_log.read_text(encoding="utf-8")
+                    for _line in log_text.splitlines():
+                        try:
+                            _row = json.loads(_line)
+                            _uuid = _row.get("session_uuid", "")
+                            if _uuid:
+                                seen_uuids.add(_uuid)
+                        except (json.JSONDecodeError, AttributeError):
+                            # Malformed line: contributes no uuid. Worst case one
+                            # self-healing re-flush (next run's well-formed line dedups it).
+                            pass
+                except OSError:
+                    pass  # Empty set -> flush everything (fallback preserved).
+
+            for pending_path in pending_files:
+                # Parse pending record.
+                try:
+                    with open(pending_path, encoding="utf-8") as f:
+                        record = json.load(f)
+                except (OSError, json.JSONDecodeError):
+                    # Skip malformed records silently.
+                    continue
+
+                # repo_root_filter: skip records that don't match (leave in buffer).
+                if repo_root_filter is not None:
+                    record_repo_root = record.get("repo_root", "")
+                    if not record_repo_root or record_repo_root != repo_root_filter:
+                        continue
+
+                session_uuid = record.get("session_uuid", "")
+
+                # O(1) dedup check against the pre-built set.
+                already_flushed = bool(session_uuid and session_uuid in seen_uuids)
+
+                if already_flushed:
+                    try:
+                        os.unlink(pending_path)
+                    except OSError:
+                        pass
+                    continue
+
+                # Build attributed line in canonical session-total shape to match
+                # writeSessionLog / writeSessionLogGlobal in hooks/stop-context.js.
+                # Fields NOT in canonical shape (schema_version, repo_root) are used
+                # only for routing/bookkeeping above and must NOT appear in the line.
+                attributed = {
+                    "ts": record.get("ts"),
+                    "phase": "session_end",
+                    "event": "session_total",
+                    "agent": None,
+                    "task_id": None,
+                    "developer_id": confirmed_dev_id,
+                    "session_uuid": record.get("session_uuid"),
+                    "project_slug": record.get("project_slug"),
+                    "branch": record.get("branch", ""),
+                    "data": record.get("data", {}),
+                }
+                attributed_line = json.dumps(attributed, separators=(",", ":"))
+
+                # Repo root validation.
+                repo_root = record.get("repo_root", "")
+                project_slug = record.get("project_slug", "")
+                if repo_root and project_slug:
+                    try:
+                        result = subprocess.check_output(
+                            ["git", "-C", repo_root, "rev-parse", "--show-toplevel"],
+                            timeout=3,
+                            stderr=subprocess.DEVNULL,
+                        )
+                        toplevel = result.decode().strip()
+                        if os.path.basename(toplevel) == project_slug:
+                            per_project_log_dir = Path(toplevel) / ".agentic" / "session-log"
+                            per_project_log_dir.mkdir(parents=True, exist_ok=True)
+                            per_project_log = per_project_log_dir / f"{confirmed_dev_id}.jsonl"
+                            with open(per_project_log, "a", encoding="utf-8") as pf:
+                                pf.write(attributed_line + "\n")
+                        else:
+                            print(
+                                f"agentic-identity: repo_root '{repo_root}' basename "
+                                f"'{os.path.basename(toplevel)}' != project_slug "
+                                f"'{project_slug}'; skipping per-project write.",
+                                file=sys.stderr,
+                            )
+                    except (subprocess.TimeoutExpired, subprocess.CalledProcessError,
+                            OSError, FileNotFoundError):
+                        print(
+                            f"agentic-identity: repo_root '{repo_root}' unreachable; "
+                            "skipping per-project write.",
+                            file=sys.stderr,
+                        )
+
+                # Always append to global log.
+                global_append_ok = False
+                try:
+                    GLOBAL_SESSION_LOG_DIR.mkdir(parents=True, exist_ok=True)
+                    with open(global_log, "a", encoding="utf-8") as gf:
+                        gf.write(attributed_line + "\n")
+                    global_append_ok = True
+                except OSError as exc:
+                    print(
+                        f"agentic-identity: global log write failed: {exc}; "
+                        "leaving pending file for retry.",
+                        file=sys.stderr,
+                    )
+
+                # Unlink pending file only after all attempted appends succeeded.
+                # Per-project write failure is non-blocking; global failure leaves file.
+                if global_append_ok:
+                    try:
+                        os.unlink(pending_path)
+                    except OSError:
+                        pass
+                    flushed += 1
+
+    except RuntimeError:
+        # acquire_exclusive_lock raises RuntimeError on timeout.
         print(
             "agentic-identity confirm: lock timeout after 30s; retry.",
             file=sys.stderr,
         )
         return 0
-
-    try:
-        pending_pattern = str(PENDING_DIR / "*.json")
-        pending_files = sorted(glob.glob(pending_pattern))
-        flushed = 0
-
-        # Dedup: read global log ONCE before the per-pending-file loop.
-        # Build a set of session_uuid strings seen in the log so each
-        # per-file check is O(1) instead of re-reading the whole file.
-        # Precision: each line is JSON-parsed and its session_uuid field collected,
-        # stricter than the prior full-text `in` check (no substring-coincidence
-        # false-positive skips). Malformed lines contribute nothing.
-        # On OSError the set is empty -> nothing is treated as already-flushed
-        # -> all pending files flush (same fallback semantics as before).
-        global_log = GLOBAL_SESSION_LOG_DIR / f"{confirmed_dev_id}.jsonl"
-        seen_uuids: set[str] = set()
-        if global_log.is_file():
-            try:
-                log_text = global_log.read_text(encoding="utf-8")
-                for _line in log_text.splitlines():
-                    try:
-                        _row = json.loads(_line)
-                        _uuid = _row.get("session_uuid", "")
-                        if _uuid:
-                            seen_uuids.add(_uuid)
-                    except (json.JSONDecodeError, AttributeError):
-                        # Malformed line: contributes no uuid. Worst case one
-                        # self-healing re-flush (next run's well-formed line dedups it).
-                        pass
-            except OSError:
-                pass  # Empty set -> flush everything (fallback preserved).
-
-        for pending_path in pending_files:
-            # Parse pending record.
-            try:
-                with open(pending_path, encoding="utf-8") as f:
-                    record = json.load(f)
-            except (OSError, json.JSONDecodeError):
-                # Skip malformed records silently.
-                continue
-
-            # repo_root_filter: skip records that don't match (leave in buffer).
-            if repo_root_filter is not None:
-                record_repo_root = record.get("repo_root", "")
-                if not record_repo_root or record_repo_root != repo_root_filter:
-                    continue
-
-            session_uuid = record.get("session_uuid", "")
-
-            # O(1) dedup check against the pre-built set.
-            already_flushed = bool(session_uuid and session_uuid in seen_uuids)
-
-            if already_flushed:
-                try:
-                    os.unlink(pending_path)
-                except OSError:
-                    pass
-                continue
-
-            # Build attributed line in canonical session-total shape to match
-            # writeSessionLog / writeSessionLogGlobal in hooks/stop-context.js.
-            # Fields NOT in canonical shape (schema_version, repo_root) are used
-            # only for routing/bookkeeping above and must NOT appear in the line.
-            attributed = {
-                "ts": record.get("ts"),
-                "phase": "session_end",
-                "event": "session_total",
-                "agent": None,
-                "task_id": None,
-                "developer_id": confirmed_dev_id,
-                "session_uuid": record.get("session_uuid"),
-                "project_slug": record.get("project_slug"),
-                "branch": record.get("branch", ""),
-                "data": record.get("data", {}),
-            }
-            attributed_line = json.dumps(attributed, separators=(",", ":"))
-
-            # Repo root validation.
-            repo_root = record.get("repo_root", "")
-            project_slug = record.get("project_slug", "")
-            if repo_root and project_slug:
-                try:
-                    result = subprocess.check_output(
-                        ["git", "-C", repo_root, "rev-parse", "--show-toplevel"],
-                        timeout=3,
-                        stderr=subprocess.DEVNULL,
-                    )
-                    toplevel = result.decode().strip()
-                    if os.path.basename(toplevel) == project_slug:
-                        per_project_log_dir = Path(toplevel) / ".agentic" / "session-log"
-                        per_project_log_dir.mkdir(parents=True, exist_ok=True)
-                        per_project_log = per_project_log_dir / f"{confirmed_dev_id}.jsonl"
-                        with open(per_project_log, "a", encoding="utf-8") as pf:
-                            pf.write(attributed_line + "\n")
-                    else:
-                        print(
-                            f"agentic-identity: repo_root '{repo_root}' basename "
-                            f"'{os.path.basename(toplevel)}' != project_slug "
-                            f"'{project_slug}'; skipping per-project write.",
-                            file=sys.stderr,
-                        )
-                except (subprocess.TimeoutExpired, subprocess.CalledProcessError,
-                        OSError, FileNotFoundError):
-                    print(
-                        f"agentic-identity: repo_root '{repo_root}' unreachable; "
-                        "skipping per-project write.",
-                        file=sys.stderr,
-                    )
-
-            # Always append to global log.
-            global_append_ok = False
-            try:
-                GLOBAL_SESSION_LOG_DIR.mkdir(parents=True, exist_ok=True)
-                with open(global_log, "a", encoding="utf-8") as gf:
-                    gf.write(attributed_line + "\n")
-                global_append_ok = True
-            except OSError as exc:
-                print(
-                    f"agentic-identity: global log write failed: {exc}; "
-                    "leaving pending file for retry.",
-                    file=sys.stderr,
-                )
-
-            # Unlink pending file only after all attempted appends succeeded.
-            # Per-project write failure is non-blocking; global failure leaves file.
-            if global_append_ok:
-                try:
-                    os.unlink(pending_path)
-                except OSError:
-                    pass
-                flushed += 1
-
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
 
     if flushed > 0:
         print(f"Flushed {flushed} pending session(s).")

--- a/bin/agentic-migrate
+++ b/bin/agentic-migrate
@@ -7,7 +7,8 @@
 #   agentic-migrate check  [--manifest PATH]
 #   agentic-migrate apply  [--manifest PATH] [--project-root PATH] [--dry-run]
 #   agentic-migrate diff   [--manifest PATH] [--project-root PATH]
-# Upstream: content/project-scaffolding.yml (canonical) or adapter-replicated copy
+# Upstream: content/project-scaffolding.yml (canonical) or adapter-replicated copy.
+#           Shared helpers: bin/_lib (atomic_write).
 # Downstream: invoked by Activation preflight Step 6 and /migrate-project command
 # Failure modes: silent-fail discipline; never throws to caller; exit codes signal status
 #   0 = success / no-op
@@ -15,11 +16,16 @@
 #   2 = manifest not found / parse error
 #   3 = partial apply (some rules errored; also raised when a manifest entry's
 #       path resolves outside project_root - path-traversal guard)
+# Note: _acquire_lock/_release_lock use a one-shot fcntl.LOCK_NB pattern with
+#       stale-lock detection and raw os.open fd - structurally distinct from the
+#       sleep-retry acquire_exclusive_lock context manager in _lib; not extracted.
 
 from __future__ import annotations
 
 import argparse
 import fcntl
+import importlib.machinery as _ilm
+import importlib.util as _ilu
 import json
 import os
 import shutil
@@ -27,6 +33,15 @@ import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+_LIB_PATH = Path(__file__).parent / "_lib.py"
+_loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+_spec = _ilu.spec_from_loader("_lib", _loader)
+_lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+_loader.exec_module(_lib_mod)
+atomic_write = _lib_mod.atomic_write
+del _ilm, _ilu, _loader, _spec, _lib_mod
 
 # ---------------------------------------------------------------------------
 # Manifest resolution
@@ -241,16 +256,18 @@ def _read_project_version(project_root: Path) -> int:
 
 
 def _stamp_project_version(project_root: Path, version: int) -> None:
-    """Write scaffolding_version into .agentic/config.json atomically."""
+    """Write scaffolding_version into .agentic/config.json atomically.
+
+    Uses atomic_write from _lib with mode=None to preserve existing file
+    permissions (config.json is not chmod'd to 0o600 - only identity files are).
+    """
     config_path = project_root / ".agentic" / "config.json"
     if not config_path.exists():
         return
     try:
         data = json.loads(config_path.read_text(encoding="utf-8"))
         data["scaffolding_version"] = version
-        tmp = config_path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-        tmp.rename(config_path)
+        atomic_write(config_path, json.dumps(data, indent=2) + "\n", mode=None)
     except Exception:
         pass
 

--- a/bin/agentic-migrate
+++ b/bin/agentic-migrate
@@ -35,13 +35,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+import sys as _sys
+
 _LIB_PATH = Path(__file__).parent / "_lib.py"
-_loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
-_spec = _ilu.spec_from_loader("_lib", _loader)
-_lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
-_loader.exec_module(_lib_mod)
+if "_lib" in _sys.modules:
+    _lib_mod = _sys.modules["_lib"]
+else:
+    _loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+    _spec = _ilu.spec_from_loader("_lib", _loader)
+    _lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+    _loader.exec_module(_lib_mod)
+    _sys.modules["_lib"] = _lib_mod
+    del _loader, _spec
 atomic_write = _lib_mod.atomic_write
-del _ilm, _ilu, _loader, _spec, _lib_mod
+del _sys, _ilm, _ilu, _lib_mod
 
 # ---------------------------------------------------------------------------
 # Manifest resolution

--- a/bin/tests/test__lib.py
+++ b/bin/tests/test__lib.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Tests for bin/_lib.py shared helpers: atomic_write and acquire_exclusive_lock.
+
+Test groups:
+  1. test_atomic_write_creates_file - basic write + rename.
+  2. test_atomic_write_mode_bits    - chmod 0o600 applied to destination.
+  3. test_atomic_write_mode_none    - mode=None skips chmod (preserves existing perms).
+  4. test_atomic_write_no_tmp_on_success - .tmp removed after successful write.
+  5. test_atomic_write_cleans_tmp_on_failure - .tmp unlinked when rename impossible.
+  6. test_acquire_lock_acquires_and_releases - context manager acquires, code runs, releases.
+  7. test_acquire_lock_blocks_second - second acquirer times out while first holds lock.
+  8. test_acquire_lock_releases_after_with - after 'with' block, second acquirer succeeds.
+
+Run with: python3 bin/tests/test__lib.py
+       or: python3 -m pytest bin/tests/test__lib.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+import stat
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load bin/_lib as a module (no .py extension needed for the CLIs, but _lib
+# does have .py - load by path to match how the CLIs do it at runtime).
+# ---------------------------------------------------------------------------
+_LIB_PATH = Path(__file__).parent.parent / "_lib.py"
+_loader = importlib.machinery.SourceFileLoader("_lib", str(_LIB_PATH))
+_spec = importlib.util.spec_from_loader("_lib", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for _lib from {_LIB_PATH}")
+_lib = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_lib)
+
+atomic_write = _lib.atomic_write
+acquire_exclusive_lock = _lib.acquire_exclusive_lock
+
+
+# ---------------------------------------------------------------------------
+# atomic_write tests
+# ---------------------------------------------------------------------------
+
+class TestAtomicWrite(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.dest = Path(self.tmp_dir) / "output.txt"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_atomic_write_creates_file(self):
+        atomic_write(self.dest, "hello world\n")
+        self.assertTrue(self.dest.is_file())
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "hello world\n")
+
+    def test_atomic_write_mode_bits(self):
+        atomic_write(self.dest, "secret\n", mode=0o600)
+        file_mode = stat.S_IMODE(os.stat(self.dest).st_mode)
+        self.assertEqual(file_mode, 0o600)
+
+    def test_atomic_write_mode_none_skips_chmod(self):
+        # Write with mode=None; verify file exists and no chmod error raised.
+        # We can't easily verify "no chmod was called" without mocking, but we
+        # can verify the file lands correctly and the pre-existing permissions
+        # of the .tmp file (umask-dependent) are left alone (not forced to 0o600).
+        atomic_write(self.dest, "config\n", mode=None)
+        self.assertTrue(self.dest.is_file())
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "config\n")
+        # mode=None must NOT force 0o600: file mode should equal umask default
+        # (typically 0o644). We just confirm it is NOT necessarily 0o600 by
+        # checking the content round-trips correctly (the main behavioral check).
+
+    def test_atomic_write_no_tmp_on_success(self):
+        tmp = self.dest.parent / (self.dest.name + ".tmp")
+        atomic_write(self.dest, "data\n")
+        self.assertFalse(tmp.exists(), ".tmp file should be removed after successful write")
+
+    def test_atomic_write_cleans_tmp_on_failure(self):
+        # Make dest a directory so rename fails; .tmp should be cleaned up.
+        self.dest.mkdir()
+        tmp = self.dest.parent / (self.dest.name + ".tmp")
+        with self.assertRaises(Exception):
+            atomic_write(self.dest, "data\n")
+        self.assertFalse(tmp.exists(), ".tmp file should be removed on failure")
+
+    def test_atomic_write_overwrites_existing(self):
+        self.dest.write_text("old content\n", encoding="utf-8")
+        atomic_write(self.dest, "new content\n")
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "new content\n")
+
+
+# ---------------------------------------------------------------------------
+# acquire_exclusive_lock tests
+# ---------------------------------------------------------------------------
+
+class TestAcquireExclusiveLock(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.lock_path = Path(self.tmp_dir) / ".test.lock"
+        self.lock_path.touch()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_acquire_lock_acquires_and_releases(self):
+        """Context manager acquires the lock, body runs, lock released on exit."""
+        ran = []
+        with acquire_exclusive_lock(self.lock_path, timeout=5.0):
+            ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_acquire_lock_blocks_second_acquirer(self):
+        """Second acquirer times out while first holds the lock."""
+        result = {}
+
+        def hold_lock():
+            with acquire_exclusive_lock(self.lock_path, timeout=10.0):
+                # Signal holder is in; sleep long enough for second acquirer to time out.
+                result["held"] = True
+                time.sleep(1.5)
+
+        holder = threading.Thread(target=hold_lock)
+        holder.start()
+
+        # Wait until holder has the lock.
+        deadline = time.monotonic() + 2.0
+        while not result.get("held") and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        # Second acquirer with very short timeout should raise RuntimeError.
+        with self.assertRaises(RuntimeError) as ctx:
+            with acquire_exclusive_lock(self.lock_path, timeout=0.2):
+                pass
+
+        self.assertIn("timeout", str(ctx.exception).lower())
+        holder.join(timeout=5.0)
+
+    def test_acquire_lock_releases_so_second_can_acquire(self):
+        """After 'with' block exits, a second acquirer succeeds."""
+        with acquire_exclusive_lock(self.lock_path, timeout=5.0):
+            pass
+
+        # Lock should now be free; second acquisition must succeed.
+        second_ran = []
+        with acquire_exclusive_lock(self.lock_path, timeout=5.0):
+            second_ran.append(True)
+        self.assertEqual(second_ran, [True])
+
+    def test_acquire_lock_releases_on_exception_in_body(self):
+        """Lock is released even when the body raises an exception."""
+        try:
+            with acquire_exclusive_lock(self.lock_path, timeout=5.0):
+                raise ValueError("body error")
+        except ValueError:
+            pass
+
+        # Lock must be free now.
+        acquired = []
+        with acquire_exclusive_lock(self.lock_path, timeout=1.0):
+            acquired.append(True)
+        self.assertEqual(acquired, [True])
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (matches existing test pattern in bin/tests/)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> **Audit batch #258 — bin-stack 3/3.** Merge order: #331 → #332 → **#333** (last). Stacked on #331+#332 — its diff shows their files until they merge. Merge **after both #331 and #332**; rebase onto `main` if either squash-merges.

Extracts two duplicated primitives from `agentic-identity` and `agentic-migrate` into a new `bin/_lib.py`. Closes #265.

- `bin/_lib.py` (new, stdlib-only): `atomic_write(path, content, mode=0o600)` (write-`.tmp` → optional chmod → rename, unlink `.tmp` on failure; `mode=None` skips chmod) and `acquire_exclusive_lock(lock_path, timeout=30.0)` (LOCK_EX|LOCK_NB sleep-retry context manager, raises `RuntimeError` on timeout, fd closed on every path).
- `agentic-identity`: `_write_identity` → `atomic_write`; `flushPendingBuffer` flock loop → `acquire_exclusive_lock`. The global-log read + entire pending-file loop stay **inside** the lock (preserves #268's dedup correctness). Timeout RuntimeError is caught → same "retry" message, no flush, no crash.
- `agentic-migrate`: `_stamp_project_version` → `atomic_write(mode=None)` (config.json was never chmod'd — preserved).
- Reconciled the `fd.close()` vs `os.close(fd)` drift onto the file-object pattern.
- `agentic-migrate`'s `_acquire_lock` is **not** extracted — it's a different mechanism (one-shot, PID-body stale detection), documented in the header note.

Tests: `test__lib.py` (10, incl lock contention + release-on-exception); both consumer suites still green (#268 dedup + #269 guard tests pass). 35 tests total.

**Stacked on #268 + #269** — merge after both land on `main` (rebase if their SHAs change on squash-merge).
