### PR TITLE
fix(hooks): clean up orphan .tmp files in stop-context atomic-write catch blocks (#262) [hooks-stack 1/3]

### DIFF
--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -220,8 +220,8 @@ function writeLoopState(cwd) {
     return;
   }
 
+  const loopStatePath = path.join(cwd, '.agentic', 'loop-state.json');
   try {
-    const loopStatePath = path.join(cwd, '.agentic', 'loop-state.json');
     if (fs.existsSync(loopStatePath)) {
       const loopState = JSON.parse(fs.readFileSync(loopStatePath, 'utf-8'));
       if (loopState.status === 'active') {
@@ -235,6 +235,7 @@ function writeLoopState(cwd) {
     }
   } catch (_) {
     // Silent failure - the 10-minute implicit-interrupt heuristic handles missed writes
+    try { fs.unlinkSync(loopStatePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
   }
 }
 
@@ -254,8 +255,8 @@ function writeBatchState(cwd, sessionId) {
     return;
   }
 
+  const batchStatePath = path.join(cwd, '.agentic', 'batch-state.json');
   try {
-    const batchStatePath = path.join(cwd, '.agentic', 'batch-state.json');
     if (!fs.existsSync(batchStatePath)) return;
     const batchState = JSON.parse(fs.readFileSync(batchStatePath, 'utf-8'));
 
@@ -281,6 +282,7 @@ function writeBatchState(cwd, sessionId) {
     fs.renameSync(tmpPath, batchStatePath);
   } catch (_) {
     // Silent failure - best-effort write; resume-time logic tolerates absent mark.
+    try { fs.unlinkSync(batchStatePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
   }
 }
 
@@ -652,6 +654,7 @@ function generateUuid() {
  * @param {string|null} sessionId - Current session uuid (uuid v4 generated if null).
  */
 function writePendingBuffer(cwd, sessionId) {
+  let pendingTmpFile = null;
   try {
     const pendingDir = path.join(os.homedir(), '.agentic', 'session-log', '.pending');
     fs.mkdirSync(pendingDir, { recursive: true });
@@ -720,11 +723,14 @@ function writePendingBuffer(cwd, sessionId) {
 
     // Atomic write: tmp + rename
     const outFile = path.join(pendingDir, `${sessionUuid}.json`);
-    const tmpFile = outFile + '.tmp';
-    fs.writeFileSync(tmpFile, JSON.stringify(record, null, 2), 'utf8');
-    fs.renameSync(tmpFile, outFile);
+    pendingTmpFile = outFile + '.tmp';
+    fs.writeFileSync(pendingTmpFile, JSON.stringify(record, null, 2), 'utf8');
+    fs.renameSync(pendingTmpFile, outFile);
   } catch (_) {
     // Silent failure - consistent with all other write paths
+    if (pendingTmpFile) {
+      try { fs.unlinkSync(pendingTmpFile); } catch (_e) { /* tmp absent or never created */ }
+    }
   }
 }
 
@@ -863,7 +869,10 @@ function appendCaptureGapNoticeToContextMd(cwd, residualOnly) {
       const tmpCursor = cursorPath + '.tmp';
       fs.writeFileSync(tmpCursor, nowIso, 'utf8');
       fs.renameSync(tmpCursor, cursorPath);
-    } catch (_) { /* silent - cursor update failure is non-fatal */ }
+    } catch (_) {
+      /* silent - cursor update failure is non-fatal */
+      try { fs.unlinkSync(cursorPath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
+    }
   } catch (_) {
     // Silent failure - consistent with all other context.md append paths.
   }

--- a/hooks/tests/test-stop-context-session-log.js
+++ b/hooks/tests/test-stop-context-session-log.js
@@ -243,6 +243,57 @@ console.log('\n[4] Write failure: session-log dir is an existing file (unwriteab
 }
 
 // ---------------------------------------------------------------------------
+// Sub-test 5: No orphan .tmp files after a normal hook run (#262 regression)
+// ---------------------------------------------------------------------------
+console.log('\n[5] No orphan .tmp files: loop-state atomic write leaves no .tmp on success or failure');
+{
+  // Two scenarios in one sub-test:
+  // (a) normal success path: active loop-state -> atomic write -> rename -> no .tmp
+  // (b) failure path: loop-state.json is corrupt JSON -> catch fires early, no
+  //     .tmp ever written -> catch cleanup is a no-op (unlink of absent file must
+  //     not throw).
+  //
+  // Both scenarios assert that no .tmp files remain after the hook exits, which
+  // is the invariant #262 introduces. If the catch cleanup is removed, a .tmp
+  // planted before scenario (b) would survive and the test would catch it.
+
+  // --- (a) success path ---
+  const { tmpDir, fakeHome, projectDir, agenticDir, identityDir } = makeTmp('ae-stop-t5a-');
+  fs.writeFileSync(path.join(identityDir, 'identity.yml'), STUB_IDENTITY, { mode: 0o600 });
+  // Active loop-state triggers the atomic write path.
+  fs.writeFileSync(
+    path.join(agenticDir, 'loop-state.json'),
+    JSON.stringify({ status: 'active', session_id: 'test-session-uuid' }),
+  );
+  try { runHook(projectDir, fakeHome, 'test-session-uuid'); } catch (_) {}
+  const tmpFilesA = fs.readdirSync(agenticDir).filter((f) => f.endsWith('.tmp'));
+  assert(tmpFilesA.length === 0,
+    `(a) no .tmp in .agentic/ after successful atomic write (found: ${tmpFilesA.join(', ') || 'none'})`);
+  cleanup(tmpDir);
+
+  // --- (b) failure path: pre-plant a .tmp, feed corrupt loop-state -> catch
+  //         fires, catch cleanup must remove the pre-planted .tmp ---
+  // This simulates a stale .tmp left by a previous crashed session being cleaned
+  // up when the next session's catch block runs. We pre-plant the .tmp at exactly
+  // the path the hook would use, feed corrupt JSON (parse fails -> outer catch),
+  // then assert the .tmp is gone.
+  const { tmpDir: tmpDir2, fakeHome: fakeHome2, projectDir: proj2,
+    agenticDir: ag2, identityDir: id2 } = makeTmp('ae-stop-t5b-');
+  fs.writeFileSync(path.join(id2, 'identity.yml'), STUB_IDENTITY, { mode: 0o600 });
+  // Corrupt loop-state.json -> JSON.parse throws -> catch block fires.
+  const loopStatePath2 = path.join(ag2, 'loop-state.json');
+  fs.writeFileSync(loopStatePath2, '{ bad json !!');
+  // Pre-plant a stale .tmp at the exact path writeLoopState would use.
+  const staleTmp = loopStatePath2 + '.tmp';
+  fs.writeFileSync(staleTmp, 'stale content from a previous crashed session');
+  try { runHook(proj2, fakeHome2, 'test-session-uuid'); } catch (_) {}
+  const tmpFilesB = fs.readdirSync(ag2).filter((f) => f.endsWith('.tmp'));
+  assert(tmpFilesB.length === 0,
+    `(b) stale .tmp cleaned up by catch block (found: ${tmpFilesB.join(', ') || 'none'})`);
+  cleanup(tmpDir2);
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed} passed, ${failed} failed.`);


### PR DESCRIPTION
> **Audit batch #258 — hooks-stack 1/3.** Merge order: **#334 → #335 → #336** (all touch `hooks/stop-context.js`). This is the base of the stack — merge first. #335 and #336 rebase onto `main` if this squash-merges (SHA changes).

Atomic-write sites in `stop-context.js` wrote to a `.tmp` then renamed; on failure the `.tmp` was orphaned in `.agentic/`. Closes #262.

- Added a best-effort `try { fs.unlinkSync(tmpPath); } catch (_) {}` to the catch of all 4 atomic-write sites: `writeLoopState`, `writeBatchState`, `writePendingBuffer`, capture-gap cursor.
- Hoisted the path vars out of their try blocks where needed (a `const` declared inside `try` is not in scope in `catch`); `writePendingBuffer` guards its `let pendingTmpFile` against the write-failed-before-assignment case.
- No logging (that is #266), no change to write/rename logic, silent-fail discipline preserved.

Regression test (sub-test 5): pre-plants a stale `.tmp`, forces the catch with corrupt JSON, asserts the `.tmp` is removed. Mutation-checked — removing the unlink fails the test. `test-stop-context-session-log.js` 19/19, `test-stop-context-deferred-wrap.js` 51/51.
