### PR TITLE
perf(hooks): read events.jsonl once per session-end in stop-context run() (#267) [hooks-stack 2/3]

### DIFF
--- a/hooks/lib/capture-gap.js
+++ b/hooks/lib/capture-gap.js
@@ -13,8 +13,10 @@
  *          PostToolUse(Task) nudge share one implementation.
  *
  * Public API (CommonJS, all exported on module.exports):
- *   detectCaptureGap(cwd, sessionId)
+ *   detectCaptureGap(cwd, sessionId[, cachedEventsRaw])
  *     -> { shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }
+ *     cachedEventsRaw: pre-read events.jsonl string (null=absent/unreadable,
+ *     undefined=back-compat file read). See param JSDoc on detectCaptureGap.
  *   GUARDRAIL_PATTERNS - RegExp[] of guardrail-file basename patterns.
  *   _tokenize(str) -> string[] - domain-proximity tokenizer.
  *
@@ -114,9 +116,15 @@ function _tokenize(str) {
  *
  * @param {string} cwd - Project root (absolute, already validated by caller).
  * @param {string|null} sessionId - Stop / PostToolUse payload session_id (harness uuid).
+ * @param {string|null} [cachedEventsRaw] - Pre-read events.jsonl contents from
+ *   run()'s single read. When provided (non-undefined), the file is NOT re-read;
+ *   null means the file was absent or unreadable at read time (treated same as
+ *   missing file: function returns no-nudge immediately). When omitted (undefined),
+ *   falls back to reading eventsPath directly for back-compat with callers that
+ *   do not thread the cache (e.g. the PostToolUse hook).
  * @returns {{ shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }}
  */
-function detectCaptureGap(cwd, sessionId) {
+function detectCaptureGap(cwd, sessionId, cachedEventsRaw) {
   try {
     if (!sessionId) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
 
@@ -133,11 +141,18 @@ function detectCaptureGap(cwd, sessionId) {
     } catch (_) { /* silent */ }
 
     let rawEvents = '';
-    try {
-      if (fs.existsSync(eventsPath)) {
-        rawEvents = fs.readFileSync(eventsPath, 'utf8');
-      }
-    } catch (_) { return { shouldNudge: false, residualOnly: false, lastEventTs: null }; }
+    if (cachedEventsRaw !== undefined) {
+      // Caller threaded the cached read: null means absent/unreadable.
+      if (cachedEventsRaw === null) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
+      rawEvents = cachedEventsRaw;
+    } else {
+      // Back-compat: no cache provided, read the file directly.
+      try {
+        if (fs.existsSync(eventsPath)) {
+          rawEvents = fs.readFileSync(eventsPath, 'utf8');
+        }
+      } catch (_) { return { shouldNudge: false, residualOnly: false, lastEventTs: null }; }
+    }
 
     const eventLines = rawEvents.split('\n');
     // On cold start (no cursor), cap to the last 100 lines.

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -18,11 +18,11 @@
  * Public API: run() — invoked immediately at module load via run() call at
  *             bottom of file. Not imported; executed as a CLI script by the
  *             Claude Code Stop hook. Internal helpers: writeLoopState(cwd),
- *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId),
- *             writeSessionTotal(cwd, sessionId), computeSessionTotals(cwd, sessionId),
- *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId),
+ *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId[, cachedRaw]),
+ *             writeSessionTotal(cwd, sessionId[, cachedRaw]), computeSessionTotals(cwd, sessionId[, cachedRaw]),
+ *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId[, cachedRaw]),
  *             writeSessionLogGlobal(identity, sessionId, data),
- *             writePendingBuffer(cwd, sessionId),
+ *             writePendingBuffer(cwd, sessionId[, cachedRaw]),
  *             appendIdentityNudgeToContextMd(repoRoot),
  *             appendCaptureGapNoticeToContextMd(cwd, residualOnly),
  *             wrapLockHeld(cwd) (thin alias to wrap-marker lib),
@@ -178,7 +178,12 @@
  * Performance: ~5-20 ms typical; one git status subprocess call (5 s timeout)
  *              plus one git diff subprocess call for the capture-gap backstop
  *              (5 s timeout, soft-fail). Synchronous I/O throughout; runs as a
- *              short-lived CLI process.
+ *              short-lived CLI process. events.jsonl is read ONCE at the top of
+ *              run() and the raw string is threaded to all consumers
+ *              (scanSessionAggregate, computeSessionTotals, writeSessionTotal,
+ *              writeSessionLog, writePendingBuffer, detectCaptureGap) so no
+ *              consumer re-reads the file. On large projects (5-10 MB events
+ *              files) this eliminates 3-4 redundant full-file reads per exit.
  */
 
 /**
@@ -487,12 +492,25 @@ function writeBatchState(cwd, sessionId) {
  *
  * @param {string} eventsPath - Absolute path to events.jsonl.
  * @param {string|null} sessionId - Current session uuid (null = include all).
+ * @param {string|null} [cachedRaw] - Pre-read file contents from run()'s single
+ *   read. When provided (non-undefined), the file is NOT re-read; null means the
+ *   file was absent or unreadable at read time and this function returns null
+ *   immediately. When omitted (undefined), falls back to reading eventsPath
+ *   directly for back-compat with callers that do not thread the cache.
  * @returns {{wall_seconds: number, tokens: object, spawn_count: number,
  *            by_agent: object}|null}
  */
-function scanSessionAggregate(eventsPath, sessionId) {
-  if (!fs.existsSync(eventsPath)) return null;
-  const raw = fs.readFileSync(eventsPath, 'utf8');
+function scanSessionAggregate(eventsPath, sessionId, cachedRaw) {
+  let raw;
+  if (cachedRaw !== undefined) {
+    // Caller threaded the cached read: null means absent/unreadable.
+    if (cachedRaw === null) return null;
+    raw = cachedRaw;
+  } else {
+    // Back-compat: no cache provided, read the file directly.
+    if (!fs.existsSync(eventsPath)) return null;
+    try { raw = fs.readFileSync(eventsPath, 'utf8'); } catch (_) { return null; }
+  }
   if (!raw.trim()) return null;
 
   const lines = raw.split('\n');
@@ -580,8 +598,11 @@ function scanSessionAggregate(eventsPath, sessionId) {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid from the Stop payload.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writeSessionTotal(cwd, sessionId) {
+function writeSessionTotal(cwd, sessionId, cachedRaw) {
   try {
     const agenticDir = path.join(cwd, '.agentic');
     const eventsPath = path.join(agenticDir, 'events.jsonl');
@@ -590,7 +611,7 @@ function writeSessionTotal(cwd, sessionId) {
     fs.mkdirSync(agenticDir, { recursive: true });
     // Bootstrap: when no qualifying events exist, write a zero-aggregate
     // session_total so events.jsonl is ALWAYS created on every session exit.
-    const agg = scanSessionAggregate(eventsPath, sessionId) || {
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw) || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
       spawn_count: 0,
@@ -731,12 +752,15 @@ function appendIdentityNudgeToContextMd(repoRoot) {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  * @returns {{wall_seconds: number, tokens: object, spawn_count: number, by_agent: object}|null}
  */
-function computeSessionTotals(cwd, sessionId) {
+function computeSessionTotals(cwd, sessionId, cachedRaw) {
   try {
     const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
-    const agg = scanSessionAggregate(eventsPath, sessionId);
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw);
     if (!agg) return null;
 
     // Re-shape by_agent: flatten 4-band tokens to a single tokens_total for the
@@ -770,8 +794,11 @@ function computeSessionTotals(cwd, sessionId) {
  * @param {string} cwd - Verified project directory.
  * @param {{developer_id: string}} identity - Identity from getIdentity().
  * @param {string|null} sessionId - Current session uuid.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writeSessionLog(cwd, identity, sessionId) {
+function writeSessionLog(cwd, identity, sessionId, cachedRaw) {
   try {
     // Resolve project slug and branch best-effort
     const projectSlug = path.basename(cwd);
@@ -785,7 +812,7 @@ function writeSessionLog(cwd, identity, sessionId) {
       // Not a git repo or detached HEAD - leave branch as empty string
     }
 
-    const totals = computeSessionTotals(cwd, sessionId);
+    const totals = computeSessionTotals(cwd, sessionId, cachedRaw);
     const data = totals || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
@@ -889,8 +916,11 @@ function generateUuid() {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid (uuid v4 generated if null).
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writePendingBuffer(cwd, sessionId) {
+function writePendingBuffer(cwd, sessionId, cachedRaw) {
   let pendingTmpFile = null;
   try {
     const pendingDir = path.join(os.homedir(), '.agentic', 'session-log', '.pending');
@@ -924,7 +954,7 @@ function writePendingBuffer(cwd, sessionId) {
     }
 
     // Compute telemetry
-    const totals = computeSessionTotals(cwd, sessionId);
+    const totals = computeSessionTotals(cwd, sessionId, cachedRaw);
     const data = totals || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
@@ -1153,6 +1183,20 @@ function run() {
     ? payload.session_id.trim()
     : null;
 
+  // --- 3b-pre. Single events.jsonl read for the entire run() ---
+  // All consumers (writeSessionTotal, computeSessionTotals, writeSessionLog,
+  // writePendingBuffer, detectCaptureGap) receive this string instead of
+  // re-reading the file. null = file absent or unreadable (consumers treat it
+  // identically to a missing file). This eliminates 3-4 redundant full reads
+  // per session exit on large events files (#267).
+  const eventsPath = cwd ? path.join(cwd, '.agentic', 'events.jsonl') : null;
+  let cachedEventsRaw = null;
+  if (eventsPath) {
+    try {
+      if (fs.existsSync(eventsPath)) cachedEventsRaw = fs.readFileSync(eventsPath, 'utf8');
+    } catch (_) { /* silent - stays null, consumers treat null as absent */ }
+  }
+
   // --- 3b. Touch this session's heartbeat (per-turn liveness signal) ---
   // Pure wastefulness defense: the daemon defers claiming a `ready` marker whose
   // session still emits turns. Local fs only (no git/network); no-op under the
@@ -1378,15 +1422,15 @@ ${toolsLine}
       // so per-ticket inner state is marked first, then outer batch envelope).
       writeBatchState(cwd, sessionId);
       // Write session_total to events.jsonl on this exit path too.
-      writeSessionTotal(cwd, sessionId);
+      writeSessionTotal(cwd, sessionId, cachedEventsRaw);
       // Three-branch identity gate (independent of all other paths).
       try {
         const identity = getIdentity(cwd);
         if (identity && !identity.provisional) {
           // Confirmed identity: per-project write + global mirror
-          writeSessionLog(cwd, identity, sessionId);
+          writeSessionLog(cwd, identity, sessionId, cachedEventsRaw);
           // Build shared metadata for global mirror
-          const totals = computeSessionTotals(cwd, sessionId);
+          const totals = computeSessionTotals(cwd, sessionId, cachedEventsRaw);
           const globalData = Object.assign(
             {
               wall_seconds: 0,
@@ -1405,7 +1449,7 @@ ${toolsLine}
           writeSessionLogGlobal(identity, sessionId, globalData);
         } else {
           // Provisional or no identity: pending buffer
-          writePendingBuffer(cwd, sessionId);
+          writePendingBuffer(cwd, sessionId, cachedEventsRaw);
           // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
           // The identity nudge is a context.md writer; defer it while a /wrap
           // holds the lock so the locked Part-A merge is not clobbered. The
@@ -1432,7 +1476,7 @@ ${toolsLine}
       }
       // Capture-gap backstop on wrap-coexistence exit path.
       try {
-        const gap = detectCaptureGap(cwd, sessionId);
+        const gap = detectCaptureGap(cwd, sessionId, cachedEventsRaw);
         if (gap.shouldNudge) {
           appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
         }
@@ -1477,7 +1521,7 @@ ${toolsLine}
 
   // --- 12. Append session_total event to .agentic/events.jsonl if present ---
   // Independent best-effort write; any failure swallowed.
-  writeSessionTotal(cwd, sessionId);
+  writeSessionTotal(cwd, sessionId, cachedEventsRaw);
 
   // --- 13. Three-branch identity gate: session log, global mirror, or pending buffer ---
   // Independent best-effort write; any failure swallowed. Never blocks exit.
@@ -1485,9 +1529,9 @@ ${toolsLine}
     const identity = getIdentity(cwd);
     if (identity && !identity.provisional) {
       // Confirmed identity: per-project write + global mirror
-      writeSessionLog(cwd, identity, sessionId);
+      writeSessionLog(cwd, identity, sessionId, cachedEventsRaw);
       // Build shared metadata for global mirror
-      const totals = computeSessionTotals(cwd, sessionId);
+      const totals = computeSessionTotals(cwd, sessionId, cachedEventsRaw);
       const globalData = Object.assign(
         {
           wall_seconds: 0,
@@ -1506,7 +1550,7 @@ ${toolsLine}
       writeSessionLogGlobal(identity, sessionId, globalData);
     } else {
       // Provisional or no identity: pending buffer
-      writePendingBuffer(cwd, sessionId);
+      writePendingBuffer(cwd, sessionId, cachedEventsRaw);
       // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
       // Defer the identity nudge (a context.md writer) while a /wrap holds the
       // lock; the sentinel is consumed atomically with the nudge, so skipping
@@ -1537,7 +1581,7 @@ ${toolsLine}
   // Detects learning-worthy sessions with no captured learnings and appends a
   // nudge to context.md. Silent failure; never blocks exit.
   try {
-    const gap = detectCaptureGap(cwd, sessionId);
+    const gap = detectCaptureGap(cwd, sessionId, cachedEventsRaw);
     if (gap.shouldNudge) {
       appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
     }


### PR DESCRIPTION
> **Audit batch #258 — hooks-stack 2/3.** Merge order: #334 → **#335** → #336. Stacked on #334 — its diff shows #334 files until it merges. Merge **after #334**; rebase onto `main` if #334 squash-merges.

`stop-context.js` re-read `.agentic/events.jsonl` 3-4 times per session exit. Closes #267.

- One `cachedEventsRaw` read at the top of `run()`, threaded through `scanSessionAggregate`, `writeSessionTotal`, `computeSessionTotals`, `writeSessionLog`, `writePendingBuffer`, and `detectCaptureGap` (in `hooks/lib/capture-gap.js`). Exit paths now read the file once.
- Each consumer keeps a back-compat path: param omitted → it reads the file itself (identical to today). `null` → same as absent-file. The PostToolUse caller of `detectCaptureGap` (2-arg) is unchanged via this path.
- No aggregation logic changed; no logging added (that is #266). The later `session_total` append is never re-consumed — `scanSessionAggregate` filters it out by event type, so the cache being taken before the append is safe.
- JSDoc + module manifests updated for the new param.

Tests: session-log 19/19 (incl #262 tmp cleanup), deferred-wrap 51/51, capture-gap 29/29.

**Stacked on #262** — merge after #262 lands on `main` (rebase if its SHA changes on squash-merge).
