### PR TITLE
feat(hooks): add .telemetry-health.json failure counter + agentic-status surface (#266) [hooks-stack 3/3]

### DIFF
--- a/bin/agentic-status
+++ b/bin/agentic-status
@@ -436,13 +436,13 @@ def _telemetry_health_line(health_path: Path | None = None) -> str:
             data = json.load(fh)
         if not isinstance(data, dict):
             return "telemetry-health: OK (unreadable)"
-        writes = data.get("writes", {})
-        if not isinstance(writes, dict):
+        targets = data.get("targets", {})
+        if not isinstance(targets, dict):
             return "telemetry-health: OK (unreadable)"
 
         total_failures = 0
         failing_targets: list[tuple[str, int, str, str]] = []  # (target, count, msg, ts)
-        for target, info in writes.items():
+        for target, info in targets.items():
             if not isinstance(info, dict):
                 continue
             count = int(info.get("failures", 0) or 0)

--- a/bin/agentic-status
+++ b/bin/agentic-status
@@ -10,16 +10,21 @@ Purpose: Read-only inspection of the agentic-engineering activation
 
 Public API: agentic-status
             Prints a fixed-format multi-line report (status lines with
-            provenance, a profile-behavior explainer, and a how-to-adjust
-            block). No subcommands, no flags. Always exits 0.
+            provenance, a profile-behavior explainer, a telemetry-health
+            summary line, and a how-to-adjust block). No subcommands, no
+            flags. Always exits 0.
             _profile_behavior_block(profile) and _how_to_adjust_block(resolved)
             are the single rendering surface for the explainer text and are
             reused by callers (e.g. init-project shells out to this binary).
+            _telemetry_health_line(health_path) reads .agentic/.telemetry-health.json
+            and returns a one-line OK/failure summary; fail-open (returns OK
+            on any read or parse error).
 
 Upstream deps: Python 3 stdlib only (json, os, sys, pathlib, re).
                Reads ~/.claude/agentic-engineering.json, the project
                root AGENTS.md (resolved through CLAUDE.md @AGENTS.md
-               import if present), and .agentic/.activated.
+               import if present), .agentic/.activated, and
+               .agentic/.telemetry-health.json (fail-open; absent = OK).
 
 Downstream consumers: content/commands/agentic-status.md (command
                       spec); developers running the command
@@ -46,6 +51,7 @@ from pathlib import Path
 
 CONFIG_PATH = Path(os.path.expanduser("~/.claude/agentic-engineering.json"))
 SENTINEL_PATH = Path(".agentic/.activated")
+TELEMETRY_HEALTH_PATH = Path(".agentic/.telemetry-health.json")
 ROLE_MODELS_GLOBAL_PATH = Path(os.path.expanduser("~/.agentic/role-models.yml"))
 ROLE_MODELS_PROJECT_PATH = Path(".agentic/role-models.yml")
 HEALTH_FILE_PATH = Path(".agentic/.telemetry-health.json")
@@ -406,6 +412,62 @@ def _telemetry_health_block() -> list[str]:
     return lines
 
 
+# ANSI escape sequence stripper for exception text rendered by _telemetry_health_line.
+_ANSI = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+
+def _telemetry_health_line(health_path: Path | None = None) -> str:
+    """Return a one-line telemetry-health summary for the current project.
+
+    Reads .agentic/.telemetry-health.json (or the provided path override).
+    Returns 'telemetry-health: OK' when the file is absent or all failure
+    counters are zero. When failures exist, returns a summary of the form:
+      'telemetry-health: N write failures across M targets; last error <target>: <msg> at <ts>'
+    Fail-open: any read or parse error returns 'telemetry-health: OK (unreadable)'.
+
+    Args:
+        health_path: Path to .telemetry-health.json; defaults to TELEMETRY_HEALTH_PATH.
+    """
+    p = health_path if health_path is not None else TELEMETRY_HEALTH_PATH
+    if not p.is_file():
+        return "telemetry-health: OK"
+    try:
+        with p.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return "telemetry-health: OK (unreadable)"
+        writes = data.get("writes", {})
+        if not isinstance(writes, dict):
+            return "telemetry-health: OK (unreadable)"
+
+        total_failures = 0
+        failing_targets: list[tuple[str, int, str, str]] = []  # (target, count, msg, ts)
+        for target, info in writes.items():
+            if not isinstance(info, dict):
+                continue
+            count = int(info.get("failures", 0) or 0)
+            if count > 0:
+                total_failures += count
+                last_msg = str(info.get("last_error", ""))
+                safe_msg = _ANSI.sub("", last_msg)[:200]
+                ts = str(info.get("last_error_ts", ""))
+                failing_targets.append((target, count, safe_msg, ts))
+
+        if total_failures == 0:
+            return "telemetry-health: OK"
+
+        # Report most-recently-failed target for the one-line summary.
+        failing_targets.sort(key=lambda x: x[3], reverse=True)
+        last_target, _, last_msg, last_ts = failing_targets[0]
+        n_targets = len(failing_targets)
+        return (
+            f"telemetry-health: {total_failures} write failure(s) across "
+            f"{n_targets} target(s); last error {last_target}: {last_msg} at {last_ts}"
+        )
+    except Exception:
+        return "telemetry-health: OK (unreadable)"
+
+
 def _how_to_adjust_block(resolved: dict) -> list[str]:
     """Return the 'How to adjust' explainer lines.
 
@@ -456,6 +518,7 @@ def main(_argv: list[str]) -> int:
     out.append(f"  marker: {res['marker']}")
     out.append(f"  active: {active_display} ({res['active_reason']})")
     out.append(f"  sentinel: {SENTINEL_PATH} ({sentinel_status})")
+    out.append(f"  {_telemetry_health_line()}")
     out.extend(_role_models_status_block())
     out.extend(_telemetry_health_block())
     out.append("")

--- a/bin/tests/test_agentic_status.py
+++ b/bin/tests/test_agentic_status.py
@@ -38,6 +38,7 @@ _profile_behavior_block = _mod._profile_behavior_block
 _role_models_status_block = _mod._role_models_status_block
 _telemetry_health_block = _mod._telemetry_health_block
 _how_to_adjust_block = _mod._how_to_adjust_block
+_telemetry_health_line = _mod._telemetry_health_line
 main = _mod.main
 
 _EXPECTED_VARS = ("PI_HARNESS", "OMP_HARNESS", "OH_MY_PI_HARNESS", "AGENTIC_HARNESS")
@@ -684,6 +685,126 @@ def test_main_reflects_config(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "opt-in" in out
     assert "relaxed" in out
+
+
+# ---------------------------------------------------------------------------
+# _telemetry_health_line
+# ---------------------------------------------------------------------------
+
+def test_telemetry_health_line_absent_file(tmp_path):
+    result = _telemetry_health_line(tmp_path / "no-such-file.json")
+    assert result == "telemetry-health: OK"
+
+
+def test_telemetry_health_line_all_zeros(tmp_path):
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text(json.dumps({
+        "writes": {
+            "loop-state.json": {"failures": 0, "last_success": "2026-01-01T00:00:00Z"},
+            "events.jsonl": {"failures": 0},
+        },
+        "updated_at": "2026-01-01T00:00:00Z",
+    }), encoding="utf-8")
+    result = _telemetry_health_line(p)
+    assert result == "telemetry-health: OK"
+
+
+def test_telemetry_health_line_with_failures(tmp_path):
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text(json.dumps({
+        "writes": {
+            "loop-state.json": {
+                "failures": 3,
+                "last_error": "ENOSPC",
+                "last_error_ts": "2026-06-01T12:00:00Z",
+            },
+            "events.jsonl": {"failures": 0},
+        },
+        "updated_at": "2026-06-01T12:00:00Z",
+    }), encoding="utf-8")
+    result = _telemetry_health_line(p)
+    assert "3 write failure(s)" in result
+    assert "1 target(s)" in result
+    assert "loop-state.json" in result
+    assert "ENOSPC" in result
+    assert "telemetry-health:" in result
+
+
+def test_telemetry_health_line_multiple_failing_targets(tmp_path):
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text(json.dumps({
+        "writes": {
+            "loop-state.json": {
+                "failures": 2,
+                "last_error": "ENOSPC",
+                "last_error_ts": "2026-06-01T10:00:00Z",
+            },
+            "batch-state.json": {
+                "failures": 1,
+                "last_error": "EPERM",
+                "last_error_ts": "2026-06-01T11:00:00Z",
+            },
+        },
+        "updated_at": "2026-06-01T11:00:00Z",
+    }), encoding="utf-8")
+    result = _telemetry_health_line(p)
+    assert "3 write failure(s)" in result
+    assert "2 target(s)" in result
+    # Most-recently-failed target appears
+    assert "batch-state.json" in result
+    assert "EPERM" in result
+
+
+def test_telemetry_health_line_malformed_json(tmp_path):
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    result = _telemetry_health_line(p)
+    assert "OK" in result
+
+
+def test_telemetry_health_line_default_path_absent(monkeypatch, tmp_path):
+    # When TELEMETRY_HEALTH_PATH points at a non-existent file, default path -> OK.
+    monkeypatch.setattr(_mod, "TELEMETRY_HEALTH_PATH", tmp_path / "no-health.json")
+    result = _telemetry_health_line()
+    assert result == "telemetry-health: OK"
+
+
+def test_main_output_contains_telemetry_health_line(monkeypatch, tmp_path, capsys):
+    _clear_harness_env(monkeypatch)
+    monkeypatch.setattr(_mod, "CONFIG_PATH", tmp_path / "no-config.json")
+    monkeypatch.setattr(_mod, "SENTINEL_PATH", tmp_path / ".activated")
+    monkeypatch.setattr(_mod, "TELEMETRY_HEALTH_PATH", tmp_path / "no-health.json")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_GLOBAL_PATH", tmp_path / "no-global.yml")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_PROJECT_PATH", tmp_path / "no-project.yml")
+    monkeypatch.chdir(tmp_path)
+    main([])
+    out = capsys.readouterr().out
+    assert "telemetry-health:" in out
+
+
+def test_main_output_shows_failures(monkeypatch, tmp_path, capsys):
+    _clear_harness_env(monkeypatch)
+    health = tmp_path / ".telemetry-health.json"
+    health.write_text(json.dumps({
+        "writes": {
+            "events.jsonl": {
+                "failures": 5,
+                "last_error": "ENOSPC: disk full",
+                "last_error_ts": "2026-06-01T09:00:00Z",
+            },
+        },
+        "updated_at": "2026-06-01T09:00:00Z",
+    }), encoding="utf-8")
+    monkeypatch.setattr(_mod, "CONFIG_PATH", tmp_path / "no-config.json")
+    monkeypatch.setattr(_mod, "SENTINEL_PATH", tmp_path / ".activated")
+    monkeypatch.setattr(_mod, "TELEMETRY_HEALTH_PATH", health)
+    monkeypatch.setattr(_mod, "ROLE_MODELS_GLOBAL_PATH", tmp_path / "no-global.yml")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_PROJECT_PATH", tmp_path / "no-project.yml")
+    monkeypatch.chdir(tmp_path)
+    main([])
+    out = capsys.readouterr().out
+    assert "5 write failure(s)" in out
+    assert "events.jsonl" in out
 
 
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_agentic_status.py
+++ b/bin/tests/test_agentic_status.py
@@ -699,7 +699,7 @@ def test_telemetry_health_line_absent_file(tmp_path):
 def test_telemetry_health_line_all_zeros(tmp_path):
     p = tmp_path / ".telemetry-health.json"
     p.write_text(json.dumps({
-        "writes": {
+        "targets": {
             "loop-state.json": {"failures": 0, "last_success": "2026-01-01T00:00:00Z"},
             "events.jsonl": {"failures": 0},
         },
@@ -712,7 +712,7 @@ def test_telemetry_health_line_all_zeros(tmp_path):
 def test_telemetry_health_line_with_failures(tmp_path):
     p = tmp_path / ".telemetry-health.json"
     p.write_text(json.dumps({
-        "writes": {
+        "targets": {
             "loop-state.json": {
                 "failures": 3,
                 "last_error": "ENOSPC",
@@ -733,7 +733,7 @@ def test_telemetry_health_line_with_failures(tmp_path):
 def test_telemetry_health_line_multiple_failing_targets(tmp_path):
     p = tmp_path / ".telemetry-health.json"
     p.write_text(json.dumps({
-        "writes": {
+        "targets": {
             "loop-state.json": {
                 "failures": 2,
                 "last_error": "ENOSPC",
@@ -786,7 +786,7 @@ def test_main_output_shows_failures(monkeypatch, tmp_path, capsys):
     _clear_harness_env(monkeypatch)
     health = tmp_path / ".telemetry-health.json"
     health.write_text(json.dumps({
-        "writes": {
+        "targets": {
             "events.jsonl": {
                 "failures": 5,
                 "last_error": "ENOSPC: disk full",

--- a/hooks/lib/capture-gap.js
+++ b/hooks/lib/capture-gap.js
@@ -13,8 +13,10 @@
  *          PostToolUse(Task) nudge share one implementation.
  *
  * Public API (CommonJS, all exported on module.exports):
- *   detectCaptureGap(cwd, sessionId)
+ *   detectCaptureGap(cwd, sessionId[, cachedEventsRaw])
  *     -> { shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }
+ *     cachedEventsRaw: pre-read events.jsonl string (null=absent/unreadable,
+ *     undefined=back-compat file read). See param JSDoc on detectCaptureGap.
  *   GUARDRAIL_PATTERNS - RegExp[] of guardrail-file basename patterns.
  *   _tokenize(str) -> string[] - domain-proximity tokenizer.
  *
@@ -114,9 +116,15 @@ function _tokenize(str) {
  *
  * @param {string} cwd - Project root (absolute, already validated by caller).
  * @param {string|null} sessionId - Stop / PostToolUse payload session_id (harness uuid).
+ * @param {string|null} [cachedEventsRaw] - Pre-read events.jsonl contents from
+ *   run()'s single read. When provided (non-undefined), the file is NOT re-read;
+ *   null means the file was absent or unreadable at read time (treated same as
+ *   missing file: function returns no-nudge immediately). When omitted (undefined),
+ *   falls back to reading eventsPath directly for back-compat with callers that
+ *   do not thread the cache (e.g. the PostToolUse hook).
  * @returns {{ shouldNudge: boolean, residualOnly: boolean, lastEventTs: string|null }}
  */
-function detectCaptureGap(cwd, sessionId) {
+function detectCaptureGap(cwd, sessionId, cachedEventsRaw) {
   try {
     if (!sessionId) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
 
@@ -133,11 +141,18 @@ function detectCaptureGap(cwd, sessionId) {
     } catch (_) { /* silent */ }
 
     let rawEvents = '';
-    try {
-      if (fs.existsSync(eventsPath)) {
-        rawEvents = fs.readFileSync(eventsPath, 'utf8');
-      }
-    } catch (_) { return { shouldNudge: false, residualOnly: false, lastEventTs: null }; }
+    if (cachedEventsRaw !== undefined) {
+      // Caller threaded the cached read: null means absent/unreadable.
+      if (cachedEventsRaw === null) return { shouldNudge: false, residualOnly: false, lastEventTs: null };
+      rawEvents = cachedEventsRaw;
+    } else {
+      // Back-compat: no cache provided, read the file directly.
+      try {
+        if (fs.existsSync(eventsPath)) {
+          rawEvents = fs.readFileSync(eventsPath, 'utf8');
+        }
+      } catch (_) { return { shouldNudge: false, residualOnly: false, lastEventTs: null }; }
+    }
 
     const eventLines = rawEvents.split('\n');
     // On cold start (no cursor), cap to the last 100 lines.

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -606,9 +606,19 @@ function scanSessionAggregate(eventsPath, sessionId, cachedRaw) {
  */
 function writeSessionTotal(cwd, sessionId, cachedRaw) {
   try {
-    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
-    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw);
-    if (!agg) return;
+    const agenticDir = path.join(cwd, '.agentic');
+    const eventsPath = path.join(agenticDir, 'events.jsonl');
+    // Ensure .agentic/ exists so the append below always works, even in
+    // ad-hoc sessions where no other hook has created the directory yet.
+    fs.mkdirSync(agenticDir, { recursive: true });
+    // Bootstrap: when no qualifying events exist, write a zero-aggregate
+    // session_total so events.jsonl is ALWAYS created on every session exit.
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw) || {
+      wall_seconds: 0,
+      tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+      spawn_count: 0,
+      by_agent: {},
+    };
 
     const totalLine = JSON.stringify({
       ts: new Date().toISOString(),

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -18,11 +18,11 @@
  * Public API: run() — invoked immediately at module load via run() call at
  *             bottom of file. Not imported; executed as a CLI script by the
  *             Claude Code Stop hook. Internal helpers: writeLoopState(cwd),
- *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId),
- *             writeSessionTotal(cwd, sessionId), computeSessionTotals(cwd, sessionId),
- *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId),
+ *             writeBatchState(cwd, sessionId), scanSessionAggregate(eventsPath, sessionId[, cachedRaw]),
+ *             writeSessionTotal(cwd, sessionId[, cachedRaw]), computeSessionTotals(cwd, sessionId[, cachedRaw]),
+ *             getIdentity(cwd), writeSessionLog(cwd, identity, sessionId[, cachedRaw]),
  *             writeSessionLogGlobal(identity, sessionId, data),
- *             writePendingBuffer(cwd, sessionId),
+ *             writePendingBuffer(cwd, sessionId[, cachedRaw]),
  *             appendIdentityNudgeToContextMd(repoRoot),
  *             appendCaptureGapNoticeToContextMd(cwd, residualOnly),
  *             wrapLockHeld(cwd) (thin alias to wrap-marker lib),
@@ -178,7 +178,12 @@
  * Performance: ~5-20 ms typical; one git status subprocess call (5 s timeout)
  *              plus one git diff subprocess call for the capture-gap backstop
  *              (5 s timeout, soft-fail). Synchronous I/O throughout; runs as a
- *              short-lived CLI process.
+ *              short-lived CLI process. events.jsonl is read ONCE at the top of
+ *              run() and the raw string is threaded to all consumers
+ *              (scanSessionAggregate, computeSessionTotals, writeSessionTotal,
+ *              writeSessionLog, writePendingBuffer, detectCaptureGap) so no
+ *              consumer re-reads the file. On large projects (5-10 MB events
+ *              files) this eliminates 3-4 redundant full-file reads per exit.
  */
 
 /**
@@ -487,12 +492,25 @@ function writeBatchState(cwd, sessionId) {
  *
  * @param {string} eventsPath - Absolute path to events.jsonl.
  * @param {string|null} sessionId - Current session uuid (null = include all).
+ * @param {string|null} [cachedRaw] - Pre-read file contents from run()'s single
+ *   read. When provided (non-undefined), the file is NOT re-read; null means the
+ *   file was absent or unreadable at read time and this function returns null
+ *   immediately. When omitted (undefined), falls back to reading eventsPath
+ *   directly for back-compat with callers that do not thread the cache.
  * @returns {{wall_seconds: number, tokens: object, spawn_count: number,
  *            by_agent: object}|null}
  */
-function scanSessionAggregate(eventsPath, sessionId) {
-  if (!fs.existsSync(eventsPath)) return null;
-  const raw = fs.readFileSync(eventsPath, 'utf8');
+function scanSessionAggregate(eventsPath, sessionId, cachedRaw) {
+  let raw;
+  if (cachedRaw !== undefined) {
+    // Caller threaded the cached read: null means absent/unreadable.
+    if (cachedRaw === null) return null;
+    raw = cachedRaw;
+  } else {
+    // Back-compat: no cache provided, read the file directly.
+    if (!fs.existsSync(eventsPath)) return null;
+    try { raw = fs.readFileSync(eventsPath, 'utf8'); } catch (_) { return null; }
+  }
   if (!raw.trim()) return null;
 
   const lines = raw.split('\n');
@@ -580,8 +598,11 @@ function scanSessionAggregate(eventsPath, sessionId) {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid from the Stop payload.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writeSessionTotal(cwd, sessionId) {
+function writeSessionTotal(cwd, sessionId, cachedRaw) {
   try {
     const agenticDir = path.join(cwd, '.agentic');
     const eventsPath = path.join(agenticDir, 'events.jsonl');
@@ -590,7 +611,7 @@ function writeSessionTotal(cwd, sessionId) {
     fs.mkdirSync(agenticDir, { recursive: true });
     // Bootstrap: when no qualifying events exist, write a zero-aggregate
     // session_total so events.jsonl is ALWAYS created on every session exit.
-    const agg = scanSessionAggregate(eventsPath, sessionId) || {
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw) || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
       spawn_count: 0,
@@ -731,12 +752,15 @@ function appendIdentityNudgeToContextMd(repoRoot) {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  * @returns {{wall_seconds: number, tokens: object, spawn_count: number, by_agent: object}|null}
  */
-function computeSessionTotals(cwd, sessionId) {
+function computeSessionTotals(cwd, sessionId, cachedRaw) {
   try {
     const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
-    const agg = scanSessionAggregate(eventsPath, sessionId);
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw);
     if (!agg) return null;
 
     // Re-shape by_agent: flatten 4-band tokens to a single tokens_total for the
@@ -770,8 +794,11 @@ function computeSessionTotals(cwd, sessionId) {
  * @param {string} cwd - Verified project directory.
  * @param {{developer_id: string}} identity - Identity from getIdentity().
  * @param {string|null} sessionId - Current session uuid.
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writeSessionLog(cwd, identity, sessionId) {
+function writeSessionLog(cwd, identity, sessionId, cachedRaw) {
   try {
     // Resolve project slug and branch best-effort
     const projectSlug = path.basename(cwd);
@@ -785,7 +812,7 @@ function writeSessionLog(cwd, identity, sessionId) {
       // Not a git repo or detached HEAD - leave branch as empty string
     }
 
-    const totals = computeSessionTotals(cwd, sessionId);
+    const totals = computeSessionTotals(cwd, sessionId, cachedRaw);
     const data = totals || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
@@ -889,8 +916,11 @@ function generateUuid() {
  *
  * @param {string} cwd - Verified project directory.
  * @param {string|null} sessionId - Current session uuid (uuid v4 generated if null).
+ * @param {string|null} [cachedRaw] - Pre-read events.jsonl contents from run()'s
+ *   single read. When provided (non-undefined), no additional file read occurs.
+ *   null means file was absent/unreadable; undefined triggers back-compat read.
  */
-function writePendingBuffer(cwd, sessionId) {
+function writePendingBuffer(cwd, sessionId, cachedRaw) {
   let pendingTmpFile = null;
   try {
     const pendingDir = path.join(os.homedir(), '.agentic', 'session-log', '.pending');
@@ -924,7 +954,7 @@ function writePendingBuffer(cwd, sessionId) {
     }
 
     // Compute telemetry
-    const totals = computeSessionTotals(cwd, sessionId);
+    const totals = computeSessionTotals(cwd, sessionId, cachedRaw);
     const data = totals || {
       wall_seconds: 0,
       tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
@@ -1153,6 +1183,20 @@ function run() {
     ? payload.session_id.trim()
     : null;
 
+  // --- 3b-pre. Single events.jsonl read for the entire run() ---
+  // All consumers (writeSessionTotal, computeSessionTotals, writeSessionLog,
+  // writePendingBuffer, detectCaptureGap) receive this string instead of
+  // re-reading the file. null = file absent or unreadable (consumers treat it
+  // identically to a missing file). This eliminates 3-4 redundant full reads
+  // per session exit on large events files (#267).
+  const eventsPath = cwd ? path.join(cwd, '.agentic', 'events.jsonl') : null;
+  let cachedEventsRaw = null;
+  if (eventsPath) {
+    try {
+      if (fs.existsSync(eventsPath)) cachedEventsRaw = fs.readFileSync(eventsPath, 'utf8');
+    } catch (_) { /* silent - stays null, consumers treat null as absent */ }
+  }
+
   // --- 3b. Touch this session's heartbeat (per-turn liveness signal) ---
   // Pure wastefulness defense: the daemon defers claiming a `ready` marker whose
   // session still emits turns. Local fs only (no git/network); no-op under the
@@ -1378,15 +1422,15 @@ ${toolsLine}
       // so per-ticket inner state is marked first, then outer batch envelope).
       writeBatchState(cwd, sessionId);
       // Write session_total to events.jsonl on this exit path too.
-      writeSessionTotal(cwd, sessionId);
+      writeSessionTotal(cwd, sessionId, cachedEventsRaw);
       // Three-branch identity gate (independent of all other paths).
       try {
         const identity = getIdentity(cwd);
         if (identity && !identity.provisional) {
           // Confirmed identity: per-project write + global mirror
-          writeSessionLog(cwd, identity, sessionId);
+          writeSessionLog(cwd, identity, sessionId, cachedEventsRaw);
           // Build shared metadata for global mirror
-          const totals = computeSessionTotals(cwd, sessionId);
+          const totals = computeSessionTotals(cwd, sessionId, cachedEventsRaw);
           const globalData = Object.assign(
             {
               wall_seconds: 0,
@@ -1405,7 +1449,7 @@ ${toolsLine}
           writeSessionLogGlobal(identity, sessionId, globalData);
         } else {
           // Provisional or no identity: pending buffer
-          writePendingBuffer(cwd, sessionId);
+          writePendingBuffer(cwd, sessionId, cachedEventsRaw);
           // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
           // The identity nudge is a context.md writer; defer it while a /wrap
           // holds the lock so the locked Part-A merge is not clobbered. The
@@ -1432,7 +1476,7 @@ ${toolsLine}
       }
       // Capture-gap backstop on wrap-coexistence exit path.
       try {
-        const gap = detectCaptureGap(cwd, sessionId);
+        const gap = detectCaptureGap(cwd, sessionId, cachedEventsRaw);
         if (gap.shouldNudge) {
           appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
         }
@@ -1477,7 +1521,7 @@ ${toolsLine}
 
   // --- 12. Append session_total event to .agentic/events.jsonl if present ---
   // Independent best-effort write; any failure swallowed.
-  writeSessionTotal(cwd, sessionId);
+  writeSessionTotal(cwd, sessionId, cachedEventsRaw);
 
   // --- 13. Three-branch identity gate: session log, global mirror, or pending buffer ---
   // Independent best-effort write; any failure swallowed. Never blocks exit.
@@ -1485,9 +1529,9 @@ ${toolsLine}
     const identity = getIdentity(cwd);
     if (identity && !identity.provisional) {
       // Confirmed identity: per-project write + global mirror
-      writeSessionLog(cwd, identity, sessionId);
+      writeSessionLog(cwd, identity, sessionId, cachedEventsRaw);
       // Build shared metadata for global mirror
-      const totals = computeSessionTotals(cwd, sessionId);
+      const totals = computeSessionTotals(cwd, sessionId, cachedEventsRaw);
       const globalData = Object.assign(
         {
           wall_seconds: 0,
@@ -1506,7 +1550,7 @@ ${toolsLine}
       writeSessionLogGlobal(identity, sessionId, globalData);
     } else {
       // Provisional or no identity: pending buffer
-      writePendingBuffer(cwd, sessionId);
+      writePendingBuffer(cwd, sessionId, cachedEventsRaw);
       // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
       // Defer the identity nudge (a context.md writer) while a /wrap holds the
       // lock; the sentinel is consumed atomically with the nudge, so skipping
@@ -1537,7 +1581,7 @@ ${toolsLine}
   // Detects learning-worthy sessions with no captured learnings and appends a
   // nudge to context.md. Silent failure; never blocks exit.
   try {
-    const gap = detectCaptureGap(cwd, sessionId);
+    const gap = detectCaptureGap(cwd, sessionId, cachedEventsRaw);
     if (gap.shouldNudge) {
       appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
     }

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -290,6 +290,8 @@ function flushHealth(cwd) {
   let tmp;
   try {
     if (!cwd) return;
+    const resolvedCwd = path.resolve(cwd);
+    if (resolvedCwd !== cwd) return; // traversal component - skip silently
     healthPath = path.join(cwd, '.agentic', '.telemetry-health.json');
     tmp = healthPath + '.tmp.' + process.pid;
 

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -604,19 +604,9 @@ function scanSessionAggregate(eventsPath, sessionId, cachedRaw) {
  */
 function writeSessionTotal(cwd, sessionId, cachedRaw) {
   try {
-    const agenticDir = path.join(cwd, '.agentic');
-    const eventsPath = path.join(agenticDir, 'events.jsonl');
-    // Ensure .agentic/ exists so the append below always works, even in
-    // ad-hoc sessions where no other hook has created the directory yet.
-    fs.mkdirSync(agenticDir, { recursive: true });
-    // Bootstrap: when no qualifying events exist, write a zero-aggregate
-    // session_total so events.jsonl is ALWAYS created on every session exit.
-    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw) || {
-      wall_seconds: 0,
-      tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
-      spawn_count: 0,
-      by_agent: {},
-    };
+    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
+    const agg = scanSessionAggregate(eventsPath, sessionId, cachedRaw);
+    if (!agg) return;
 
     const totalLine = JSON.stringify({
       ts: new Date().toISOString(),


### PR DESCRIPTION
> **Audit batch #258 — hooks-stack 3/3.** Merge order: #334 → #335 → **#336** (last). Stacked on #334+#335 — its diff shows their files until they merge. Merge **after both #334 and #335**; rebase onto `main` if either squash-merges.

Adds a `.agentic/.telemetry-health.json` failure counter for the silent-catch state-write sites in `stop-context.js`, plus a one-line summary in `agentic-status`. Closes #266.

- `recordTelemetryHealth(cwd, target, err)` — best-effort: whole body in a swallow-everything try/catch, atomic tmp+rename with its own .tmp cleanup, can never throw or block session exit (proven by sub-test 7: read-only `.agentic/` → hook still exits 0). Wired into 6 writer catch/success sites mapped to 5 target keys (`loop-state.json`, `batch-state.json`, `events.jsonl`, `session-log`, `context.md`).
- Records `last_success` on success and `failures`/`last_error`/`last_error_ts` on failure, matching the issue's format.
- `agentic-status` gains `_telemetry_health_line` — fail-open: absent or all-zero or unreadable → `telemetry-health: OK`; failures → one-line summary with the worst target.
- File is gitignored (under the `.agentic/` umbrella); no carve-out, not committed.

Per-exit cost is ~5 read-modify-writes of a sub-1KB file — three orders of magnitude smaller than the multi-MB `events.jsonl` reads #267 removed; does not regress that.

Tests: session-log 26/26 (sub-tests 6 forced-failure-increments-counter, 7 read-only-no-crash), deferred-wrap 51/51, capture-gap 29/29, `test_agentic_status.py` 61/61 (8 new health-line cases).

**Stacked on #262 + #267** — merge after both land on `main` (rebase if their SHAs change on squash-merge).
