### PR TITLE
fix(hooks): abdication-guard counter fails toward allow-stop when unpersistable

### DIFF
--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -47,6 +47,11 @@ Failure modes:
     - Any exception: fail-open via outer try/except (exit 0).
     - stop_hook_active=true: exit 0 immediately (primary re-entrancy guard).
     - Counter >= CAP: exit 0 without block (backstop for CC bug #54360).
+    - Counter write fails (unwritable .agentic/, full disk, corrupt tmp, etc.):
+      exit 0 and ALLOW the stop on that invocation. Rationale: a block whose
+      count cannot be recorded loses its loop bound; the safe degradation is
+      "don't block" (status quo, never an infinite loop). Only blocks after the
+      incremented count has been successfully persisted.
     - Invalid/garbage stdout: guarded via atomic print-then-exit pattern;
       any exception before the print results in no stdout = allow.
 
@@ -208,8 +213,14 @@ def _read_counter(cwd: str) -> dict:
         return {"count": 0, "last_user_msg_count": 0}
 
 
-def _write_counter(cwd: str, count: int, last_user_msg_count: int) -> None:
-    """Write counter state. Fail silently."""
+def _write_counter(cwd: str, count: int, last_user_msg_count: int) -> bool:
+    """Write counter state. Returns True on success, False on any failure.
+
+    The caller MUST check the return value when deciding whether to block:
+    a block emitted without a successful counter write loses its loop bound
+    and can cause an infinite block loop when stop_hook_active also fails
+    (CC bug #54360). Fail toward allow-stop on any write failure.
+    """
     try:
         agentic_dir = os.path.join(cwd, ".agentic")
         os.makedirs(agentic_dir, exist_ok=True)
@@ -218,13 +229,14 @@ def _write_counter(cwd: str, count: int, last_user_msg_count: int) -> None:
         with open(tmp, "w") as f:
             json.dump({"count": count, "last_user_msg_count": last_user_msg_count}, f)
         os.replace(tmp, path)
+        return True
     except Exception:
-        pass
+        return False
 
 
 def _reset_counter(cwd: str, current_user_msg_count: int) -> None:
-    """Reset consecutive block count (new user turn detected)."""
-    _write_counter(cwd, 0, current_user_msg_count)
+    """Reset consecutive block count (new user turn detected). Best-effort."""
+    _write_counter(cwd, 0, current_user_msg_count)  # return value intentionally ignored
 
 
 # ---------------------------------------------------------------------------
@@ -437,9 +449,13 @@ def main() -> None:
             _reset_counter(cwd, current_user_msg_count)
             sys.exit(0)
 
-        # Abdication detected. Increment counter and block.
+        # Abdication detected. Only block if we can persist the incremented count.
+        # If persistence fails (unwritable .agentic/, full disk, etc.) the loop
+        # bound is lost; the safe degradation is allow-stop to avoid an infinite
+        # block loop when stop_hook_active also fails (CC bug #54360).
         new_count = state["count"] + 1
-        _write_counter(cwd, new_count, current_user_msg_count)
+        if not _write_counter(cwd, new_count, current_user_msg_count):
+            sys.exit(0)
 
         reason = (
             "ABDICATION GUARD: You ended your turn by asking the user permission "

--- a/hooks/tests/test-enforce-no-abdication.py
+++ b/hooks/tests/test-enforce-no-abdication.py
@@ -549,6 +549,68 @@ def test_counter_reset_on_new_user_turn(tmp_dir: str) -> int:
     return failed
 
 
+def test_unwritable_counter_allows_stop(tmp_dir: str) -> int:
+    """REGRESSION: unwritable .agentic/ + stop_hook_active never set -> no infinite block.
+
+    Simulates the conjunction identified in the Skeptic Minor finding:
+      - .agentic/ directory is read-only, so _write_counter always fails.
+      - stop_hook_active never flips to True (CC bug #54360).
+
+    Pre-fix behavior: _write_counter fails silently, the count never increments,
+    the loop bound is lost, and the hook blocks on every invocation indefinitely.
+
+    Post-fix behavior: the hook only emits a block AFTER the incremented count
+    has been successfully persisted. On write failure it exits 0 (allow-stop)
+    so the session is never stuck in an infinite block loop.
+    """
+    print("\n  [Unwritable counter + #54360 conjunction regression]")
+    failed = 0
+    unwrite_dir = os.path.join(tmp_dir, "unwritable_cwd")
+    os.makedirs(unwrite_dir, exist_ok=True)
+    agentic_dir = os.path.join(unwrite_dir, ".agentic")
+    os.makedirs(agentic_dir, exist_ok=True)
+
+    # Write config while the directory is still writable.
+    config_path = os.path.join(agentic_dir, "config.json")
+    with open(config_path, "w") as f:
+        json.dump({"abdication_guard_enabled": True}, f)
+
+    # Make .agentic/ read-only so counter writes fail (file creation denied).
+    os.chmod(agentic_dir, 0o555)
+    try:
+        # Simulate CAP+2 re-entries with stop_hook_active=False (bug never fixed).
+        # Each call finds count=0 (read fails, defaults to 0), tries to write new
+        # count, fails, and - under the fix - must ALLOW rather than block.
+        blocked_rounds = []
+        for i in range(CONSECUTIVE_BLOCK_CAP + 2):
+            payload = json.dumps({
+                "hook_event_name": "Stop",
+                "session_id": "unwritable-regression",
+                "cwd": unwrite_dir,
+                "stop_hook_active": False,   # bug: never propagates
+                "permission_mode": "default",
+                "last_assistant_message": ABDICATING_MSG,
+            })
+            rc, stdout, _ = run_hook(payload)
+            blocked_rounds.append(is_block(rc, stdout))
+
+        # Every invocation must ALLOW (no block without a persisted loop bound).
+        all_allowed = not any(blocked_rounds)
+        print(
+            f"    [{'PASS' if all_allowed else 'FAIL'}] "
+            f"Unwritable .agentic/ + stop_hook_active=False on {CONSECUTIVE_BLOCK_CAP + 2} "
+            f"invocations -> all ALLOW (no infinite block loop)"
+        )
+        if not all_allowed:
+            failed += 1
+            print(f"         blocked_rounds={blocked_rounds} (expected all False)")
+    finally:
+        # Restore write permission so temp dir cleanup succeeds.
+        os.chmod(agentic_dir, 0o755)
+
+    return failed
+
+
 def test_corrupt_counter_file(tmp_dir: str) -> int:
     """Test that a corrupt counter file is treated as 0."""
     print("\n  [Corrupt counter file tests]")
@@ -706,6 +768,7 @@ def main() -> None:
         total_failed += test_54360_loop_terminates(tmp_dir)
         total_failed += test_counter_reset_on_new_user_turn(tmp_dir)
         total_failed += test_corrupt_counter_file(tmp_dir)
+        total_failed += test_unwritable_counter_allows_stop(tmp_dir)
 
         # Transcript fallback.
         total_failed += test_transcript_fallback(tmp_dir)
@@ -720,6 +783,7 @@ def main() -> None:
         + 1   # #54360 loop-termination regression
         + 1   # counter reset
         + 1   # corrupt counter
+        + 1   # unwritable counter + #54360 conjunction regression
         + 2   # transcript fallback
         + 3   # smoke checks
     )


### PR DESCRIPTION
Closes the residual loop-safety Minor on `enforce-no-abdication.py`: if `.agentic/` is unwritable AND CC bug #54360 hits (`stop_hook_active` never propagates), both loop guards failed together and the hook could block every Stop forever.

Fix: `_write_counter` returns `bool`; the block JSON is emitted only after the incremented count is durably persisted. On any write failure the hook exits 0 (allow-stop) - a block whose count can't be recorded loses its loop bound, so the safe degradation is "don't block."

Regression test `test_unwritable_counter_allows_stop`: read-only `.agentic/` + `stop_hook_active=False` across CAP+2 re-entries → every invocation allows (pre-fix blocked all). Normal writable path unchanged (cap still works). 66 assertions pass.

Hooks-only: no content/, no adapter, no baseline. Skeptic sign-off (0/0), both decisive probes (loop closed, normal blocking preserved) verified.