### PR TITLE
feat(skill-candidate): wire detector into stop-context (session-end scan)

### DIFF
--- a/hooks/lib/skill-candidate-detector.js
+++ b/hooks/lib/skill-candidate-detector.js
@@ -31,7 +31,7 @@
  *   [cwd]/.agentic/skill-candidates.md (appended when domain first crosses threshold)
  *
  * Downstream consumers:
- *   hooks/stop-context.js (Stop-hook write path; NOT YET WIRED - to be wired in a later unit)
+ *   hooks/stop-context.js (Stop-hook write path; wired as of this PR)
  *   hooks/post-tool-use-capture-nudge.js (Layer-2 peek path; NOT YET WIRED - later unit)
  *
  * Failure modes: runSkillCandidateScan never throws - top-level try/catch absorbs

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -31,12 +31,15 @@
  *             stagePending, touchHeartbeat, etc.) now live in
  *             hooks/lib/wrap-marker.js, the single source of truth.
  *
- * Upstream deps: Node built-ins only (fs, path, os, child_process) plus two
+ * Upstream deps: Node built-ins only (fs, path, os, child_process) plus three
  *                local CommonJS modules: hooks/lib/wrap-marker.js (the deferred-/wrap
  *                marker single source of truth - lock gate, per-session staging,
- *                heartbeat) and hooks/lib/capture-gap.js (the shared capture-gap
+ *                heartbeat), hooks/lib/capture-gap.js (the shared capture-gap
  *                detector - detectCaptureGap, GUARDRAIL_PATTERNS, _tokenize,
- *                extracted so the in-session PostToolUse nudge reuses it).
+ *                extracted so the in-session PostToolUse nudge reuses it), and
+ *                hooks/lib/skill-candidate-detector.js (Stop-hook write path
+ *                runSkillCandidateScan; required lazily inside the skill-candidate
+ *                detection path, gated by the skill_candidate_detection toggle).
  *                No npm dependencies. Reads from stdin (fd 0).
  *                Reads/writes
  *                ~/.claude/projects/[hash]/context.md,
@@ -48,11 +51,18 @@
  *                ~/.agentic/identity.yml (read-only, global),
  *                [cwd]/.agentic/identity.yml (read-only, project-local; takes precedence
  *                over global when confirmed, per 4-tier resolution in getIdentity(cwd)),
- *                [cwd]/.agentic/config.json (read-only, deferred_wrap_daemon toggle),
- *                [cwd]/.agentic/events.jsonl (read-only for capture-gap backstop),
- *                [cwd]/.agentic/learnings.md (read-only for capture-gap backstop),
+ *                [cwd]/.agentic/config.json (read-only, deferred_wrap_daemon +
+ *                skill_candidate_detection toggles),
+ *                [cwd]/.agentic/events.jsonl (read-only for capture-gap backstop and
+ *                skill-candidate scan),
+ *                [cwd]/.agentic/learnings.md (read-only for capture-gap backstop and
+ *                skill-candidate scan),
  *                [cwd]/.agentic/.capture-gap-last-sweep (pagination cursor; atomic
- *                tmp+rename on write).
+ *                tmp+rename on write),
+ *                [cwd]/.agentic/.skill-candidate-tally.json (atomic tmp+rename),
+ *                [cwd]/.agentic/.skill-candidate-cursor (ISO8601 high-water mark),
+ *                [cwd]/.agentic/skill-candidates.md (appended when a domain first
+ *                crosses the candidate threshold).
  *                Via wrap-marker.js it also touches [cwd]/.agentic/wrap/heartbeats/<session_id>
  *                (per-turn liveness mtime) and may stage
  *                [cwd]/.agentic/wrap/pending-<session_id>.json (per-session marker).
@@ -67,7 +77,7 @@
  *                        globbed by agentic-cost (operator or team) - it is consumed
  *                        only by agentic-identity confirm/init via flushPendingBuffer.
  *
- * Failure modes: All failures are silent (process.exit(0)). Eleven independent
+ * Failure modes: All failures are silent (process.exit(0)). Twelve independent
  *                write paths: (1) context.md write is best-effort; any fs error
  *                is swallowed and the file may not be written. (2) loop-state.json
  *                write is also best-effort; any fs error is swallowed independently
@@ -111,7 +121,15 @@
  *                any fs error swallowed independently of all other paths.
  *                Marker staging (stageWrapPending -> wrap-marker lib) shares this
  *                fail-open discipline and is never counted as blocking exit.
- *                All eleven paths are independent - a failure in one does not
+ *                (12) runSkillCandidateScan writes .agentic/.skill-candidate-tally.json,
+ *                .agentic/.skill-candidate-cursor, and .agentic/skill-candidates.md
+ *                (when a domain first crosses the candidate threshold). Gated by
+ *                skill_candidate_detection in config.json (default true when absent
+ *                or unreadable). Any error is absorbed by runSkillCandidateScan's
+ *                own top-level try/catch; the path is additionally wrapped here in
+ *                an independent try/catch so a crash inside the detector can never
+ *                affect paths (1)-(11) or block session exit.
+ *                All twelve paths are independent - a failure in one does not
  *                affect the others. The 10-minute implicit-interrupt heuristic
  *                handles missed loop-state writes. cwd values with path
  *                traversal components are rejected for the loop-state and
@@ -201,6 +219,31 @@ function deferredDaemonEnabled(cwd) {
     return config && config.deferred_wrap_daemon === true;
   } catch (_) {
     return false;
+  }
+}
+
+/**
+ * Read the `skill_candidate_detection` toggle from [cwd]/.agentic/config.json.
+ * Fail-open: absent file, unreadable file, parse error, or absent key all
+ * resolve to TRUE (default-on per the spec: detection is enabled unless
+ * explicitly set to false). When the key is explicitly false, returns false.
+ *
+ * @param {string} cwd - Project root directory.
+ * @returns {boolean}
+ */
+function skillCandidateDetectionEnabled(cwd) {
+  try {
+    const configPath = path.join(cwd, '.agentic', 'config.json');
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(raw);
+    // Only disable when the key is explicitly set to false (boolean).
+    if (config && config.skill_candidate_detection === false) {
+      return false;
+    }
+    return true;
+  } catch (_) {
+    // Absent file, unreadable, or parse error -> default true.
+    return true;
   }
 }
 
@@ -1188,6 +1231,17 @@ ${toolsLine}
         }
       } catch (_) { /* silent */ }
       removeLearningsAgentSession(cwd, sessionId);
+      // --- Skill-candidate detection (path 12 - independent soft-fail) ---
+      // Gated on skill_candidate_detection toggle (default true when absent).
+      // runSkillCandidateScan has its own top-level try/catch; this outer
+      // try/catch is an additional belt-and-suspenders layer so no error inside
+      // the detector can ever reach this exit path and block session exit.
+      try {
+        if (skillCandidateDetectionEnabled(cwd)) {
+          const { runSkillCandidateScan } = require('./lib/skill-candidate-detector.js');
+          runSkillCandidateScan(cwd, sessionId).catch(() => { /* soft-fail: async errors swallowed */ });
+        }
+      } catch (_) { /* soft-fail: require or sync setup errors swallowed */ }
       // Stage the wrap-pending marker (after the context.md decision, on every
       // exit path). Gated on deferredDaemonEnabled so the flag-off default never
       // accumulates markers. Fail-open; never blocks exit.
@@ -1278,6 +1332,19 @@ ${toolsLine}
       appendCaptureGapNoticeToContextMd(cwd, gap.residualOnly);
     }
   } catch (_) { /* silent */ }
+
+  // --- 16b. Skill-candidate detection (path 12 - independent soft-fail) ---
+  // Gated on skill_candidate_detection toggle (default true when absent or
+  // unreadable). runSkillCandidateScan has its own top-level try/catch; this
+  // outer try/catch is an additional layer so no error can reach this exit path
+  // and block session exit. Lazy-require so the module is only loaded when the
+  // toggle is on.
+  try {
+    if (skillCandidateDetectionEnabled(cwd)) {
+      const { runSkillCandidateScan } = require('./lib/skill-candidate-detector.js');
+      runSkillCandidateScan(cwd, sessionId).catch(() => { /* soft-fail: async errors swallowed */ });
+    }
+  } catch (_) { /* soft-fail: require or sync setup errors swallowed */ }
 
   // --- 16. Stage the wrap-pending marker (deferred-wrap safety-net) ---
   // Runs after the context.md decision, on this exit path. Gated on

--- a/hooks/tests/test-stop-context-skill-candidate.js
+++ b/hooks/tests/test-stop-context-skill-candidate.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Integration tests: skill-candidate detection wired into stop-context.js.
+ *
+ * All tests use temp HOME/cwd and NEVER touch the real .agentic/ directory.
+ * The Stop hook is invoked as a child process (exactly as Claude Code does).
+ *
+ * Sub-tests:
+ *   (a) scan-writes: seeded events.jsonl with >=3 tool_failure_workaround events
+ *       sharing a domain_tag (with session_uuid present) -> hook exits 0 and
+ *       .agentic/skill-candidates.md + .agentic/.skill-candidate-tally.json
+ *       are written.
+ *   (b) toggle-off-skips: skill_candidate_detection: false in config.json ->
+ *       scan skipped; neither .skill-candidate-tally.json nor skill-candidates.md
+ *       are written after the hook runs.
+ *   (c) error-doesnt-break: simulated error in the scan (corrupt detector module
+ *       monkey-patched via env override NOT possible, so we force a corrupt events
+ *       line + absence of .agentic dir writability to ensure the hook never throws
+ *       and exits 0; other write paths still complete [context.md written]).
+ *
+ * Run with: node hooks/tests/test-stop-context-skill-candidate.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const hookScript = path.resolve(__dirname, '..', 'stop-context.js');
+if (!fs.existsSync(hookScript)) {
+  console.error(`FAIL: hook not found at ${hookScript}`);
+  process.exit(1);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTmp(prefix) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const fakeHome = path.join(tmpDir, 'home');
+  const projectDir = path.join(tmpDir, 'project');
+  const agenticDir = path.join(projectDir, '.agentic');
+  const identityDir = path.join(fakeHome, '.agentic');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(agenticDir, { recursive: true });
+  fs.mkdirSync(identityDir, { recursive: true });
+  return { tmpDir, fakeHome, projectDir, agenticDir, identityDir };
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+}
+
+/**
+ * Run the Stop hook synchronously. Returns the spawnSync result.
+ * stdio: ['pipe', 'pipe', 'pipe'] captures all output.
+ */
+function runHook(projectDir, fakeHome, sessionId) {
+  const payload = JSON.stringify({
+    cwd: projectDir,
+    session_id: sessionId,
+    transcript: [],
+  });
+  return spawnSync('node', [hookScript], {
+    input: payload,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: fakeHome },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * Build a single tool_failure_workaround event line.
+ */
+function makeWorkaroundEvent(domainTag, sessionUuid, ts) {
+  return JSON.stringify({
+    ts,
+    phase: 'workaround',
+    event: 'tool_failure_workaround',
+    agent: null,
+    data: {
+      session_uuid: sessionUuid,
+      domain_tag: domainTag,
+      tool: 'Bash',
+      note: `workaround for ${domainTag}`,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test (a): scan-writes
+// 3 events sharing the same domain_tag -> skill-candidates.md + tally written
+// ---------------------------------------------------------------------------
+
+{
+  const { tmpDir, fakeHome, projectDir, agenticDir } = makeTmp('sc-scan-writes-');
+  try {
+    console.log('\nTest (a): scan-writes - 3 events sharing domain_tag -> candidates + tally written');
+
+    const sessionId = 'test-session-scan-001';
+    const domainTag = 'adapter-rebuild';
+
+    // Seed events.jsonl with exactly 3 matching events.
+    const events = [
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:01.000Z'),
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:02.000Z'),
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:03.000Z'),
+    ].join('\n') + '\n';
+
+    fs.writeFileSync(path.join(agenticDir, 'events.jsonl'), events, 'utf8');
+
+    const result = runHook(projectDir, fakeHome, sessionId);
+
+    assert(result.status === 0, 'hook exits with status 0');
+
+    const tallyPath = path.join(agenticDir, '.skill-candidate-tally.json');
+    const candidatesPath = path.join(agenticDir, 'skill-candidates.md');
+
+    // The writes complete before exit because runSkillCandidateScan uses only
+    // SYNCHRONOUS fs calls internally (no `await`), so the function body runs
+    // to completion before the Promise yields. If real async I/O were ever added
+    // to the detector, this guarantee would break. The retry loop below is a
+    // belt-and-suspenders fallback; it should never fire in practice.
+    let tallyExists = fs.existsSync(tallyPath);
+    let candidatesExists = fs.existsSync(candidatesPath);
+
+    // Brief retry if async write hasn't landed yet (shouldn't happen in practice).
+    if (!tallyExists || !candidatesExists) {
+      const deadline = Date.now() + 500;
+      while (Date.now() < deadline) {
+        tallyExists = fs.existsSync(tallyPath);
+        candidatesExists = fs.existsSync(candidatesPath);
+        if (tallyExists && candidatesExists) break;
+        // Busy-wait 50ms
+        const until = Date.now() + 50;
+        while (Date.now() < until) { /* spin */ }
+      }
+    }
+
+    assert(tallyExists, '.skill-candidate-tally.json written');
+    assert(candidatesExists, 'skill-candidates.md written');
+
+    if (tallyExists) {
+      const tally = JSON.parse(fs.readFileSync(tallyPath, 'utf8'));
+      assert(
+        tally.candidates && tally.candidates[domainTag] &&
+        tally.candidates[domainTag].count >= 3,
+        `tally[${domainTag}].count >= 3`
+      );
+      assert(
+        tally.candidates[domainTag].surfacedAt != null,
+        `tally[${domainTag}].surfacedAt is set`
+      );
+    }
+
+    if (candidatesExists) {
+      const md = fs.readFileSync(candidatesPath, 'utf8');
+      assert(md.includes(domainTag), `skill-candidates.md contains domain "${domainTag}"`);
+    }
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test (b): toggle-off-skips
+// skill_candidate_detection: false -> no tally, no candidates.md written
+// ---------------------------------------------------------------------------
+
+{
+  const { tmpDir, fakeHome, projectDir, agenticDir } = makeTmp('sc-toggle-off-');
+  try {
+    console.log('\nTest (b): toggle-off-skips - skill_candidate_detection: false -> scan skipped');
+
+    const sessionId = 'test-session-toggle-002';
+    const domainTag = 'adapter-rebuild';
+
+    // Seed events.jsonl with 3 matching events.
+    const events = [
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:01.000Z'),
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:02.000Z'),
+      makeWorkaroundEvent(domainTag, sessionId, '2026-06-01T10:00:03.000Z'),
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(agenticDir, 'events.jsonl'), events, 'utf8');
+
+    // Write config.json with detection explicitly disabled.
+    fs.writeFileSync(
+      path.join(agenticDir, 'config.json'),
+      JSON.stringify({ skill_candidate_detection: false }),
+      'utf8'
+    );
+
+    const result = runHook(projectDir, fakeHome, sessionId);
+
+    assert(result.status === 0, 'hook exits with status 0');
+
+    const tallyPath = path.join(agenticDir, '.skill-candidate-tally.json');
+    const candidatesPath = path.join(agenticDir, 'skill-candidates.md');
+
+    // Brief wait to rule out a race with async write.
+    const deadline = Date.now() + 300;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(tallyPath) || fs.existsSync(candidatesPath)) break;
+      const until = Date.now() + 30;
+      while (Date.now() < until) { /* spin */ }
+    }
+
+    assert(!fs.existsSync(tallyPath), '.skill-candidate-tally.json NOT written (toggle off)');
+    assert(!fs.existsSync(candidatesPath), 'skill-candidates.md NOT written (toggle off)');
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test (c): error-doesnt-break
+// A forced error in the scan (corrupt events.jsonl entries) does not throw out
+// of the Stop hook; other write paths still complete (context.md is written).
+// ---------------------------------------------------------------------------
+
+{
+  const { tmpDir, fakeHome, projectDir, agenticDir } = makeTmp('sc-error-safe-');
+  try {
+    console.log('\nTest (c): error-doesnt-break - corrupt events still exit 0; context.md written');
+
+    const sessionId = 'test-session-error-003';
+
+    // Seed events.jsonl with entirely corrupt/garbage lines so the scan
+    // encounters parse errors on every line. The detector's top-level try/catch
+    // absorbs these; the outer try/catch in stop-context.js is the second layer.
+    const corruptEvents = 'not json at all\n}{invalid\n\n';
+    fs.writeFileSync(path.join(agenticDir, 'events.jsonl'), corruptEvents, 'utf8');
+
+    const result = runHook(projectDir, fakeHome, sessionId);
+
+    assert(result.status === 0, 'hook exits with status 0 despite corrupt events');
+
+    // context.md (path 1) should still be written - it does not depend on the
+    // skill-candidate detection path.
+    const contextPath = path.join(agenticDir, 'context.md');
+    assert(fs.existsSync(contextPath), 'context.md still written (other paths unaffected)');
+
+    // No stderr output from the hook itself (errors are fully swallowed).
+    // The hook may write to stderr in special cases (pending buffer cap), but not
+    // for skill-candidate errors.
+    const stderr = (result.stderr || '').trim();
+    assert(
+      !stderr.includes('skill-candidate') && !stderr.includes('TypeError') && !stderr.includes('SyntaxError'),
+      'no skill-candidate error leaked to stderr'
+    );
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Unit 2 of skill-candidate detection. Wires `runSkillCandidateScan` into `hooks/stop-context.js` as an independent soft-fail path (path 12), run after the capture-gap backstop on whichever exit branch fires (mutually exclusive - runs once).

- Gated by `skill_candidate_detection` (default TRUE when the key is absent; the toggle is seeded in a later unit). `false` skips.
- Double-wrapped soft-fail: a crash in the scan cannot break the other 11 Stop-hook paths or block exit. Writes flush before `process.exit` because the detector is all-sync internally (Skeptic-confirmed).
- Updated both manifests (stop-context path-count 11->12 + 3 new writes; detector "Downstream consumers" flipped to wired).

3-scenario child-process integration test (scan-writes / toggle-off-skips / corrupt-events-doesnt-break) + 145 existing regressions green. Skeptic: sign-off after fixing a stale-manifest Major + 2 minors.