### PR TITLE
feat(skill-candidate): Layer-2 opt-in in-session nudge

### DIFF
--- a/hooks/post-tool-use-capture-nudge.js
+++ b/hooks/post-tool-use-capture-nudge.js
@@ -1,30 +1,46 @@
 #!/usr/bin/env node
 
 /**
- * Purpose: Claude Code PostToolUse(Task/Agent) hook that surfaces an in-session
- *          capture-gap nudge. When a subagent spawn launches (async_launched) and the
- *          session has a learning-worthy event with no learning captured yet, the
- *          hook prints a hookSpecificOutput.additionalContext message so the
- *          conductor emits its Capture: declaration and spawns learnings-agent
- *          autonomously - in-session, not waiting for the Stop-hook backstop. This
- *          closes the gap where free-form (non-/implement-ticket) sessions skip
- *          mandatory capture or ask the user.
+ * Purpose: Claude Code PostToolUse(Task/Agent) hook. Runs two independent advisory
+ *          nudges on every background subagent spawn (async_launched):
+ *
+ *          1. Capture-gap nudge (always active): when a learning-worthy event exists
+ *             but no learning has been captured yet, emits a CAPTURE-NUDGE so the
+ *             conductor can spawn learnings-agent in-session rather than waiting for
+ *             the Stop-hook backstop.
+ *
+ *          2. Skill-candidate nudge (Layer 2, opt-in): when both
+ *             skill_candidate_detection !== false AND skill_candidate_nudge === true
+ *             in [cwd]/.agentic/config.json, calls peekActiveCandidates() (read-only
+ *             - never writes the tally or advances the cursor) and emits a
+ *             SKILL-CANDIDATE-NUDGE for each candidate not yet nudged this session.
+ *             Default: off (skill_candidate_nudge defaults to false when absent).
  *
  * Public API: run() - invoked immediately at module load via run() call at the
  *             bottom of the file. Not imported in production; executed as a CLI
  *             script by the Claude Code PostToolUse(Task/Agent) hook. The test loads
  *             it via a tmp shim that suppresses run() and exercises the body.
  *
- * Upstream deps: Node built-ins only (fs, path) plus the local CommonJS module
- *                hooks/lib/capture-gap.js (detectCaptureGap). No npm dependencies.
+ * Upstream deps: Node built-ins only (fs, path) plus two local CommonJS modules:
+ *                hooks/lib/capture-gap.js (detectCaptureGap) and
+ *                hooks/lib/skill-candidate-detector.js (peekActiveCandidates).
+ *                No npm dependencies.
  *                Reads PostToolUse payload from stdin (fd 0); reads
- *                [cwd]/.agentic/.capture-gap-surfaced (dedup tracker, fail-open);
+ *                [cwd]/.agentic/.capture-gap-surfaced (capture dedup tracker, fail-open);
+ *                [cwd]/.agentic/.skill-candidates-in-session (skill dedup, JSONL
+ *                {session_id, candidate_id}, fail-open);
+ *                [cwd]/.agentic/config.json (read-only, skill_candidate_detection +
+ *                skill_candidate_nudge toggles);
  *                detectCaptureGap reads [cwd]/.agentic/events.jsonl,
  *                [cwd]/.agentic/learnings.md, [cwd]/.agentic/.capture-gap-last-sweep
  *                (cursor READ only), and runs one git diff subprocess.
- *                Writes ONLY [cwd]/.agentic/.capture-gap-surfaced (atomic
- *                tmp+rename). NEVER writes .capture-gap-last-sweep (owned by
- *                stop-context.js) and NEVER writes learnings.md / context.md.
+ *                peekActiveCandidates reads [cwd]/.agentic/.skill-candidate-tally.json
+ *                (READ-ONLY - never writes the tally or cursor).
+ *                Writes ONLY [cwd]/.agentic/.capture-gap-surfaced (atomic tmp+rename)
+ *                and [cwd]/.agentic/.skill-candidates-in-session (atomic append).
+ *                NEVER writes .capture-gap-last-sweep (owned by stop-context.js),
+ *                .skill-candidate-tally.json, .skill-candidate-cursor, or any other
+ *                tally/cursor file.
  *
  * Downstream consumers: Claude Code PostToolUse(Task/Agent) hook (wired by
  *                        .claude/install.sh; matchers "Task" and "Agent"). The
@@ -36,15 +52,16 @@
  *                writes to stderr, never emits non-JSON to stdout. Malformed
  *                stdin, a non-Task/Agent tool, a non-async_launched response, an absent
  *                dedup tracker, a detector error, or a tracker-write failure all
- *                resolve to a silent exit 0. The dedup tracker is fail-open: a
+ *                resolve to a silent exit 0. Both dedup trackers are fail-open: a
  *                missing or unreadable tracker is treated as "not yet surfaced"
- *                so the nudge fires (a duplicate nudge is cheaper than a missed
- *                one). The (session_id, lastEventTs) tuple keys the dedup so a
- *                single worthy event nudges at most once per session.
+ *                so the nudge fires (a duplicate nudge is cheaper than a missed one).
+ *                The skill-candidate nudge path is independently gated; an error
+ *                in it never suppresses the capture-gap nudge.
  *
- * Performance: ~5-20 ms typical; detectCaptureGap's git subprocess (5 s timeout)
+ * Performance: ~5-30 ms typical; detectCaptureGap's git subprocess (5 s timeout)
  *              runs only once a worthy event is found, so the common no-event
- *              spawn costs a single events.jsonl read and returns early.
+ *              spawn costs a single events.jsonl read and returns early. The skill
+ *              peek adds one tally file read only when both toggles are enabled.
  */
 
 'use strict';
@@ -52,6 +69,7 @@
 const fs = require('fs');
 const path = require('path');
 const { detectCaptureGap } = require('./lib/capture-gap.js');
+const { peekActiveCandidates } = require('./lib/skill-candidate-detector.js');
 
 // Verbatim nudge texts (handoff section 3). The standard variant fires when no
 // guardrail was added this session; the residualOnly variant fires when a
@@ -66,6 +84,102 @@ const NUDGE_RESIDUAL =
   'CAPTURE-NUDGE: a related guardrail was added this session but is not domain-proximate to '
   + 'the learning-worthy event. Emit your Capture: declaration now for any residual WHY or '
   + 'dead-end reasoning. If Capture: MUST, spawn learnings-agent autonomously.';
+
+// Skill-candidate nudge text. {domain}, {artifact}, and {count} are substituted per candidate.
+const SKILL_NUDGE_TEMPLATE =
+  'SKILL-CANDIDATE-NUDGE: recurring friction pattern detected for domain "{domain}" '
+  + '(lifetime count: {count}, suggested artifact: {artifact}). '
+  + 'This may warrant a new skill. Run /skill-candidates to review the backlog, '
+  + 'or invoke the skill-creator skill to convert this pattern into a reusable skill.';
+
+/**
+ * Read the skill_candidate_detection and skill_candidate_nudge toggles from
+ * [cwd]/.agentic/config.json.
+ *
+ * - skill_candidate_detection: default TRUE when absent/unreadable (master toggle).
+ *   Only disabled when explicitly set to false (boolean). Consistent with
+ *   stop-context.js skillCandidateDetectionEnabled.
+ * - skill_candidate_nudge: default FALSE when absent/unreadable (Layer 2 opt-in).
+ *   Only enabled when explicitly set to true (boolean). Default-off by design.
+ *
+ * Returns { detectionEnabled: boolean, nudgeEnabled: boolean }.
+ * Fail-open on any error: detection defaults true, nudge defaults false.
+ *
+ * @param {string} cwd - Project root.
+ * @returns {{ detectionEnabled: boolean, nudgeEnabled: boolean }}
+ */
+function readSkillConfig(cwd) {
+  try {
+    const configPath = path.join(cwd, '.agentic', 'config.json');
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(raw);
+    const detectionEnabled = !(config && config.skill_candidate_detection === false);
+    const nudgeEnabled = !!(config && config.skill_candidate_nudge === true);
+    return { detectionEnabled, nudgeEnabled };
+  } catch (_) {
+    // Absent/unreadable/invalid config: master default on, nudge default off.
+    return { detectionEnabled: true, nudgeEnabled: false };
+  }
+}
+
+/**
+ * Read the skill-candidate in-session dedup tracker. Returns a Set of
+ * "session_id:candidate_id" keys that have already been nudged this session.
+ * Fail-open: missing or unreadable tracker returns an empty Set (fires nudge).
+ *
+ * Tracker format: JSONL, one { session_id, candidate_id } per line.
+ *
+ * @param {string} cwd - Project root.
+ * @returns {Set<string>} keys in the form "session_id:candidate_id"
+ */
+function readSkillNudgeSurfaced(cwd) {
+  try {
+    const trackerPath = path.join(cwd, '.agentic', '.skill-candidates-in-session');
+    if (!fs.existsSync(trackerPath)) return new Set();
+    const raw = fs.readFileSync(trackerPath, 'utf8');
+    const result = new Set();
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try { obj = JSON.parse(trimmed); } catch (_) { continue; }
+      if (obj && typeof obj.session_id === 'string' && typeof obj.candidate_id === 'string') {
+        result.add(`${obj.session_id}:${obj.candidate_id}`);
+      }
+    }
+    return result;
+  } catch (_) {
+    return new Set();
+  }
+}
+
+/**
+ * Atomically append a dedup entry for (session_id, candidate_id) to the
+ * in-session tracker. Uses read-existing + tmp-write + rename for atomicity.
+ * Silent failure: a missed write at worst re-nudges on the next spawn.
+ *
+ * @param {string} cwd - Project root.
+ * @param {string} sessionId
+ * @param {string} candidateId - domain slug used as the candidate identifier
+ */
+function recordSkillNudgeSurfaced(cwd, sessionId, candidateId) {
+  const agenticDir = path.join(cwd, '.agentic');
+  const trackerPath = path.join(agenticDir, '.skill-candidates-in-session');
+  fs.mkdirSync(agenticDir, { recursive: true });
+
+  let existing = '';
+  try {
+    if (fs.existsSync(trackerPath)) existing = fs.readFileSync(trackerPath, 'utf8');
+  } catch (_) { /* fall through with empty existing */ }
+
+  const entry = JSON.stringify({ session_id: sessionId, candidate_id: candidateId });
+  const body = (existing && !existing.endsWith('\n')) ? existing + '\n' : existing;
+  const next = body + entry + '\n';
+
+  const tmpPath = trackerPath + '.tmp';
+  fs.writeFileSync(tmpPath, next, 'utf8');
+  fs.renameSync(tmpPath, trackerPath);
+}
 
 /**
  * Read the dedup tracker and return true if this (session_id, lastEventTs) tuple
@@ -168,22 +282,87 @@ function run() {
       : null;
     if (!sessionId) process.exit(0);
 
-    // --- 4. Detect capture gap (shared detector; pure read-only) ---
+    // --- 4. Capture-gap nudge path ---
+    // Runs first; emits and exits if a capture gap is found and not yet surfaced.
+    // Falls through to the skill-nudge path when no gap exists or already surfaced.
     const gap = detectCaptureGap(cwd, sessionId);
-    if (!gap || gap.shouldNudge !== true) process.exit(0);
+    if (gap && gap.shouldNudge === true && !alreadySurfaced(cwd, sessionId, gap.lastEventTs)) {
+      // Record dedup + emit. On tracker write failure, still emit (cheap duplicate
+      // nudge is acceptable; a missed dedup record at worst re-nudges next spawn).
+      try {
+        recordSurfaced(cwd, sessionId, gap.lastEventTs);
+      } catch (_) { /* soft-fail */ }
 
-    // --- 5. Dedup on (session_id, lastEventTs) ---
-    if (alreadySurfaced(cwd, sessionId, gap.lastEventTs)) process.exit(0);
-
-    // --- 6. Record + emit ---
-    try {
-      recordSurfaced(cwd, sessionId, gap.lastEventTs);
-    } catch (_) {
-      // Tracker write failed - still emit the nudge once; a missed dedup record
-      // at worst re-nudges on the next spawn, which is acceptable.
+      const additionalContext = gap.residualOnly ? NUDGE_RESIDUAL : NUDGE_STANDARD;
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext,
+        },
+        suppressOutput: true,
+      }));
+      process.exit(0);
     }
 
-    const additionalContext = gap.residualOnly ? NUDGE_RESIDUAL : NUDGE_STANDARD;
+    // --- 5. Skill-candidate Layer-2 nudge path ---
+    // Runs when the capture-gap path did not fire (no gap, or already surfaced).
+    // Independently gated on both skill toggles; read-only peek on the tally.
+    runSkillNudge(cwd, sessionId);
+
+    process.exit(0);
+  } catch (_) {
+    // Soft-fail: any unexpected error -> silent exit 0. Never block a spawn.
+    process.exit(0);
+  }
+}
+
+/**
+ * Skill-candidate Layer-2 nudge path. Runs independently after the capture-gap
+ * path (which may have already exited). Called from run() only when the capture-gap
+ * path determines the tool/response is a valid async_launched Task/Agent spawn.
+ *
+ * Gating: both skill_candidate_detection !== false AND skill_candidate_nudge === true
+ * must hold. Out-of-the-box the nudge is SILENT (nudge defaults false).
+ *
+ * Peek is READ-ONLY: peekActiveCandidates never writes the tally or cursor.
+ *
+ * @param {string} cwd - Project root.
+ * @param {string} sessionId - Session uuid for dedup keying.
+ */
+function runSkillNudge(cwd, sessionId) {
+  try {
+    // Gate 1: both toggles must be on.
+    const { detectionEnabled, nudgeEnabled } = readSkillConfig(cwd);
+    if (!detectionEnabled || !nudgeEnabled) return;
+
+    // Gate 2: read active candidates (read-only peek; never writes).
+    const candidates = peekActiveCandidates(cwd);
+    if (!candidates || candidates.length === 0) return;
+
+    // Gate 3: per-candidate dedup (one nudge per candidate per session).
+    const alreadySurfacedSet = readSkillNudgeSurfaced(cwd);
+    const toNudge = candidates.filter((c) => {
+      const key = `${sessionId}:${c.domain}`;
+      return !alreadySurfacedSet.has(key);
+    });
+    if (toNudge.length === 0) return;
+
+    // Record dedup entries BEFORE emitting (fail-open: a write error still emits).
+    for (const c of toNudge) {
+      try {
+        recordSkillNudgeSurfaced(cwd, sessionId, c.domain);
+      } catch (_) { /* soft-fail; at worst re-nudges next spawn */ }
+    }
+
+    // Compose and emit the nudge for all unseen candidates.
+    const lines = toNudge.map((c) =>
+      SKILL_NUDGE_TEMPLATE
+        .replace('{domain}', c.domain)
+        .replace('{count}', String(c.count))
+        .replace('{artifact}', c.suggestedArtifact || 'command')
+    );
+    const additionalContext = lines.join('\n');
+
     process.stdout.write(JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PostToolUse',
@@ -191,10 +370,8 @@ function run() {
       },
       suppressOutput: true,
     }));
-    process.exit(0);
   } catch (_) {
-    // Soft-fail: any unexpected error -> silent exit 0. Never block a spawn.
-    process.exit(0);
+    // Soft-fail: skill nudge errors never propagate or block the spawn.
   }
 }
 

--- a/hooks/tests/test-post-tool-use-capture-nudge.js
+++ b/hooks/tests/test-post-tool-use-capture-nudge.js
@@ -45,16 +45,21 @@ const hookPath = path.resolve(__dirname, '..', 'post-tool-use-capture-nudge.js')
 // ---------------------------------------------------------------------------
 const hookSource = fs.readFileSync(hookPath, 'utf8');
 const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
+const libSkillDetectorAbs = path.resolve(__dirname, '..', 'lib', 'skill-candidate-detector.js');
 const shimmedSource = hookSource
   // Suppress the trailing bare run() call so requiring the shim does not read stdin.
   .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
-  // Re-anchor the relative lib require to an absolute path to the real lib.
+  // Re-anchor relative lib requires to absolute paths so the /tmp shim can resolve them.
   .replace(
     /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
     `require(${JSON.stringify(libCaptureGapAbs)})`
+  )
+  .replace(
+    /require\(['"]\.\/lib\/skill-candidate-detector\.js['"]\)/,
+    `require(${JSON.stringify(libSkillDetectorAbs)})`
   );
 
-// Fail loud if the re-anchor did not fire (require text changed form).
+// Fail loud if any relative ./lib/ require survived the re-anchor (require text changed form).
 if (/require\(['"]\.\/lib\//.test(shimmedSource)) {
   console.error(
     '  FATAL: a relative ./lib/ require survived the shim re-anchor - update the '

--- a/hooks/tests/test-post-tool-use-skill-nudge.js
+++ b/hooks/tests/test-post-tool-use-skill-nudge.js
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: skill-candidate Layer-2 in-session nudge wired into
+ * post-tool-use-capture-nudge.js.
+ *
+ * The hook is a stdin-driven CLI script (run() reads fd 0 and process.exit(0)s),
+ * so each case drives the REAL hook as a subprocess with a controlled payload on
+ * stdin and a temporary .agentic/ fixture, then asserts on the hook's stdout.
+ *
+ * Test cases:
+ *   (a) fires-with-candidate:        both toggles on + tally with >=threshold
+ *                                     candidate -> SKILL-CANDIDATE-NUDGE emitted.
+ *   (b) dedup-suppresses-repeat:     same candidate again in the same session ->
+ *                                     NOT re-emitted (.skill-candidates-in-session
+ *                                     dedup fires).
+ *   (c) nudge-toggle-absent-silent:  skill_candidate_nudge absent (default false)
+ *                                     -> no nudge even if candidates exist.
+ *   (d) nudge-toggle-false-silent:   skill_candidate_nudge explicitly false ->
+ *                                     no nudge.
+ *   (e) detection-false-silent:      skill_candidate_detection: false -> no nudge
+ *                                     even if nudge toggle is true.
+ *   (f) peek-read-only:              hook run does not alter tally mtime. Asserts
+ *                                     that peekActiveCandidates() is read-only: the
+ *                                     tally file mtime is unchanged after the hook.
+ *
+ * All tests use temp dirs under os.tmpdir(). NEVER touch real ~/.claude or .agentic/.
+ *
+ * Run with: node hooks/tests/test-post-tool-use-skill-nudge.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const hookPath = path.resolve(__dirname, '..', 'post-tool-use-capture-nudge.js');
+
+// ---------------------------------------------------------------------------
+// Tmp-shim load: suppress run(), re-anchor relative lib requires to absolute
+// paths so the /tmp shim resolves them correctly. Mirrors the pattern from
+// test-post-tool-use-capture-nudge.js.
+// ---------------------------------------------------------------------------
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
+const libSkillDetectorAbs = path.resolve(__dirname, '..', 'lib', 'skill-candidate-detector.js');
+
+let shimmedSource = hookSource
+  .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
+  .replace(
+    /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
+    `require(${JSON.stringify(libCaptureGapAbs)})`
+  )
+  .replace(
+    /require\(['"]\.\/lib\/skill-candidate-detector\.js['"]\)/,
+    `require(${JSON.stringify(libSkillDetectorAbs)})`
+  );
+
+// Fail loud if any relative ./lib/ require survived re-anchoring.
+if (/require\(['"]\.\/lib\//.test(shimmedSource)) {
+  console.error(
+    '  FATAL: a relative ./lib/ require survived the shim re-anchor - update the '
+    + 'rewrite in test-post-tool-use-skill-nudge.js so the /tmp shim can resolve it.'
+  );
+  process.exit(1);
+}
+
+const tmpShimPath = path.join(os.tmpdir(), `ptu-skill-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+try {
+  require(tmpShimPath); // must load without reading stdin or throwing
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTempProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-skill-nudge-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+/**
+ * Write .agentic/config.json with the given skill toggle values.
+ * @param {string} cwd
+ * @param {object} overrides - keys to set/override (e.g. { skill_candidate_nudge: true })
+ */
+function writeConfig(cwd, overrides) {
+  const configPath = path.join(cwd, '.agentic', 'config.json');
+  const base = {};
+  const config = Object.assign(base, overrides);
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Write .agentic/.skill-candidate-tally.json with at least one candidate at or
+ * above CANDIDATE_THRESHOLD (3).
+ * @param {string} cwd
+ * @param {string} domain - candidate domain slug
+ * @param {number} count - candidate count (default 3 = at threshold)
+ */
+function writeTally(cwd, domain, count) {
+  count = typeof count === 'number' ? count : 3;
+  const tallyPath = path.join(cwd, '.agentic', '.skill-candidate-tally.json');
+  const tally = {
+    version: 1,
+    lastCursorTs: new Date().toISOString(),
+    candidates: {
+      [domain]: {
+        count,
+        exampleNote: `example note for ${domain}`,
+        firstSeen: '2026-06-01T00:00:00.000Z',
+        lastSeen: new Date().toISOString(),
+        suggestedArtifact: 'command',
+        surfacedAt: null,
+        learnDatesApplied: [],
+      },
+    },
+  };
+  fs.writeFileSync(tallyPath, JSON.stringify(tally, null, 2) + '\n', 'utf8');
+  return tallyPath;
+}
+
+/**
+ * Drive the real hook as a subprocess with the given payload on stdin.
+ * Returns { stdout, status }. spawnSync so a clean exit 0 with empty stdout
+ * is captured rather than treated as an error.
+ * @param {object} payload
+ * @param {string} cwd
+ * @returns {{ stdout: string, status: number }}
+ */
+function runHook(payload, cwd) {
+  const input = JSON.stringify(payload);
+  const res = spawnSync('node', [hookPath], {
+    input, cwd, timeout: 15000, encoding: 'utf8',
+  });
+  return { stdout: res.stdout || '', status: res.status };
+}
+
+/**
+ * Build a standard PostToolUse(Task) async_launched payload.
+ * @param {string} cwd
+ * @param {string} sessionId
+ * @param {object} overrides
+ * @returns {object}
+ */
+function taskPayload(cwd, sessionId, overrides) {
+  return Object.assign({
+    cwd,
+    session_id: sessionId,
+    tool_name: 'Task',
+    tool_response: { status: 'async_launched' },
+  }, overrides || {});
+}
+
+// ---------------------------------------------------------------------------
+// Test (a): fires-with-candidate
+// Both toggles on, tally has a domain at count=3 (at threshold).
+// Hook must emit SKILL-CANDIDATE-NUDGE with the domain name.
+// ---------------------------------------------------------------------------
+console.log('\nTest (a): fires-with-candidate');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-a';
+  const domain = 'git-workaround';
+
+  writeConfig(cwd, { skill_candidate_detection: true, skill_candidate_nudge: true });
+  writeTally(cwd, domain, 3);
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  let out = null;
+  try { out = JSON.parse(stdout); } catch (_) { /* leave null */ }
+  assert(out !== null, 'hook emitted parseable JSON');
+  assert(
+    out && out.hookSpecificOutput && out.hookSpecificOutput.hookEventName === 'PostToolUse',
+    'hookEventName is PostToolUse'
+  );
+  const ctx = out && out.hookSpecificOutput ? out.hookSpecificOutput.additionalContext : '';
+  assert(
+    ctx.includes('SKILL-CANDIDATE-NUDGE'),
+    'additionalContext contains SKILL-CANDIDATE-NUDGE'
+  );
+  assert(ctx.includes(domain), `additionalContext mentions the domain "${domain}"`);
+  assert(ctx.includes('skill-creator'), 'additionalContext references skill-creator skill');
+  assert(ctx.includes('/skill-candidates'), 'additionalContext references /skill-candidates command');
+  // Dedup tracker was written.
+  const trackerPath = path.join(cwd, '.agentic', '.skill-candidates-in-session');
+  assert(fs.existsSync(trackerPath), 'dedup tracker written after firing');
+  const trackerContent = fs.readFileSync(trackerPath, 'utf8');
+  const parsed = JSON.parse(trackerContent.trim());
+  assert(
+    parsed.session_id === sessionId && parsed.candidate_id === domain,
+    'dedup tracker entry has correct session_id and candidate_id'
+  );
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test (b): dedup-suppresses-repeat
+// Same candidate, same session -> no second nudge.
+// ---------------------------------------------------------------------------
+console.log('\nTest (b): dedup-suppresses-repeat');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-b';
+  const domain = 'adapter-build';
+
+  writeConfig(cwd, { skill_candidate_detection: true, skill_candidate_nudge: true });
+  writeTally(cwd, domain, 5);
+
+  const first = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(first.stdout.includes('SKILL-CANDIDATE-NUDGE'), 'first spawn emits skill nudge');
+
+  const second = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(second.status === 0, 'second spawn exits 0');
+  assert(second.stdout.trim() === '', 'second spawn (same candidate) emits nothing - dedup');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test (c): nudge-toggle-absent-silent
+// skill_candidate_nudge key absent from config -> defaults false -> no nudge.
+// ---------------------------------------------------------------------------
+console.log('\nTest (c): nudge-toggle-absent-silent');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-c';
+  const domain = 'some-domain';
+
+  // Config has NO skill_candidate_nudge key (absent = default false).
+  writeConfig(cwd, { skill_candidate_detection: true });
+  writeTally(cwd, domain, 4);
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge when skill_candidate_nudge absent (default false)');
+  assert(
+    !fs.existsSync(path.join(cwd, '.agentic', '.skill-candidates-in-session')),
+    'no dedup tracker written when nudge is off'
+  );
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test (d): nudge-toggle-false-silent
+// skill_candidate_nudge: false explicitly -> no nudge.
+// ---------------------------------------------------------------------------
+console.log('\nTest (d): nudge-toggle-false-silent');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-d';
+  const domain = 'another-domain';
+
+  writeConfig(cwd, { skill_candidate_detection: true, skill_candidate_nudge: false });
+  writeTally(cwd, domain, 3);
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge when skill_candidate_nudge is false');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test (e): detection-false-silent
+// skill_candidate_detection: false -> master toggle off -> no nudge even if
+// skill_candidate_nudge: true.
+// ---------------------------------------------------------------------------
+console.log('\nTest (e): detection-false-silent');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-e';
+  const domain = 'some-domain';
+
+  writeConfig(cwd, { skill_candidate_detection: false, skill_candidate_nudge: true });
+  writeTally(cwd, domain, 3);
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout.trim() === '', 'no nudge when skill_candidate_detection is false');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test (f): peek-read-only
+// Both toggles on, tally exists. After the hook fires, the tally mtime must
+// be unchanged - peekActiveCandidates() must NEVER write the tally or cursor.
+// ---------------------------------------------------------------------------
+console.log('\nTest (f): peek-read-only (tally mtime unchanged after hook)');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'skill-nudge-session-f';
+  const domain = 'lint-workaround';
+
+  writeConfig(cwd, { skill_candidate_detection: true, skill_candidate_nudge: true });
+  const tallyPath = writeTally(cwd, domain, 3);
+  const cursorPath = path.join(cwd, '.agentic', '.skill-candidate-cursor');
+
+  // Record mtime BEFORE hook run.
+  const tallyMtimeBefore = fs.statSync(tallyPath).mtimeMs;
+  // Cursor does not exist yet - we just record absence.
+  const cursorExistedBefore = fs.existsSync(cursorPath);
+
+  const { stdout, status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0 (peek-read-only case)');
+  assert(stdout.includes('SKILL-CANDIDATE-NUDGE'), 'nudge was emitted (confirming tally was readable)');
+
+  const tallyMtimeAfter = fs.statSync(tallyPath).mtimeMs;
+  assert(
+    tallyMtimeAfter === tallyMtimeBefore,
+    'tally mtime unchanged - peekActiveCandidates did not write the tally'
+  );
+
+  const cursorExistedAfter = fs.existsSync(cursorPath);
+  assert(
+    cursorExistedAfter === cursorExistedBefore,
+    'cursor file presence unchanged - peekActiveCandidates did not create/write cursor'
+  );
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Unit 3 of skill-candidate detection. Adds the Layer-2 opt-in in-session nudge as a second path inside `hooks/post-tool-use-capture-nudge.js` (per the locked spec's file/CI map - no new hook file; existing PostToolUse(Task/Agent) wiring covers it).

- Fires only when `skill_candidate_detection !== false` (default true) AND `skill_candidate_nudge === true` (default false) - silent out of the box.
- Calls `peekActiveCandidates` (read-only - never writes tally/cursor). Per-candidate-per-session dedup via `.agentic/.skill-candidates-in-session`.
- Fall-through: runs only when the capture-gap path doesn't fire (avoids competing nudges); starvation bounded to one invocation per gap event (Skeptic-confirmed).
- Full soft-fail, always exit 0.

23 new + 87 regression tests pass. Skeptic: sign-off, 0 Critical/Major (1 test-robustness Minor noted).