### PR TITLE
fix(install): quote heredoc delimiter so backtick in body is not command-substituted

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -393,7 +393,7 @@ fi
 
 echo "Updating ~/.claude/settings.json..."
 
-python3 - <<PYEOF
+python3 - <<'PYEOF'
 import json, os, sys
 
 settings_path = os.path.expanduser("~/.claude/settings.json")


### PR DESCRIPTION
Line 396 of `.claude/install.sh` opened a heredoc with an unquoted delimiter (`<<PYEOF`). The shell ran command substitution on the body, so the backtick-wrapped `ready` in the Python comment on line 525 produced `install.sh: line 396: ready: command not found` on every install run.

Fix: quote the opening delimiter (`<<'PYEOF'`). Closing `PYEOF` unchanged.

- Body reads inputs via `os.environ.get` and Python f-strings; no shell `$VAR`/`${VAR}`/`$(...)` expansion used or needed, so quoting is behavior-neutral on current content and hardens against future `$`-containing Python literals.
- `bash -n` clean; install dry-run yields zero "command not found" matches.
- Isolated to `.claude/install.sh` (other adapters already use quoted delimiters).