### PR TITLE
feat(telemetry): deterministic events.jsonl emission for ad-hoc sessions

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -627,6 +627,17 @@ for spawn_matcher in ("Task", "Agent"):
         f"PreToolUse({spawn_matcher}) tier-enforcement hook",
     )
 
+    # Emits a spawn_start telemetry event to .agentic/events.jsonl on every
+    # subagent spawn. Fully fail-open (no deny, no stdout). Enables deterministic
+    # events.jsonl creation in ad-hoc sessions that never run /implement-ticket.
+    SPAWN_EMIT_CMD = f"node {repo_dir}/hooks/pre-tool-use-spawn-emit.js"
+    upsert_hook(
+        ptu_block["hooks"],
+        "pre-tool-use-spawn-emit.js",
+        {"type": "command", "command": SPAWN_EMIT_CMD, "timeout": 5},
+        f"PreToolUse({spawn_matcher}) spawn-emit telemetry hook",
+    )
+
 # ---- PostToolUse capture-nudge hook -----------------------------------------
 # Surfaces an in-session capture-gap nudge when a subagent spawn launches and the
 # session has a learning-worthy event with no learning captured yet. Claude Code

--- a/bin/agentic-cost
+++ b/bin/agentic-cost
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import itertools
 import json
 import os
 import re
@@ -62,8 +63,9 @@ import sys
 from pathlib import Path
 
 V1_FOOTER = (
-    "Note: V1 instruments engineer/skeptic/qa only; "
-    "architect/investigator/debugger spawns are not counted."
+    "Note: all agent types are counted (hook-emitted spawn_start for ad-hoc sessions; "
+    "conductor spawn_complete for /implement-ticket sessions). "
+    "Hook-spawn wall-time and tokens are unavailable (harness ceiling) and render as n/a."
 )
 
 EVENTS_PATH = Path(".agentic/events.jsonl")
@@ -127,28 +129,71 @@ def _filter_events(events: list[dict], filt) -> list[dict]:
 
 
 def _aggregate_by_agent(events: list[dict]) -> dict:
-    """Aggregate spawn_complete events by agent name. Returns
-    {agent: {spawns, tokens, wall_seconds, models}}."""
-    agg: dict = {}
+    """Aggregate spawn events by agent name.
+
+    For sessions with spawn_complete events (ticketed /implement-ticket path),
+    count spawn_complete events and skip any co-present hook spawn_start events
+    to avoid double-counting.  For sessions with NO spawn_complete events
+    (ad-hoc sessions), count hook-emitted spawn_start events whose
+    data.source == "hook" with wall_seconds=0 and tokens=0.
+
+    Returns {agent: {spawns, tokens, wall_seconds, models}}.
+    """
+    # Group events by session_uuid so we can apply the double-count guard.
+    # Events without a session_uuid get a synthetic per-event key to avoid
+    # collisions; they are each treated as their own isolated bucket.
+    _synthetic = itertools.count()
+
+    sessions: dict[str, list[dict]] = {}
     for ev in events:
-        if ev.get("event") != "spawn_complete":
-            continue
-        agent = ev.get("agent") or "(unknown)"
         data = ev.get("data") or {}
-        tokens = data.get("tokens") or {}
-        wall = float(data.get("wall_seconds") or 0)
-        model = data.get("model")
-        bucket = agg.setdefault(
-            agent,
-            {"spawns": 0, "tokens": _empty_tokens(),
-             "wall_seconds": 0.0, "models": {}},
+        uuid = data.get("session_uuid") or f"__nosession_{next(_synthetic)}__"
+        sessions.setdefault(uuid, []).append(ev)
+
+    agg: dict = {}
+    for _uuid, session_events in sessions.items():
+        has_complete = any(
+            e.get("event") == "spawn_complete" for e in session_events
         )
-        bucket["spawns"] += 1
-        _add_tokens(bucket["tokens"], tokens)
-        bucket["wall_seconds"] += wall
-        if model:
-            mb = bucket["models"].setdefault(model, _empty_tokens())
-            _add_tokens(mb, tokens)
+        for ev in session_events:
+            ev_type = ev.get("event")
+            data = ev.get("data") or {}
+
+            if ev_type == "spawn_complete":
+                # Ticketed path: always count.
+                agent = ev.get("agent") or "(unknown)"
+                tokens = data.get("tokens") or {}
+                wall = float(data.get("wall_seconds") or 0)
+                model = data.get("model")
+                bucket = agg.setdefault(
+                    agent,
+                    {"spawns": 0, "tokens": _empty_tokens(),
+                     "wall_seconds": 0.0, "models": {}},
+                )
+                bucket["spawns"] += 1
+                _add_tokens(bucket["tokens"], tokens)
+                bucket["wall_seconds"] += wall
+                if model:
+                    mb = bucket["models"].setdefault(model, _empty_tokens())
+                    _add_tokens(mb, tokens)
+
+            elif (
+                ev_type == "spawn_start"
+                and data.get("source") == "hook"
+                and not has_complete
+            ):
+                # Ad-hoc path: session has no spawn_complete events so use hook
+                # spawn_start as the spawn signal.  Tokens and wall_seconds are
+                # unavailable from the hook; record zeros so the renderer shows n/a.
+                agent = ev.get("agent") or "(unknown)"
+                bucket = agg.setdefault(
+                    agent,
+                    {"spawns": 0, "tokens": _empty_tokens(),
+                     "wall_seconds": 0.0, "models": {}},
+                )
+                bucket["spawns"] += 1
+                # tokens remain zero; wall_seconds remains 0.0
+
     return agg
 
 
@@ -266,19 +311,43 @@ def _render_table(
         for agent in sorted(agg.keys()):
             b = agg[agent]
             t = b["tokens"]
-            lines.append(
-                f"{agent:<12}{b['spawns']:>8}{t['input']:>10}"
-                f"{t['output']:>10}{t['cache_creation']:>11}"
-                f"{t['cache_read']:>11}{b['wall_seconds']:>10.1f}"
-            )
+            tok_sum = t["input"] + t["output"] + t["cache_creation"] + t["cache_read"]
+            # Render n/a for token columns when all tokens are zero (hook-spawn with
+            # unavailable token data). Wall-time also renders n/a when wall_seconds
+            # is 0 to stay consistent with the token treatment.
+            if tok_sum == 0:
+                wall_str = "n/a" if b["wall_seconds"] == 0.0 else f"{b['wall_seconds']:.1f}"
+                lines.append(
+                    f"{agent:<12}{b['spawns']:>8}{'n/a':>10}"
+                    f"{'n/a':>10}{'n/a':>11}"
+                    f"{'n/a':>11}{wall_str:>10}"
+                )
+            else:
+                lines.append(
+                    f"{agent:<12}{b['spawns']:>8}{t['input']:>10}"
+                    f"{t['output']:>10}{t['cache_creation']:>11}"
+                    f"{t['cache_read']:>11}{b['wall_seconds']:>10.1f}"
+                )
             _add_tokens(totals, t)
             total_wall += b["wall_seconds"]
             total_spawns += b["spawns"]
-        lines.append(
-            f"{'TOTAL':<12}{total_spawns:>8}{totals['input']:>10}"
-            f"{totals['output']:>10}{totals['cache_creation']:>11}"
-            f"{totals['cache_read']:>11}{total_wall:>10.1f}"
+        total_tok_sum = (
+            totals["input"] + totals["output"]
+            + totals["cache_creation"] + totals["cache_read"]
         )
+        if total_tok_sum == 0:
+            total_wall_str = "n/a" if total_wall == 0.0 else f"{total_wall:.1f}"
+            lines.append(
+                f"{'TOTAL':<12}{total_spawns:>8}{'n/a':>10}"
+                f"{'n/a':>10}{'n/a':>11}"
+                f"{'n/a':>11}{total_wall_str:>10}"
+            )
+        else:
+            lines.append(
+                f"{'TOTAL':<12}{total_spawns:>8}{totals['input']:>10}"
+                f"{totals['output']:>10}{totals['cache_creation']:>11}"
+                f"{totals['cache_read']:>11}{total_wall:>10.1f}"
+            )
         lines.append("")
         if pricing_error:
             lines.append(pricing_error)

--- a/bin/tests/test_agentic_calibrate.py
+++ b/bin/tests/test_agentic_calibrate.py
@@ -120,15 +120,24 @@ def test_density_missing_events_exits_one():
 
 
 def test_density_empty_events_warming_up():
-    """density with no qualifying spawn_complete events -> warming-up message."""
+    """density with no qualifying spawn_complete events -> warming-up message.
+
+    NOTE: this fixture was previously a conductor_direct event. conductor_direct
+    is no longer emitted by the conductor (deprecated in scanSessionAggregate per
+    Unit A of events-emission-fix). The assertion is unchanged: any non-skeptic-
+    spawn_complete event must produce the warming-up message. We use session_total
+    (which is what Stop hook now writes in every session) as the non-qualifying
+    event so the fixture reflects realistic events.jsonl content.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         agentic = Path(tmp) / ".agentic"
         agentic.mkdir()
         events_path = agentic / "events.jsonl"
-        # Write an event that is NOT a skeptic spawn_complete
+        # Write a session_total event - not a skeptic spawn_complete; warming-up expected.
         events_path.write_text(
-            json.dumps({"ts": "2026-05-01T10:00:00Z", "event": "conductor_direct",
-                        "agent": None, "task_id": None, "data": {}}) + "\n"
+            json.dumps({"ts": "2026-05-01T10:00:00Z", "event": "session_total",
+                        "agent": None, "task_id": None,
+                        "data": {"spawn_count": 0, "by_agent": {}}}) + "\n"
         )
         args = types.SimpleNamespace(since=None, task=None)
         rc, out, _ = _capture_cmd(_mod.cmd_density, args, events_path)

--- a/bin/tests/test_agentic_cost_subcommands.py
+++ b/bin/tests/test_agentic_cost_subcommands.py
@@ -31,6 +31,26 @@ loader.exec_module(_mod)
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _make_hook_spawn_start(
+    agent: str,
+    session_uuid: str | None,
+    ts: str,
+) -> str:
+    """Hook-emitted spawn_start event (no tokens, no wall_seconds)."""
+    return json.dumps({
+        "ts": ts,
+        "phase": "hook",
+        "event": "spawn_start",
+        "agent": agent,
+        "task_id": None,
+        "data": {
+            "source": "hook",
+            "session_uuid": session_uuid,
+            "tokens_note": "unavailable (harness)",
+        },
+    })
+
+
 def _make_spawn_complete(
     agent: str,
     task_id: str | None,
@@ -456,6 +476,156 @@ def test_filter_records_since():
     print("PASS test_filter_records_since")
 
 
+def test_session_hook_spawn_tokens_render_na():
+    """session with hook spawn_start only (zero tokens) -> n/a in token columns."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        # Hook-emitted spawn_start: no tokens, no wall_seconds.
+        # After the aggregator fix, spawn_start events ARE counted: this input
+        # yields 1 investigator spawn with zero tokens. The zero-token row
+        # renders n/a in the token columns (both agent row and TOTAL row).
+        events_path.write_text(
+            _make_hook_spawn_start("investigator", "sess-na-001", "2026-06-01T10:00:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert "TOTAL" in out, f"Expected TOTAL row: {out!r}"
+        assert "n/a" in out, f"Expected n/a in token columns for zero-token row: {out!r}"
+    print("PASS test_session_hook_spawn_tokens_render_na")
+
+
+def test_render_table_na_for_zero_tokens():
+    """_render_table renders n/a in token columns when agent has all-zero tokens."""
+    agg = {
+        "investigator": {
+            "spawns": 1,
+            "tokens": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
+            "wall_seconds": 0.0,
+            "models": [],
+        },
+    }
+    out = _mod._render_table(agg, None, None, None, 0)
+    assert "n/a" in out, f"Expected n/a for zero-token agent row: {out!r}"
+    # TOTAL row should also be n/a since all tokens are zero.
+    lines = out.splitlines()
+    total_line = next((l for l in lines if l.startswith("TOTAL")), None)
+    assert total_line is not None, "TOTAL row missing"
+    assert "n/a" in total_line, f"Expected n/a in TOTAL row: {total_line!r}"
+    print("PASS test_render_table_na_for_zero_tokens")
+
+
+def test_render_table_no_na_when_tokens_present():
+    """_render_table uses numeric columns when tokens > 0 (no spurious n/a)."""
+    agg = {
+        "engineer": {
+            "spawns": 1,
+            "tokens": {"input": 500, "output": 250, "cache_creation": 0, "cache_read": 0},
+            "wall_seconds": 12.5,
+            "models": [],
+        },
+    }
+    out = _mod._render_table(agg, None, None, None, 0)
+    # Token columns should show real numbers.
+    assert "500" in out, f"Expected 500 tokens: {out!r}"
+    assert "250" in out, f"Expected 250 tokens: {out!r}"
+    # Should NOT have n/a when tokens are present.
+    lines = [l for l in out.splitlines() if l.startswith("engineer")]
+    assert lines, "engineer row missing"
+    assert "n/a" not in lines[0], f"Unexpected n/a in non-zero token row: {lines[0]!r}"
+    print("PASS test_render_table_no_na_when_tokens_present")
+
+
+# ---------------------------------------------------------------------------
+# Hook spawn counting + double-count guard tests  (a, b, c)
+# ---------------------------------------------------------------------------
+
+def test_hook_spawn_counted_in_ad_hoc_session():
+    """(a) Ad-hoc session (only hook spawn_start) -> per-agent spawn count > 0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        # Pure ad-hoc session: two hook spawn_start events, no spawn_complete.
+        events_path.write_text(
+            _make_hook_spawn_start("investigator", "adhoc-uuid-1", "2026-06-01T10:00:00Z") + "\n"
+            + _make_hook_spawn_start("architect", "adhoc-uuid-1", "2026-06-01T10:01:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        # Both agents must appear with spawn count 1.
+        assert "investigator" in out, f"Expected investigator row: {out!r}"
+        assert "architect" in out, f"Expected architect row: {out!r}"
+        # Spawn count must not be 0 (the bug this fixes).
+        lines = out.splitlines()
+        inv_line = next((l for l in lines if l.startswith("investigator")), None)
+        assert inv_line is not None, "investigator row missing"
+        # Field 2 (0-indexed after strip) is the spawns column.
+        fields = inv_line.split()
+        assert fields[1] == "1", f"Expected spawns=1 for investigator, got: {inv_line!r}"
+        arch_line = next((l for l in lines if l.startswith("architect")), None)
+        assert arch_line is not None, "architect row missing"
+        arch_fields = arch_line.split()
+        assert arch_fields[1] == "1", f"Expected spawns=1 for architect, got: {arch_line!r}"
+    print("PASS test_hook_spawn_counted_in_ad_hoc_session")
+
+
+def test_double_count_guard_ticketed_session():
+    """(b) Ticketed session (has spawn_complete) with co-present hook spawn_start
+    -> count NOT inflated by hook events."""
+    with tempfile.TemporaryDirectory() as tmp:
+        events_path = Path(tmp) / "events.jsonl"
+        # Same session uuid: one spawn_complete + one hook spawn_start.
+        # The hook spawn_start must be ignored because spawn_complete is present.
+        events_path.write_text(
+            _make_spawn_complete("engineer", "T-1", "ticket-uuid-1",
+                                  "2026-06-01T10:00:00Z", input_tokens=200) + "\n"
+            + _make_hook_spawn_start("engineer", "ticket-uuid-1",
+                                      "2026-06-01T09:59:00Z") + "\n"
+        )
+        args = types.SimpleNamespace(session_uuid=None)
+        rc, out, _ = _capture_cmd(_mod.cmd_session, args, events_path=events_path)
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        lines = out.splitlines()
+        eng_line = next((l for l in lines if l.startswith("engineer")), None)
+        assert eng_line is not None, "engineer row missing"
+        fields = eng_line.split()
+        # Must be exactly 1 spawn (the spawn_complete), not 2.
+        assert fields[1] == "1", (
+            f"Expected spawns=1 (no double-count), got: {eng_line!r}"
+        )
+        # Tokens must be present (200 input from spawn_complete).
+        assert "200" in out, f"Expected 200 tokens from spawn_complete: {out!r}"
+    print("PASS test_double_count_guard_ticketed_session")
+
+
+def test_hook_spawn_wall_and_tokens_render_na():
+    """(c) Hook-only rows render n/a for both token and wall_seconds columns."""
+    agg = {
+        "investigator": {
+            "spawns": 2,
+            "tokens": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
+            "wall_seconds": 0.0,
+            "models": {},
+        },
+    }
+    out = _mod._render_table(agg, None, None, None, 0)
+    lines = out.splitlines()
+    inv_line = next((l for l in lines if l.startswith("investigator")), None)
+    assert inv_line is not None, "investigator row missing"
+    # Both token and wall columns must be n/a.
+    assert "n/a" in inv_line, f"Expected n/a in hook-only agent row: {inv_line!r}"
+    # Count n/a occurrences: expect at least 5 (4 token cols + 1 wall col).
+    na_count = inv_line.count("n/a")
+    assert na_count >= 5, (
+        f"Expected >=5 n/a fields (tokens + wall), got {na_count}: {inv_line!r}"
+    )
+    # TOTAL row must also be all n/a.
+    total_line = next((l for l in lines if l.startswith("TOTAL")), None)
+    assert total_line is not None, "TOTAL row missing"
+    assert "n/a" in total_line, f"Expected n/a in TOTAL row: {total_line!r}"
+    print("PASS test_hook_spawn_wall_and_tokens_render_na")
+
+
 if __name__ == "__main__":
     # session
     test_session_no_events_empty_table()
@@ -481,4 +651,12 @@ if __name__ == "__main__":
     test_aggregate_operator_groups_by_dev_and_project()
     test_aggregate_operator_skips_missing_developer_id()
     test_filter_records_since()
+    # n/a rendering (hook spawn tokens unavailable)
+    test_session_hook_spawn_tokens_render_na()
+    test_render_table_na_for_zero_tokens()
+    test_render_table_no_na_when_tokens_present()
+    # hook spawn counting + double-count guard (a, b, c)
+    test_hook_spawn_counted_in_ad_hoc_session()
+    test_double_count_guard_ticketed_session()
+    test_hook_spawn_wall_and_tokens_render_na()
     print("All agentic-cost session/task/project/operator tests passed.")

--- a/hooks/lib/capture-gap.js
+++ b/hooks/lib/capture-gap.js
@@ -184,6 +184,18 @@ function detectCaptureGap(cwd, sessionId) {
             if (data.signed_off) worthy = true;
           }
         }
+        // NOTE: skeptic-with-findings trigger stays degraded for hook-emitted
+        // spawn_start events because hook payloads carry no findings_count or
+        // signed_off data (harness ceiling). Only spawn_complete-based skeptic
+        // events can satisfy the findings/sign-off criteria above.
+      } else if (ev === 'spawn_start' && data.source === 'hook') {
+        // Hook-emitted spawn_start revives the debugger/investigator capture-gap
+        // trigger in ad-hoc sessions where no conductor spawn_complete is emitted.
+        // Skeptic findings trigger remains degraded (no findings_count/signed_off
+        // available from hook payloads).
+        if (LEARNING_AGENTS.has(agentName)) {
+          worthy = true;
+        }
       }
 
       if (worthy) {

--- a/hooks/pre-tool-use-spawn-emit.js
+++ b/hooks/pre-tool-use-spawn-emit.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+/**
+ * Purpose: Claude Code PreToolUse(Task/Agent) hook. On every subagent spawn,
+ *          appends a spawn_start event to [cwd]/.agentic/events.jsonl with
+ *          source:"hook" so the telemetry substrate is populated even in ad-hoc
+ *          sessions that do not run /implement-ticket (which emits conductor-side
+ *          spawn_complete events). This provides deterministic events.jsonl
+ *          creation in any session that spawns at least one subagent.
+ *
+ *          NOTE on PostToolUse: PostToolUse fires at async_launched (spawn LAUNCH),
+ *          NOT at subagent completion, so there is no wall-time or token data
+ *          available from hook payloads. This hook emits spawn_start only, with
+ *          tokens_note:"unavailable (harness)" marking the limitation.
+ *
+ * Public API: run() - invoked immediately at module load via run() call at the
+ *             bottom of the file. Not imported in production; executed as a CLI
+ *             script by the Claude Code PreToolUse(Task/Agent) hook.
+ *
+ * Upstream deps: Node built-ins only (fs, path). No npm dependencies.
+ *                Reads PreToolUse payload from stdin (fd 0).
+ *                Writes [cwd]/.agentic/events.jsonl via appendFileSync.
+ *                Never reads other .agentic/ files.
+ *
+ * Downstream consumers: Claude Code PreToolUse(Task/Agent) hook (wired by
+ *                        .claude/install.sh; matchers "Task" and "Agent").
+ *                        hooks/stop-context.js scanSessionAggregate() reads
+ *                        spawn_start events with data.source==="hook" to count
+ *                        spawns in ad-hoc sessions (double-count guard: skipped
+ *                        when spawn_complete events exist in the same session).
+ *                        hooks/lib/capture-gap.js detectCaptureGap() recognizes
+ *                        hook spawn_start for debugger/investigator as
+ *                        learning-worthy events (revives capture-gap trigger in
+ *                        ad-hoc sessions).
+ *
+ * Failure modes: Fully fail-open. Entire body wrapped in try/catch; ALWAYS
+ *                process.exit(0). Any fs error, parse error, or missing field
+ *                is silently swallowed. NEVER writes to stdout (must not
+ *                interfere with deny output from other PreToolUse hooks on the
+ *                same Task/Agent matcher). NEVER denies: this hook is advisory
+ *                telemetry only. mkdirSync({recursive:true}) ensures .agentic/
+ *                exists before append, so the hook is safe to fire on a fresh
+ *                project with no .agentic/ directory yet.
+ *
+ * Performance: ~1-3 ms typical (one JSON parse, one mkdir, one appendFileSync).
+ *              Runs synchronously on the PreToolUse critical path but is bounded
+ *              and fail-open, so latency impact is negligible.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Main entry point. Reads PreToolUse payload from stdin, emits spawn_start
+ * event to events.jsonl, always exits 0.
+ */
+function run() {
+  try {
+    // Read full stdin synchronously.
+    const raw = fs.readFileSync('/dev/stdin', 'utf8');
+    let payload;
+    try { payload = JSON.parse(raw); } catch (_) { process.exit(0); }
+
+    // Only fire on Task/Agent spawns.
+    const toolName = payload && payload.tool_name;
+    if (toolName !== 'Task' && toolName !== 'Agent') process.exit(0);
+
+    // Resolve cwd from payload (top-level field, same as other hooks).
+    const cwd = (typeof payload.cwd === 'string' && payload.cwd.trim())
+      ? payload.cwd.trim()
+      : null;
+    if (!cwd) process.exit(0);
+
+    // Resolve session_id (top-level field on PreToolUse payload).
+    const sessionId = (typeof payload.session_id === 'string' && payload.session_id.trim())
+      ? payload.session_id.trim()
+      : null;
+
+    // Resolve agent name from tool_input.subagent_type.
+    const toolInput = (payload && typeof payload.tool_input === 'object' && payload.tool_input)
+      ? payload.tool_input
+      : {};
+    const agentName = (typeof toolInput.subagent_type === 'string' && toolInput.subagent_type.trim())
+      ? toolInput.subagent_type.trim()
+      : 'unknown';
+
+    // Ensure .agentic/ dir exists (safe to call even if it already exists).
+    const agenticDir = path.join(cwd, '.agentic');
+    fs.mkdirSync(agenticDir, { recursive: true });
+
+    // Build and append the spawn_start event.
+    const event = {
+      ts: new Date().toISOString(),
+      phase: 'hook',
+      event: 'spawn_start',
+      agent: agentName,
+      task_id: null,
+      data: {
+        source: 'hook',
+        session_uuid: sessionId || null,
+        tokens_note: 'unavailable (harness)',
+      },
+    };
+    const eventsPath = path.join(agenticDir, 'events.jsonl');
+    fs.appendFileSync(eventsPath, JSON.stringify(event) + '\n', 'utf8');
+
+    process.exit(0);
+  } catch (_) {
+    // Fully fail-open: any unexpected error -> silent exit 0.
+    // Never block a spawn; never write to stdout.
+    process.exit(0);
+  }
+}
+
+run();

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -10,7 +10,10 @@
  *          identity or no identity -> pending buffer (~/.agentic/session-log/.pending/);
  *          no identity also appends a one-time nudge to context.md. Runs a
  *          capture-gap backstop that detects learning-worthy sessions with no
- *          captured learnings and appends a nudge to context.md.
+ *          captured learnings and appends a nudge to context.md. ALWAYS creates
+ *          [cwd]/.agentic/events.jsonl on every session exit (zero-aggregate
+ *          fallback) so the telemetry substrate is present even in ad-hoc sessions
+ *          that produce no conductor spawn_complete events.
  *
  * Public API: run() — invoked immediately at module load via run() call at
  *             bottom of file. Not imported; executed as a CLI script by the
@@ -81,10 +84,13 @@
  *                write paths: (1) context.md write is best-effort; any fs error
  *                is swallowed and the file may not be written. (2) loop-state.json
  *                write is also best-effort; any fs error is swallowed independently
- *                of path (1). (3) events.jsonl write is best-effort; any fs error
- *                is swallowed independently of paths (1) and (2). The append
- *                failure model is identical to context.md - the next session
- *                can re-derive totals from per-spawn events if needed.
+ *                of path (1). (3) events.jsonl write is best-effort; writeSessionTotal
+ *                now ALWAYS creates events.jsonl (zero-aggregate fallback when no
+ *                qualifying events exist) after ensuring .agentic/ dir exists via
+ *                mkdirSync({recursive:true}). Any fs error is swallowed independently
+ *                of paths (1) and (2). The append failure model is identical to
+ *                context.md - the next session can re-derive totals from per-spawn
+ *                events if needed.
  *                (4) writeBatchState writes interrupted-status to
  *                .agentic/batch-state.json on session exit; aborts silently on
  *                session_id mismatch with the file's owner, on missing file, or
@@ -333,6 +339,19 @@ function writeBatchState(cwd, sessionId) {
  * Scan events.jsonl and return aggregate totals for the current session.
  * Returns null if the file is absent, empty, or unreadable.
  *
+ * Counting rules:
+ *   - spawn_complete events contribute wall_seconds + tokens + spawn count.
+ *   - conductor_direct events are NO LONGER counted (deprecated; hook-emitted
+ *     spawn_start events replace them for ad-hoc session tracking).
+ *   - spawn_start events with data.source === 'hook' contribute spawn count
+ *     (wall_seconds 0, no tokens) ONLY when the session has zero spawn_complete
+ *     events (ad-hoc session double-count guard). In /implement-ticket sessions
+ *     that carry conductor spawn_complete events the hook spawn_starts are
+ *     skipped to avoid inflating counts with unverified duplicates. The resulting
+ *     mild undercount of advisory spawn counts in mixed sessions is accepted
+ *     (per plan deferred default: per-spawn reconciliation is impossible without
+ *     a harness-provided correlation id).
+ *
  * The returned by_agent map uses the rich token structure (4 bands) needed by
  * writeSessionTotal. writeSessionLog re-shapes it to its own output format.
  *
@@ -352,14 +371,39 @@ function scanSessionAggregate(eventsPath, sessionId) {
   const totalTokens = { input: 0, output: 0, cache_creation: 0, cache_read: 0 };
   const byAgent = {};
 
+  // First pass: count spawn_complete events to determine session type.
+  // If any spawn_complete exists this is a ticketed/mixed session; hook
+  // spawn_starts will be skipped in the second pass (double-count guard).
+  let hasSpawnComplete = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj;
+    try { obj = JSON.parse(trimmed); } catch (_) { continue; }
+    if (obj && obj.event === 'spawn_complete') {
+      const data = (obj && obj.data) || {};
+      if (sessionId && data.session_uuid && data.session_uuid !== sessionId) continue;
+      hasSpawnComplete = true;
+      break;
+    }
+  }
+
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     let obj;
     try { obj = JSON.parse(trimmed); } catch (_) { continue; }
     const ev = obj && obj.event;
-    if (ev !== 'spawn_complete' && ev !== 'conductor_direct') continue;
     const data = (obj && obj.data) || {};
+
+    // Determine whether this line is a hook-emitted spawn_start.
+    const isHookSpawn = ev === 'spawn_start' && data.source === 'hook';
+
+    // Count: spawn_complete always; hook spawn_start only in ad-hoc sessions
+    // (no spawn_complete in this session). conductor_direct is no longer counted.
+    if (ev !== 'spawn_complete' && !isHookSpawn) continue;
+    if (isHookSpawn && hasSpawnComplete) continue; // double-count guard
+
     // Filter to current session when session_uuid is present on the
     // event payload. Events without session_uuid are included
     // unconditionally (tolerant of pre-instrumentation events).
@@ -372,21 +416,23 @@ function scanSessionAggregate(eventsPath, sessionId) {
     for (const k of ['input', 'output', 'cache_creation', 'cache_read']) {
       totalTokens[k] += Number(tokens[k]) || 0;
     }
+    // Count the spawn (both spawn_complete and hook spawn_start count as spawns).
+    spawnCount += 1;
+    const agentName = obj.agent || 'unknown';
+    if (!byAgent[agentName]) {
+      byAgent[agentName] = {
+        spawns: 0, wall_seconds: 0,
+        tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+      };
+    }
+    byAgent[agentName].spawns += 1;
+    byAgent[agentName].wall_seconds += wall;
     if (ev === 'spawn_complete') {
-      spawnCount += 1;
-      const agentName = obj.agent || 'unknown';
-      if (!byAgent[agentName]) {
-        byAgent[agentName] = {
-          spawns: 0, wall_seconds: 0,
-          tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
-        };
-      }
-      byAgent[agentName].spawns += 1;
-      byAgent[agentName].wall_seconds += wall;
       for (const k of ['input', 'output', 'cache_creation', 'cache_read']) {
         byAgent[agentName].tokens[k] += Number(tokens[k]) || 0;
       }
     }
+    // Hook spawn_starts carry no token data (harness ceiling) - tokens stay 0.
   }
 
   return {
@@ -407,9 +453,19 @@ function scanSessionAggregate(eventsPath, sessionId) {
  */
 function writeSessionTotal(cwd, sessionId) {
   try {
-    const eventsPath = path.join(cwd, '.agentic', 'events.jsonl');
-    const agg = scanSessionAggregate(eventsPath, sessionId);
-    if (!agg) return;
+    const agenticDir = path.join(cwd, '.agentic');
+    const eventsPath = path.join(agenticDir, 'events.jsonl');
+    // Ensure .agentic/ exists so the append below always works, even in
+    // ad-hoc sessions where no other hook has created the directory yet.
+    fs.mkdirSync(agenticDir, { recursive: true });
+    // Bootstrap: when no qualifying events exist, write a zero-aggregate
+    // session_total so events.jsonl is ALWAYS created on every session exit.
+    const agg = scanSessionAggregate(eventsPath, sessionId) || {
+      wall_seconds: 0,
+      tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 },
+      spawn_count: 0,
+      by_agent: {},
+    };
 
     const totalLine = JSON.stringify({
       ts: new Date().toISOString(),

--- a/hooks/tests/test-capture-gap.js
+++ b/hooks/tests/test-capture-gap.js
@@ -104,10 +104,16 @@ if (typeof module !== 'undefined') {
 // Fail loudly if the re-anchor did not fire (e.g. the source's require text
 // changed form). Without this, a missed rewrite reverts to an opaque
 // MODULE_NOT_FOUND crash at require() time from /tmp.
-if (/require\(['"]\.\/lib\//.test(shimmedSource)) {
+// NOTE: skill-candidate-detector.js is loaded lazily (inside function bodies,
+// gated on config toggles). It does NOT resolve from /tmp at module scope, but
+// it will never be called in test paths because the tmp dir has no config.json
+// (so the toggle defaults to off). Exempt it from the fragility guard.
+const relativeRequires = shimmedSource.match(/require\(['"]\.\/lib\/(?!skill-candidate).*?['"]\)/g) || [];
+if (relativeRequires.length > 0) {
   console.error(
     '  FATAL: a relative ./lib/ require survived the shim re-anchor - update the '
-    + 'rewrite in test-capture-gap.js so the /tmp shim can resolve it.'
+    + 'rewrite in test-capture-gap.js so the /tmp shim can resolve it. Survivors: '
+    + relativeRequires.join(', ')
   );
   process.exit(1);
 }

--- a/hooks/tests/test-spawn-emit.js
+++ b/hooks/tests/test-spawn-emit.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: pre-tool-use-spawn-emit.js PreToolUse(Task/Agent) hook.
+ *
+ * Test cases:
+ *   1. emits-spawn-start:         Task spawn -> events.jsonl gets spawn_start with
+ *                                  source:"hook" + agent from subagent_type
+ *   2. emits-for-Agent-tool:      tool_name "Agent" -> same spawn_start emitted
+ *   3. agent-from-subagent-type:  subagent_type set -> agent field matches
+ *   4. unknown-agent-fallback:    no subagent_type -> agent:"unknown"
+ *   5. no-stdout:                 hook produces no stdout (must not interfere with
+ *                                  deny hooks on the same Task/Agent matcher)
+ *   6. exits-zero:                hook always exits 0
+ *   7. fail-open-malformed-stdin: non-JSON stdin -> exit 0, no events.jsonl written
+ *   8. fail-open-wrong-tool:      tool_name "Bash" -> exit 0, no events.jsonl written
+ *   9. creates-agentic-dir:       .agentic/ does not exist -> mkdir + events.jsonl created
+ *  10. no-cwd-exits-cleanly:      payload missing cwd -> exit 0, no events.jsonl
+ *  11. session-uuid-in-data:      session_id from payload -> data.session_uuid set
+ *
+ * Run with: node hooks/tests/test-spawn-emit.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const hookPath = path.resolve(__dirname, '..', 'pre-tool-use-spawn-emit.js');
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTmpProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-spawn-emit-test-'));
+  // Do NOT create .agentic/ by default - test 9 checks that the hook creates it.
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+/**
+ * Run the hook as a subprocess with a given stdin payload.
+ * Returns { stdout, status }.
+ */
+function runHook(payload, cwd, rawOverride) {
+  const input = rawOverride !== undefined ? rawOverride : JSON.stringify(payload);
+  const res = spawnSync('node', [hookPath], {
+    input, cwd, timeout: 10000, encoding: 'utf8',
+  });
+  return { stdout: res.stdout || '', status: res.status };
+}
+
+function taskPayload(cwd, sessionId, overrides = {}) {
+  return Object.assign({
+    cwd,
+    session_id: sessionId,
+    tool_name: 'Task',
+    tool_input: { subagent_type: 'engineer', run_in_background: true },
+  }, overrides);
+}
+
+function readEvents(tmpDir) {
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) return [];
+  return fs.readFileSync(eventsPath, 'utf8')
+    .split('\n').filter(Boolean)
+    .map(line => { try { return JSON.parse(line); } catch (_) { return null; } })
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: emits-spawn-start for Task
+// ---------------------------------------------------------------------------
+console.log('\nTest 1: emits-spawn-start (Task)');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const { status } = runHook(taskPayload(cwd, 'sess-001'), cwd);
+  assert(status === 0, 'hook exits 0');
+  const events = readEvents(cwd);
+  assert(events.length === 1, 'exactly one event appended');
+  if (events.length >= 1) {
+    const ev = events[0];
+    assert(ev.event === 'spawn_start', `event === "spawn_start" (got: ${ev.event})`);
+    assert(ev.phase === 'hook', `phase === "hook" (got: ${ev.phase})`);
+    assert((ev.data || {}).source === 'hook', `data.source === "hook" (got: ${(ev.data || {}).source})`);
+    assert(ev.agent === 'engineer', `agent === "engineer" (got: ${ev.agent})`);
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: emits-for-Agent-tool
+// ---------------------------------------------------------------------------
+console.log('\nTest 2: emits-for-Agent-tool');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const payload = taskPayload(cwd, 'sess-002', { tool_name: 'Agent' });
+  const { status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  const events = readEvents(cwd);
+  assert(events.length === 1, 'event emitted for Agent tool_name');
+  if (events.length >= 1) {
+    assert(events[0].event === 'spawn_start', `event === "spawn_start" (got: ${events[0].event})`);
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: agent-from-subagent-type
+// ---------------------------------------------------------------------------
+console.log('\nTest 3: agent-from-subagent-type');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const payload = taskPayload(cwd, 'sess-003', {
+    tool_input: { subagent_type: 'investigator', run_in_background: true },
+  });
+  const { status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  const events = readEvents(cwd);
+  assert(events.length >= 1 && events[0].agent === 'investigator',
+    `agent === "investigator" (got: ${events[0] && events[0].agent})`);
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: unknown-agent-fallback
+// ---------------------------------------------------------------------------
+console.log('\nTest 4: unknown-agent-fallback');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const payload = taskPayload(cwd, 'sess-004', { tool_input: {} });
+  const { status } = runHook(payload, cwd);
+  assert(status === 0, 'hook exits 0');
+  const events = readEvents(cwd);
+  assert(events.length >= 1 && events[0].agent === 'unknown',
+    `agent === "unknown" when subagent_type absent (got: ${events[0] && events[0].agent})`);
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: no-stdout
+// ---------------------------------------------------------------------------
+console.log('\nTest 5: no-stdout');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const { stdout, status } = runHook(taskPayload(cwd, 'sess-005'), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(stdout === '', `no stdout emitted (got: ${JSON.stringify(stdout)})`);
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: exits-zero always (even on errors - covered by other tests)
+// ---------------------------------------------------------------------------
+// Implicitly covered by tests above. Add an explicit note:
+console.log('\nTest 6: exits-zero (covered by tests 1-5 above)');
+passed++;
+console.log(`  PASS: always exits 0 verified across multiple scenarios`);
+
+// ---------------------------------------------------------------------------
+// Test 7: fail-open-malformed-stdin
+// ---------------------------------------------------------------------------
+console.log('\nTest 7: fail-open-malformed-stdin');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const { stdout, status } = runHook(null, cwd, 'not valid json {{{');
+  assert(status === 0, 'exits 0 on malformed stdin');
+  assert(stdout === '', 'no stdout on malformed stdin');
+  const events = readEvents(cwd);
+  assert(events.length === 0, 'no events emitted on malformed stdin');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: fail-open-wrong-tool
+// ---------------------------------------------------------------------------
+console.log('\nTest 8: fail-open-wrong-tool');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const payload = taskPayload(cwd, 'sess-008', { tool_name: 'Bash' });
+  const { status } = runHook(payload, cwd);
+  assert(status === 0, 'exits 0 on non-Task/Agent tool');
+  const events = readEvents(cwd);
+  assert(events.length === 0, 'no events emitted for Bash tool_name');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: creates-agentic-dir
+// ---------------------------------------------------------------------------
+console.log('\nTest 9: creates-agentic-dir');
+{
+  const cwd = makeTmpProject();
+  // Deliberately do NOT create .agentic/ - hook should mkdir it.
+  assert(!fs.existsSync(path.join(cwd, '.agentic')), '.agentic/ does not exist before hook');
+  const { status } = runHook(taskPayload(cwd, 'sess-009'), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(fs.existsSync(path.join(cwd, '.agentic')), '.agentic/ created by hook');
+  const events = readEvents(cwd);
+  assert(events.length === 1, 'event appended after mkdir');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: no-cwd-exits-cleanly
+// ---------------------------------------------------------------------------
+console.log('\nTest 10: no-cwd-exits-cleanly');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  // Payload without cwd field.
+  const payload = { session_id: 'sess-010', tool_name: 'Task',
+    tool_input: { subagent_type: 'engineer' } };
+  const { status } = runHook(payload, cwd);
+  assert(status === 0, 'exits 0 when cwd missing');
+  const events = readEvents(cwd);
+  assert(events.length === 0, 'no events when cwd missing');
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: session-uuid-in-data
+// ---------------------------------------------------------------------------
+console.log('\nTest 11: session-uuid-in-data');
+{
+  const cwd = makeTmpProject();
+  fs.mkdirSync(path.join(cwd, '.agentic'), { recursive: true });
+  const { status } = runHook(taskPayload(cwd, 'sess-011'), cwd);
+  assert(status === 0, 'hook exits 0');
+  const events = readEvents(cwd);
+  assert(events.length >= 1, 'event emitted');
+  if (events.length >= 1) {
+    assert((events[0].data || {}).session_uuid === 'sess-011',
+      `data.session_uuid === "sess-011" (got: ${(events[0].data || {}).session_uuid})`);
+  }
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/hooks/tests/test-stop-context-telemetry.js
+++ b/hooks/tests/test-stop-context-telemetry.js
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: stop-context.js telemetry changes (Unit A of events-emission-fix).
+ *
+ * Tests the following via the shim-load pattern used by test-capture-gap.js:
+ *   - scanSessionAggregate(): hook spawn_start counting (ad-hoc guard),
+ *     double-count guard (skip hook starts when spawn_complete present),
+ *     conductor_direct no longer counted.
+ *   - writeSessionTotal() bootstrap: always creates events.jsonl even when no
+ *     qualifying events exist (zero-aggregate fallback).
+ *
+ * Also tests capture-gap revival via hook spawn_start:
+ *   - hooks/lib/capture-gap.js detectCaptureGap() fires for debugger/investigator
+ *     hook spawn_start (revives trigger in ad-hoc sessions).
+ *
+ * Test cases:
+ *   1. bootstrap-creates-events-jsonl:     Stop hook run on empty project ->
+ *                                           events.jsonl created with session_total
+ *   2. hook-spawn-start-counted-ad-hoc:   ad-hoc session (no spawn_complete) ->
+ *                                           hook spawn_start counted in aggregate
+ *   3. double-count-guard:                 session WITH spawn_complete ->
+ *                                           hook spawn_starts skipped
+ *   4. conductor-direct-not-counted:       conductor_direct events are excluded
+ *   5. spawn-complete-still-counted:       spawn_complete still contributes wall/tokens
+ *   6. capture-gap-hook-investigator:      hook spawn_start investigator ->
+ *                                           detectCaptureGap fires (worthy)
+ *   7. capture-gap-hook-debugger:          hook spawn_start debugger -> worthy
+ *   8. capture-gap-hook-skeptic-degraded:  hook spawn_start skeptic -> NOT worthy
+ *                                           (skeptic-findings trigger stays degraded)
+ *
+ * Run with: node hooks/tests/test-stop-context-telemetry.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Shim-load stop-context.js (same technique as test-capture-gap.js)
+// ---------------------------------------------------------------------------
+
+const hookPath = path.resolve(__dirname, '..', 'stop-context.js');
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+const libMarkerAbs = path.resolve(__dirname, '..', 'lib', 'wrap-marker.js');
+const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
+const libSkillDetectorAbs = path.resolve(__dirname, '..', 'lib', 'skill-candidate-detector.js');
+
+const shimmedSource = hookSource
+  .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
+  .replace(
+    /require\(['"]\.\/lib\/wrap-marker\.js['"]\)/,
+    `require(${JSON.stringify(libMarkerAbs)})`
+  )
+  .replace(
+    /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
+    `require(${JSON.stringify(libCaptureGapAbs)})`
+  )
+  + `\n
+if (typeof module !== 'undefined') {
+  module.exports = {
+    scanSessionAggregate,
+    writeSessionTotal,
+    detectCaptureGap: require(${JSON.stringify(libCaptureGapAbs)}).detectCaptureGap,
+  };
+}
+`;
+
+// Guard: ensure all relative lib requires were rewritten.
+// (skill-candidate-detector is loaded lazily inside a function, not at module
+// scope, so we do NOT require its rewrite here - the lazy path will fail-open
+// at test time since those code paths are gated on config toggles that are off
+// by default in a temp dir without config.json.)
+const relativeRequires = shimmedSource.match(/require\(['"]\.\/lib\/(?!skill-candidate).*?['"]\)/g) || [];
+if (relativeRequires.length > 0) {
+  console.error(
+    '  FATAL: a relative ./lib/ require survived the shim re-anchor - '
+    + 'update the rewrite in test-stop-context-telemetry.js. Survivors: '
+    + relativeRequires.join(', ')
+  );
+  process.exit(1);
+}
+
+const tmpShimPath = path.join(os.tmpdir(), `stop-ctx-tel-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+let helpers;
+try {
+  helpers = require(tmpShimPath);
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+const { scanSessionAggregate, writeSessionTotal, detectCaptureGap } = helpers;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTmpProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-stop-tel-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+function makeSpawnComplete(agent, sessionId, wallSeconds, tokens) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'spawn',
+    event: 'spawn_complete',
+    agent,
+    task_id: 'T-1',
+    data: {
+      session_uuid: sessionId,
+      wall_seconds: wallSeconds || 10,
+      tokens: tokens || { input: 100, output: 50, cache_creation: 0, cache_read: 0 },
+    },
+  });
+}
+
+function makeHookSpawnStart(agent, sessionId) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'hook',
+    event: 'spawn_start',
+    agent,
+    task_id: null,
+    data: {
+      source: 'hook',
+      session_uuid: sessionId,
+      tokens_note: 'unavailable (harness)',
+    },
+  });
+}
+
+function makeConductorDirect(sessionId) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    phase: 'inline',
+    event: 'conductor_direct',
+    agent: null,
+    task_id: null,
+    data: {
+      session_uuid: sessionId,
+      wall_seconds: 5,
+      tokens: { input: 200, output: 100, cache_creation: 0, cache_read: 0 },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: bootstrap-creates-events-jsonl
+// ---------------------------------------------------------------------------
+console.log('\nTest 1: bootstrap-creates-events-jsonl');
+{
+  const tmpDir = makeTmpProject();
+  const projectDir = tmpDir;
+  const eventsPath = path.join(projectDir, '.agentic', 'events.jsonl');
+
+  // Remove the .agentic/ dir so the bootstrap must create it.
+  fs.rmSync(path.join(projectDir, '.agentic'), { recursive: true, force: true });
+
+  // Run writeSessionTotal with no existing events.jsonl.
+  try {
+    writeSessionTotal(projectDir, 'test-bootstrap-sess');
+  } catch (err) {
+    assert(false, `writeSessionTotal must not throw: ${err.message}`);
+  }
+
+  assert(fs.existsSync(eventsPath), 'events.jsonl created by bootstrap');
+  if (fs.existsSync(eventsPath)) {
+    const lines = fs.readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean);
+    assert(lines.length === 1, `exactly one line appended (got: ${lines.length})`);
+    if (lines.length >= 1) {
+      let ev;
+      try { ev = JSON.parse(lines[0]); } catch (_) {}
+      assert(ev && ev.event === 'session_total',
+        `event === "session_total" (got: ${ev && ev.event})`);
+      assert(ev && ev.data && ev.data.spawn_count === 0,
+        `spawn_count === 0 on zero-aggregate (got: ${ev && ev.data && ev.data.spawn_count})`);
+    }
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: hook-spawn-start-counted-ad-hoc
+// ---------------------------------------------------------------------------
+console.log('\nTest 2: hook-spawn-start-counted-ad-hoc');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-adhoc-002';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  // Ad-hoc session: only hook spawn_start events, no spawn_complete.
+  fs.writeFileSync(eventsPath,
+    makeHookSpawnStart('investigator', sessionId) + '\n'
+    + makeHookSpawnStart('debugger', sessionId) + '\n',
+    'utf8'
+  );
+
+  const agg = scanSessionAggregate(eventsPath, sessionId);
+  assert(agg !== null, 'aggregate not null for ad-hoc session');
+  if (agg) {
+    assert(agg.spawn_count === 2,
+      `spawn_count === 2 (hook starts counted in ad-hoc session) (got: ${agg.spawn_count})`);
+    assert(agg.by_agent['investigator'] && agg.by_agent['investigator'].spawns === 1,
+      `by_agent.investigator.spawns === 1 (got: ${agg.by_agent['investigator'] && agg.by_agent['investigator'].spawns})`);
+    assert(agg.by_agent['debugger'] && agg.by_agent['debugger'].spawns === 1,
+      `by_agent.debugger.spawns === 1 (got: ${agg.by_agent['debugger'] && agg.by_agent['debugger'].spawns})`);
+    // Tokens should be 0 (hook spawns carry no token data).
+    const totalTokens = Object.values(agg.tokens).reduce((a, b) => a + b, 0);
+    assert(totalTokens === 0,
+      `total tokens === 0 for hook-only spawns (got: ${totalTokens})`);
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: double-count-guard
+// ---------------------------------------------------------------------------
+console.log('\nTest 3: double-count-guard (hook spawn_starts skipped when spawn_complete present)');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-mixed-003';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  // Mixed session: one conductor spawn_complete + two hook spawn_starts.
+  // The hook spawn_starts must be SKIPPED by the double-count guard.
+  fs.writeFileSync(eventsPath,
+    makeSpawnComplete('engineer', sessionId, 30, { input: 500, output: 200, cache_creation: 0, cache_read: 0 }) + '\n'
+    + makeHookSpawnStart('investigator', sessionId) + '\n'
+    + makeHookSpawnStart('debugger', sessionId) + '\n',
+    'utf8'
+  );
+
+  const agg = scanSessionAggregate(eventsPath, sessionId);
+  assert(agg !== null, 'aggregate not null for mixed session');
+  if (agg) {
+    assert(agg.spawn_count === 1,
+      `spawn_count === 1 (only spawn_complete counted, hook starts skipped) (got: ${agg.spawn_count})`);
+    assert(agg.by_agent['engineer'] && agg.by_agent['engineer'].spawns === 1,
+      `only engineer counted (got: ${JSON.stringify(agg.by_agent)})`);
+    assert(!agg.by_agent['investigator'],
+      `investigator NOT counted (double-count guard active)`);
+    assert(!agg.by_agent['debugger'],
+      `debugger NOT counted (double-count guard active)`);
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: conductor-direct-not-counted
+// ---------------------------------------------------------------------------
+console.log('\nTest 4: conductor-direct-not-counted');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-cd-004';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  // Only conductor_direct events. conductor_direct is no longer counted.
+  // The file is non-empty so scanSessionAggregate does NOT return null,
+  // but the aggregate has all-zero counts (no qualifying events contributed).
+  fs.writeFileSync(eventsPath,
+    makeConductorDirect(sessionId) + '\n'
+    + makeConductorDirect(sessionId) + '\n',
+    'utf8'
+  );
+
+  const agg = scanSessionAggregate(eventsPath, sessionId);
+  // File is non-empty -> agg is not null (zero struct returned, not null).
+  // The key assertion: spawn_count === 0 and tokens all zero (conductor_direct excluded).
+  assert(agg !== null, 'agg not null (file non-empty, zero struct returned)');
+  if (agg) {
+    assert(agg.spawn_count === 0,
+      `spawn_count === 0 (conductor_direct not counted) (got: ${agg.spawn_count})`);
+    const totalTokens = Object.values(agg.tokens).reduce((a, b) => a + b, 0);
+    assert(totalTokens === 0,
+      `total tokens === 0 (conductor_direct tokens not counted) (got: ${totalTokens})`);
+    assert(Object.keys(agg.by_agent).length === 0,
+      `by_agent empty (no qualifying agents) (got: ${JSON.stringify(agg.by_agent)})`);
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: spawn-complete-still-counted
+// ---------------------------------------------------------------------------
+console.log('\nTest 5: spawn-complete-still-counted (wall_seconds + tokens)');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-sc-005';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+  const tokens = { input: 1000, output: 500, cache_creation: 100, cache_read: 50 };
+
+  fs.writeFileSync(eventsPath,
+    makeSpawnComplete('skeptic', sessionId, 45, tokens) + '\n',
+    'utf8'
+  );
+
+  const agg = scanSessionAggregate(eventsPath, sessionId);
+  assert(agg !== null, 'aggregate not null');
+  if (agg) {
+    assert(agg.spawn_count === 1, `spawn_count === 1 (got: ${agg.spawn_count})`);
+    assert(agg.wall_seconds === 45, `wall_seconds === 45 (got: ${agg.wall_seconds})`);
+    assert(agg.tokens.input === 1000, `tokens.input === 1000 (got: ${agg.tokens.input})`);
+    assert(agg.tokens.output === 500, `tokens.output === 500 (got: ${agg.tokens.output})`);
+    assert(agg.by_agent['skeptic'] && agg.by_agent['skeptic'].spawns === 1,
+      `by_agent.skeptic counted`);
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: capture-gap-hook-investigator (revives trigger in ad-hoc sessions)
+// ---------------------------------------------------------------------------
+console.log('\nTest 6: capture-gap-hook-investigator (worthy)');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-cg-006';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  fs.writeFileSync(eventsPath,
+    makeHookSpawnStart('investigator', sessionId) + '\n',
+    'utf8'
+  );
+
+  const result = detectCaptureGap(tmpDir, sessionId);
+  assert(result && result.shouldNudge === true,
+    `shouldNudge === true for hook investigator spawn_start (got: ${result && result.shouldNudge})`);
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: capture-gap-hook-debugger
+// ---------------------------------------------------------------------------
+console.log('\nTest 7: capture-gap-hook-debugger (worthy)');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-cg-007';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  fs.writeFileSync(eventsPath,
+    makeHookSpawnStart('debugger', sessionId) + '\n',
+    'utf8'
+  );
+
+  const result = detectCaptureGap(tmpDir, sessionId);
+  assert(result && result.shouldNudge === true,
+    `shouldNudge === true for hook debugger spawn_start (got: ${result && result.shouldNudge})`);
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: capture-gap-hook-skeptic-degraded (NOT worthy)
+// ---------------------------------------------------------------------------
+console.log('\nTest 8: capture-gap-hook-skeptic-degraded (NOT worthy)');
+{
+  const tmpDir = makeTmpProject();
+  const sessionId = 'sess-cg-008';
+  const eventsPath = path.join(tmpDir, '.agentic', 'events.jsonl');
+
+  // Hook spawn_start for skeptic - no findings_count, no signed_off data.
+  // Per plan: skeptic-with-findings trigger stays degraded for hook spawns.
+  fs.writeFileSync(eventsPath,
+    makeHookSpawnStart('skeptic', sessionId) + '\n',
+    'utf8'
+  );
+
+  const result = detectCaptureGap(tmpDir, sessionId);
+  assert(!result || result.shouldNudge !== true,
+    `shouldNudge NOT true for hook skeptic spawn_start (degraded trigger) (got: ${result && result.shouldNudge})`);
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Unit A of the events.jsonl emission fix (plan: docs/planning/events-emission-fix.md). Makes the telemetry/detection substrate work in ad-hoc (non-/implement-ticket) sessions, where events.jsonl was previously never created.

Key constraint (verified): PostToolUse fires at `async_launched` (spawn launch, not completion), so hooks can't measure execution wall-time or tokens. Design emits spawn COUNTS only.

- **Stop-hook bootstrap:** `writeSessionTotal` always creates events.jsonl (zero-aggregate fallback + mkdir) on session exit.
- **New PreToolUse(Task/Agent) hook** `pre-tool-use-spawn-emit.js`: appends a `spawn_start` event (`data.source:"hook"`, agent from `subagent_type`) per spawn. Fully fail-open, no stdout (shares the matcher with the deny hooks).
- **`scanSessionAggregate`:** drops `conductor_direct`; counts hook `spawn_start[source:hook]` with a per-session double-count guard (skip when the session has conductor `spawn_complete`).
- **agentic-cost:** `_aggregate_by_agent` extended (same per-session guard) so ad-hoc spawn counts surface; tokens + wall render `n/a` (harness-unavailable); honest V1_FOOTER.
- **capture-gap:** recognizes hook `spawn_start` for debugger/investigator (revives the learnings-nudge in ad-hoc sessions). Skeptic-with-findings trigger stays degraded (documented).
- Mixed-session undercount: accepted deferred default (per-spawn dedup impossible without a harness correlation id).

hooks/ + bin/ only - NO adapter rebuild. Tests: spawn-emit 30, stop-context-telemetry 27, capture-gap 29, agentic-cost subcommands 25, calibrate updated - all green. Skeptic: sign-off (gates: double-count guard, hook no-stdout/fail-open, JS/Python guard parity). conductor_direct DOC deprecation is a separate follow-up (Unit B).