### PR TITLE
docs(overview): commit North Star vision + reference it in CONTRIBUTING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,8 @@ docs/planning/
 docs/research/
 docs/technical/
 docs/operations/
-docs/overview/
+docs/overview/*
+!docs/overview/vision.md
 docs/_archive/session-learnings/
 
 # Stray .agentic/ runtime working dirs created when a command/subagent runs with a non-root cwd.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Changes to the methodology itself - conductor rules, the Skeptic protocol, risk 
 - One concern per PR — don't bundle unrelated changes
 - Describe the *why* in the PR body, not just the *what*
 - Test locally before opening: re-run `install.sh`, open a Claude Code session, verify the change works as expected
+- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction) without regressing another, with operator attention as the tie-breaker
 
 ### Adapter compatibility declaration
 
@@ -109,6 +110,7 @@ When contributing a new feature, pick the right home for each artifact:
 | End user of the feature | `content/commands/<command>.md` or `content/references/<ref>.md`. Note: editing `content/**` requires rebuilding adapters in the same PR, or CI (`check-adapter-sync` / `methodology-drift`) fails. |
 | Operator / maintainer of a non-trivial feature | A committed feature README co-located with the code (e.g. `hooks/<feature>.README.md`). Include: how to enable/configure it, what state it owns, how to stop/reset it, the security model, and the rollback procedure. This is the committed home for content that would otherwise be stranded in `docs/planning/`. |
 | Durable facts and decisions | `MEMORY.md` (facts + rationale), `decisions.md` (decision log, where the project keeps one), or the relevant `AGENTS.md` (agent-facing conventions). |
+| Contributors / reviewers (North Star alignment) | `docs/overview/vision.md` - the product-intent lens every PR is measured against. Read it before opening a change that affects operator attention, autonomy, or verifiability. |
 
 ## Contributing a feature - documentation checklist
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -869,7 +869,7 @@
   <div class="side-nav-brand">
     <img class="side-nav-logo" src="images/dinostack-logo.svg" alt="DinoStack" />
   </div>
-  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jun 23, 2026
+  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jun 28, 2026
   <hr class="side-nav-divider">
   <a href="#decks"><span class="nav-dot" style="background: var(--text-muted);"></span> Slide Decks</a>
   <a href="#infographics"><span class="nav-dot" style="background: var(--gold);"></span> Infographics</a>

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -1,0 +1,48 @@
+# DinoStack Product Vision (North Star)
+
+**Status:** Ratified (committed 2026-06-28). This is the operator-owned product-intent layer - the
+lens every review and design decision is measured against. Authored 2026-06-24; synthesized from
+DinoStack's README/CLAUDE.md and the Helios vision
+(`../helios/docs/overview/vision.md`), which DinoStack exists to serve.
+
+## The problem
+
+Agentic engineering has made code generation cheap. The scarce resource is now the **operator's
+attention** — the cost of deciding what to build, trusting that it was built correctly, and not
+having to babysit the machine to find out. DinoStack is the protocol layer that makes delegated
+work *trustworthy enough to ignore*: structured delegation, risk classification, adversarial
+review (the Skeptic loop), code-quality gates, and named agents, so an operator can hand off a
+task and get back a verifiable outcome.
+
+## North Star (what every change should serve)
+
+1. **Guard operator attention.** Surface decisions and work-stoppages, not status. A change that
+   adds capability but increases what the operator must read, watch, or babysit is a regression,
+   not a feature. (The "attention test" is the tie-breaker when trade-offs are unclear.)
+2. **Produce verifiable outcomes autonomously.** Agents should drive work to a checkable result
+   — tests/lints/gates passing, an adversarial Skeptic sign-off, a clear `ok | needs_human |
+   blocked` exit — without a human in the loop for routine steps. Verifiability is what makes
+   autonomy safe to trust.
+3. **Low friction.** Sensible defaults, minimal setup, global-default/per-project-override
+   everywhere. The protocol should reduce ceremony, not add it.
+
+## What it does
+
+Provides the portable, evolving rule set + agent definitions that let an operator delegate
+software work to sandboxed AE teams and receive results that are reviewed, gated, and ready to
+trust — escalating to the human only for genuine decisions.
+
+## Explicit non-goals
+
+- **Not** a tool that requires the operator to watch it work or read everything it produces.
+- **Not** capability-for-capability's-sake: features that raise attention tax without a
+  proportional autonomy/verifiability gain are out of scope.
+- **Not** a finished product — it is a living system meant to evolve as patterns improve.
+
+## How to use this for PR alignment
+
+A pull request is **aligned** if it advances at least one North Star pillar without regressing
+another (especially the attention test). A PR is **misaligned** if it adds operator attention
+tax for little autonomy/verifiability gain, makes outcomes harder to verify, increases friction
+without justification, or pulls the methodology toward "human must babysit." Misalignment is a
+*direction* signal for the operator — not necessarily a request-changes verdict on correctness.


### PR DESCRIPTION
## Why

`docs/overview/vision.md` (the DinoStack North Star) was gitignored, so it functioned as a private ruler: external contributors and any reviewer running on GitHub could not see it, and the shipped adapter files that cite it as authoritative product intent (`.cursor/`, `.gemini/` planning-artifacts / agent-team / conventions) pointed at a file absent from the repo. This commits and ratifies it so it works as the shared review lens the methodology already treats it as.

## What changed

- **`.gitignore`**: un-ignore `docs/overview/vision.md` only, via a negation pattern (`docs/overview/*` + `!docs/overview/vision.md`). Other working docs under `docs/overview/` stay local. Verified: `vision.md` is now trackable and other `docs/overview/*` paths are still ignored.
- **`docs/overview/vision.md`**: status marked Ratified (was "Draft for operator ratification"). Pillars, non-goals, and alignment-test wording are unchanged.
- **`CONTRIBUTING.md`**: added a North Star alignment bullet to `## PR guidelines` and a row in the `## Where documentation lives` table pointing contributors at the vision.
- **`docs/index.html`**: automatic last-updated date stamp from the pre-commit hook (unrelated mechanical churn).

## Adapter compatibility

Adapters affected: **None**. No `content/` or agent-behavior changes - docs + `.gitignore` only. No adapter rebuild required, and `check-adapter-sync` / `methodology-drift` / `no-planning-docs` are unaffected.

## AI assistance

AI-assisted: I reviewed the AI-generated edits and have the right to submit them under the project license (per CONTRIBUTING). DCO sign-off is on the commit.