### PR TITLE
feat(telemetry): telemetry-health counter for silent-fail visibility (#266)

### DIFF
--- a/bin/agentic-status
+++ b/bin/agentic-status
@@ -48,6 +48,7 @@ CONFIG_PATH = Path(os.path.expanduser("~/.claude/agentic-engineering.json"))
 SENTINEL_PATH = Path(".agentic/.activated")
 ROLE_MODELS_GLOBAL_PATH = Path(os.path.expanduser("~/.agentic/role-models.yml"))
 ROLE_MODELS_PROJECT_PATH = Path(".agentic/role-models.yml")
+HEALTH_FILE_PATH = Path(".agentic/.telemetry-health.json")
 
 PRESET_TABLE = {
     "lean": "relaxed",
@@ -349,6 +350,62 @@ def _role_models_status_block() -> list[str]:
     return lines
 
 
+def _telemetry_health_block() -> list[str]:
+    """Return telemetry-health status lines from .agentic/.telemetry-health.json.
+
+    Absent or unreadable file -> return [] (section omitted silently).
+    Tri-state per target via ISO8601 lexicographic string compare:
+      - failures == 0                                         -> OK
+      - failures > 0 AND last_success present AND
+        last_success > last_error_ts                          -> RECOVERED
+      - otherwise (failures > 0, currently failing)          -> FAILING
+    """
+    if not HEALTH_FILE_PATH.is_file():
+        return []
+    try:
+        data = json.loads(HEALTH_FILE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    targets = data.get("targets")
+    if not isinstance(targets, dict) or not targets:
+        return []
+
+    lines: list[str] = [""]
+    lines.append("Telemetry health")
+    updated_at = data.get("updated_at") or "unknown"
+    lines.append(f"  last updated: {updated_at}")
+
+    for target, info in sorted(targets.items()):
+        if not isinstance(info, dict):
+            continue
+        failures = info.get("failures") or 0
+        last_success = info.get("last_success") or ""
+        last_error = info.get("last_error") or ""
+        last_error_ts = info.get("last_error_ts") or ""
+
+        if failures == 0:
+            status = "OK"
+            lines.append(f"  {target}: {status}  (last_success: {last_success or 'none'})")
+        elif failures > 0 and last_success and last_success > last_error_ts:
+            status = "RECOVERED"
+            lines.append(
+                f"  {target}: {status} ({failures} failure(s))  "
+                f"(last_success: {last_success}, last_failure: {last_error_ts})"
+            )
+        else:
+            status = f"FAILING ({failures} failure(s))"
+            detail = f"last_failure: {last_error_ts}"
+            if last_error:
+                detail += f", error: {last_error}"
+            if last_success:
+                detail += f", last_success: {last_success}"
+            lines.append(f"  {target}: {status}  ({detail})")
+
+    return lines
+
+
 def _how_to_adjust_block(resolved: dict) -> list[str]:
     """Return the 'How to adjust' explainer lines.
 
@@ -400,6 +457,7 @@ def main(_argv: list[str]) -> int:
     out.append(f"  active: {active_display} ({res['active_reason']})")
     out.append(f"  sentinel: {SENTINEL_PATH} ({sentinel_status})")
     out.extend(_role_models_status_block())
+    out.extend(_telemetry_health_block())
     out.append("")
     out.append("What this means")
     active_sentence = (

--- a/bin/tests/test_agentic_status.py
+++ b/bin/tests/test_agentic_status.py
@@ -36,6 +36,7 @@ _scan_agents_md = _mod._scan_agents_md
 _resolve = _mod._resolve
 _profile_behavior_block = _mod._profile_behavior_block
 _role_models_status_block = _mod._role_models_status_block
+_telemetry_health_block = _mod._telemetry_health_block
 _how_to_adjust_block = _mod._how_to_adjust_block
 main = _mod.main
 
@@ -505,6 +506,139 @@ def test_how_to_adjust_block_no_marker_path_key():
     lines = _how_to_adjust_block({})
     joined = "\n".join(lines)
     assert "AGENTS.md" in joined
+
+
+# ---------------------------------------------------------------------------
+# _telemetry_health_block
+# ---------------------------------------------------------------------------
+
+def _write_health_file(tmp_path: Path, data: dict) -> Path:
+    """Write .agentic/.telemetry-health.json and return its Path."""
+    agentic = tmp_path / ".agentic"
+    agentic.mkdir(parents=True, exist_ok=True)
+    p = agentic / ".telemetry-health.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+def test_telemetry_health_block_absent_file(monkeypatch, tmp_path):
+    """Absent health file -> empty list (section omitted silently)."""
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", tmp_path / "no-such-file.json")
+    result = _telemetry_health_block()
+    assert result == []
+
+
+def test_telemetry_health_block_malformed_json(monkeypatch, tmp_path):
+    """Malformed JSON -> empty list."""
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    assert result == []
+
+
+def test_telemetry_health_block_ok_entry(monkeypatch, tmp_path):
+    """failures == 0 -> OK status."""
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeSessionLog": {
+                "failures": 0,
+                "last_success": "2026-01-01T12:00:00Z",
+                "last_error": None,
+                "last_error_ts": None,
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    joined = "\n".join(result)
+    assert "Telemetry health" in joined
+    assert "writeSessionLog" in joined
+    assert "OK" in joined
+
+
+def test_telemetry_health_block_failing_entry(monkeypatch, tmp_path):
+    """failures > 0 and no recovery -> FAILING status."""
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeLoopState": {
+                "failures": 3,
+                "last_success": None,
+                "last_error": "ENOSPC: no space left on device",
+                "last_error_ts": "2026-01-01T11:59:00Z",
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    joined = "\n".join(result)
+    assert "FAILING" in joined
+    assert "3 failure(s)" in joined
+    assert "ENOSPC" in joined
+
+
+def test_telemetry_health_block_recovered_entry(monkeypatch, tmp_path):
+    """failures > 0 AND last_success > last_error_ts -> RECOVERED status."""
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeContextMd": {
+                "failures": 1,
+                "last_success": "2026-01-01T12:00:00Z",  # later than error
+                "last_error": "EACCES: permission denied",
+                "last_error_ts": "2026-01-01T11:00:00Z",
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    joined = "\n".join(result)
+    assert "RECOVERED" in joined
+    assert "1 failure(s)" in joined
+    # Both timestamps rendered.
+    assert "2026-01-01T12:00:00Z" in joined
+    assert "2026-01-01T11:00:00Z" in joined
+
+
+def test_telemetry_health_block_empty_targets(monkeypatch, tmp_path):
+    """Empty targets dict -> empty list (section omitted)."""
+    data = {"updated_at": "2026-01-01T12:00:00Z", "targets": {}}
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    assert result == []
+
+
+def test_main_output_contains_telemetry_health(monkeypatch, tmp_path, capsys):
+    """main() includes 'Telemetry health' when health file is present."""
+    _clear_harness_env(monkeypatch)
+    monkeypatch.setattr(_mod, "CONFIG_PATH", tmp_path / "no-config.json")
+    monkeypatch.setattr(_mod, "SENTINEL_PATH", tmp_path / ".activated")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_GLOBAL_PATH", tmp_path / "no-global.yml")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_PROJECT_PATH", tmp_path / "no-project.yml")
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeSessionTotal": {
+                "failures": 0,
+                "last_success": "2026-01-01T12:00:00Z",
+                "last_error": None,
+                "last_error_ts": None,
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    monkeypatch.chdir(tmp_path)
+    rc = main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Telemetry health" in out
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -29,9 +29,14 @@
  *             appendSpilloverRecord(cwd, record),
  *             writeContextMdOrSpill(cwd, outputPath, projectDir, body, record),
  *             stageWrapPending(cwd, sessionId, scan) (thin alias to wrap-marker
- *             lib stagePending). The marker reads/transitions (readLastWrap,
- *             liveMarkerForSession - which replaces the former liveMarkerExists -
- *             stagePending, touchHeartbeat, etc.) now live in
+ *             lib stagePending),
+ *             recordHealth(target, success, errMsg) — synchronous in-memory
+ *             accumulator for per-write-path success/failure counts; never throws,
+ *             flushHealth(cwd) — atomic read-merge-write of
+ *             [cwd]/.agentic/.telemetry-health.json; never throws; called once
+ *             before each process.exit(0). The marker reads/transitions
+ *             (readLastWrap, liveMarkerForSession - which replaces the former
+ *             liveMarkerExists - stagePending, touchHeartbeat, etc.) now live in
  *             hooks/lib/wrap-marker.js, the single source of truth.
  *
  * Upstream deps: Node built-ins only (fs, path, os, child_process) plus three
@@ -66,6 +71,8 @@
  *                [cwd]/.agentic/.skill-candidate-cursor (ISO8601 high-water mark),
  *                [cwd]/.agentic/skill-candidates.md (appended when a domain first
  *                crosses the candidate threshold).
+ *                [cwd]/.agentic/.telemetry-health.json (atomic tmp+rename;
+ *                accumulated health outcomes flushed once per exit by flushHealth).
  *                Via wrap-marker.js it also touches [cwd]/.agentic/wrap/heartbeats/<session_id>
  *                (per-turn liveness mtime) and may stage
  *                [cwd]/.agentic/wrap/pending-<session_id>.json (per-session marker).
@@ -81,7 +88,8 @@
  *                        only by agentic-identity confirm/init via flushPendingBuffer.
  *
  * Failure modes: All failures are silent (process.exit(0)). Twelve independent
- *                write paths: (1) context.md write is best-effort; any fs error
+ *                write paths (plus the health-flush observability layer described
+ *                below): (1) context.md write is best-effort; any fs error
  *                is swallowed and the file may not be written. (2) loop-state.json
  *                write is also best-effort; any fs error is swallowed independently
  *                of path (1). (3) events.jsonl write is best-effort; writeSessionTotal
@@ -135,6 +143,17 @@
  *                own top-level try/catch; the path is additionally wrapped here in
  *                an independent try/catch so a crash inside the detector can never
  *                affect paths (1)-(11) or block session exit.
+ *                Health-flush observability layer: recordHealth(target, success,
+ *                errMsg) is called at success and catch sites for each of the
+ *                twelve paths (excludes: marker unlink, JSON-line-skip catches,
+ *                git-subprocess catches, appendSpilloverRecord, and the one-time
+ *                sentinel wx writes at ~1271/1367 where EEXIST is the expected
+ *                normal path - not a failure). flushHealth(cwd) atomically
+ *                merges accumulated counts into .agentic/.telemetry-health.json;
+ *                called once before each process.exit(0). Both functions are
+ *                wrapped in outer try/catch and never throw. The health flush is
+ *                the observability layer for existing paths, not a new data-loss
+ *                path itself.
  *                All twelve paths are independent - a failure in one does not
  *                affect the others. The 10-minute implicit-interrupt heuristic
  *                handles missed loop-state writes. cwd values with path
@@ -206,6 +225,113 @@ const wrapMarker = require('./lib/wrap-marker.js');
 // exported by the lib for test-capture-gap.js. appendCaptureGapNoticeToContextMd
 // (the sole writer of the .capture-gap-last-sweep cursor) stays in this file.
 const { detectCaptureGap } = require('./lib/capture-gap.js');
+
+// ---------------------------------------------------------------------------
+// Telemetry-health counter (in-memory accumulate + single flush per exit)
+// ---------------------------------------------------------------------------
+// Module-level accumulator: keyed by target label, holds per-path outcome state.
+// Populated by recordHealth(); flushed to disk once by flushHealth(cwd).
+const healthOutcomes = {};
+
+/**
+ * Record a success or failure for a named write-path target.
+ * Pure synchronous in-memory mutation — never throws (outer try/catch).
+ *
+ * @param {string} target   - Stable label for the write path (e.g. 'writeLoopState').
+ * @param {boolean} success - True on the success branch; false in the catch.
+ * @param {string|null} errMsg - Error message on failure; null on success.
+ */
+function recordHealth(target, success, errMsg) {
+  try {
+    if (!healthOutcomes[target]) {
+      healthOutcomes[target] = {
+        failures: 0,
+        last_success: null,
+        last_error: null,
+        last_error_ts: null,
+      };
+    }
+    const now = new Date().toISOString();
+    if (success) {
+      healthOutcomes[target].last_success = now;
+    } else {
+      healthOutcomes[target].failures += 1;
+      healthOutcomes[target].last_error = errMsg || null;
+      healthOutcomes[target].last_error_ts = now;
+    }
+  } catch (_) {
+    // Never throw from the health layer.
+  }
+}
+
+/**
+ * Flush accumulated health outcomes to [cwd]/.agentic/.telemetry-health.json.
+ * Single atomic read-merge-write: reads existing file (parse-fail or absent ->
+ * start fresh), merges accumulated outcomes (cumulative failures, latest
+ * timestamps), sets updated_at, writes to a .tmp file then renames.
+ *
+ * Schema note: `failures` is cumulative and approximate — concurrent same-repo
+ * sessions may both read a stale count before either flushes, causing undercounts.
+ * No lock by design — health flush must never block session exit.
+ *
+ * Never throws — entire body is wrapped in an outer try/catch.
+ *
+ * @param {string} cwd - Verified project root directory.
+ */
+function flushHealth(cwd) {
+  // Declare both paths before the outer try so the catch-block cleanup can
+  // reference them (avoids referencing try-scoped vars from catch).
+  let healthPath;
+  let tmp;
+  try {
+    if (!cwd) return;
+    healthPath = path.join(cwd, '.agentic', '.telemetry-health.json');
+    tmp = healthPath + '.tmp.' + process.pid;
+
+    // Read existing file (absent or parse-fail -> start fresh).
+    let existing = { updated_at: null, targets: {} };
+    try {
+      const raw = fs.readFileSync(healthPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.targets === 'object') {
+        existing = parsed;
+      }
+    } catch (_) {
+      // Absent or unreadable -> start fresh.
+    }
+
+    // Merge accumulated outcomes into the existing state.
+    for (const [target, outcome] of Object.entries(healthOutcomes)) {
+      if (!existing.targets[target]) {
+        existing.targets[target] = {
+          failures: 0,
+          last_success: null,
+          last_error: null,
+          last_error_ts: null,
+        };
+      }
+      const stored = existing.targets[target];
+      stored.failures = (stored.failures || 0) + outcome.failures;
+      if (outcome.last_success) {
+        stored.last_success = outcome.last_success;
+      }
+      if (outcome.last_error_ts) {
+        stored.last_error = outcome.last_error;
+        stored.last_error_ts = outcome.last_error_ts;
+      }
+    }
+    existing.updated_at = new Date().toISOString();
+
+    // Atomic write: tmp + rename.
+    fs.writeFileSync(tmp, JSON.stringify(existing, null, 2), 'utf8');
+    fs.renameSync(tmp, healthPath);
+  } catch (_) {
+    // Silent failure - health flush must never block session exit.
+    if (tmp) {
+      try { fs.unlinkSync(tmp); } catch (_e) { /* tmp absent or never created */ }
+    }
+  }
+}
 
 /**
  * Read the `deferred_wrap_daemon` toggle from [cwd]/.agentic/config.json.
@@ -280,9 +406,11 @@ function writeLoopState(cwd) {
         const tmpPath = loopStatePath + '.tmp';
         fs.writeFileSync(tmpPath, JSON.stringify(loopState, null, 2));
         fs.renameSync(tmpPath, loopStatePath);
+        recordHealth('writeLoopState', true, null);
       }
     }
   } catch (_) {
+    recordHealth('writeLoopState', false, _ && _.message);
     // Silent failure - the 10-minute implicit-interrupt heuristic handles missed writes
     try { fs.unlinkSync(loopStatePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
   }
@@ -329,7 +457,9 @@ function writeBatchState(cwd, sessionId) {
     const tmpPath = batchStatePath + '.tmp';
     fs.writeFileSync(tmpPath, JSON.stringify(batchState, null, 2));
     fs.renameSync(tmpPath, batchStatePath);
+    recordHealth('writeBatchState', true, null);
   } catch (_) {
+    recordHealth('writeBatchState', false, _ && _.message);
     // Silent failure - best-effort write; resume-time logic tolerates absent mark.
     try { fs.unlinkSync(batchStatePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
   }
@@ -482,7 +612,9 @@ function writeSessionTotal(cwd, sessionId) {
       },
     });
     fs.appendFileSync(eventsPath, totalLine + '\n');
+    recordHealth('writeSessionTotal', true, null);
   } catch (_) {
+    recordHealth('writeSessionTotal', false, _ && _.message);
     // Silent failure - consistent with context.md / loop-state.json paths.
   }
 }
@@ -584,7 +716,9 @@ function appendIdentityNudgeToContextMd(repoRoot) {
       'Sentinel: ~/.agentic/.identity-nudged (delete to re-nudge)',
     ].join('\n') + '\n';
     fs.appendFileSync(contextPath, nudge, 'utf8');
+    recordHealth('appendIdentityNudgeToContextMd', true, null);
   } catch (_) {
+    recordHealth('appendIdentityNudgeToContextMd', false, _ && _.message);
     // Silent failure
   }
 }
@@ -676,7 +810,9 @@ function writeSessionLog(cwd, identity, sessionId) {
     fs.mkdirSync(sessionLogDir, { recursive: true });
     const logFile = path.join(sessionLogDir, `${identity.developer_id}.jsonl`);
     fs.appendFileSync(logFile, logLine + '\n', 'utf8');
+    recordHealth('writeSessionLog', true, null);
   } catch (_) {
+    recordHealth('writeSessionLog', false, _ && _.message);
     // Silent failure - consistent with all other write paths
   }
 }
@@ -714,7 +850,9 @@ function writeSessionLogGlobal(identity, sessionId, data) {
     });
     const logFile = path.join(globalLogDir, `${identity.developer_id}.jsonl`);
     fs.appendFileSync(logFile, logLine + '\n', 'utf8');
+    recordHealth('writeSessionLogGlobal', true, null);
   } catch (_) {
+    recordHealth('writeSessionLogGlobal', false, _ && _.message);
     // Silent failure - independent of per-project write
   }
 }
@@ -825,7 +963,9 @@ function writePendingBuffer(cwd, sessionId) {
     pendingTmpFile = outFile + '.tmp';
     fs.writeFileSync(pendingTmpFile, JSON.stringify(record, null, 2), 'utf8');
     fs.renameSync(pendingTmpFile, outFile);
+    recordHealth('writePendingBuffer', true, null);
   } catch (_) {
+    recordHealth('writePendingBuffer', false, _ && _.message);
     // Silent failure - consistent with all other write paths
     if (pendingTmpFile) {
       try { fs.unlinkSync(pendingTmpFile); } catch (_e) { /* tmp absent or never created */ }
@@ -887,8 +1027,10 @@ function writeContextMdOrSpill(cwd, outputPath, projectDir, body, spilloverRecor
       appendSpilloverRecord(cwd, spilloverRecord);
     } else {
       fs.writeFileSync(outputPath, body, 'utf8');
+      recordHealth('writeContextMd', true, null);
     }
   } catch (_) {
+    recordHealth('writeContextMd', false, _ && _.message);
     // Silent failure
   }
 }
@@ -961,18 +1103,25 @@ function appendCaptureGapNoticeToContextMd(cwd, residualOnly) {
     }
 
     fs.appendFileSync(contextPath, nudgeText, 'utf8');
+    recordHealth('appendCaptureGapNoticeToContextMd-context', true, null);
 
     // Update pagination cursor atomically so the same session doesn't fire twice.
+    // Note: the inner catch uses _cursorErr to avoid shadowing the outer _ at the
+    // outer catch below. recordHealth for the cursor write goes in this catch, not
+    // in the _e cleanup catch (which handles tmp cleanup only).
     try {
       const nowIso = new Date().toISOString();
       const tmpCursor = cursorPath + '.tmp';
       fs.writeFileSync(tmpCursor, nowIso, 'utf8');
       fs.renameSync(tmpCursor, cursorPath);
-    } catch (_) {
+      recordHealth('appendCaptureGapNoticeToContextMd-cursor', true, null);
+    } catch (_cursorErr) {
+      recordHealth('appendCaptureGapNoticeToContextMd-cursor', false, _cursorErr && _cursorErr.message);
       /* silent - cursor update failure is non-fatal */
       try { fs.unlinkSync(cursorPath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
     }
   } catch (_) {
+    recordHealth('appendCaptureGapNoticeToContextMd-context', false, _ && _.message);
     // Silent failure - consistent with all other context.md append paths.
   }
 }
@@ -1268,6 +1417,8 @@ ${toolsLine}
             const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
             try {
               fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
+              // NOTE: this wx write is intentionally NOT instrumented by recordHealth -
+              // EEXIST is the expected normal path (sentinel already written), not a failure.
               fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
               // Write succeeded - sentinel did not exist, so nudge once
               appendIdentityNudgeToContextMd(cwd);
@@ -1303,6 +1454,7 @@ ${toolsLine}
       // accumulates markers. Fail-open; never blocks exit.
       // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
       if (deferredDaemonEnabled(cwd)) stageWrapPending(cwd, sessionId, spilloverScan);
+      flushHealth(cwd);
       process.exit(0);
     }
   } catch (_) {
@@ -1364,6 +1516,8 @@ ${toolsLine}
         const sentinelPath = path.join(os.homedir(), '.agentic', '.identity-nudged');
         try {
           fs.mkdirSync(path.join(os.homedir(), '.agentic'), { recursive: true });
+          // NOTE: this wx write is intentionally NOT instrumented by recordHealth -
+          // EEXIST is the expected normal path (sentinel already written), not a failure.
           fs.writeFileSync(sentinelPath, '', { flag: 'wx' });
           // Sentinel did not exist - nudge once
           appendIdentityNudgeToContextMd(cwd);
@@ -1411,7 +1565,15 @@ ${toolsLine}
   // OpenCode intentionally omits this lock-gate / heartbeat / staging logic (Claude-only feature; no parity obligation)
   if (deferredDaemonEnabled(cwd)) stageWrapPending(cwd, sessionId, spilloverScan);
 
+  flushHealth(cwd);
   process.exit(0);
 }
 
 run();
+
+// Test shim: appended at module load so test files can import internals without
+// executing run(). stop-context.js has no production module.exports; this shim
+// is only reached when the test replaces `run();` before requiring.
+if (typeof module !== 'undefined') {
+  module.exports = { recordHealth, flushHealth, healthOutcomes };
+}

--- a/hooks/tests/test-stop-context-health.js
+++ b/hooks/tests/test-stop-context-health.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: stop-context.js telemetry-health counter (#266).
+ *
+ * Tests recordHealth, flushHealth, and healthOutcomes via the shim-load
+ * pattern used by test-stop-context-telemetry.js.
+ *
+ * Test cases:
+ *   M1a. recordHealth-success: recordHealth fires success -> last_success set,
+ *        failures === 0.
+ *   M1b. recordHealth-failure: recordHealth fires failure -> failures incremented,
+ *        last_error and last_error_ts set.
+ *   M1c. recordHealth-accumulates: multiple failures accumulate; success does not
+ *        clear failures count.
+ *   M1d. recordHealth-never-throws: even when healthOutcomes is pathological,
+ *        recordHealth does not throw.
+ *   M2.  forced-failure: stub fs.writeFileSync to throw for the health path;
+ *        flushHealth does NOT throw, stubHit is true, file NOT written.
+ *   M1e. flushHealth-writes-file: recordHealth then flushHealth -> file is valid
+ *        JSON, targets present, correct fields.
+ *   M1f. flushHealth-merges-existing: existing file has prior failures;
+ *        flushHealth merges (cumulative failures).
+ *   M1g. flushHealth-absent-file: no prior health file -> starts fresh, writes OK.
+ *   M1h. flushHealth-corrupted-existing: corrupted existing file -> starts fresh.
+ *   M1i. flushHealth-never-throws-bad-cwd: flushHealth with null cwd does not throw.
+ *
+ * Run with: node hooks/tests/test-stop-context-health.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Shim-load stop-context.js (same technique as test-stop-context-telemetry.js)
+// ---------------------------------------------------------------------------
+
+const hookPath = path.resolve(__dirname, '..', 'stop-context.js');
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+const libMarkerAbs = path.resolve(__dirname, '..', 'lib', 'wrap-marker.js');
+const libCaptureGapAbs = path.resolve(__dirname, '..', 'lib', 'capture-gap.js');
+
+const shimmedSource = hookSource
+  .replace(/^run\(\);\s*$/m, '// test shim: run() suppressed')
+  .replace(
+    /require\(['"]\.\/lib\/wrap-marker\.js['"]\)/,
+    `require(${JSON.stringify(libMarkerAbs)})`
+  )
+  .replace(
+    /require\(['"]\.\/lib\/capture-gap\.js['"]\)/,
+    `require(${JSON.stringify(libCaptureGapAbs)})`
+  );
+
+// Guard: ensure all relative lib requires were rewritten.
+// (skill-candidate-detector is loaded lazily inside a function, not at module
+// scope, so we do NOT require its rewrite here.)
+const relativeRequires = shimmedSource.match(/require\(['"]\.\/lib\/(?!skill-candidate).*?['"]\)/g) || [];
+if (relativeRequires.length > 0) {
+  console.error(
+    '  FATAL: a relative ./lib/ require survived the shim re-anchor - '
+    + 'update the rewrite in test-stop-context-health.js. Survivors: '
+    + relativeRequires.join(', ')
+  );
+  process.exit(1);
+}
+
+const tmpShimPath = path.join(os.tmpdir(), `stop-ctx-health-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+let helpers;
+try {
+  helpers = require(tmpShimPath);
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+const { recordHealth, flushHealth, healthOutcomes } = helpers;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTmpProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-stop-health-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+function clearOutcomes() {
+  Object.keys(healthOutcomes).forEach((k) => delete healthOutcomes[k]);
+}
+
+// ---------------------------------------------------------------------------
+// M1a: recordHealth-success
+// ---------------------------------------------------------------------------
+console.log('\nM1a: recordHealth-success');
+{
+  clearOutcomes();
+  recordHealth('testTarget', true, null);
+  const o = healthOutcomes['testTarget'];
+  assert(o !== undefined, 'testTarget entry created');
+  assert(o.failures === 0, `failures === 0 (got: ${o && o.failures})`);
+  assert(typeof o.last_success === 'string' && o.last_success.length > 0,
+    `last_success is a non-empty string (got: ${o && o.last_success})`);
+  assert(o.last_error === null, `last_error === null (got: ${o && o.last_error})`);
+  assert(o.last_error_ts === null, `last_error_ts === null (got: ${o && o.last_error_ts})`);
+}
+
+// ---------------------------------------------------------------------------
+// M1b: recordHealth-failure
+// ---------------------------------------------------------------------------
+console.log('\nM1b: recordHealth-failure');
+{
+  clearOutcomes();
+  recordHealth('testTarget', false, 'EACCES: permission denied');
+  const o = healthOutcomes['testTarget'];
+  assert(o !== undefined, 'testTarget entry created on failure');
+  assert(o.failures === 1, `failures === 1 (got: ${o && o.failures})`);
+  assert(o.last_error === 'EACCES: permission denied',
+    `last_error set (got: ${o && o.last_error})`);
+  assert(typeof o.last_error_ts === 'string' && o.last_error_ts.length > 0,
+    `last_error_ts is a non-empty string (got: ${o && o.last_error_ts})`);
+  assert(o.last_success === null, `last_success === null after only failure (got: ${o && o.last_success})`);
+}
+
+// ---------------------------------------------------------------------------
+// M1c: recordHealth-accumulates
+// ---------------------------------------------------------------------------
+console.log('\nM1c: recordHealth-accumulates (multiple failures do not reset)');
+{
+  clearOutcomes();
+  recordHealth('acc', false, 'err1');
+  recordHealth('acc', false, 'err2');
+  recordHealth('acc', true, null);  // success does not clear failures count
+  const o = healthOutcomes['acc'];
+  assert(o.failures === 2, `failures === 2 after two failures (got: ${o && o.failures})`);
+  assert(typeof o.last_success === 'string', 'last_success set after subsequent success');
+  assert(o.last_error === 'err2', `last_error is most recent (got: ${o && o.last_error})`);
+}
+
+// ---------------------------------------------------------------------------
+// M1d: recordHealth-never-throws
+// ---------------------------------------------------------------------------
+console.log('\nM1d: recordHealth-never-throws');
+{
+  clearOutcomes();
+  let threw = false;
+  try {
+    // Pass non-string error message (non-Error throw case: _ && _.message = undefined -> null)
+    recordHealth('safe', false, undefined);
+    recordHealth(null, true, null);
+    recordHealth(undefined, false, 'msg');
+  } catch (_) {
+    threw = true;
+  }
+  assert(!threw, 'recordHealth does not throw on pathological inputs');
+}
+
+// ---------------------------------------------------------------------------
+// M1e: flushHealth-writes-file
+// ---------------------------------------------------------------------------
+console.log('\nM1e: flushHealth-writes-file');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  recordHealth('writeSessionLog', true, null);
+  recordHealth('writeLoopState', false, 'ENOSPC: no space left on device');
+
+  try {
+    flushHealth(tmpDir);
+  } catch (err) {
+    assert(false, `flushHealth must not throw: ${err.message}`);
+  }
+
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+  assert(fs.existsSync(healthPath), '.telemetry-health.json written');
+  if (fs.existsSync(healthPath)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+      assert(true, 'health file is valid JSON');
+    } catch (e) {
+      assert(false, `health file is valid JSON (parse error: ${e.message})`);
+    }
+    if (parsed) {
+      assert(typeof parsed.updated_at === 'string', 'updated_at is a string');
+      assert(parsed.targets && typeof parsed.targets === 'object', 'targets object present');
+      assert(parsed.targets.writeSessionLog !== undefined, 'writeSessionLog target present');
+      assert(parsed.targets.writeLoopState !== undefined, 'writeLoopState target present');
+      assert(parsed.targets.writeSessionLog.failures === 0,
+        `writeSessionLog.failures === 0 (got: ${parsed.targets.writeSessionLog && parsed.targets.writeSessionLog.failures})`);
+      assert(parsed.targets.writeLoopState.failures === 1,
+        `writeLoopState.failures === 1 (got: ${parsed.targets.writeLoopState && parsed.targets.writeLoopState.failures})`);
+      assert(parsed.targets.writeLoopState.last_error === 'ENOSPC: no space left on device',
+        `writeLoopState.last_error correct (got: ${parsed.targets.writeLoopState && parsed.targets.writeLoopState.last_error})`);
+    }
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// M1f: flushHealth-merges-existing (cumulative failures)
+// ---------------------------------------------------------------------------
+console.log('\nM1f: flushHealth-merges-existing');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+
+  // Write a pre-existing file with 3 prior failures.
+  const prior = {
+    updated_at: '2026-01-01T00:00:00Z',
+    targets: {
+      writeLoopState: {
+        failures: 3,
+        last_success: '2026-01-01T00:00:00Z',
+        last_error: 'prior error',
+        last_error_ts: '2026-01-01T00:00:00Z',
+      },
+    },
+  };
+  fs.writeFileSync(healthPath, JSON.stringify(prior, null, 2), 'utf8');
+
+  // This session adds 2 more failures.
+  recordHealth('writeLoopState', false, 'new error 1');
+  recordHealth('writeLoopState', false, 'new error 2');
+
+  flushHealth(tmpDir);
+
+  const parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+  // 3 prior + 2 new = 5 cumulative.
+  assert(parsed.targets.writeLoopState.failures === 5,
+    `cumulative failures === 5 (got: ${parsed.targets.writeLoopState.failures})`);
+  assert(parsed.targets.writeLoopState.last_error === 'new error 2',
+    `last_error is most recent session value (got: ${parsed.targets.writeLoopState.last_error})`);
+
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// M1g: flushHealth-absent-file (starts fresh)
+// ---------------------------------------------------------------------------
+console.log('\nM1g: flushHealth-absent-file');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  // No prior health file.
+  recordHealth('writeSessionTotal', true, null);
+
+  let threw = false;
+  try {
+    flushHealth(tmpDir);
+  } catch (_) {
+    threw = true;
+  }
+
+  assert(!threw, 'flushHealth does not throw when health file is absent');
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+  assert(fs.existsSync(healthPath), 'health file created from scratch');
+  if (fs.existsSync(healthPath)) {
+    const parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+    assert(parsed.targets.writeSessionTotal !== undefined, 'writeSessionTotal present');
+    assert(parsed.targets.writeSessionTotal.failures === 0,
+      `failures === 0 (got: ${parsed.targets.writeSessionTotal && parsed.targets.writeSessionTotal.failures})`);
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// M1h: flushHealth-corrupted-existing (starts fresh on parse failure)
+// ---------------------------------------------------------------------------
+console.log('\nM1h: flushHealth-corrupted-existing');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+  fs.writeFileSync(healthPath, '{ bad json !!', 'utf8');
+
+  recordHealth('writePendingBuffer', true, null);
+
+  let threw = false;
+  try {
+    flushHealth(tmpDir);
+  } catch (_) {
+    threw = true;
+  }
+
+  assert(!threw, 'flushHealth does not throw on corrupted existing file');
+  if (fs.existsSync(healthPath)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+      assert(true, 'health file rewritten as valid JSON after corruption');
+      assert(parsed.targets !== undefined, 'targets present in fresh file');
+    } catch (e) {
+      assert(false, `health file is valid JSON after rewrite (parse error: ${e.message})`);
+    }
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// M1i: flushHealth-never-throws-bad-cwd
+// ---------------------------------------------------------------------------
+console.log('\nM1i: flushHealth-never-throws-bad-cwd');
+{
+  clearOutcomes();
+  let threw = false;
+  try {
+    flushHealth(null);
+    flushHealth(undefined);
+    flushHealth('/this/path/does/not/exist/anywhere/agentic-test');
+  } catch (_) {
+    threw = true;
+  }
+  assert(!threw, 'flushHealth does not throw on null/undefined/invalid cwd');
+}
+
+// ---------------------------------------------------------------------------
+// M2: forced-failure (privilege-independent)
+// ---------------------------------------------------------------------------
+console.log('\nM2: forced-failure (stub fs.writeFileSync to force failure branch)');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  const healthFileSuffix = '.telemetry-health.json';
+
+  const originalWriteFileSync = fs.writeFileSync;
+  let stubHit = false;
+  fs.writeFileSync = function (filePath, ...args) {
+    if (typeof filePath === 'string' && filePath.endsWith(healthFileSuffix + '.tmp.' + process.pid)) {
+      stubHit = true;
+      throw new Error('STUB: simulated write failure for health file');
+    }
+    return originalWriteFileSync.call(this, filePath, ...args);
+  };
+
+  recordHealth('writeContextMd', false, 'ENOSPC');
+  let threw = false;
+  try {
+    flushHealth(tmpDir);
+  } catch (_) {
+    threw = true;
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+
+  assert(!threw, '(a) flushHealth does NOT throw when write is stubbed to fail');
+  assert(stubHit === true, '(b) failure branch was reached (stub was hit)');
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+  assert(!fs.existsSync(healthPath), '(c) health file NOT written when write fails');
+
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);
+process.exit(0);

--- a/hooks/tests/test-stop-context-session-log.js
+++ b/hooks/tests/test-stop-context-session-log.js
@@ -294,6 +294,57 @@ console.log('\n[5] No orphan .tmp files: loop-state atomic write leaves no .tmp 
 }
 
 // ---------------------------------------------------------------------------
+// Sub-test 6: M3 — health file written on full hook run (integration)
+// ---------------------------------------------------------------------------
+console.log('\n[6] M3 integration: health file written and valid after full hook run');
+{
+  // Full run with STUB_IDENTITY and a spawn_complete event.
+  // Asserts: (a) hook exits 0, (b) .telemetry-health.json exists and is valid
+  // JSON, (c) targets.writeSessionLogGlobal present with failures === 0 and
+  // populated last_success — proves recordHealth fired and flushHealth ran at
+  // the real exit with cwd in scope.
+  const { tmpDir, fakeHome, projectDir, agenticDir, identityDir } = makeTmp('ae-stop-t6-');
+
+  fs.writeFileSync(path.join(identityDir, 'identity.yml'), STUB_IDENTITY, { mode: 0o600 });
+  fs.writeFileSync(path.join(agenticDir, 'events.jsonl'), STUB_EVENT + '\n');
+
+  try {
+    runHook(projectDir, fakeHome, 'test-session-uuid');
+  } catch (err) {
+    console.error('  FAIL: hook execution threw:', err.message);
+    cleanup(tmpDir);
+    process.exit(1);
+  }
+
+  const healthPath = path.join(agenticDir, '.telemetry-health.json');
+  assert(fs.existsSync(healthPath), '.telemetry-health.json exists after full hook run');
+  if (fs.existsSync(healthPath)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+      assert(true, '.telemetry-health.json is valid JSON');
+    } catch (e) {
+      assert(false, `.telemetry-health.json is valid JSON (parse error: ${e.message})`);
+      parsed = null;
+    }
+    if (parsed) {
+      assert(parsed.targets && typeof parsed.targets === 'object',
+        'targets object present in health file');
+      // writeSessionLogGlobal fires on the confirmed-identity path (STUB_IDENTITY).
+      const wslg = parsed.targets && parsed.targets.writeSessionLogGlobal;
+      assert(wslg !== undefined, 'targets.writeSessionLogGlobal present');
+      if (wslg !== undefined) {
+        assert(wslg.failures === 0,
+          `writeSessionLogGlobal.failures === 0 (got: ${wslg.failures})`);
+        assert(typeof wslg.last_success === 'string' && wslg.last_success.length > 0,
+          `writeSessionLogGlobal.last_success populated (got: ${wslg.last_success})`);
+      }
+    }
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed} passed, ${failed} failed.`);


### PR DESCRIPTION
Closes #266.

Adds `.agentic/.telemetry-health.json` as an observable failure counter for the silent-catch state-write paths in `hooks/stop-context.js`. Write failures (disk full, perms drift, corrupted JSON) that previously vanished silently now accumulate across sessions and surface via `bin/agentic-status`.

## Design
- Module-level `healthOutcomes` accumulator + pure `recordHealth(target, success, errMsg)` (memory-only, never throws) at 10 state-write sites.
- A single `flushHealth(cwd)` does one atomic read-merge-write before each `process.exit(0)`. `failures` is cumulative; merge preserves other targets' entries.
- No function signatures change. No new dependencies. No `content/**` changes (adapter-sync unaffected).
- `bin/agentic-status` gains a Python tri-state renderer: `OK` / `RECOVERED` / `FAILING`.

## Failure isolation
`recordHealth` and `flushHealth` are both fully try-wrapped and cannot throw — the Stop hook still exits cleanly on any health-layer error (covered by a privilege-independent forced-failure test).

## Tests
- New `hooks/tests/test-stop-context-health.js` (36 assertions): unit coverage + forced-failure no-throw.
- `hooks/tests/test-stop-context-session-log.js`: integration sub-test asserting the health file is written through the real exit path.
- `bin/tests/test_agentic_status.py`: 7 renderer tests (absent/malformed/OK/FAILING/RECOVERED/empty + main() output).
- All 8 hook + Python suites pass (278 assertions).

## Review
Architect plan + implementation both passed independent adversarial Skeptic review (full-diff read; zero Critical/Major findings).