### PR TITLE
docs: add capability-preflight and wrap-deferred end-user pages

### DIFF
--- a/docs/capability-preflight.md
+++ b/docs/capability-preflight.md
@@ -1,0 +1,188 @@
+<!--
+Purpose: Operator-facing guide for the capability preflight system.
+         Explains the capabilities: YAML block agents declare, required_when
+         predicates, auto_install safety, advisory vs blocking mode, and what
+         happens when a block is absent.
+
+Public API: Operator-facing prose. Entry point for anyone who wants to add
+            capability manifests to custom agents or tune the preflight mode.
+            Deeper schema, predicate grammar, 7-step procedure, output format,
+            and cache schema live in content/references/capability-preflight.md.
+
+Upstream deps: content/references/capability-preflight.md (full spec);
+               content/sections/06-capability-preflight.md (METHODOLOGY.md section);
+               .agentic/config.json (capability_preflight_mode key).
+
+Downstream consumers: docs site root index.
+
+Failure modes: Stale if the schema, predicate grammar, mode default, or
+               auto_install safety constraints change. Update alongside
+               content/references/capability-preflight.md in the same change.
+
+Performance: Standard.
+-->
+
+# Capability preflight
+
+Before spawning any agent, the conductor checks whether the tools that agent
+needs are actually installed. The check is driven by a `capabilities:` block
+each agent optionally declares in its spec file. No block means no check - the
+feature is fully incremental.
+
+This document covers what to put in a `capabilities:` block, how the conductor
+decides whether a missing tool blocks or just warns, and how to tune the
+behavior per project.
+
+The full schema, predicate grammar, 7-step procedure, output format, and cache
+schema live in `content/references/capability-preflight.md`. This page is the
+operator entry point.
+
+## Why it exists
+
+An agent that silently fails because a CLI tool is missing wastes a Worker turn
+and produces confusing output. Capability preflight surfaces the gap before the
+spawn, not after - you see "install: npm install --no-save @axe-core/playwright"
+instead of a cryptic runtime error three steps into a QA run.
+
+## The capabilities: block
+
+Each agent spec under `content/agents/` may carry a top-level `capabilities:`
+block. Two sections: `required` entries that must be present, and `optional`
+entries that trigger a warning but never block a spawn.
+
+```yaml
+capabilities:
+  required:
+    - tool: "node"
+      check: "command -v node"
+    - tool: "@axe-core/playwright"
+      check: "node -e \"require('@axe-core/playwright')\" 2>/dev/null"
+      install: "npm install --no-save @axe-core/playwright"
+      auto_install: true
+      required_when: "scenario.method == 'accessibility'"
+  optional:
+    - tool: "agent-browser"
+      check: "command -v agent-browser"
+      install_hint: "npm install -g agent-browser"
+```
+
+**Field summary:**
+
+| Field | Required? | Description |
+|---|---|---|
+| `tool` | Yes | Human-readable name, shown verbatim in preflight output. |
+| `check` | Yes | POSIX shell command. Exit 0 = present; non-zero = missing. |
+| `install` | Conditional | Machine-executable install command. Required when `auto_install: true`. Also used as the install hint when `install_hint` is absent. |
+| `install_hint` | No | Human-facing install note. Overrides `install` in output when both are set. Use for commands with side effects (browser binary downloads, global installs) that cannot run automatically. |
+| `auto_install` | No | Default `false`. When `true`, the conductor runs `install` automatically on miss, then re-checks before deciding. Restricted to safe side effects - see below. |
+| `required_when` | No | Conditional predicate. When absent, the entry is always required. When present, evaluated per-spawn - entries that evaluate to `false` become optional warnings for that spawn. |
+
+**Absent block.** When an agent carries no `capabilities:` block at all,
+preflight is a no-op for that agent. Agents without a block are never blocked
+by preflight. This keeps adoption incremental - existing agents work unchanged
+until a manifest is added.
+
+## required_when predicates
+
+Use `required_when` when a tool is only needed for certain spawn contexts - for
+example, an accessibility tool only needed when the QA scenario uses the
+`accessibility` method.
+
+The predicate language is a small fixed grammar:
+
+```yaml
+# true when any QA scenario uses the 'accessibility' method
+required_when: "scenario.method == 'accessibility'"
+
+# true when any scenario uses either method
+required_when: "scenario.method == 'accessibility' || scenario.method == 'perceptual_diff'"
+
+# true only when an accessibility scenario AND a wcag_level field are both present
+required_when: "scenario.method == 'accessibility' && brief.has_field('wcag_level')"
+```
+
+Supported forms:
+
+| Form | Meaning |
+|---|---|
+| `scenario.method == 'X'` | At least one QA scenario has `method == X`. |
+| `scenario.method in ['X', 'Y']` | At least one scenario matches any value in the list. |
+| `brief.has_field('name')` | The Brief for this spawn contains the named field. |
+
+Combine atomics with `&&` (AND) and `||` (OR). `&&` binds tighter. Parentheses
+are not supported. All string literals use single quotes.
+
+When no Brief is present (single-unit Trivial or ad-hoc spawn),
+`brief.has_field('anything')` evaluates to `false`, so entries gated only on
+that form are downgraded to optional for briefless spawns.
+
+## auto_install safety
+
+`auto_install: true` is restricted to commands whose only side effect is
+mutating `node_modules/` in the project directory or `~/.local/` pip user
+site-packages.
+
+**Permitted:**
+- `npm install --no-save <pkg>` - project `node_modules/` only; does not touch `package.json` or lock files.
+- `pip install --user <pkg>` - user site-packages; no global or system path mutation.
+
+**Forbidden (use `install_hint` instead):**
+- Anything that downloads browser binaries (e.g. `playwright install chromium`).
+- Global npm installs (`npm install -g <pkg>`).
+- Anything requiring `sudo` or elevated privileges.
+- Anything that mutates `package.json`, lock files, or any manifest.
+
+If your install command falls in the forbidden category, set `install_hint`
+with the human-facing instruction and leave `auto_install` off. The hint is
+surfaced as an action item in preflight output but never auto-executed.
+
+## Advisory vs blocking mode
+
+The mode controls what happens when a required tool is missing after any
+auto-install attempt.
+
+| Mode | Behavior |
+|---|---|
+| `advisory` | Emit a warning with the agent name, tool, and install hint. Proceed with the spawn. |
+| `blocking` | Emit the same warning. Refuse the spawn until the dependency is resolved. |
+
+Set the mode in `.agentic/config.json`:
+
+```json
+{
+  "capability_preflight_mode": "advisory"
+}
+```
+
+Valid values: `advisory` and `blocking`. Any missing or unrecognized value
+falls back to `blocking`. The default at initial setup is `advisory` - a
+deliberate choice to let you onboard agents incrementally without breaking
+existing workflows. Once every agent you use has a populated manifest, flipping
+to `blocking` is a one-line config change.
+
+## What preflight output looks like
+
+When a dependency is missing, the conductor emits a structured notice before
+deciding whether to proceed or refuse:
+
+```
+qa-engineer preflight: blocking
+  required missing: @axe-core/playwright -- install: npm install --no-save @axe-core/playwright
+  optional missing: agent-browser -- install: npm install -g agent-browser
+```
+
+When all checks pass, nothing is emitted - a clean preflight produces no
+output.
+
+## Cache
+
+Successful checks are cached in `.agentic/.capability-cache.json` (gitignored)
+under a key of `<agent>:<tool>`, with a 30-minute TTL. Miss results are never
+cached, so installing a dep mid-session is picked up immediately on the next
+spawn without any manual cache-bust.
+
+## Related references
+
+- `content/references/capability-preflight.md` - full spec: YAML schema, predicate grammar, 7-step flow, cache schema, POSIX shell precondition.
+- `content/sections/06-capability-preflight.md` - the METHODOLOGY.md section that governs when preflight runs relative to the QA gate and Worker boot.
+- `.agentic/config.json` - project-level config where `capability_preflight_mode` lives.

--- a/docs/capability-preflight.md
+++ b/docs/capability-preflight.md
@@ -155,10 +155,13 @@ Set the mode in `.agentic/config.json`:
 ```
 
 Valid values: `advisory` and `blocking`. Any missing or unrecognized value
-falls back to `blocking`. The default at initial setup is `advisory` - a
-deliberate choice to let you onboard agents incrementally without breaking
-existing workflows. Once every agent you use has a populated manifest, flipping
-to `blocking` is a one-line config change.
+falls back to `blocking`. The default is `blocking` as of P2, because all
+shipped AE agent manifests are now populated. In `blocking` mode the conductor
+refuses a spawn when a required declared dependency is still missing after the
+auto-install attempt. `advisory` mode (warn and proceed) is opt-in - set
+`capability_preflight_mode: advisory` in `.agentic/config.json` if you are
+still populating manifests on custom agents and do not want spawns blocked in
+the interim.
 
 ## What preflight output looks like
 
@@ -171,8 +174,9 @@ qa-engineer preflight: blocking
   optional missing: agent-browser -- install: npm install -g agent-browser
 ```
 
-When all checks pass, nothing is emitted - a clean preflight produces no
-output.
+The exact format is illustrative - runtime output formatting may differ
+slightly. When all checks pass, nothing is emitted - a clean preflight produces
+no output.
 
 ## Cache
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1131,6 +1131,8 @@
       <div class="node node-protocol"><a href="cross-harness-teams.md" target="_blank" rel="noopener">cross-harness-teams.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="role-model-routing.md" target="_blank" rel="noopener">role-model-routing.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="skill-candidates.md" target="_blank" rel="noopener">skill-candidates.md</a> <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol"><a href="capability-preflight.md" target="_blank" rel="noopener">capability-preflight.md</a> <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol"><a href="wrap-deferred.md" target="_blank" rel="noopener">wrap-deferred.md</a> <span class="load-badge on-demand">on demand</span></div>
     </div>
     <p class="desc">Not auto-loaded. Read on-demand when protocols are triggered (e.g., Elevated risk declared, Skeptic review needed).</p>
   </div>

--- a/docs/wrap-deferred.md
+++ b/docs/wrap-deferred.md
@@ -1,0 +1,154 @@
+<!--
+Purpose: Operator-facing guide for the /wrap-deferred command and the
+         deferred-wrap daemon. Explains what it is, how it differs from /wrap,
+         when it runs, the non-interactive contract, and the security model.
+
+Public API: Operator-facing prose. Entry point for anyone who sees the daemon
+            in logs or wants to understand why a session was enriched without
+            a manual /wrap call. Full daemon setup, runtime state, and security
+            design live in hooks/wrap-deferred.README.md.
+
+Upstream deps: content/commands/wrap-deferred.md (command spec);
+               hooks/wrap-deferred.README.md (daemon setup and security model);
+               content/commands/wrap.md (interactive counterpart).
+
+Downstream consumers: docs site root index.
+
+Failure modes: Stale if the non-interactive contract, omission table, or
+               security model changes. Update alongside
+               content/commands/wrap-deferred.md in the same change.
+
+Performance: Standard.
+-->
+
+# /wrap-deferred
+
+`/wrap-deferred` is the non-interactive counterpart of `/wrap`. It runs
+automatically via a background daemon to finalize session enrichment when a
+session ends without a manual `/wrap` call.
+
+You do not invoke this command yourself. The daemon (`hooks/wrap-daemon.js`)
+detects cleanly-ended sessions, resumes them headlessly, and runs
+`/wrap-deferred` to write the same three targets as `/wrap` - session context,
+memory, and AGENTS.md updates - in a single unattended pass.
+
+The daemon setup, runtime state, stop/reset procedure, and security model
+are in `hooks/wrap-deferred.README.md`. This page explains what the command
+does and why it exists.
+
+## Why it exists
+
+The interactive `/wrap` hangs headlessly. It reaches a human-decision point
+early in its pipeline (a stale-lock prompt) and waits for input that never
+arrives. `/wrap-deferred` exists to close that gap: a single-pass command with
+no prompts, no subagents, and no loops that the daemon can run safely without
+a human at the other end.
+
+The result: sessions that end without a manual `/wrap` still get their context,
+memory, and AGENTS.md updated - just with less fidelity than the full
+interactive path.
+
+## How it differs from /wrap
+
+The interactive `/wrap` is a multi-pass, Skeptic-reviewed pipeline. `/wrap-deferred`
+is a single in-session model pass with the same write targets but fewer steps.
+
+| `/wrap` step | `/wrap-deferred` |
+|---|---|
+| Draft Worker (subagent) | Omitted - conductor surveys inline |
+| Skeptic review (two passes) | Omitted |
+| context.md merge (Part A) | Kept |
+| memory.md Open-PR deferral path | Omitted - writes directly to memory.md |
+| AGENTS.md Open-PR deferral path | Omitted - writes directly to AGENTS.md |
+| Part D skill-candidate signal | Omitted - Bash tool is removed in daemon context |
+| Part E compression | Omitted |
+| open-PR enumeration | Omitted |
+| /cleanup-worktrees | Omitted |
+| Marker transition to `done` | Omitted - the daemon owns this after the child exits 0 |
+| Scaffold migration prompts | Omitted - detected drift becomes a "Watch Out For" bullet in context.md |
+
+The write targets are identical: `.agentic/context.md`, `.agentic/memory.md`,
+and touched-track AGENTS.md files. The content quality is lower because there
+is no draft-review loop - it is a best-effort single pass.
+
+## The non-interactive contract
+
+`/wrap-deferred` satisfies these constraints on every execution path:
+
+- **Never prompts.** No question, no confirmation, no escalation. Any
+  ambiguity, blocker, or drift becomes a `## Watch Out For` bullet in
+  context.md and the command moves on.
+- **One model pass.** Surveys the resumed transcript and live file state, then
+  writes. No iteration, no re-route, no re-draft.
+- **No subagents.** Spawns nothing. All work happens inline in the resumed
+  session.
+- **Always reaches a terminal state.** Every path ends in a write or a clean
+  exit. No hangs, no wait loops.
+- **No git access.** The daemon launches the command with `--disallowedTools "Bash"`,
+  removing the Bash tool from the session entirely. This is a deliberate
+  security boundary - see below.
+
+## The Bash removal and why it matters
+
+The daemon launches `/wrap-deferred` with `--disallowedTools "Bash"` under
+`--permission-mode bypassPermissions`. Under bypass-permissions mode,
+`--allowedTools` does not constrain the tool set - it only suppresses approval
+prompts. The actual boundary is `--disallowedTools "Bash"`, which removes the
+Bash tool from context before the bypass step runs.
+
+This matters because a malicious cloned repository can execute attacker code
+through ordinary read-only git verbs (`core.fsmonitor` on `git status`,
+`diff.external` on `git diff`, `core.pager`). Running git in a daemon context
+that bypasses permissions creates an RCE path. Removing Bash closes that
+vector entirely.
+
+The consequence for the command itself: git state (uncommitted changes, recent
+commits, branch, stashes) is derived from the resumed conversation transcript
+when the ended session described that state, and is omitted otherwise. No
+`git status`, `git log`, `git stash list`, or `git diff` runs under the daemon.
+The interactive `/wrap`, which runs under normal permissions with a human
+present, still reads git normally.
+
+## What it writes
+
+The inputs are the resumed transcript and live reads of a small set of files:
+`.agentic/context.md`, `.agentic/memory.md`, root and track `AGENTS.md` files,
+and `.agentic/learnings.md` (read-only, to avoid duplicating already-captured
+facts).
+
+The write sequence is fixed:
+
+1. **Survey inline.** From the transcript and live file reads, compile: main
+   task and state, files touched, errors and gotchas, next steps, stable facts,
+   and which AGENTS.md files need updates.
+
+2. **Write context.md** using the shared rolling-session-label merge algorithm.
+   The daemon holds a `wrap/lock` window across this step; the child never
+   touches the lock directly.
+
+3. **Write memory.md** with append-dedup. Skip if there is nothing stable to
+   record. No Open-PR deferral path - writes directly.
+
+4. **Write AGENTS.md updates** with semantic dedup against existing content.
+   Skip if nothing to add. No Open-PR deferral path - writes directly.
+
+5. **Exit 0.** The daemon then transitions the per-session marker to `done`.
+
+## Manual /wrap --sync is still the full-fidelity path
+
+`/wrap-deferred` is a fallback for forgotten wraps, not a replacement. Run
+`/wrap --sync` manually when the session's work matters and you want:
+
+- Skeptic review of the draft context and memory entries.
+- Open-PR deferral for memory and AGENTS.md changes that need review before
+  merging.
+- Skill-candidate detection (Part D).
+- Part E context compression for long sessions.
+
+The daemon enriches unattended; you enrich deliberately.
+
+## Related references
+
+- `hooks/wrap-deferred.README.md` - daemon setup, runtime state, stop/reset, and full security model.
+- `content/commands/wrap-deferred.md` - command spec: non-interactive contract, inputs, procedure, and the full omission table vs `/wrap`.
+- `content/commands/wrap.md` - interactive `/wrap` pipeline.


### PR DESCRIPTION
## Summary
- Add `docs/capability-preflight.md`: operator guide for capability preflight - the `capabilities:` YAML block agents declare, `required_when` predicate grammar, `auto_install` safety boundary, advisory vs blocking mode (default `blocking` as of P2), and the absent-block no-op. Grounded in `content/references/capability-preflight.md` + `content/sections/06-capability-preflight.md`.
- Add `docs/wrap-deferred.md`: operator guide for `/wrap-deferred` - the non-interactive contract, how it differs from `/wrap`, and the `--disallowedTools "Bash"` git-RCE security boundary under daemon bypass mode. Grounded in `content/commands/wrap-deferred.md`.
- Wire both into the `docs/index.html` Protocol Documents grid.

## Review
- Skeptic-reviewed: every claim verified against canonical sources; security boundary directionality confirmed correct. One Critical (page stated default mode as advisory; corrected to blocking-as-of-P2) + one Minor fixed; re-review APPROVED. A reported Major (components.md regression) was verified as a stale-base diff artifact - this branch does not touch components.md.

## Follow-up (out of scope)
- Upstream drift: `content/sections/06-capability-preflight.md` still says "advisory at P0" while the authoritative reference says "blocking as of P2". Fixing `content/` triggers the adapter rebuild; tracked separately.