### PR TITLE
feat(protocol): implement-ticket delegates >=2-ticket batch planning to /ticket-triage

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -142,7 +142,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -483,10 +483,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -499,7 +502,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -509,34 +512,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2238,6 +2297,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.claude/commands/ticket-triage.md
+++ b/.claude/commands/ticket-triage.md
@@ -27,12 +27,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -127,15 +138,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -222,6 +242,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -140,7 +140,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -481,10 +481,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -497,7 +500,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -507,34 +510,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2236,6 +2295,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.codex/commands/ticket-triage.md
+++ b/.codex/commands/ticket-triage.md
@@ -25,12 +25,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -125,15 +136,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -220,6 +240,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -140,7 +140,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -481,10 +481,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -497,7 +500,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -507,34 +510,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2236,6 +2295,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.cursor/commands/ticket-triage.md
+++ b/.cursor/commands/ticket-triage.md
@@ -25,12 +25,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -125,15 +136,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -220,6 +240,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -146,7 +146,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -487,10 +487,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -503,7 +506,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -513,34 +516,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2242,6 +2301,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.gemini/commands/ticket-triage.toml
+++ b/.gemini/commands/ticket-triage.toml
@@ -31,12 +31,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -131,15 +142,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -226,6 +246,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -143,7 +143,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -484,10 +484,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -500,7 +503,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -510,34 +513,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2239,6 +2298,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.github/prompts/ticket-triage.prompt.md
+++ b/.github/prompts/ticket-triage.prompt.md
@@ -28,12 +28,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -128,15 +139,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -223,6 +243,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -11351,7 +11351,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -11692,10 +11692,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -11708,7 +11711,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -11718,34 +11721,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -13447,6 +13506,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 
@@ -16044,12 +16105,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -16144,15 +16216,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -16239,6 +16320,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -145,7 +145,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -486,10 +486,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -502,7 +505,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -512,34 +515,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2241,6 +2300,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.openclaw/skills/ticket-triage/SKILL.md
+++ b/.openclaw/skills/ticket-triage/SKILL.md
@@ -30,12 +30,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -130,15 +141,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -225,6 +245,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -144,7 +144,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -485,10 +485,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -501,7 +504,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -511,34 +514,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2240,6 +2299,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/.opencode/commands/ticket-triage.md
+++ b/.opencode/commands/ticket-triage.md
@@ -29,12 +29,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -129,15 +140,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -224,6 +244,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -140,7 +140,7 @@ The Stop hook (`hooks/stop-context.js`) mirrors its `loop-state.json` interrupte
 - `pause_reason`: enum `stale_pace | operator_pause | wallclock_cap | null` — these three values match the three Phase 12a triggers.
 - `wallclock_started_at`: set once at Phase 0a init; preserved across resume. The wallclock cap is per-batch lifetime, not per-session.
 - `wallclock_cap_min`: integer minutes. Default `90`. Overridable via env `AGENTIC_BATCH_MAX_WALLCLOCK_MIN`.
-- `tickets[]`: planner-derived; `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
+- `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included). `status` per-ticket is `pending | in_progress | complete | blocked | skipped_already_merged`.
 - `replan_log[]`: append-only audit log. Each entry: `{ts, action, ticket_id, detail}`. Actions include `drop_merged`, `investigator_rerun`, `re_sequence`. Preserved by Contract B.
 
 ---
@@ -481,10 +481,13 @@ classifiers:
 | Parse failure | Print warning. Prompt: `delete-and-fresh / abort`. On `abort`: exit. On `delete-and-fresh`: delete file and fall through. |
 | Inconsistent pair (`batch-state.json` says `active`, `loop-state.json` says `interrupted`) | Trust the non-active file. If both are stale-active (>10 min), treat as implicit interrupt for both. |
 
-**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input that does not match the on-disk `tickets[]`, Phase 0a-pre MUST surface a warning before falling through:
+**Move ordering hazard (resume case).** On resume, `batch-state.json.tickets[]` is the authoritative ticket cursor and supersedes any Phase 0 output produced in the resuming session. If the operator re-supplied input, compare Phase 0 entries[] against on-disk tickets[]:
+
+- **SUBSET match (all tickets[] IDs are present in entries[], but entries[] has extras):** this is NOT a hazard. The extras were deferred or excluded at original triage time. Note: extras beyond the original deferred set that were not part of the original input are not auto-added on resume - surface them to the operator or run them separately; they are never mis-run. Proceed silently with `batch-state.json.tickets[]` as the cursor.
+- **GENUINE divergence (tickets[] contains IDs NOT present in entries[]):** surface the warning below.
 
 ```
-WARNING: resumed batch tickets[] = [<list>] do not match this invocation's Phase 0 entries[] = [<list>].
+WARNING: resumed batch tickets[] = [<list>] contain ticket IDs not present in this invocation's Phase 0 entries[] = [<list>].
 The on-disk batch state takes precedence on resume. Continue resuming the prior batch, or abandon resume and use the new input?
 (continue-resume / abandon-resume-and-use-new-input)
 ```
@@ -497,7 +500,7 @@ On `continue-resume`: discard Phase 0 output, use `batch-state.json.tickets[]`. 
 
 1. `git fetch origin`.
 2. For each ticket in `tickets[]` with `status` `pending` or `blocked`: re-fetch the tracker record. If the ticket has been merged elsewhere (per tracker status, or per `gh pr list --state merged --head <branch>` returning a non-empty result), append a `replan_log` entry `{ts, action: "drop_merged", ticket_id, detail}` and set the ticket's `status` to `skipped_already_merged`.
-3. Spawn `orchestration-planner` over the surviving pending/blocked tickets to re-sequence. Re-spawn `investigator` only when `replan_count >= 2` (counted from `replan_log` entries with `action: "investigator_rerun"`).
+3. Run /ticket-triage Phases 1-3 over the surviving pending/blocked tickets to re-sequence. Level 2 investigator (Phase 2b) is gated on `replan_count >= 2`: count `replan_log` entries with `action: "investigator_rerun"`; if the count is >= 2, spawn a real background investigator (including the functional-duplicate brief); otherwise run Level 1 only (conductor-direct). Append the `replan_log` entry `{ts, action: "investigator_rerun", ticket_id: null, detail: "replan #N"}` BEFORE spawning the investigator when it fires. Map the resulting lanes back to the surviving tickets' `cluster_id` and `depends_on` fields (array order); deferred or in-progress-excluded tickets discovered during re-plan are surfaced to the operator and excluded from tickets[].
 4. All writes apply Contract A (per-write `session_id` gate) and Contract B (`replan_log[]` read-merge-write preservation). See "Batch state contracts" below.
 5. Bump `status` back to `active`. Preserve `wallclock_started_at` from the prior batch (the wallclock cap is per-batch lifetime, not per-session - a batch resumed in a later session continues counting against the original `wallclock_started_at`).
 
@@ -507,34 +510,90 @@ Emit breadcrumb: `[phase: batch-resume | tickets_remaining=K]`.
 
 ## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)
 
+<!--
+Phase 0a manifest:
+  Purpose: run /ticket-triage Phases 1-3 (algorithm by reference) over the Phase 0
+           entries[], surface triage results to the operator, map lane-assigned tickets
+           to batch-state.json, then iterate per-ticket phases 1-12 in array order.
+  Public API: reads Phase 0 entries[]; writes .agentic/batch-state.json tickets[]
+              (lane-assigned only; deferred and in-progress-excluded are NOT written).
+  Upstream deps: /ticket-triage Phases 1-3 (algorithm reference - no copy);
+                 investigator (Phase 2b Level 2, conditional on len(entries) <= 20);
+                 Phase 0 entries[] (already normalized, no re-normalization).
+  Downstream consumers: Phase 0a-pre (resume), Phase 12a (handoff), all per-ticket
+                        phases (1-12) which iterate tickets[] in array order.
+  Failure modes: soft-fail per ticket in Phase 1 metadata fetch; HEURISTIC_ONLY=true
+                 when len(entries)>20; functional-duplicate defer prompts are
+                 operator-gated (one prompt per pair after Phase 3).
+-->
+
 **Trigger:** Phase 0 normalization produced ≥ 2 entries.
 
 **Skip:** Phase 0 produced exactly 1 entry. Mixed-form inputs that Phase 0 normalized down to a single entry count as single-entry and skip Phase 0a.
 
 **Flow:**
 
-1. Spawn `investigator` (Tier 2) to read each ticket, identify shared files, flag duplicates, and cluster by surface area. The investigator returns a structured table mapping each ticket to its files-touched, related tickets, and any duplicates.
-2. Spawn `orchestration-planner` (Tier 2) with the investigator's output. The planner returns a sequenced execution plan: which tickets can be processed in parallel, which must be sequential, which are blocked by others.
+1. **Run the /ticket-triage planning algorithm (Phases 1-3) conductor-orchestrated.** Phase 0a feeds its OWN already-normalized `entries[]` directly into triage Phase 1 - triage Phase 0 is NOT re-run (entries are already normalized).
+
+   - **Phase 1 (metadata fetch, conductor-direct, soft-fail):** for each entry, fetch priority, status, story_points, labels, components, assignee, and issuelinks from the tracker (same per-ticket fetch as /ticket-triage Phase 1). Soft-fail per ticket (mark `fetch_failed: true` and proceed). Detect `terminal: true` (Done/Cancelled) and `in_progress: true` (active workflow state) per the /ticket-triage Phase 1 rules.
+
+   - **Phase 2a (DAG + cycle handling, conductor-direct):** build the dependency graph from `blocks`/`is-blocked-by` links, detect cycles (break at lowest-confidence link, defer both with `cycle_warning: true`). External deps noted but not used for lane assignment.
+
+   - **Phase 2b conflict-surface analysis:** Level 1 is always conductor-direct (shared component/label overlap check). Level 2 applies when `len(entries) <= 20`: spawn ONE real background investigator with the full /ticket-triage Phase 2b brief, including the functional-duplicate detection task (bar: "a reasonable engineer would implement them with exactly the same change"). When `len(entries) > 20`: set `HEURISTIC_ONLY=true` and proceed WITHOUT prompting - rationale: the batch was already committed via Phase 0, and prompting mid-initialization wastes operator context.
+
+   - **Phase 3 (Rules 1-4, conductor-direct):** distribute surviving tickets across lanes using the /ticket-triage Phase 3 consume-and-remainder pipeline. Lane cap is fixed at 3 on this path (`--lanes` override is not available for the /implement-ticket integration path).
+
+   The result is an in-memory `triage_result` containing:
+   `{lanes[], deferred[], in_progress_excluded[], functional_duplicates[], conflict_warnings[], heuristic_only}`.
+
+2. **Surface triage findings to the operator BEFORE building tickets[].** Present a structured summary covering:
+
+   - **Functional duplicate warnings** (when `functional_duplicates[]` is non-empty): for each pair, print the ticket IDs and the one-sentence reason. Prompt the operator PER PAIR (after all lane assignments are known, since Phase 3 has already run):
+
+     ```
+     Functional duplicate detected: <A> + <B> - <summary>
+     Both tickets appear to describe the same functional work.
+     Action: (defer-first / defer-second / keep-both)
+     ```
+
+     On `defer-first`: add ticket A to `deferred[]`, remove it from its lane. On `defer-second`: add ticket B to `deferred[]`, remove it from its lane. On `keep-both`: no change. Do NOT recompute the lane distribution after a defer choice - surgically remove the deferred ticket from its lane only.
+
+   - **Deferred tickets** (from Phase 3 Rule 1 + any operator-deferred duplicates): list each with its reason.
+
+   - **In-progress tickets** (from Phase 1): list each. These are excluded from tickets[] and kickoff.
+
+   - **HEURISTIC_ONLY notice** (when `HEURISTIC_ONLY=true`): "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
+
+   After surfacing, map ONLY the lane-assigned tickets to `tickets[]` (deferred and in-progress-excluded tickets are NOT written to tickets[]).
+
+   Map in ARRAY ORDER: lane 1 first, lane 2 next, lane 3 last. Within each lane, chains are topo-sorted (blockers first); parallel tickets within the same lane are sorted priority-descending then ticket_id-ascending. Each entry:
+   - `status: "pending"`
+   - `cluster_id: "lane-N"` (where N is the lane number)
+   - `depends_on: ["<prev-ticket-id>"]` (chain) or `[]` (parallel lane head or independent)
+
+   No `merge_order` field. Array position is the execution cursor.
+
+   Emit breadcrumb: `[phase: batch-triage | triage_algorithm=ticket-triage-phases-1-3 | N tickets | lanes=K | lane_cap=3 | deferred=P | excluded_in_progress=Q | heuristic_only=<bool>]`.
+
 3. **Initialize `.agentic/batch-state.json`** (persistent batch cursor). First apply the Contract C concurrent-batch refusal: if the file already exists with `status=active`, a different `session_id`, and `last_updated` within the last 10 minutes, REFUSE with the verbatim Contract C message and exit. Otherwise, write the initial skeleton:
    - `schema_version: 1`
    - `session_id: <current>`
    - `batch_id: "<first ticket's TICKET_PREFIX>-batch-<ISO8601>-<4hex>"`
    - `status: "active"`
-   - `tickets[]`: populated from planner output, each entry `status: "pending"`, with `cluster_id` and `depends_on` carried through from the planner
+   - `tickets[]`: triage-derived executable cursor; contains only lane-assigned tickets (deferred and in-progress-excluded tickets are not included); in array order as described in step 2 above
    - `wallclock_started_at: now`, `wallclock_cap_min: <env AGENTIC_BATCH_MAX_WALLCLOCK_MIN or 90>`
    - `replan_log: []`
    - `created_at: now`, `updated_at: now`
 
    Atomic tmp+rename. Apply Contract A on the write (this is a fresh write so no prior `session_id`; the gate effectively passes).
-4. Conductor iterates through the planner's order, running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
+
+4. Conductor iterates through tickets[] in array order (tickets[] contains only lane-assigned executable tickets; deferred and in-progress-excluded tickets were surfaced in step 2 and are not present), running existing per-ticket phases (1 → 12) for each ticket. **Per-ticket transition writes to `batch-state.json`** (each via Contract A + Contract B):
    - At ticket start: `status: "pending" → "in_progress"`, set `started_at`, update `updated_at`.
    - At ticket complete: `status: "in_progress" → "complete"`, set `ended_at`, `last_summary`, `pr_number`, `branch`.
    - At ticket block: `status → "blocked"` with detail in `last_summary`.
    - At ticket merged-elsewhere skip: `status → "skipped_already_merged"` with `replan_log` append.
 
 **Persistent batch state lives in `.agentic/batch-state.json`. See Phase 0a-pre for the resume protocol.**
-
-Emit breadcrumb: `[phase: batch-triage | N tickets | clusters=K]`.
 
 ---
 
@@ -2236,6 +2295,8 @@ Remaining: <N-k> tickets
   ...
 Resume: /implement-ticket from this directory
 ```
+
+Note: N is the executable-cursor count (lane-assigned tickets only). Deferred and in-progress-excluded tickets were surfaced in Phase 0a step 2 and are not included in N.
 
 Exit cleanly. Do NOT advance to the next ticket. Emit breadcrumb: `[phase: batch-paused | reason=<trigger>]`.
 

--- a/content/commands/ticket-triage.md
+++ b/content/commands/ticket-triage.md
@@ -25,12 +25,23 @@ Upstream deps: content/commands/implement-ticket.md Phase 0 (input normalizer,
                (mcp__linear__get_issue); content/references/trigger-catalog.md
                (yolo-guard, §d).
 
-Downstream consumers: operator-invoked only. Output artifact is
+Downstream consumers: operator-invoked only (standalone) OR /implement-ticket
+                      Phase 0a (integration path - algorithm reused by reference,
+                      no copy). Output artifact (standalone path only) is
                       docs/planning/triage-<YYYYMMDD>-<4hex>.md (gitignored by
                       convention; gitignore status is project-dependent in
-                      consumer repos). Kickoff prompts in the artifact are inputs for the
-                      conductor on the operator's next /implement-ticket session;
-                      they do not bypass risk classification or Skeptic review.
+                      consumer repos). Kickoff prompts in the artifact are inputs
+                      for the conductor on the operator's next /implement-ticket
+                      session; they do not bypass risk classification or Skeptic
+                      review.
+
+Output description: triage_result {lanes[], deferred[], in_progress_excluded[],
+                    functional_duplicates[], conflict_warnings[], heuristic_only}
+                    where functional_duplicates[] contains
+                    {ticket_ids: [A, B], summary: "<one-sentence why same work>"}
+                    entries (empty array when none). Level-1-only / HEURISTIC_ONLY
+                    runs skip functional-duplicate detection (no ticket content
+                    read at Level 1).
 
 Failure modes: soft-fail per ticket throughout; fetch failures treated as
                independent tickets, not as aborts. Single-ticket degenerate
@@ -125,15 +136,24 @@ From the `blocks` / `is-blocked-by` link fields, build a directed acyclic graph 
 
 ## Phase 2b: Conflict-surface analysis
 
-**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group.
+**Level 1 (always, conductor-direct):** for each pair of tickets, check for shared `components[]` or `labels[]`. Mark any overlapping pair as in the same conflict group. Functional-duplicate detection is NOT performed at Level 1 (no ticket content is read).
 
 **Level 2 (when `!HEURISTIC_ONLY` and `len(entries) <= 20`):** spawn one background investigator over all tickets. The investigator reads only:
 - root `AGENTS.md` and any track-level `AGENTS.md` for tracks whose names appear in ticket titles/descriptions.
 - A top-level directory listing of the repo.
+- The title and description of each ticket in the set.
 
-The investigator returns `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+The investigator brief MUST include the following two tasks:
 
-**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped)."
+1. **Conflict analysis.** Return `{ticket_id -> affected_areas[]}`. Two tickets conflict if their `affected_areas[]` overlap OR they share a Level 1 conflict group.
+
+2. **Functional-duplicate detection.** For every pair of DISTINCT tickets in the set, assess whether a reasonable engineer would implement them with exactly the same change. The bar is strict: related-but-distinct work (e.g. add-login vs add-logout, two separate bug fixes in the same file) is NOT a duplicate. A duplicate pair is only flagged when the descriptions define the same functional requirement such that a single implementation resolves both. Return `functional_duplicates: [{ticket_ids: [A, B], summary: "<one-sentence explanation of why the same change resolves both>"}]` (empty array when none).
+
+The investigator output contract is `{ticket_id -> affected_areas[], functional_duplicates[{ticket_ids, summary}]}`.
+
+**Conductor handling:** store `functional_duplicates[]` from the investigator output into `triage_result.functional_duplicates[]`. Surface this in Phase 4a artifact and, on the /implement-ticket integration path, in Phase 0a step 2.
+
+**HEURISTIC_ONLY stamp:** when `HEURISTIC_ONLY=true`, Phase 2b runs Level 1 only. The artifact header is stamped: "Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investigator pass skipped). Functional-duplicate detection was also skipped."
 
 `[phase: ticket-triage | phase=conflict]`
 
@@ -220,6 +240,19 @@ Parallel-safe grouping is heuristic - based on ticket metadata and directory-lev
 analysis, not file-level diffing. Verify before running lanes truly concurrently;
 each /implement-ticket session's own Skeptic chain still catches collisions at
 merge time.
+
+## Functional duplicate warnings
+
+<!-- Only present when functional_duplicates[] is non-empty (Level 2 investigator ran).
+     List each pair and its one-sentence rationale. Omit this section entirely when
+     the array is empty or when HEURISTIC_ONLY=true (investigator was skipped). -->
+
+| Pair | Why same work |
+|------|---------------|
+| A + B | Both implement the same email validation rule in the same form handler |
+
+Consider deferring one ticket of each pair or merging them into a single ticket before
+running /implement-ticket. Running both risks a merge conflict or duplicated effort.
 
 ## Deferred tickets
 


### PR DESCRIPTION
## Summary

Unit 2 of 2 (follow-up to #364, which added the standalone `/ticket-triage` command).

- `/implement-ticket` Phase 0a (batch triage, >=2 tickets) now delegates planning to the `/ticket-triage` algorithm (Phases 1-3) by reference, replacing the prior investigator + orchestration-planner pair. Single planning brain, two entry points.
- `batch-state.json tickets[]` is now a triage-derived executable cursor: lane-assigned tickets only, in array order, with `cluster_id` + `depends_on`. Deferred and in-progress-excluded tickets are surfaced to the operator (chat + breadcrumb), not written to state. No schema enum change; no `merge_order` field.
- Functional-duplicate detection added to the shared `/ticket-triage` Phase 2b algorithm (flags distinct tickets that are the same work); both the standalone command and the Phase 0a path inherit it. Operator-gated (defer/keep), never auto-removed.
- Resume move-ordering-hazard guard amended: a subset match (cursor is a subset of re-supplied input) is no longer a false-positive; genuine divergence still fires.
- Phase 0a-pre re-plan preserves the `replan_count >= 2` investigator gate exactly.

No code edits, no behavior change for single-ticket invocations, no change to the #360 ticket-driven gate.

## Test plan

- [ ] adapter-sync CI green on the merge result (all 11 adapters)
- [ ] check-drift green (command files; baseline unchanged)
- [ ] Review: algorithm referenced by name only (no copy of triage Rules 1-4 into implement-ticket)
- [ ] Review: tickets[] is lane-assigned-only; deferred/in-progress reported not enqueued; status enum unchanged

Architect-designed, two Skeptic passes on the plan (4 Majors resolved) + a full-diff Skeptic on the implementation (clean sign-off).