### PR TITLE
feat(vision): universality (works-for-everyone) North Star pillar + scope /ticket-triage no-args to configured project/team

### DIFF
--- a/.claude/commands/ticket-triage.md
+++ b/.claude/commands/ticket-triage.md
@@ -94,8 +94,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.codex/commands/ticket-triage.md
+++ b/.codex/commands/ticket-triage.md
@@ -92,8 +92,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.cursor/commands/ticket-triage.md
+++ b/.cursor/commands/ticket-triage.md
@@ -92,8 +92,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.gemini/commands/ticket-triage.toml
+++ b/.gemini/commands/ticket-triage.toml
@@ -98,8 +98,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.github/agents/qa-engineer.md
+++ b/.github/agents/qa-engineer.md
@@ -106,7 +106,7 @@ agent-browser close --all 2>/dev/null || true   # close every agent-browser sess
 kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 ```
 
-The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the snippet above handles it.
+The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
 **Applying project knowledge:**
 
@@ -127,6 +127,8 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 - `motion` entries: operator-declared route and element list that overrides the scenario's `route` and `elements` fields when both are present. Format: `motion: /route [selector,selector,...]` or `motion: /route auto`
 
 ## Workflow
+
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
 
 ### 1. Pre-flight
 

--- a/.github/prompts/ticket-triage.prompt.md
+++ b/.github/prompts/ticket-triage.prompt.md
@@ -95,8 +95,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -16173,8 +16173,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.openclaw/skills/ticket-triage/SKILL.md
+++ b/.openclaw/skills/ticket-triage/SKILL.md
@@ -97,8 +97,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/.opencode/commands/ticket-triage.md
+++ b/.opencode/commands/ticket-triage.md
@@ -96,8 +96,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/content/commands/ticket-triage.md
+++ b/content/commands/ticket-triage.md
@@ -92,8 +92,8 @@ Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolutio
 When `/ticket-triage` is invoked with no input, resolve the operator's open assigned tickets from the configured tracker (read-only query; no tracker writes):
 
 - **`TRACKER == none`:** print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit.
-- **Jira:** query `assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
-- **Linear:** query issues where `assignee: me` and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Jira:** query `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC` in the configured project using `mcp__mcp-atlassian__jira_search`, where `<TICKET_PREFIX>` is the project key resolved by the Preflight. Use the same pagination cap (50 results) as Phase 0's JQL resolver. Collect entries as `{ticket_id, source: "assigned"}`.
+- **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /implement-ticket <id> directly." and exit).
 - **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -25,6 +25,15 @@ task and get back a verifiable outcome.
    autonomy safe to trust.
 3. **Low friction.** Sensible defaults, minimal setup, global-default/per-project-override
    everywhere. The protocol should reduce ceremony, not add it.
+4. **Works for everyone (universality).** The protocol is a shared, portable package — every
+   rule, command, and agent must work for any operator, not just its author. No operator's
+   identity, workspace, tracker, or local setup may be baked into shared behavior: resolve
+   per-operator context at runtime (e.g. "my assigned tickets" via the tracker's own
+   current-user, scoped to the configured project — never a hardcoded account or workspace),
+   honor the global-default / per-project-override seam, and degrade gracefully when a
+   capability isn't configured rather than breaking. A change that only works for its author's
+   setup is a regression. (The "portability test": would this behave correctly for a teammate
+   with different credentials, a different tracker, or a different harness?)
 
 ## What it does
 
@@ -38,11 +47,14 @@ trust — escalating to the human only for genuine decisions.
 - **Not** capability-for-capability's-sake: features that raise attention tax without a
   proportional autonomy/verifiability gain are out of scope.
 - **Not** a finished product — it is a living system meant to evolve as patterns improve.
+- **Not** single-operator software: behavior hardwired to one person's identity, tracker,
+  workspace, or machine has no place in the shared rule set.
 
 ## How to use this for PR alignment
 
 A pull request is **aligned** if it advances at least one North Star pillar without regressing
 another (especially the attention test). A PR is **misaligned** if it adds operator attention
 tax for little autonomy/verifiability gain, makes outcomes harder to verify, increases friction
-without justification, or pulls the methodology toward "human must babysit." Misalignment is a
+without justification, pulls the methodology toward "human must babysit," or fails the
+portability test (works only for the author's identity, tracker, or setup). Misalignment is a
 *direction* signal for the operator — not necessarily a request-changes verdict on correctness.


### PR DESCRIPTION
## Summary

Adds "works for everyone" as an explicit product principle, and fixes the first violation it catches.

**Vision (`docs/overview/vision.md`):**
- New 4th North Star pillar: **Works for everyone (universality)** - no operator's identity, workspace, tracker, or local setup may be baked into shared behavior; resolve per-operator context at runtime and scope to the configured project. Defines the **portability test**.
- Matching non-goal ("Not single-operator software") and a PR-alignment misalignment condition, so the pillar is enforceable in review, not just aspirational.

**Enforcement (`/ticket-triage` no-args queries):**
- Jira no-args JQL now scoped: `project = <TICKET_PREFIX> AND assignee = currentUser() AND statusCategory != Done`. Previously unscoped, so a multi-project operator got their assigned tickets across every project - a firehose for a triage scoped to one repo.
- Linear no-args now scoped to the resolved team.
- Fully runtime-resolved (`currentUser()` / `me` + `TICKET_PREFIX`/team from the per-project tracker config). Zero hardcoded account IDs, project keys, or workspaces. Read-only.

All 11 adapters rebuilt. (A stale generated `.github/agents/qa-engineer.md` was corrected by the rebuild - pre-existing drift, source untouched.)

## Test plan
- [ ] adapter-sync green on merge result
- [ ] Review: no hardcoded identity/project/workspace in the no-args queries
- [ ] Review: vision pillar 4 + portability test read coherently and match the file's voice