### PR TITLE
docs(safe-configuration): add token-spend / right-sizing section + preset alias

### DIFF
--- a/docs/safe-configuration.md
+++ b/docs/safe-configuration.md
@@ -163,9 +163,11 @@ the same result as `preset: lean`.
 **Where to set it:**
 
 - **Global** - add a `"preset"` key to `~/.claude/agentic-engineering.json`:
-  `{ "mode": "opt-in", "preset": "lean" }`
+  `{ "preset": "lean" }` (omit `mode` - it controls activation, not profile,
+  and its default value should be left unchanged).
 - **Per-project** - add a marker line to the project's `AGENTS.md`:
-  `agentic-engineering-preset: lean`
+  `agentic-engineering-preset: lean`. This overrides the global preset and
+  any direct `agentic-engineering-profile:` line in the same file.
 
 **Collision rule:** when both a `preset` and a direct `profile` are set, the
 `preset` wins. It is the higher-level knob. When `preset` is absent or null,

--- a/docs/safe-configuration.md
+++ b/docs/safe-configuration.md
@@ -133,3 +133,49 @@ sensitive or shared repos, prefer `strict`.
 These are starting points, not guarantees. Whatever the context, review
 irreversible and shared-state operations before they land - see the run-safely
 checklist in [SAFETY.md](../SAFETY.md).
+
+## Controlling token spend (right-sizing review)
+
+The dominant driver of token cost is the Elevated classification. Nearly every
+code edit with behavioral effect, new file, multi-file change, and config change
+trips Elevated. Each Elevated task fans out to a Worker + Skeptic (and often an
+architect, orchestration-planner, and QA engineer too), each re-reading context.
+Small tasks pay the full pipeline.
+
+The **risk profile** is the primary lever for cutting that cost. Moving from
+`strict` or `default` toward `relaxed` reclassifies more small work as Low
+(conductor direct action, no spawns), which removes the Worker + Skeptic
+overhead entirely. See the [Risk profiles](#risk-profiles) section above for
+the full list of which signals shift at each level.
+
+### The `preset` alias
+
+`preset` is a session-wide shorthand that resolves to a profile. It is an alias,
+not extra capability - setting `agentic-engineering-profile: relaxed` achieves
+the same result as `preset: lean`.
+
+| Preset     | Resolves to profile |
+|------------|---------------------|
+| `lean`     | `relaxed`           |
+| `standard` | `default`           |
+| `strict`   | `strict`            |
+
+**Where to set it:**
+
+- **Global** - add a `"preset"` key to `~/.claude/agentic-engineering.json`:
+  `{ "mode": "opt-in", "preset": "lean" }`
+- **Per-project** - add a marker line to the project's `AGENTS.md`:
+  `agentic-engineering-preset: lean`
+
+**Collision rule:** when both a `preset` and a direct `profile` are set, the
+`preset` wins. It is the higher-level knob. When `preset` is absent or null,
+the direct `profile` value is used (back-compat).
+
+### Tradeoff
+
+Use `relaxed` (or `lean`) for solo work and trusted-repo iteration to reduce
+token spend; accept that small behavioral edits skip independent Skeptic review.
+Keep `default` or `strict` where a mistake costs time or data - shared repos,
+security-sensitive paths, or any work that is hard to revert. The
+[recommended configs table](#risk-profiles-and-recommended-configs) maps
+common contexts to sensible starting points.


### PR DESCRIPTION
## Summary

Adds a "Controlling token spend (right-sizing review)" section to `docs/safe-configuration.md`, framing the risk **profile** as the primary lever for cutting token cost and documenting the previously-undocumented `preset` alias.

- **Cost framing:** Elevated classification is the dominant token-cost driver (each Elevated task fans out to Worker + Skeptic, often architect/planner/QA). Moving toward `relaxed` reclassifies more small work as Low (no spawns).
- **`preset` alias:** documents the `lean`/`standard`/`strict` -> `relaxed`/`default`/`strict` table, where to set it (global JSON `"preset"` key or `agentic-engineering-preset:` AGENTS.md marker), and the collision rule (preset wins over direct profile; per-project overrides global).
- **Tradeoff** paragraph pointing back to the recommended-configs table.

Docs-only; no methodology/content, adapters, or baseline touched.

## Review
- Skeptic sign-off after fixing a footgun in the global-config example (`mode: opt-in` removed - it controls activation, not profile) and adding the per-project precedence note.