### PR TITLE
docs(index): lead Configuration Layer with a settings-at-a-glance table

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1024,6 +1024,81 @@
 <!-- ═══ LAYER 1: Configuration Files ═══ -->
 <div id="config" class="section config-layer">
   <div class="section-title" data-num="01"><h2>Configuration Layer <a class="slide-link" href="slides/getting-started-slides.html" target="_blank" rel="noopener noreferrer">slides: getting started</a> <a class="slide-link" href="slides/agents-md-hierarchy-slides.html" target="_blank" rel="noopener noreferrer">slides: AGENTS.md hierarchy</a></h2><h3>Skill-based entry point auto-triggered for engineering tasks</h3></div>
+  <p class="desc" style="margin-bottom: 12px;">Every setting you can tune, where each lives, and how to set it. Full list with every key: <a href="configuration-reference.md" style="color: var(--cyan);">configuration-reference.md</a>.</p>
+  <table style="font-size: 13px; border-collapse: collapse; width: 100%; margin-bottom: 20px;">
+    <thead>
+      <tr>
+        <th style="text-align: left; padding: 5px 14px 5px 0; color: var(--text-secondary); font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08);">Setting</th>
+        <th style="text-align: left; padding: 5px 14px 5px 0; color: var(--text-secondary); font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08);">Options</th>
+        <th style="text-align: left; padding: 5px 14px 5px 0; color: var(--text-secondary); font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08);">Default</th>
+        <th style="text-align: left; padding: 5px 0; color: var(--text-secondary); font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08);">How to set</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Risk profile</td>
+        <td style="padding: 5px 14px 5px 0;"><code>relaxed</code> / <code><strong>default</strong></code> / <code>strict</code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>default</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Install: <code>install.sh --profile=&lt;v&gt;</code>; or post-install: <code>profile</code> in <code>~/.claude/agentic-engineering.json</code>, or <code>agentic-engineering-profile:</code> in AGENTS.md</td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Preset (profile alias)</td>
+        <td style="padding: 5px 14px 5px 0;"><code>lean</code> / <code>standard</code> / <code>strict</code></td>
+        <td style="padding: 5px 14px 5px 0;">none</td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>preset</code> in <code>~/.claude/agentic-engineering.json</code>, or <code>agentic-engineering-preset:</code> in AGENTS.md</td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Activation mode</td>
+        <td style="padding: 5px 14px 5px 0;"><code><strong>opt-out</strong></code> / <code>opt-in</code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>opt-out</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);"><code>mode</code> in <code>~/.claude/agentic-engineering.json</code>, or <code>agentic-engineering:</code> marker in AGENTS.md</td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Auto-merge on green CI</td>
+        <td style="padding: 5px 14px 5px 0;"><code>true</code> / <code><strong>false</strong></code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>false</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>auto_merge_on_ci_green</code> in <code>.agentic/config.json</code></td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Commit telemetry</td>
+        <td style="padding: 5px 14px 5px 0;"><code><strong>true</strong></code> / <code>false</code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>true</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>commit_telemetry</code> in <code>.agentic/config.json</code></td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Capability preflight</td>
+        <td style="padding: 5px 14px 5px 0;"><code>advisory</code> / <code><strong>blocking</strong></code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>blocking</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>capability_preflight_mode</code> in <code>.agentic/config.json</code></td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Abdication guard</td>
+        <td style="padding: 5px 14px 5px 0;"><code>true</code> / <code><strong>false</strong></code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>false</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>abdication_guard_enabled</code> in <code>.agentic/config.json</code>; disable per-session: <code>export AE_ABDICATION_GUARD_DISABLE=1</code></td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Ticket-driven</td>
+        <td style="padding: 5px 14px 5px 0;"><code>off</code> / <code>offer</code> / <code>require</code></td>
+        <td style="padding: 5px 14px 5px 0;"><code>offer</code> if tracker connected, else <code>off</code></td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">Post-install: <code>ticket_driven</code> in <code>.agentic/config.json</code></td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Guard kill-switches</td>
+        <td style="padding: 5px 14px 5px 0; font-size: 12px;"><code>AE_SINGULARITY_GUARD_DISABLE</code> / <code>AE_TIER_GUARD_DISABLE</code> / <code>AGENTIC_QUIET</code></td>
+        <td style="padding: 5px 14px 5px 0;">unset</td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);">In-session: <code>export &lt;VAR&gt;=1</code> before launching</td>
+      </tr>
+      <tr>
+        <td style="padding: 5px 14px 5px 0; white-space: nowrap;">Identity handle</td>
+        <td style="padding: 5px 14px 5px 0; font-size: 12px;">any string</td>
+        <td style="padding: 5px 14px 5px 0; font-size: 12px;">derived from GitHub login</td>
+        <td style="padding: 5px 0; font-size: 12px; color: var(--text-secondary);"><code>agentic-identity auto</code> / <code>init &lt;handle&gt;</code> / <code>confirm</code></td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="desc" style="margin-bottom: 20px; font-size: 13px;">File settings (<code>agentic-engineering.json</code>, <code>.agentic/config.json</code>, AGENTS.md) take effect at the next session start. <code>export</code>ed env vars apply to the current session. Full reference: <a href="configuration-reference.md" style="color: var(--cyan);">configuration-reference.md</a>.</p>
+
   <p class="desc" style="margin-bottom: 16px;">The system uses a <strong>skill-based architecture</strong>. The global <code>~/.claude/[AGENTS|CLAUDE].md</code> is minimal - just personal preferences and pointers to available domain skills. The real entry point is the <code>/agentic-engineering</code> skill, which auto-triggers when engineering tasks are detected and loads all rules and protocol references. This keeps always-loaded context small while giving the full methodology to sessions that need it.</p>
   <div class="two-col">
     <div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1025,6 +1025,7 @@
 <div id="config" class="section config-layer">
   <div class="section-title" data-num="01"><h2>Configuration Layer <a class="slide-link" href="slides/getting-started-slides.html" target="_blank" rel="noopener noreferrer">slides: getting started</a> <a class="slide-link" href="slides/agents-md-hierarchy-slides.html" target="_blank" rel="noopener noreferrer">slides: AGENTS.md hierarchy</a></h2><h3>Skill-based entry point auto-triggered for engineering tasks</h3></div>
   <p class="desc" style="margin-bottom: 12px;">Every setting you can tune, where each lives, and how to set it. Full list with every key: <a href="configuration-reference.md" style="color: var(--cyan);">configuration-reference.md</a>.</p>
+  <div style="overflow-x: auto;">
   <table style="font-size: 13px; border-collapse: collapse; width: 100%; margin-bottom: 20px;">
     <thead>
       <tr>
@@ -1097,6 +1098,7 @@
       </tr>
     </tbody>
   </table>
+  </div>
   <p class="desc" style="margin-bottom: 20px; font-size: 13px;">File settings (<code>agentic-engineering.json</code>, <code>.agentic/config.json</code>, AGENTS.md) take effect at the next session start. <code>export</code>ed env vars apply to the current session. Full reference: <a href="configuration-reference.md" style="color: var(--cyan);">configuration-reference.md</a>.</p>
 
   <p class="desc" style="margin-bottom: 16px;">The system uses a <strong>skill-based architecture</strong>. The global <code>~/.claude/[AGENTS|CLAUDE].md</code> is minimal - just personal preferences and pointers to available domain skills. The real entry point is the <code>/agentic-engineering</code> skill, which auto-triggers when engineering tasks are detected and loads all rules and protocol references. This keeps always-loaded context small while giving the full methodology to sessions that need it.</p>


### PR DESCRIPTION
## Summary

Makes the public landing page's Configuration Layer section lead with a scannable **Settings at a glance** table - what people need, up front.

- 10 rows: risk profile, preset, activation mode, auto-merge, commit telemetry, capability preflight, abdication guard, ticket-driven, guard kill-switches, identity.
- Columns: **Setting / Options / Default / How to set** - the How-to-set column covers the install / post-install-file / in-session-env distinction.
- Defaults marked; links to `configuration-reference.md` for the full list.
- Wrapped in `overflow-x: auto` so it scrolls (not clips) on narrow viewports, matching the doc's existing wide-table pattern.

Additive only, top of `#config`; existing architecture prose and notes untouched. No `mode: opt-in` JSON snippet. Skeptic sign-off: all 10 defaults verified against `configuration-reference.md`; the overflow wrapper resolves the one Minor.