### PR TITLE
feat(update): warn when a git pull changes hooks/ (DS-54)

### DIFF
--- a/.claude/commands/pull-and-install.md
+++ b/.claude/commands/pull-and-install.md
@@ -176,6 +176,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.claude/commands/update-agentic-engineering.md
+++ b/.claude/commands/update-agentic-engineering.md
@@ -132,10 +132,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -169,7 +179,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.codex/commands/pull-and-install.md
+++ b/.codex/commands/pull-and-install.md
@@ -174,6 +174,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.codex/commands/update-agentic-engineering.md
+++ b/.codex/commands/update-agentic-engineering.md
@@ -130,10 +130,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -167,7 +177,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.cursor/commands/pull-and-install.md
+++ b/.cursor/commands/pull-and-install.md
@@ -174,6 +174,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.cursor/commands/update-agentic-engineering.md
+++ b/.cursor/commands/update-agentic-engineering.md
@@ -130,10 +130,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -167,7 +177,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.gemini/commands/pull-and-install.toml
+++ b/.gemini/commands/pull-and-install.toml
@@ -180,6 +180,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.gemini/commands/update-agentic-engineering.toml
+++ b/.gemini/commands/update-agentic-engineering.toml
@@ -136,10 +136,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -173,7 +183,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.github/prompts/pull-and-install.prompt.md
+++ b/.github/prompts/pull-and-install.prompt.md
@@ -177,6 +177,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.github/prompts/update-agentic-engineering.prompt.md
+++ b/.github/prompts/update-agentic-engineering.prompt.md
@@ -133,10 +133,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -170,7 +180,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -15263,6 +15263,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
@@ -16566,10 +16576,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -16603,7 +16623,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.openclaw/skills/pull-and-install/SKILL.md
+++ b/.openclaw/skills/pull-and-install/SKILL.md
@@ -179,6 +179,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.openclaw/skills/update-agentic-engineering/SKILL.md
+++ b/.openclaw/skills/update-agentic-engineering/SKILL.md
@@ -135,10 +135,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -172,7 +182,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/.opencode/commands/pull-and-install.md
+++ b/.opencode/commands/pull-and-install.md
@@ -178,6 +178,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/.opencode/commands/update-agentic-engineering.md
+++ b/.opencode/commands/update-agentic-engineering.md
@@ -134,10 +134,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -171,7 +181,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -41,6 +41,13 @@ Failure modes: exit 1 on non-main branch, dirty working tree, pull failure,
                is non-fatal: failures emit a warning and execution continues.
                Missing agentic-doctor binary: warning, exit 0.
 
+Advisory: when a pull changes any file under hooks/, a non-blocking warning
+          is printed to stderr (_hooks_touched / _build_hooks_warning) -
+          Claude Code (and other adapters) load hook scripts by absolute
+          path and re-read them from disk on every tool call, so other open
+          sessions against this checkout pick up the change with no
+          restart. Never blocks the update.
+
 Performance: network-bound (git fetch); rebuild decision and adapter installs
              add seconds only when adapter sources changed.
 """
@@ -222,6 +229,44 @@ def _needs_rebuild(old_head: str, new_head: str, changed_paths: list[str]) -> bo
             return True
 
     return False
+
+
+def _hooks_touched(changed_paths: list[str]) -> bool:
+    """Return True if any changed path lives under hooks/.
+
+    Ported from scripts/update.js hooksTouched(). Keep in sync - same
+    normalisation as _needs_rebuild (backslash -> forward slash, strip one
+    leading slash) and the same hooks/ prefix test.
+
+    Drives a non-blocking stderr warning after a pull: Claude Code (and
+    other adapters) load hook scripts by absolute path and re-read them
+    from disk on every tool call, so an OTHER open session against this
+    checkout picks up the change on its next tool call with no restart.
+    """
+    for p in changed_paths:
+        normalised = re.sub(r'^/', '', p.replace("\\", "/"))
+        if normalised.startswith("hooks/"):
+            return True
+    return False
+
+
+def _build_hooks_warning(changed_paths: list[str]) -> str:
+    """Build the non-blocking hooks/-change advisory (mirrors buildHooksWarning()
+    in scripts/update.js). Changed: lists the hooks/-prefixed subset only.
+    """
+    changed_list = ", ".join(
+        p for p in changed_paths
+        if re.sub(r'^/', '', p.replace("\\", "/")).startswith("hooks/")
+    )
+    return (
+        "warning: this update changed files under hooks/. Claude Code (and other adapters) "
+        "load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on "
+        "every tool call - there is no copy step. Any OTHER session with an open terminal "
+        "already using this checkout will pick up the new hook behavior on its NEXT tool call: "
+        "no restart, no re-run of install.sh, no in-session notice. If other sessions are active "
+        "against this checkout, tell them to /exit and restart once this update finishes - or "
+        "expect hook behavior to change under them mid-session. Changed: " + changed_list
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -429,6 +474,10 @@ def main() -> int:
         rc, diff_out, _ = _git(repo_dir, "diff", "--name-only", old_head, new_head)
         if rc == 0 and diff_out:
             changed_paths = [p for p in diff_out.splitlines() if p.strip()]
+
+    # Non-blocking advisory: warn (never block) when the pull touched hooks/.
+    if _hooks_touched(changed_paths):
+        print(_build_hooks_warning(changed_paths), file=sys.stderr)
 
     # Count commits pulled
     commits_pulled = 0

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -495,6 +495,157 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
+# Test 11 (DS-54): Direct _hooks_touched unit test via importlib
+#
+# Mirrors Test 9's importlib pattern. Covers the same case table as
+# scripts/test/update-hookstouched.test.js so the JS and Python ports of
+# the predicate agree.
+# ---------------------------------------------------------------------------
+python3 - "$UPDATER" > /tmp/t11_agentic_update_out.$$ 2>&1 <<'PYEOF'
+import importlib.util, importlib.machinery, sys
+
+updater_path = sys.argv[1]
+loader = importlib.machinery.SourceFileLoader("agentic_update_t11", updater_path)
+spec = importlib.util.spec_from_file_location("agentic_update_t11", updater_path, loader=loader)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+ht = mod._hooks_touched
+failures = []
+
+if not ht(["hooks/enforce-background-spawn.py"]):
+    failures.append("hooks/-prefixed path should be touched")
+if ht(["content/agents/engineer.md"]):
+    failures.append("non-hooks path should NOT be touched")
+if not ht(["README.md", "hooks/x.sh"]):
+    failures.append("mixed paths (one hooks/) should be touched")
+if ht([]):
+    failures.append("empty changed_paths should NOT be touched")
+if not ht(["hooks\\foo.py"]):
+    failures.append("backslash-normalized hooks path should be touched")
+if not ht(["/hooks/foo.py"]):
+    failures.append("leading-slash hooks path should be touched")
+
+if failures:
+    for f in failures:
+        print("FAIL:", f)
+    sys.exit(1)
+print("all cases ok")
+sys.exit(0)
+PYEOF
+HT_RC=$?
+HT_OUT=$(cat /tmp/t11_agentic_update_out.$$ 2>/dev/null)
+rm -f /tmp/t11_agentic_update_out.$$
+
+if [[ "$HT_RC" == "0" ]]; then
+  _pass "T11 _hooks_touched: hooks/-prefixed path -> touched"
+  _pass "T11 _hooks_touched: non-hooks path -> not touched"
+  _pass "T11 _hooks_touched: mixed paths -> touched"
+  _pass "T11 _hooks_touched: empty changed_paths -> not touched"
+  _pass "T11 _hooks_touched: backslash-normalized path -> touched"
+  _pass "T11 _hooks_touched: leading-slash path -> touched"
+else
+  _fail "T11 _hooks_touched: one or more cases wrong: $HT_OUT"
+fi
+
+# push_ahead_hooks_commit: like push_ahead_commit, but the pushed commit adds
+# a file under hooks/ instead of .claude/install.sh. Used to exercise the
+# hooks-changed warning (DS-54) integration test.
+push_ahead_hooks_commit() {
+  local pusher_dir="$TEMP_HOME/pusher"
+  git clone --quiet "$FAKE_REMOTE" "$pusher_dir" 2>/dev/null
+  (
+    cd "$pusher_dir"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    mkdir -p hooks
+    printf '#!/usr/bin/env python3\n# test hook\n' > hooks/fake-hook.py
+    git add hooks/fake-hook.py
+    git commit -m "add fake hook under hooks/" -q
+    git push -q origin main 2>/dev/null
+  )
+  rm -rf "$pusher_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 11b (DS-54): integration - pulling a commit that adds a hooks/ file
+# prints the warning substring.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_hooks_commit   # remote 1 ahead; commit adds hooks/fake-hook.py
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T11b hooks-changed update: exits 0"
+else
+  _fail "T11b hooks-changed update: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -q "this update changed files under hooks/"; then
+  _pass "T11b hooks-changed update: warning PRESENT in output"
+else
+  _fail "T11b hooks-changed update: warning missing (got: $OUT)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 11c (DS-54, negative): pulling a commit that touches only a non-hooks
+# file must NOT print the warning.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_commit   # adds .claude/install.sh only - no hooks/ files
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T11c non-hooks update: exits 0"
+else
+  _fail "T11c non-hooks update: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -q "this update changed files under hooks/"; then
+  _fail "T11c non-hooks update: warning present but should be ABSENT (got: $OUT)"
+else
+  _pass "T11c non-hooks update: warning ABSENT (no hooks/ files changed)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 11d (DS-54, negative): a no-op pull (already up to date) must NOT
+# print the warning.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+# No push_ahead_commit call - remote and local are identical (already up to date).
+
+invoke_updater --no-doctor
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T11d no-op pull: exits 0"
+else
+  _fail "T11d no-op pull: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -q "this update changed files under hooks/"; then
+  _fail "T11d no-op pull: warning present but should be ABSENT (already up to date)"
+else
+  _pass "T11d no-op pull: warning ABSENT (no-op / already up to date)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/content/commands/pull-and-install.md
+++ b/content/commands/pull-and-install.md
@@ -174,6 +174,16 @@ NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
 ```
 On non-zero exit: stop and show the error verbatim. Do not proceed to adapter installs.
 
+**4a-2 - Hook-change warning:**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
+
 **4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"

--- a/content/commands/update-agentic-engineering.md
+++ b/content/commands/update-agentic-engineering.md
@@ -130,10 +130,20 @@ Before making any edits, the main agent (not a subagent - git state decisions re
 Decision matrix:
 
 - **Clean tree AND local == origin/main:** proceed to Step 1.
-- **Clean tree AND origin is ahead (local behind):** fast-forward pull (`git pull --ff-only origin main`), then proceed to Step 1.
+- **Clean tree AND origin is ahead (local behind):** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, fast-forward pull (`git pull --ff-only origin main`), capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, then run the hook-change warning check below, then proceed to Step 1.
 - **Clean tree AND local is ahead (origin behind):** note this in the user-facing summary but proceed - the push in Step 4 will include the prior commits too.
 - **Clean tree AND both are ahead (divergence):** STOP. Tell the user: "Local and origin have diverged (N local commits, M origin commits). Resolve the divergence manually before running /update-agentic-engineering again." Do not attempt auto-merge or rebase.
 - **Dirty tree (any uncommitted changes):** STOP. Show the user `git status` output and tell them to commit, stash, or discard before running /update-agentic-engineering. Do not auto-stash - the WIP may be important and this command is not authorized to touch it.
+
+**Hook-change warning (after any pull in this step):**
+```bash
+HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
+```
+If `HOOK_CHANGES` is non-empty, print the following non-blocking warning (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`), then continue. Never stop the flow for this - it is advisory only.
+
+> warning: this update changed files under hooks/. Claude Code (and other adapters) load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on every tool call - there is no copy step. Any OTHER session with an open terminal already using this checkout will pick up the new hook behavior on its NEXT tool call: no restart, no re-run of install.sh, no in-session notice. If other sessions are active against this checkout, tell them to /exit and restart once this update finishes - or expect hook behavior to change under them mid-session. Changed: `<comma-joined HOOK_CHANGES>`
+
+If `HOOK_CHANGES` is empty, skip silently.
 
 ## Step 1 - Spawn a Worker
 
@@ -167,7 +177,7 @@ Otherwise (normal isolation-worktree path), after the user approves in Step 2:
    ```
 
 2. Check whether local main has diverged from origin/main using the same decision matrix as Step 0:
-   - **Local behind, fast-forwardable:** `git pull --ff-only origin main`, then continue.
+   - **Local behind, fast-forwardable:** capture `OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, `git pull --ff-only origin main`, capture `NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"`, run the same hook-change warning check as Step 0 (`git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/`; print the shared advisory when non-empty, never block), then continue.
    - **Diverged (both sides ahead):** STOP. Tell the user: "Local and origin have diverged since Step 0. Resolve the divergence manually before continuing." Do not force or auto-merge.
    - **Local ahead or equal:** proceed.
 

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -56,3 +56,29 @@ to blanket blocks. Hooks never raise to the Claude Code harness; non-fatal
 errors are swallowed or written to stderr. The only intentional side effects
 are append-only writes to `.agentic/` files and deny decisions on clearly
 violating tool calls.
+
+## Fail-open on absent tool_input fields
+
+A PreToolUse hook that gates on a `tool_input` field must fail OPEN (exit 0 /
+allow) when that field is entirely ABSENT from the payload for the guarded
+`tool_name` - this is distinct from present-but-false, which MAY deny. A
+field that is present and `false` is a real signal from the harness; a field
+that never appears in the payload at all is not a signal - it means this
+harness/tool-name combination does not emit that field, and denying on its
+absence blocks every call unconditionally.
+
+Cautionary example: `enforce-background-spawn.py` originally denied any
+`Task`/`Agent` spawn missing `run_in_background: true`. The Claude Code
+harness strips `run_in_background` from the `Agent` tool's PreToolUse
+payload entirely (confirmed by live payload capture: `tool_input` keys for
+an `Agent` spawn are exactly `['description', 'prompt', 'subagent_type']`) -
+`Agent` is background-by-default at the harness level and the field simply
+never arrives. The hook denied every `Agent` spawn until this was found and
+fixed; enforcement was scoped back to the legacy `Task` tool only, where the
+field genuinely is present in the payload.
+
+**Discipline before gating on a field:** capture or obtain one real
+`PreToolUse` payload for the guarded `tool_name` and confirm the field is
+actually present in that harness's real shape. Do not assume a field
+documented for one tool name (or one harness) is present for a related tool
+name or a different harness - verify per tool_name.

--- a/scripts/test/update-hookstouched.test.js
+++ b/scripts/test/update-hookstouched.test.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the hooksTouched() pure predicate in scripts/update.js.
+ *
+ * Run: node scripts/test/update-hookstouched.test.js
+ *
+ * Decision table:
+ *   (a) hooks/-prefixed path       -> true
+ *   (b) non-hooks path             -> false
+ *   (c) mixed paths                -> true
+ *   (d) empty changedPaths         -> false (first-install proxy / no-op pull)
+ *   (e) backslash-normalized path  -> true
+ *   (f) leading-slash path         -> true
+ *   (g) no-op changedPaths (single non-hooks file) -> false
+ */
+
+'use strict';
+
+const path = require('path');
+const { hooksTouched } = require(path.join(__dirname, '..', 'update.js'));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, msg) {
+  if (condition) {
+    console.log(`  PASS  ${msg}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${msg}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Case (a): hooks/-prefixed path -> true
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (a): hooks/-prefixed path -> true');
+assert(hooksTouched(['hooks/enforce-background-spawn.py']), 'hooks/enforce-*.py -> true');
+assert(hooksTouched(['hooks/stop-context.js']),              'hooks/stop-context.js -> true');
+assert(hooksTouched(['hooks/lib/wrap-marker.js']),           'hooks/lib/... -> true');
+
+// ---------------------------------------------------------------------------
+// Case (b): non-hooks path -> false
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (b): non-hooks path -> false');
+assert(!hooksTouched(['README.md']),                     'README.md -> false');
+assert(!hooksTouched(['content/agents/engineer.md']),     'content/... -> false');
+assert(!hooksTouched(['bin/agentic-update']),             'bin/... -> false');
+assert(!hooksTouched(['scripts/hooks-something.js']),     'scripts/hooks-something.js (not under hooks/) -> false');
+
+// ---------------------------------------------------------------------------
+// Case (c): mixed paths -> true
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (c): mixed paths -> true');
+assert(hooksTouched(['README.md', 'hooks/x.sh']),                     'mixed: hooks/ among others -> true');
+assert(hooksTouched(['content/agents/engineer.md', 'hooks/y.py', 'bin/z']), 'mixed: multiple non-hooks + one hooks -> true');
+
+// ---------------------------------------------------------------------------
+// Case (d): empty changedPaths -> false (first-install proxy)
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (d): empty changedPaths -> false');
+assert(!hooksTouched([]), 'empty array -> false');
+
+// ---------------------------------------------------------------------------
+// Case (e): backslash-normalized path -> true
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (e): backslash-normalized path -> true');
+assert(hooksTouched(['hooks\\foo.py']), 'backslash path hooks\\foo.py -> true');
+
+// ---------------------------------------------------------------------------
+// Case (f): leading-slash path -> true
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (f): leading-slash path -> true');
+assert(hooksTouched(['/hooks/foo.py']), 'leading-slash /hooks/foo.py -> true');
+
+// ---------------------------------------------------------------------------
+// Case (g): no-op changedPaths (single non-hooks file) -> false
+// ---------------------------------------------------------------------------
+
+console.log('\nCase (g): no-op changedPaths (single non-hooks file) -> false');
+assert(!hooksTouched(['README.md']), 'single non-hooks file, no-op-equivalent -> false');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed + failed} test(s): ${passed} passed, ${failed} failed.\n`);
+if (failed > 0) process.exit(1);

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -12,6 +12,13 @@
  *                   executed as a script.
  *   needsRebuild(oldHead, newHead, changedPaths) - pure predicate; exported
  *                   for unit tests via module.exports when not run directly.
+ *   hooksTouched(changedPaths) - pure predicate; true when any changed path
+ *                   is under hooks/. Drives a non-blocking stderr warning
+ *                   after a pull, since Claude Code (and other adapters)
+ *                   load hook scripts by absolute path and re-read them from
+ *                   disk on every tool call - other open sessions against
+ *                   this checkout pick up the change with no restart.
+ *                   Exported for unit tests via module.exports.
  *
  * Upstream deps: Node built-ins (fs, path, child_process, readline). No
  *                external packages.
@@ -239,6 +246,14 @@ const REBUILD_TRIGGERS = [
   'bin/',
 ];
 
+// Normalise a repo-relative path for prefix/exact-match comparisons:
+// convert backslashes to forward slashes (Windows safety) and strip exactly
+// one leading slash. Shared by needsRebuild() and hooksTouched() so the two
+// predicates never drift on path normalisation semantics.
+function normalisePath(p) {
+  return p.replace(/\\/g, '/').replace(/^\//, '');
+}
+
 // Returns true if adapter install scripts should be run after a pull.
 //
 // Decision table:
@@ -258,8 +273,7 @@ function needsRebuild(oldHead, newHead, changedPaths) {
 
   // Check each changed path against rebuild triggers.
   for (const p of changedPaths) {
-    // Normalise separators (Windows safety) and strip leading slashes.
-    const normalised = p.replace(/\\/g, '/').replace(/^\//, '');
+    const normalised = normalisePath(p);
     for (const trigger of REBUILD_TRIGGERS) {
       if (trigger.endsWith('/')) {
         // Directory prefix: match any file under this directory.
@@ -278,6 +292,39 @@ function needsRebuild(oldHead, newHead, changedPaths) {
   }
 
   return false;
+}
+
+// Returns the subset of changedPaths that live under hooks/, after path
+// normalisation. Shared by hooksTouched() and the pull-warning Changed: line
+// so both use the exact same subset.
+function hooksPaths(changedPaths) {
+  return changedPaths.filter((p) => normalisePath(p).startsWith('hooks/'));
+}
+
+// Returns true if any changedPath lives under hooks/. Pure predicate - takes
+// no oldHead/newHead because the caller (main()) only computes changedPaths
+// when a pull actually moved HEAD, so an empty changedPaths array already
+// means "nothing to warn about" (first install or no-op pull).
+function hooksTouched(changedPaths) {
+  return hooksPaths(changedPaths).length > 0;
+}
+
+// Builds the non-blocking advisory printed to stderr when a pull changes
+// files under hooks/. Claude Code (and other adapters) load hook scripts by
+// absolute path and re-read them from disk on every tool call - there is no
+// copy step - so any OTHER session with an open terminal already using this
+// checkout picks up the new hook behavior on its NEXT tool call, with no
+// restart and no in-session notice.
+function buildHooksWarning(changedList) {
+  return (
+    'warning: this update changed files under hooks/. Claude Code (and other adapters) ' +
+    'load hook scripts by ABSOLUTE PATH into this checkout and re-read them from disk on ' +
+    'every tool call - there is no copy step. Any OTHER session with an open terminal ' +
+    'already using this checkout will pick up the new hook behavior on its NEXT tool call: ' +
+    'no restart, no re-run of install.sh, no in-session notice. If other sessions are active ' +
+    'against this checkout, tell them to /exit and restart once this update finishes - or ' +
+    'expect hook behavior to change under them mid-session. Changed: ' + changedList
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -671,6 +718,14 @@ async function main() {
     }
   }
 
+  // Non-blocking advisory: hook scripts are loaded by absolute path and
+  // re-read from disk on every tool call, so a changed hooks/ file rewires
+  // any OTHER open session against this checkout with no restart. Warn but
+  // never block the update.
+  if (hooksTouched(changedPaths)) {
+    console.warn('\n' + buildHooksWarning(hooksPaths(changedPaths).join(', ')));
+  }
+
   const rebuild = needsRebuild(oldHead, newHead, changedPaths);
 
   // Run install scripts (fail-fast: stop on first failure)
@@ -741,5 +796,5 @@ if (require.main === module) {
     process.exit(1);
   });
 } else {
-  module.exports = { needsRebuild };
+  module.exports = { needsRebuild, hooksTouched };
 }


### PR DESCRIPTION
Fixes the DS-54 root cause surface: a routine update silently rewiring live sessions.

## Why
Hooks are wired into `settings.json` by **absolute path into the checkout** and re-read from disk on **every tool call**. A `git pull` that changes any file under `hooks/` alters hook behavior in every live session on its next tool call - no restart, no re-install, no in-session notice. PR #301's all-deny-`Agent` hook regression propagated to every open session exactly this way (root cause of DS-54).

## What
Non-blocking advisory fires when the pulled diff touches `hooks/`, at **all four** update entry points:
- `scripts/update.js` - new exported `hooksTouched()` (reuses `needsRebuild`'s normalization via extracted `normalisePath()`)
- `bin/agentic-update` - Python port `_hooks_touched()`, kept in sync, prints to stderr
- `content/commands/pull-and-install.md` - new `4a-2` sub-step (UPDATE-FLOW only)
- `content/commands/update-agentic-engineering.md` - both pull surfaces (Step 0 matrix + Step 2.5)

Plus a generalized hook-authoring rule in `hooks/AGENTS.md`: **fail open when a gated `tool_input` field is entirely absent** for the guarded `tool_name` (distinct from present-but-false). This is the discipline that would have caught PR #301 - it enforced `run_in_background`, which the harness strips from the `Agent` payload, so the check could never pass and denied every spawn.

## Tests
- DS-54 regression coverage **already existed** (`hooks/tests/test-enforce-background-spawn.py` asserts the `Agent`-with-no-`run_in_background` ALLOW case) - verified, cited, unchanged.
- New: `scripts/test/update-hookstouched.test.js` (13 cases) + `bin/tests/test_agentic_update.sh` Test 11/11b/11c/11d (importlib unit + real-CLI integration: warning present on hooks/ change, absent on non-hooks change, absent on no-op pull).
- No-misfire edges covered: empty changedPaths, first-install (empty oldHead), no-op pull (oldHead==newHead).
- Gates: 15/15 + 13/13 + 28/28 + 39/39 green; all 11 adapters rebuilt, sync idempotent.

## Scope
Tier 1 only. The structural fix (decouple hook activation from raw `git pull` so a pull can never rewire a live session) is deferred to a separate ADR - options analysis done, recommendation pending an operator call on the auto-propagate tradeoff.

Reviewed: architect plan (Skeptic sign-off) + implementation (Skeptic sign-off after `.copilot` adapter regen fix).