### PR TITLE
DS-48 Lever 9 Unit B: presence-aware profile resolver (deprecate session preset)

### DIFF
--- a/bin/agentic-disable
+++ b/bin/agentic-disable
@@ -28,9 +28,9 @@ Failure modes: opt-in conflict without --force -> exit 2 with a
                Atomic writes via tmp+rename; partial writes cannot
                leave AGENTS.md or the JSON config corrupted. JSON
                round-trip preserves ONLY the keys already present in
-               the file (never invents profile/preset). Read-only
-               filesystems or permission errors -> exit 1 with the
-               OS error message; no partial state.
+               the file (never invents any key not already present in
+               the file). Read-only filesystems or permission errors ->
+               exit 1 with the OS error message; no partial state.
 
 Performance: O(small). One AGENTS.md read+write and one optional JSON
              read+write. Constant time; <50 ms on a cold start.

--- a/bin/agentic-help
+++ b/bin/agentic-help
@@ -33,7 +33,7 @@ HELP_TEXT = """\
 agentic-engineering - command reference
 
 Inspect & configure
-  /agentic-status              Show resolved config (mode, profile, preset, marker) with provenance and a plain-English explainer. Run this first when unsure what the skill is doing.
+  /agentic-status              Show resolved config (mode, profile, marker) with provenance and a plain-English explainer. Run this first when unsure what the skill is doing.
   /agentic-help                This list.
   /agentic-disable             Opt this project out (writes an opt-out marker to AGENTS.md). --global also sets global mode=opt-out.
   /agentic-cost                Token and wall-time rollups per agent/session/task from .agentic/events.jsonl.
@@ -62,7 +62,7 @@ Audit & improve the methodology
 Usage patterns
 
   Check what the skill is doing right now:
-    /agentic-status            Shows the resolved mode/profile/preset, WHERE each value comes from, what behavior it produces, and how to change it.
+    /agentic-status            Shows the resolved mode/profile, WHERE each value comes from, what behavior it produces, and how to change it.
 
   Use the skill deliberately when it is globally disabled or in opt-in mode:
     By default the skill auto-loads only when it is in opt-out mode AND the project has not opted out.

--- a/bin/agentic-status
+++ b/bin/agentic-status
@@ -2,11 +2,25 @@
 """
 Purpose: Read-only inspection of the agentic-engineering activation
          resolver. Dumps the resolved global config, project marker,
-         profile/preset, and first-activation sentinel state to stdout,
-         each value annotated with its provenance, followed by a
+         profile, and first-activation sentinel state to stdout, each
+         value annotated with its provenance, followed by a
          plain-English "What this means" behavior explainer and a
          "How to adjust" block. The CLI for the /agentic-status command.
          Writes nothing.
+
+         The session-wide `preset` (lean/standard/strict) layer is a
+         time-bounded, presence-aware legacy shim (DS-48 Lever 9). A
+         valid legacy preset at either scope resolves to a profile ONLY
+         when no explicit `profile` value is present at that same
+         precedence step: project profile > project preset (legacy,
+         only if project profile absent) > global profile > global
+         preset (legacy, only if global profile absent) > hardcoded
+         "default". Presence of a legacy preset key ALWAYS emits a
+         DEPRECATED notice, regardless of whether it wins - an operator
+         with a stale preset key sees a migrate-off nudge even when a
+         profile override already shadows it. The resolved `preset`
+         value is no longer part of `_resolve`'s return or the printed
+         output - only `profile` and the deprecation notices surface.
 
 Public API: agentic-status
             Prints a fixed-format multi-line report (status lines with
@@ -56,7 +70,10 @@ ROLE_MODELS_GLOBAL_PATH = Path(os.path.expanduser("~/.agentic/role-models.yml"))
 ROLE_MODELS_PROJECT_PATH = Path(".agentic/role-models.yml")
 HEALTH_FILE_PATH = Path(".agentic/.telemetry-health.json")
 
-PRESET_TABLE = {
+# DEPRECATED: legacy session-wide preset->profile alias table (DS-48 Lever 9).
+# preset support will be removed after the deprecation window; profile is the
+# single risk knob going forward.
+LEGACY_PRESET_TABLE = {
     "lean": "relaxed",
     "standard": "default",
     "strict": "strict",
@@ -108,14 +125,22 @@ _PROFILE_RE = re.compile(
     r"^\s*(?:-\s+)?agentic-engineering-profile:\s*(\S+)\s*$",
     re.IGNORECASE,
 )
-_PRESET_RE = re.compile(
+# DEPRECATED: legacy per-project preset marker line (DS-48 Lever 9).
+_LEGACY_PRESET_RE = re.compile(
     r"^\s*(?:-\s+)?agentic-engineering-preset:\s*(\S+)\s*$",
     re.IGNORECASE,
 )
 
 
 def _scan_agents_md(path: Path | None) -> dict:
-    """Return {marker, project_profile, project_preset} from AGENTS.md."""
+    """Return {marker, project_profile, project_preset} from AGENTS.md.
+
+    project_preset is the legacy `agentic-engineering-preset:` marker
+    (DEPRECATED, DS-48 Lever 9) - still scanned because it feeds the
+    presence-aware legacy fallback in `_resolve` and the deprecation
+    notices; it no longer has any resolution weight when a project
+    `profile` value is also present.
+    """
     out = {"marker": "none", "project_profile": None, "project_preset": None}
     if path is None:
         return out
@@ -133,7 +158,7 @@ def _scan_agents_md(path: Path | None) -> dict:
             val = p.group(1).lower()
             if val in ("relaxed", "default", "strict"):
                 out["project_profile"] = val
-        pr = _PRESET_RE.match(line)
+        pr = _LEGACY_PRESET_RE.match(line)
         if pr and out["project_preset"] is None:
             val = pr.group(1).lower()
             if val in ("lean", "standard", "strict"):
@@ -143,8 +168,36 @@ def _scan_agents_md(path: Path | None) -> dict:
     return out
 
 
+_LEGACY_WON_TEMPLATE = (
+    "DEPRECATED: preset key '{value}' ({scope}) resolved to profile={resolved}; "
+    "migrate by setting profile={resolved} directly - preset support will be "
+    "removed after the deprecation window."
+)
+
+_LEGACY_NOT_USED_TEMPLATE = (
+    "DEPRECATED: preset key '{value}' ({scope}) is present but NOT used - "
+    "effective profile is '{effective}' (source: {source}). Remove the stale "
+    "preset key/marker - it has no effect and will be rejected after the "
+    "deprecation window."
+)
+
+
 def _resolve(config: dict, scan: dict, config_status: str = "found") -> dict:
-    """Resolve effective profile, preset, and active state."""
+    """Resolve effective profile and active state (presence-aware, DS-48 Lever 9).
+
+    Precedence: project profile > project preset (legacy, only if project
+    profile absent) > global profile > global preset (legacy, only if global
+    profile absent) > hardcoded "default". An explicit valid value at a given
+    scope is distinguished from an ABSENT or INVALID value at that scope -
+    `config.get("profile")` returning None (absent) is never conflated with an
+    explicit "default" (present); an invalid value is treated identically to
+    absent for precedence purposes, allowing a legacy preset at the same scope
+    to apply.
+
+    Deprecation notices fire on PRESENCE of a valid legacy preset at either
+    scope, regardless of whether it wins the precedence chain - see
+    `legacy_notices` in the returned dict.
+    """
     raw_mode = str(config.get("mode") or "opt-out").lower()
     mode = "opt-in" if raw_mode == "opt-in" else "opt-out"
     mode_source = (
@@ -153,38 +206,83 @@ def _resolve(config: dict, scan: dict, config_status: str = "found") -> dict:
         else "global config (default; file missing)"
     )
 
-    raw_profile = str(config.get("profile") or "default").lower()
-    if raw_profile not in ("relaxed", "default", "strict"):
-        raw_profile = "default"
-    global_profile = raw_profile
+    # Presence-aware validation: None means absent-or-invalid, never conflated
+    # with an explicit "default" value.
+    _raw_global_profile = config.get("profile")
+    global_valid_profile = (
+        _raw_global_profile.lower()
+        if isinstance(_raw_global_profile, str)
+        and _raw_global_profile.lower() in ("relaxed", "default", "strict")
+        else None
+    )
+    _raw_global_preset = config.get("preset")
+    global_valid_preset = (
+        _raw_global_preset.lower()
+        if isinstance(_raw_global_preset, str)
+        and _raw_global_preset.lower() in LEGACY_PRESET_TABLE
+        else None
+    )
 
-    raw_preset = config.get("preset")
-    if isinstance(raw_preset, str) and raw_preset.lower() in PRESET_TABLE:
-        global_preset: str | None = raw_preset.lower()
-    else:
-        global_preset = None
+    project_valid_profile = scan["project_profile"]
+    project_valid_preset = scan["project_preset"]
 
-    # Resolution order: project preset > project profile > global preset > global profile.
-    if scan["project_preset"]:
-        effective_profile = PRESET_TABLE[scan["project_preset"]]
-        profile_source = "preset-resolved"
-        effective_preset: str | None = scan["project_preset"]
-        preset_source = "project"
-    elif scan["project_profile"]:
-        effective_profile = scan["project_profile"]
+    # Precedence chain (see docstring). Each branch sets both the effective
+    # profile and a human-readable provenance label.
+    if project_valid_profile is not None:
+        effective_profile = project_valid_profile
         profile_source = "project"
-        effective_preset = global_preset
-        preset_source = "global" if global_preset else "none"
-    elif global_preset:
-        effective_profile = PRESET_TABLE[global_preset]
-        profile_source = "preset-resolved"
-        effective_preset = global_preset
-        preset_source = "global"
-    else:
-        effective_profile = global_profile
+    elif project_valid_preset is not None:
+        effective_profile = LEGACY_PRESET_TABLE[project_valid_preset]
+        profile_source = "project (legacy preset)"
+    elif global_valid_profile is not None:
+        effective_profile = global_valid_profile
         profile_source = "global"
-        effective_preset = None
-        preset_source = "none"
+    elif global_valid_preset is not None:
+        effective_profile = LEGACY_PRESET_TABLE[global_valid_preset]
+        profile_source = "global (legacy preset)"
+    else:
+        effective_profile = "default"
+        profile_source = "global (default; unset)"
+
+    # Deprecation notices: fire on presence, independent of whether the value
+    # won. Project notice (if any) precedes global notice (if any).
+    legacy_notices: list[str] = []
+    if project_valid_preset is not None:
+        if profile_source == "project (legacy preset)":
+            legacy_notices.append(
+                _LEGACY_WON_TEMPLATE.format(
+                    value=project_valid_preset,
+                    scope="project",
+                    resolved=effective_profile,
+                )
+            )
+        else:
+            legacy_notices.append(
+                _LEGACY_NOT_USED_TEMPLATE.format(
+                    value=project_valid_preset,
+                    scope="project",
+                    effective=effective_profile,
+                    source=profile_source,
+                )
+            )
+    if global_valid_preset is not None:
+        if profile_source == "global (legacy preset)":
+            legacy_notices.append(
+                _LEGACY_WON_TEMPLATE.format(
+                    value=global_valid_preset,
+                    scope="global",
+                    resolved=effective_profile,
+                )
+            )
+        else:
+            legacy_notices.append(
+                _LEGACY_NOT_USED_TEMPLATE.format(
+                    value=global_valid_preset,
+                    scope="global",
+                    effective=effective_profile,
+                    source=profile_source,
+                )
+            )
 
     marker = scan["marker"]
     if mode == "opt-out" and marker == "opt-out":
@@ -216,8 +314,7 @@ def _resolve(config: dict, scan: dict, config_status: str = "found") -> dict:
         "mode_source": mode_source,
         "profile": effective_profile,
         "profile_source": profile_source,
-        "preset": effective_preset,
-        "preset_source": preset_source,
+        "legacy_notices": legacy_notices,
         "set_at": config.get("set_at") or "unset",
         "marker": marker,
         "active": active,
@@ -484,9 +581,6 @@ def _how_to_adjust_block(resolved: dict) -> list[str]:
         f'    edit {config_display}  ->  "profile": "relaxed" | "default" | "strict"',
         "  Turn the skill OFF for this project:        /agentic-disable",
         "  Turn it off EVERYWHERE:                      /agentic-disable --global",
-        "  Use a preset instead of a raw profile:",
-        "    project: agentic-engineering-preset: lean|standard|strict in AGENTS.md",
-        '    global:  "preset": "lean" | "standard" | "strict" in the JSON config',
         "  See every command:                           /agentic-help",
     ]
 
@@ -500,7 +594,6 @@ def main(_argv: list[str]) -> int:
     sentinel_status = "present" if SENTINEL_PATH.is_file() else "absent"
     marker_path_display = str(agents_path) if agents_path else "none"
     res["marker_path_display"] = marker_path_display
-    preset_display = res["preset"] if res["preset"] else "none"
     active_display = "yes" if res["active"] else "no"
 
     out = []
@@ -510,9 +603,8 @@ def main(_argv: list[str]) -> int:
     out.append(
         f"  profile: {res['profile']} (source: {res['profile_source']})"
     )
-    out.append(
-        f"  preset: {preset_display} (source: {res['preset_source']})"
-    )
+    for notice in res["legacy_notices"]:
+        out.append(f"  {notice}")
     out.append(f"  set_at: {res['set_at']}")
     out.append(f"  project marker file: {marker_path_display}")
     out.append(f"  marker: {res['marker']}")

--- a/bin/tests/test_agentic_status.py
+++ b/bin/tests/test_agentic_status.py
@@ -218,7 +218,7 @@ def test_scan_profile_line(tmp_path):
     assert result["project_profile"] == "strict"
 
 
-def test_scan_preset_line(tmp_path):
+def test_scan_legacy_preset_line(tmp_path):
     f = tmp_path / "AGENTS.md"
     f.write_text(
         "agentic-engineering: opt-in\nagentic-engineering-preset: lean\n",
@@ -272,7 +272,7 @@ def test_resolve_missing_config_defaults():
     res = _resolve({}, _empty_scan(), "missing")
     assert res["mode"] == "opt-out"
     assert res["profile"] == "default"
-    assert res["preset"] is None
+    assert res["legacy_notices"] == []
     assert res["active"] is True
     assert "global config (default; file missing)" in res["mode_source"]
 
@@ -303,14 +303,18 @@ def test_resolve_optout_mode_no_marker_active():
     assert res["active"] is True
 
 
-def test_resolve_project_preset_overrides_all(tmp_path):
-    # project preset -> resolves to profile via PRESET_TABLE; overrides global profile.
+def test_resolve_project_profile_present_ignores_project_preset(tmp_path):
+    # project profile present -> project preset is a legacy fallback that does
+    # NOT win (fallback-only-when-absent semantics, not "preset wins").
     scan = {"marker": "opt-in", "project_profile": "strict", "project_preset": "lean"}
     res = _resolve({"mode": "opt-in", "profile": "strict"}, scan, "found")
-    assert res["profile"] == "relaxed"  # lean -> relaxed
-    assert res["preset"] == "lean"
-    assert res["profile_source"] == "preset-resolved"
-    assert res["preset_source"] == "project"
+    assert res["profile"] == "strict"  # project profile wins, not lean->relaxed
+    assert res["profile_source"] == "project"
+    # The legacy project preset is present but did not win -> a NOT-used notice fires.
+    assert len(res["legacy_notices"]) == 1
+    assert "NOT used" in res["legacy_notices"][0]
+    assert "lean" in res["legacy_notices"][0]
+    assert "strict" in res["legacy_notices"][0]
 
 
 def test_resolve_project_profile_no_preset(tmp_path):
@@ -320,19 +324,20 @@ def test_resolve_project_profile_no_preset(tmp_path):
     assert res["profile_source"] == "project"
 
 
-def test_resolve_global_preset_when_no_project_override():
+def test_resolve_global_preset_only_when_no_global_profile():
+    # global profile absent -> global preset is the legacy fallback and wins.
     res = _resolve({"mode": "opt-out", "preset": "standard"}, _empty_scan(), "found")
     assert res["profile"] == "default"  # standard -> default
-    assert res["preset"] == "standard"
-    assert res["profile_source"] == "preset-resolved"
-    assert res["preset_source"] == "global"
+    assert res["profile_source"] == "global (legacy preset)"
+    assert len(res["legacy_notices"]) == 1
+    assert "resolved to profile=default" in res["legacy_notices"][0]
 
 
 def test_resolve_global_profile_fallback():
     res = _resolve({"mode": "opt-out", "profile": "relaxed"}, _empty_scan(), "found")
     assert res["profile"] == "relaxed"
     assert res["profile_source"] == "global"
-    assert res["preset"] is None
+    assert res["legacy_notices"] == []
 
 
 def test_resolve_invalid_mode_treated_as_optout():
@@ -343,6 +348,61 @@ def test_resolve_invalid_mode_treated_as_optout():
 def test_resolve_invalid_profile_treated_as_default():
     res = _resolve({"profile": "mega-strict"}, _empty_scan(), "found")
     assert res["profile"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# _resolve - DS-48 Lever 9 presence-aware regression tests
+# ---------------------------------------------------------------------------
+
+def test_resolve_global_preset_only_no_profile_resolves_strict():
+    # (1) global {"preset":"strict"} no profile -> profile=="strict",
+    # source "global (legacy preset)".
+    res = _resolve({"preset": "strict"}, _empty_scan(), "found")
+    assert res["profile"] == "strict"
+    assert res["profile_source"] == "global (legacy preset)"
+    assert len(res["legacy_notices"]) == 1
+    assert "resolved to profile=strict" in res["legacy_notices"][0]
+
+
+def test_resolve_project_preset_only_no_project_profile_resolves_relaxed(tmp_path):
+    # (2) project AGENTS.md with only agentic-engineering-preset: lean ->
+    # project_profile is None, resolves "relaxed".
+    f = tmp_path / "AGENTS.md"
+    f.write_text("agentic-engineering-preset: lean\n", encoding="utf-8")
+    scan = _scan_agents_md(f)
+    assert scan["project_profile"] is None
+    res = _resolve({}, scan, "found")
+    assert res["profile"] == "relaxed"
+    assert res["profile_source"] == "project (legacy preset)"
+
+
+def test_resolve_coexist_profile_wins_not_used_notice_names_both():
+    # (3) coexist {"profile":"relaxed","preset":"strict"} -> profile=="relaxed"
+    # AND legacy_notices has one NOT-used entry naming both strict and relaxed.
+    res = _resolve({"profile": "relaxed", "preset": "strict"}, _empty_scan(), "found")
+    assert res["profile"] == "relaxed"
+    assert len(res["legacy_notices"]) == 1
+    notice = res["legacy_notices"][0]
+    assert "NOT used" in notice
+    assert "strict" in notice
+    assert "relaxed" in notice
+
+
+def test_resolve_invalid_profile_valid_preset_resolves_via_legacy():
+    # (4) invalid {"profile":"mega-strict","preset":"strict"} -> resolves
+    # "strict" (legacy preset), source "global (legacy preset)".
+    res = _resolve({"profile": "mega-strict", "preset": "strict"}, _empty_scan(), "found")
+    assert res["profile"] == "strict"
+    assert res["profile_source"] == "global (legacy preset)"
+    assert len(res["legacy_notices"]) == 1
+    assert "resolved to profile=strict" in res["legacy_notices"][0]
+
+
+def test_resolve_profile_only_no_deprecation_notice():
+    # No preset key anywhere -> no deprecation line.
+    scan = {"marker": "none", "project_profile": "strict", "project_preset": None}
+    res = _resolve({"mode": "opt-out", "profile": "relaxed"}, scan, "found")
+    assert res["legacy_notices"] == []
 
 
 def test_resolve_set_at_forwarded():
@@ -685,6 +745,23 @@ def test_main_reflects_config(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "opt-in" in out
     assert "relaxed" in out
+    # No legacy preset key set anywhere -> no DEPRECATED line.
+    assert "DEPRECATED" not in out
+
+
+def test_main_reflects_config_shows_deprecated_line_when_legacy_preset_set(monkeypatch, tmp_path, capsys):
+    _clear_harness_env(monkeypatch)
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"mode": "opt-in", "preset": "strict"}), encoding="utf-8")
+    monkeypatch.setattr(_mod, "CONFIG_PATH", cfg)
+    monkeypatch.setattr(_mod, "SENTINEL_PATH", tmp_path / ".activated")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_GLOBAL_PATH", tmp_path / "no-global.yml")
+    monkeypatch.setattr(_mod, "ROLE_MODELS_PROJECT_PATH", tmp_path / "no-project.yml")
+    monkeypatch.chdir(tmp_path)
+    main([])
+    out = capsys.readouterr().out
+    assert "DEPRECATED" in out
+    assert "strict" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Unit B of DS-48 Lever 9 (collapse the redundant session-wide `preset` config layer). **bin/ only** - the resolver + tests. Companion Unit A (content/docs, PR follows) lands right after per the merge-ordering.

Fixes a resolver Critical: `config.get("profile") or "default"` collapsed *absent-key* and *explicit-default* into one value, which - once the legacy preset branch is removed - would silently downgrade a `{"preset":"strict"}`-only operator to `default` (less Skeptic review).

- Presence-aware precedence: project profile > project preset (legacy) > global profile > global preset (legacy) > `default`. Absent-key != explicit `default`; invalid profile treated as absent.
- `PRESET_TABLE`->`LEGACY_PRESET_TABLE`, `_PRESET_RE`->`_LEGACY_PRESET_RE` (marked DEPRECATED).
- `_resolve` drops `preset`/`preset_source`, adds `legacy_notices` that fire on **presence** of a legacy preset regardless of whether it wins (covers the coexist blind spot).
- `main()` drops the unconditional `preset:` line, prints legacy notices in its place. Module manifest updated.

## Tests
- `pytest bin/tests/test_agentic_status.py` - **74 passed**. 4 new regression tests: global-preset-only->strict, project-preset-only->relaxed, coexist->profile-wins+NOT-used-notice, invalid-profile+valid-preset->strict.

Design + implementation Skeptic-signed-off; integration Skeptic (with Unit A) 0 findings.