### PR TITLE
docs(omp): list configure-team in Pi adapter command inventory

### DIFF
--- a/.omp/skills/agentic-engineering/SKILL.md
+++ b/.omp/skills/agentic-engineering/SKILL.md
@@ -110,6 +110,7 @@ Command templates live in `commands/`. Pi does not support custom markdown comma
 Available commands:
 
 - **cleanup-worktrees** - Clean up stale git worktrees and local branches.
+- **configure-team** - Set up and verify a cross-harness agent team for role-to-harness dispatch.
 - **implement-ticket** - End-to-end ticket implementation with architect, engineer, and skeptic.
 - **init-project** - Initialize agentic-engineering in a new repository.
 - **memory-update** - Update session context and memory files.


### PR DESCRIPTION
## Summary

Unit 3 of the all-harness-conductor plan targeted `.omp` and `.copilot` as the two adapters missing `configure-team`. Investigation found:

- **`.copilot`**: already has full coverage. `.github/prompts/configure-team.prompt.md` was added in #357 (VS Code Copilot adapter) and generated correctly by `.copilot/build.sh` step 4 (prompts, one per `content/commands/*.md`). No gap, no change needed.
- **`.omp`**: `content/commands/configure-team.md` was already reachable via the existing `commands` symlink (`.omp/skills/agentic-engineering/commands` -> `../../../content/commands`), so the file was never missing on disk. The actual gap: `SKILL.md`'s hand-maintained "Available commands" enumeration omitted `configure-team`, so a Pi user reading the skill had no discovery path to it (`.omp/build.sh` does not generate this list; it's authored content, same as the rest of `SKILL.md`).

Fix: add the missing line to `.omp/skills/agentic-engineering/SKILL.md`'s command list.

## Idempotence evidence

\`\`\`
\$ bash .omp/build.sh; git diff --stat -- .omp/     # run 1
 .omp/skills/agentic-engineering/SKILL.md | 1 +
\$ bash .omp/build.sh; git diff --stat -- .omp/     # run 2 (same as run 1 - build.sh doesn't touch SKILL.md, edit persists as a manual diff)
 .omp/skills/agentic-engineering/SKILL.md | 1 +

\$ bash .copilot/build.sh; git diff --stat -- .github/ .copilot/   # run 1
(no output - zero diff)
\$ bash .copilot/build.sh; git diff --stat -- .github/ .copilot/   # run 2
(no output - zero diff)
\`\`\`

## Out of scope / deviations

- Did not touch \`bin/agentic-team\`, hooks, \`content/references/cross-harness-teams.md\`, or \`content/commands/configure-team.md\` (Unit 1 owns these, in flight).
- README doc-sync check: no per-adapter command-coverage enumeration found in README.md that references \`configure-team\`, so no doc-sync update needed.
- No test suite applies to this one-line markdown enumeration change; verification is the build-script idempotence run above.