### PR TITLE
fix(tests): update version-check notice extraction for PR #322 phrasing (DS-59)

### DIFF
--- a/hooks/tests/test-version-check-core-repo-dir.sh
+++ b/hooks/tests/test-version-check-core-repo-dir.sh
@@ -61,11 +61,14 @@ write_fake_cache() {
 }
 
 # Extract the repo path from the notice line:
-#   "... Update with /update-agentic-engineering ... or <PATH>/update.sh ..."
+#   "... No PATH? <PATH>/update.sh"
+# Anchored on the "No PATH? " token (not "or ") because PR #322 added a
+# second "or /pull-and-install (in session)" phrase earlier in the notice;
+# a greedy "or " anchor would swallow that phrase into the captured path.
 extract_path_from_notice() {
   local notice="$1"
-  # The path appears as the substring before "/update.sh" in the notice.
-  echo "$notice" | sed 's|.*or \(.*\)/update\.sh.*|\1|'
+  # The path appears as the substring between "No PATH? " and "/update.sh".
+  echo "$notice" | sed 's|.*No PATH? \(.*\)/update\.sh.*|\1|'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes DS-59 (pre-existing test failure on clean main; surfaced during DS-54 work).

`hooks/tests/test-version-check-core-repo-dir.sh` failed on a clean checkout: its `extract_path_from_notice` sed anchored on the first `or `, and PR #322 added a second `or /pull-and-install (in session)` phrase to the notice emitted by `hooks/lib/version-check-core.sh`, so the capture swallowed extra prose instead of the repo path.

## Fix
Re-anchor extraction on the unique `No PATH? ` token that sits directly adjacent to the resolved path, instead of the ambiguous `or `. `version-check-core.sh` is untouched - its notice text is correct; only the stale test pattern needed updating.

## Tests
- `bash hooks/tests/test-version-check-core-repo-dir.sh` now 10/10 (was 5/10).
- Assertions unchanged - still validates lib/vcc parity, valid-config + absent-config-fallback + strict-mode resolution.
- Single-file change; Skeptic-verified the anchor is unique and the test isn't neutered.