### PR TITLE
fix(codex): make skill-auto-load hook resolve to a real script + resolution test (DS-57)

### DIFF
--- a/.codex/build.sh
+++ b/.codex/build.sh
@@ -105,6 +105,26 @@ done
 
 echo "Rebuilt skill/references/ hardlinks"
 
+# ---------------------------------------------------------------------------
+# Build .codex/hooks/skill-auto-load-check.sh
+#
+# .codex/config/hooks.json wires a UserPromptSubmit hook whose command
+# self-locates at runtime via dirname(dirname(realpath(~/.codex/hooks.json)))
+# + "/hooks/<script>" - since ~/.codex/hooks.json symlinks to
+# .codex/config/hooks.json (or its hooks-snapshot copy), this resolves to
+# .codex/hooks/<script>, NOT the repo-root hooks/ directory. The other two
+# Codex hooks (risk-reminder.sh, stop-context-codex.js) are hand-authored
+# directly in .codex/hooks/ because they are Codex-specific. skill-auto-load
+# behavior is adapter-agnostic and its single source of truth is repo-root
+# hooks/skill-auto-load-check.sh - hardlink it into .codex/hooks/ so the
+# already-wired hooks.json command resolves to a real script.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$CODEX_DIR/hooks"
+hardlink_from_content "$REPO_DIR/hooks/skill-auto-load-check.sh" "$CODEX_DIR/hooks/skill-auto-load-check.sh"
+
+echo "Rebuilt hooks/skill-auto-load-check.sh hardlink"
+
 # SKILL.md is a static file maintained in .codex/skill/SKILL.md
 # (not generated - its frontmatter and body are hand-authored for Codex's skill format)
 if [[ ! -f "$SKILL_DST/SKILL.md" ]]; then

--- a/.codex/hooks/skill-auto-load-check.sh
+++ b/.codex/hooks/skill-auto-load-check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Purpose: Emits a skill-load instruction to stdout when skill_auto_load is enabled in the
+#          agentic-engineering config. Called by Claude Code, Codex, and Gemini hook handlers.
+# Public API: bash hooks/skill-auto-load-check.sh (no args; reads ~/.claude/agentic-engineering.json)
+# Upstream deps: ~/.claude/agentic-engineering.json (optional; missing = silent exit)
+# Downstream consumers: .claude/install.sh (UserPromptSubmit hook), .codex/config/hooks.json
+#                       (UserPromptSubmit hook), .gemini/install.sh (BeforeAgent hook)
+# Failure modes: always exits 0; missing config or false flag = silent no-op; never blocks hook chain
+# Performance: <50ms; python3 JSON parse only
+
+ae_config="$HOME/.claude/agentic-engineering.json"
+
+skill_auto_load=$(python3 -c "
+import json, sys
+try:
+    with open('$ae_config') as f:
+        val = json.load(f).get('skill_auto_load', False)
+        print('true' if val is True else 'false')
+except Exception:
+    print('false')
+" 2>/dev/null || echo "false")
+
+if [[ "$skill_auto_load" == "true" ]]; then
+  echo "SKILL CHECK [agentic-engineering]: skill_auto_load=true."
+  echo "Before responding to any software development request, read ~/.claude/skills/agentic-engineering/SKILL.md."
+  echo "Do not implement directly - follow the delegation and risk classification protocol in that file."
+fi
+
+exit 0

--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -28,3 +28,5 @@ jobs:
             echo "::error::Adapter output is out of sync with content/. Run the build scripts locally and commit the regenerated adapter files." >&2
             exit 1
           fi
+      - name: Verify Codex hook commands resolve (DS-57 regression guard)
+        run: bash bin/tests/test_codex_hooks_resolve.sh

--- a/bin/tests/test_codex_hooks_resolve.sh
+++ b/bin/tests/test_codex_hooks_resolve.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Purpose: Regression guard for DS-57. .codex/config/hooks.json wires each
+#          hook command to self-locate at runtime via
+#          dirname(dirname(realpath($HOME/.codex/hooks.json)))/hooks/<script>
+#          - a script that is committed nowhere gets silently dropped (the
+#          hook fires, the resolved path does not exist, nothing errors).
+#          This test asserts every "command" entry in the checkout's
+#          .codex/config/hooks.json resolves to an existing, executable
+#          file - the same failure mode DS-57 fixed for
+#          skill-auto-load-check.sh.
+#
+# Public API: ./bin/tests/test_codex_hooks_resolve.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, mktemp.
+#
+# Downstream consumers: developer running locally before commit; CI
+#                        (wired into .github/workflows/adapter-sync.yml).
+#
+# Failure modes: any command whose resolved script path does not exist (or
+#                is not executable) fails the test. A temporary fake HOME is
+#                used to stand in for ~/.codex/hooks.json -> the real HOME
+#                is never touched. Only the path-resolution expression
+#                inside each command is evaluated (via bash arithmetic
+#                substitution) - the interpreter is never actually invoked,
+#                so this test has no side effects even if a resolved script
+#                has some.
+#
+# Performance: < 1 s wall time (pure shell + python3, no network).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOKS_JSON="$REPO_DIR/.codex/config/hooks.json"
+
+if [[ ! -f "$HOOKS_JSON" ]]; then
+  echo "FAIL: $HOOKS_JSON not found" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+_cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap _cleanup EXIT
+
+# Stand in for ~/.codex/hooks.json -> .codex/config/hooks.json, exactly as
+# .codex/install.sh wires it (a symlink), so realpath-based self-location in
+# each command resolves the same way it would for a real install.
+FAKE_HOME="$TMP_ROOT/home"
+mkdir -p "$FAKE_HOME/.codex"
+ln -s "$HOOKS_JSON" "$FAKE_HOME/.codex/hooks.json"
+
+# Extract every "command" string from hooks.json (order-independent walk).
+mapfile -t COMMANDS < <(python3 -c "
+import json, sys
+with open('$HOOKS_JSON') as f:
+    data = json.load(f)
+
+def walk(node):
+    if isinstance(node, dict):
+        cmd = node.get('command')
+        if isinstance(cmd, str):
+            print(cmd)
+        for v in node.values():
+            yield from walk(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from walk(item)
+    return
+    yield
+
+list(walk(data))
+")
+
+if [[ ${#COMMANDS[@]} -eq 0 ]]; then
+  _fail "no 'command' entries found in $HOOKS_JSON - parser or fixture regressed"
+else
+  _pass "found ${#COMMANDS[@]} command entries in $HOOKS_JSON"
+fi
+
+for cmd in "${COMMANDS[@]}"; do
+  # Each command has the shape:
+  #   <interpreter> "<path-expression-with-$(...)-substitutions>"
+  # Extract just the quoted path expression and evaluate it under FAKE_HOME
+  # (arithmetic-only - never invokes the interpreter itself).
+  if [[ "$cmd" =~ ^[a-zA-Z0-9_]+[[:space:]]+\"(.+)\"$ ]]; then
+    path_expr="${BASH_REMATCH[1]}"
+  else
+    _fail "command does not match '<interpreter> \"<path>\"' shape: $cmd"
+    continue
+  fi
+
+  resolved="$(HOME="$FAKE_HOME" bash -c "printf '%s' \"$path_expr\"" 2>/dev/null)"
+
+  if [[ -z "$resolved" ]]; then
+    _fail "command resolved to an empty path: $cmd"
+    continue
+  fi
+
+  if [[ ! -f "$resolved" ]]; then
+    _fail "command resolves to a missing script: $resolved (command: $cmd)"
+    continue
+  fi
+
+  if [[ ! -x "$resolved" ]]; then
+    _fail "command resolves to a non-executable script: $resolved (command: $cmd)"
+    continue
+  fi
+
+  _pass "command resolves to an existing, executable script: $resolved"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_codex_hooks_resolve.sh
+++ b/bin/tests/test_codex_hooks_resolve.sh
@@ -21,7 +21,7 @@
 #                is not executable) fails the test. A temporary fake HOME is
 #                used to stand in for ~/.codex/hooks.json -> the real HOME
 #                is never touched. Only the path-resolution expression
-#                inside each command is evaluated (via bash arithmetic
+#                inside each command is evaluated (via bash command
 #                substitution) - the interpreter is never actually invoked,
 #                so this test has no side effects even if a resolved script
 #                has some.
@@ -96,7 +96,7 @@ for cmd in "${COMMANDS[@]}"; do
   # Each command has the shape:
   #   <interpreter> "<path-expression-with-$(...)-substitutions>"
   # Extract just the quoted path expression and evaluate it under FAKE_HOME
-  # (arithmetic-only - never invokes the interpreter itself).
+  # (command-substitution-only - never invokes the interpreter itself).
   if [[ "$cmd" =~ ^[a-zA-Z0-9_]+[[:space:]]+\"(.+)\"$ ]]; then
     path_expr="${BASH_REMATCH[1]}"
   else


### PR DESCRIPTION
Fixes DS-57 (pre-existing dangling hook; surfaced during DS-54 work).

`.codex/config/hooks.json` wires a UserPromptSubmit hook whose runtime path resolves to `<checkout>/.codex/hooks/skill-auto-load-check.sh` - but that script didn't exist there (only `risk-reminder.sh` + `stop-context-codex.js` did), so the Codex skill-auto-load hook was a silent no-op.

## Root cause (corrected from the ticket premise)
Codex hooks self-locate at runtime via `dirname(dirname(realpath(~/.codex/hooks.json)))/hooks/<script>`, which always resolves into a per-adapter `.codex/hooks/` dir - unlike Claude/Gemini which bake an install-time absolute path to repo-root `hooks/`. The `skill-auto-load` toggle is genuinely wired in `.codex/install.sh` (not intentionally omitted), so the fix is to make the script present, not remove the entry.

## Fix
- `.codex/build.sh` hardlinks `hooks/skill-auto-load-check.sh` into `.codex/hooks/` (reusing the existing `hardlink_from_content` helper, same pattern as references/commands/agents). Flows through the DS-54 snapshot automatically (`sync_hooks_snapshot` copies `.codex/hooks/` wholesale).
- New `bin/tests/test_codex_hooks_resolve.sh`: parses every command in `.codex/config/hooks.json` and asserts each resolves to an existing executable (fails 1/4 pre-fix, passes 4/4 post-fix).
- Wired that test into `.github/workflows/adapter-sync.yml` so it runs in CI.

## Verification (Skeptic-confirmed)
- Committed `.codex/hooks/skill-auto-load-check.sh` is byte-identical to source (shared git blob); `.codex/build.sh` re-links every build; `adapter-sync` `git diff --exit-code` catches drift if source changes without rebuild.
- DS-54 snapshot tests still pass (16/16, 8/8).