### PR TITLE
fix(tests): DS-59 anchor extract_path_from_notice regex to current notice text (stale since #322)

### DIFF
--- a/hooks/tests/test-version-check-core-repo-dir.sh
+++ b/hooks/tests/test-version-check-core-repo-dir.sh
@@ -63,11 +63,11 @@ write_fake_cache() {
 # Extract the repo path from the notice line:
 #   "... Run: agentic-update (shell) or /pull-and-install (in session). No PATH? <PATH>/update.sh"
 #
-# NOTE: do not anchor on "or " - the notice text has multiple "or " phrases
-# (e.g. "agentic-update (shell) or /pull-and-install (in session)"), so a
-# greedy ".*or " match swallows the wrong segment. Anchor on the fixed
-# "No PATH? " marker instead, which sits directly before the path and is
-# stable even if another "or ..." phrase is added to the notice later.
+# NOTE: do not anchor on "or " - since PR #322 the path no longer follows
+# "or " directly (the notice gained "/pull-and-install (in session). No
+# PATH? " between them), so a greedy ".*or " capture swallows that
+# intervening text. Anchor on the fixed "No PATH? " marker instead, which
+# sits directly before the path and stays stable if more wording is added.
 extract_path_from_notice() {
   local notice="$1"
   # The path appears between "No PATH? " and the trailing "/update.sh".

--- a/hooks/tests/test-version-check-core-repo-dir.sh
+++ b/hooks/tests/test-version-check-core-repo-dir.sh
@@ -61,11 +61,17 @@ write_fake_cache() {
 }
 
 # Extract the repo path from the notice line:
-#   "... Update with /update-agentic-engineering ... or <PATH>/update.sh ..."
+#   "... Run: agentic-update (shell) or /pull-and-install (in session). No PATH? <PATH>/update.sh"
+#
+# NOTE: do not anchor on "or " - the notice text has multiple "or " phrases
+# (e.g. "agentic-update (shell) or /pull-and-install (in session)"), so a
+# greedy ".*or " match swallows the wrong segment. Anchor on the fixed
+# "No PATH? " marker instead, which sits directly before the path and is
+# stable even if another "or ..." phrase is added to the notice later.
 extract_path_from_notice() {
   local notice="$1"
-  # The path appears as the substring before "/update.sh" in the notice.
-  echo "$notice" | sed 's|.*or \(.*\)/update\.sh.*|\1|'
+  # The path appears between "No PATH? " and the trailing "/update.sh".
+  echo "$notice" | sed 's|.*No PATH? \(.*\)/update\.sh.*|\1|'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes [DS-59](https://solara6.atlassian.net/browse/DS-59): hooks/tests/test-version-check-core-repo-dir.sh has failed on clean main since PR #322 added "/pull-and-install (in session)" to the update notice. The test's extract_path_from_notice sed pattern anchored greedily on "or " and captured the intervening text instead of the repo path.

Fix is test-only: re-anchor extraction on the stable "No PATH? " marker that sits directly before the path. Product code (hooks/lib/version-check-core.sh) untouched.

- Pre-fix: 5/10 assertions fail on clean checkout (captured "/pull-and-install (in session). No PATH? <repo>" instead of "<repo>")
- Post-fix: 10/10 pass; test-hooks-staleness-core.sh also pass (8/8)
- Grep confirms no other test carries the same extraction pattern
- Skeptic: round 1 approve with one Minor (comment rationale wording), fixed in follow-up commit