### PR TITLE
ci(security): least-privilege permissions on read-only CI workflows (CodeQL #60-66)

### DIFF
--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   check-adapter-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-codex-skill-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/methodology-drift.yml
+++ b/.github/workflows/methodology-drift.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/no-planning-docs.yml
+++ b/.github/workflows/no-planning-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   check-no-planning-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/slides-sync.yml
+++ b/.github/workflows/slides-sync.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   check-slides-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/wrap-lock-tests.yml
+++ b/.github/workflows/wrap-lock-tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   wrap-lock-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: { contents: read }` to the 6 CI workflows that lacked a permissions block, so `GITHUB_TOKEN` no longer inherits the broad repo default. Resolves CodeQL #66 (high, TokenPermissionsID) + #60-65 (medium). All 6 are read-only checks; security-auditor confirmed none needs write, additive-only diff, and the 4 excluded workflows correctly keep their scopes. Surfaced during DS-48.