### PR TITLE
fix(install): DS-58 resolve gitdir for pre-commit hook when .git is a worktree pointer file

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -42,6 +42,11 @@ export REPO_DIR
   echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
 }
 
+# shellcheck source=scripts/lib/precommit.sh
+[[ -f "$REPO_DIR/scripts/lib/precommit.sh" ]] && . "$REPO_DIR/scripts/lib/precommit.sh" || {
+  echo "  ! scripts/lib/precommit.sh not found - pre-commit hook install skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters)
 #
@@ -973,37 +978,10 @@ bash "$REPO_DIR/.cursor/build.sh"
 
 echo "Installing pre-commit hook..."
 
-HOOK_SRC="$REPO_DIR/hooks/pre-commit"
-HOOK_DST="$REPO_DIR/.git/hooks/pre-commit"
-
-if [[ -L "$HOOK_DST" ]]; then
-  current_target="$(readlink "$HOOK_DST")"
-  if [[ "$current_target" == "$HOOK_SRC" ]]; then
-    echo "  = pre-commit hook already linked"
-  elif _ae_is_ours "$HOOK_DST"; then
-    # Stale symlink pointing to another methodology checkout - re-point it.
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ~ pre-commit hook (would re-point to repo_dir)"
-    else
-      ln -sfn "$HOOK_SRC" "$HOOK_DST"
-      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
-    fi
-  else
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
-    else
-      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
-    fi
-  fi
-elif [[ -e "$HOOK_DST" ]]; then
-  echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
+if declare -f install_precommit_hook >/dev/null; then
+  install_precommit_hook "$REPO_DIR"
 else
-  if [[ "$AE_DRY_RUN" == "true" ]]; then
-    echo "  + pre-commit hook (would create)"
-  else
-    ln -s "$HOOK_SRC" "$HOOK_DST"
-    echo "  + pre-commit hook installed"
-  fi
+  echo "  ! install_precommit_hook not available - pre-commit hook install skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -8,6 +8,11 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
 }
 
+# shellcheck source=scripts/lib/precommit.sh
+[[ -f "$REPO_DIR/scripts/lib/precommit.sh" ]] && . "$REPO_DIR/scripts/lib/precommit.sh" || {
+  echo "  ! scripts/lib/precommit.sh not found - pre-commit hook install skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Activation mode (shared across all adapters - see .claude/install.sh)
 # Persists to ~/.claude/agentic-engineering.json. Read by the skill preflight.
@@ -369,37 +374,10 @@ bash "$REPO_DIR/.cursor/build.sh"
 
 echo "Installing pre-commit hook..."
 
-HOOK_SRC="$REPO_DIR/hooks/pre-commit"
-HOOK_DST="$REPO_DIR/.git/hooks/pre-commit"
-
-if [[ -L "$HOOK_DST" ]]; then
-  current_target="$(readlink "$HOOK_DST")"
-  if [[ "$current_target" == "$HOOK_SRC" ]]; then
-    echo "  = pre-commit hook already linked"
-  elif _ae_is_ours "$HOOK_DST"; then
-    # Stale symlink pointing to another methodology checkout - re-point it.
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ~ pre-commit hook (would re-point to repo_dir)"
-    else
-      ln -sfn "$HOOK_SRC" "$HOOK_DST"
-      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
-    fi
-  else
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
-    else
-      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
-    fi
-  fi
-elif [[ -e "$HOOK_DST" ]]; then
-  echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
+if declare -f install_precommit_hook >/dev/null; then
+  install_precommit_hook "$REPO_DIR"
 else
-  if [[ "$AE_DRY_RUN" == "true" ]]; then
-    echo "  + pre-commit hook (would create)"
-  else
-    ln -s "$HOOK_SRC" "$HOOK_DST"
-    echo "  + pre-commit hook installed"
-  fi
+  echo "  ! install_precommit_hook not available - pre-commit hook install skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -32,3 +32,5 @@ jobs:
           fi
       - name: Verify Codex hook commands resolve (DS-57 regression guard)
         run: bash bin/tests/test_codex_hooks_resolve.sh
+      - name: Verify pre-commit install resolves gitdir in worktrees (DS-58 regression guard)
+        run: bash bin/tests/test_precommit_worktree.sh

--- a/.opencode/install.sh
+++ b/.opencode/install.sh
@@ -9,6 +9,11 @@ export REPO_DIR
   echo "  ! scripts/lib/identity.sh not found - identity setup skipped"
 }
 
+# shellcheck source=scripts/lib/precommit.sh
+[[ -f "$REPO_DIR/scripts/lib/precommit.sh" ]] && . "$REPO_DIR/scripts/lib/precommit.sh" || {
+  echo "  ! scripts/lib/precommit.sh not found - pre-commit hook install skipped"
+}
+
 # ---------------------------------------------------------------------------
 # Run build first (generates agents/ and commands/ from content/)
 # ---------------------------------------------------------------------------
@@ -458,37 +463,10 @@ PYEOF
 
 echo "Installing pre-commit hook..."
 
-HOOK_SRC="$REPO_DIR/hooks/pre-commit"
-HOOK_DST="$REPO_DIR/.git/hooks/pre-commit"
-
-if [[ -L "$HOOK_DST" ]]; then
-  current_target="$(readlink "$HOOK_DST")"
-  if [[ "$current_target" == "$HOOK_SRC" ]]; then
-    echo "  = pre-commit hook already linked"
-  elif _ae_is_ours "$HOOK_DST"; then
-    # Stale symlink pointing to another methodology checkout - re-point it.
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ~ pre-commit hook (would re-point to repo_dir)"
-    else
-      ln -sfn "$HOOK_SRC" "$HOOK_DST"
-      echo "  ~ pre-commit hook (re-pointed to repo_dir)"
-    fi
-  else
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
-      echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
-    else
-      echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
-    fi
-  fi
-elif [[ -e "$HOOK_DST" ]]; then
-  echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
+if declare -f install_precommit_hook >/dev/null; then
+  install_precommit_hook "$REPO_DIR"
 else
-  if [[ "$AE_DRY_RUN" == "true" ]]; then
-    echo "  + pre-commit hook (would create)"
-  else
-    ln -s "$HOOK_SRC" "$HOOK_DST"
-    echo "  + pre-commit hook installed"
-  fi
+  echo "  ! install_precommit_hook not available - pre-commit hook install skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Purpose: Regression test for scripts/lib/precommit.sh's install_precommit_hook.
+#          Ensures the pre-commit hook installer resolves the REAL git hooks
+#          directory (via `git rev-parse --git-path hooks`) instead of the
+#          hardcoded "$REPO_DIR/.git/hooks", which breaks when REPO_DIR is a
+#          git worktree - there ".git" is a FILE (a gitdir pointer), not a
+#          directory, so a plain `ln -s ... "$REPO_DIR/.git/hooks/..."` fails
+#          with "Not a directory" (DS-58).
+#
+# Public API: ./bin/tests/test_precommit_worktree.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, git, mktemp.
+#
+# Downstream consumers: developer running locally before commit; can be
+#                       wired into CI.
+#
+# Failure modes: any assertion failure prints the failing assertion and exits 1.
+#                All fixtures live under a temporary directory; the real repo
+#                and its .git/hooks are never touched.
+#
+# Performance: < 2 s wall time (pure git + shell, no network).
+#
+# Regression coverage:
+#   - DS-58: `ln -s "$REPO_DIR/hooks/pre-commit" "$REPO_DIR/.git/hooks/pre-commit"`
+#     fails with "Not a directory" when REPO_DIR is a git worktree (.git is a
+#     file there, not a directory). install_precommit_hook resolves the real
+#     hooks dir via `git -C "$REPO_DIR" rev-parse --git-path hooks`, which
+#     follows the worktree's gitdir pointer back to the common repo's hooks
+#     dir. This test re-creates a worktree fixture to prevent regression.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="$REPO_DIR/scripts/lib/precommit.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  echo "FAIL: $LIB not found" >&2
+  exit 1
+fi
+
+# shellcheck source=scripts/lib/precommit.sh
+. "$LIB"
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# Stub matching the real per-adapter _ae_is_ours contract closely enough for
+# this test: nothing pre-existing points at another methodology checkout, so
+# it always reports "not ours" (never re-points a stale symlink).
+_ae_is_ours() {
+  return 1
+}
+
+AE_DRY_RUN=false
+
+TMP_ROOT="$(mktemp -d)"
+_cleanup() {
+  [[ -n "${TMP_ROOT:-}" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
+}
+trap _cleanup EXIT
+
+# _make_fixture_repo <dir>
+#   git-inits <dir>, commits a tracked hooks/pre-commit file.
+_make_fixture_repo() {
+  local dir="$1"
+  mkdir -p "$dir/hooks"
+  git init -q "$dir"
+  git -C "$dir" config user.email test@test.com
+  git -C "$dir" config user.name test
+  printf '#!/usr/bin/env bash\necho fixture pre-commit\n' > "$dir/hooks/pre-commit"
+  chmod +x "$dir/hooks/pre-commit"
+  git -C "$dir" add hooks/pre-commit
+  git -C "$dir" commit -q -m "fixture: add pre-commit hook"
+}
+
+# ============================================================
+# Test 1: normal checkout (.git is a directory) - baseline still works
+# ============================================================
+
+NORMAL_REPO="$TMP_ROOT/normal-repo"
+_make_fixture_repo "$NORMAL_REPO"
+
+if [[ -d "$NORMAL_REPO/.git" ]]; then
+  _pass "normal-repo fixture: .git is a directory"
+else
+  _fail "normal-repo fixture: .git is not a directory (fixture setup bug)"
+fi
+
+OUT="$(install_precommit_hook "$NORMAL_REPO" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "normal case: install_precommit_hook exits 0"
+else
+  _fail "normal case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "not a directory"; then
+  _fail "normal case: unexpected 'Not a directory' error. Output: $OUT"
+else
+  _pass "normal case: no 'Not a directory' error"
+fi
+
+NORMAL_HOOK_DST="$NORMAL_REPO/.git/hooks/pre-commit"
+if [[ -L "$NORMAL_HOOK_DST" ]] && [[ "$(readlink "$NORMAL_HOOK_DST")" == "$NORMAL_REPO/hooks/pre-commit" ]]; then
+  _pass "normal case: pre-commit symlink installed at $NORMAL_HOOK_DST"
+else
+  _fail "normal case: pre-commit symlink not found/correct at $NORMAL_HOOK_DST. Output: $OUT"
+fi
+
+# ============================================================
+# Test 2: worktree checkout (.git is a FILE) - DS-58 regression
+# ============================================================
+
+WT_MAIN="$TMP_ROOT/wt-main-repo"
+_make_fixture_repo "$WT_MAIN"
+
+WT_BRANCH="$TMP_ROOT/wt-branch"
+git -C "$WT_MAIN" worktree add -q "$WT_BRANCH" -b wt-test-branch >/dev/null 2>&1
+
+if [[ -f "$WT_BRANCH/.git" ]] && [[ ! -d "$WT_BRANCH/.git" ]]; then
+  _pass "worktree fixture: .git is a file (gitdir pointer), not a directory"
+else
+  _fail "worktree fixture: .git is not a file as expected (fixture setup bug)"
+fi
+
+OUT="$(install_precommit_hook "$WT_BRANCH" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "worktree case: install_precommit_hook exits 0"
+else
+  _fail "worktree case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "not a directory"; then
+  _fail "worktree case (DS-58 regression): 'Not a directory' error resurfaced. Output: $OUT"
+else
+  _pass "worktree case: no 'Not a directory' error (DS-58 fixed)"
+fi
+
+# The real hooks dir for a worktree is the MAIN repo's .git/hooks, shared
+# across all of that repo's worktrees.
+REAL_HOOKS_DIR="$(git -C "$WT_BRANCH" rev-parse --git-path hooks)"
+case "$REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) REAL_HOOKS_DIR="$WT_BRANCH/$REAL_HOOKS_DIR" ;;
+esac
+WT_HOOK_DST="$REAL_HOOKS_DIR/pre-commit"
+
+if [[ "$REAL_HOOKS_DIR" -ef "$WT_MAIN/.git/hooks" ]]; then
+  _pass "worktree case: real hooks dir resolves to the main repo's .git/hooks"
+else
+  _fail "worktree case: real hooks dir resolved to unexpected path: $REAL_HOOKS_DIR"
+fi
+
+if [[ -L "$WT_HOOK_DST" ]] && [[ "$(readlink "$WT_HOOK_DST")" == "$WT_BRANCH/hooks/pre-commit" ]]; then
+  _pass "worktree case: pre-commit symlink installed at real hooks dir ($WT_HOOK_DST)"
+else
+  _fail "worktree case: pre-commit symlink not found/correct at $WT_HOOK_DST. Output: $OUT"
+fi
+
+# ============================================================
+# Test 3: hooks-dir resolution failure is non-fatal
+# ============================================================
+
+NOT_A_REPO="$TMP_ROOT/not-a-repo"
+mkdir -p "$NOT_A_REPO/hooks"
+printf '#!/usr/bin/env bash\necho fixture pre-commit\n' > "$NOT_A_REPO/hooks/pre-commit"
+
+OUT="$(install_precommit_hook "$NOT_A_REPO" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "non-repo case: install_precommit_hook returns 0 (non-fatal) when git-path resolution fails"
+else
+  _fail "non-repo case: install_precommit_hook exited $RC instead of 0. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "skipping pre-commit hook install"; then
+  _pass "non-repo case: prints a non-fatal skip warning"
+else
+  _fail "non-repo case: expected a non-fatal skip warning. Output: $OUT"
+fi
+
+# ---- Results ----
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -1,0 +1,96 @@
+# shellcheck shell=bash
+# ---------------------------------------------------------------------------
+# Purpose: Shared pre-commit hook installer sourced by every adapter
+#          installer that wires the methodology's git pre-commit hook.
+#          Resolves the REAL git hooks directory instead of hardcoding
+#          "$REPO_DIR/.git/hooks" - the hardcoded form breaks when REPO_DIR
+#          is a git worktree, where ".git" is a file (a gitdir pointer) and
+#          not a directory (DS-58).
+#
+# Public API:
+#   install_precommit_hook <repo_dir>
+#     Resolves the real hooks dir via `git -C <repo_dir> rev-parse
+#     --git-path hooks` (this correctly follows a worktree's gitdir pointer
+#     back to the common repo's hooks dir), mkdir -p's it if needed, and
+#     symlinks hooks/pre-commit into it. Honours the caller's $AE_DRY_RUN
+#     ("true"/"false") and reuses the caller's _ae_is_ours function (must
+#     already be defined in the sourcing script) to detect and re-point
+#     stale symlinks from another methodology checkout. If hooks-dir
+#     resolution fails for any reason, prints a non-fatal warning and
+#     returns 0 - never aborts the caller.
+#
+# Upstream dependencies:
+#   git (rev-parse --git-path), the caller's $REPO_DIR/hooks/pre-commit
+#   source file, the caller's $AE_DRY_RUN variable, the caller's
+#   _ae_is_ours function (duplicated per-adapter helper).
+#
+# Downstream consumers:
+#   .claude/install.sh, .cursor/install.sh, .opencode/install.sh
+#   (the only adapters that install a pre-commit hook).
+#
+# Failure modes:
+#   - `git rev-parse --git-path hooks` fails (not a git repo, git missing):
+#     prints a non-fatal warning, returns 0, install.sh continues.
+#   - Resolved hooks dir does not yet exist (fresh worktree/repo): created
+#     via mkdir -p before the symlink is written.
+#   - Safe to source under set -euo pipefail; no top-level side effects
+#     beyond the function definition.
+#
+# Performance: one `git rev-parse` call per invocation.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# install_precommit_hook <repo_dir>
+#   See "Public API" above.
+# ---------------------------------------------------------------------------
+install_precommit_hook() {
+  local repo_dir="$1"
+  local hook_src="$repo_dir/hooks/pre-commit"
+
+  local hooks_dir
+  if ! hooks_dir="$(git -C "$repo_dir" rev-parse --git-path hooks 2>/dev/null)" || [[ -z "$hooks_dir" ]]; then
+    echo "  ! could not resolve git hooks directory - skipping pre-commit hook install (non-fatal)"
+    return 0
+  fi
+  # `--git-path` returns a path relative to repo_dir in a normal checkout,
+  # but an absolute path (via the worktree's common-dir) inside a worktree.
+  # Normalise to absolute either way.
+  case "$hooks_dir" in
+    /*) : ;;
+    *) hooks_dir="$repo_dir/$hooks_dir" ;;
+  esac
+
+  mkdir -p "$hooks_dir"
+  local hook_dst="$hooks_dir/pre-commit"
+
+  if [[ -L "$hook_dst" ]]; then
+    local current_target
+    current_target="$(readlink "$hook_dst")"
+    if [[ "$current_target" == "$hook_src" ]]; then
+      echo "  = pre-commit hook already linked"
+    elif _ae_is_ours "$hook_dst"; then
+      # Stale symlink pointing to another methodology checkout - re-point it.
+      if [[ "$AE_DRY_RUN" == "true" ]]; then
+        echo "  ~ pre-commit hook (would re-point to repo_dir)"
+      else
+        ln -sfn "$hook_src" "$hook_dst"
+        echo "  ~ pre-commit hook (re-pointed to repo_dir)"
+      fi
+    else
+      if [[ "$AE_DRY_RUN" == "true" ]]; then
+        echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
+      else
+        echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+      fi
+    fi
+  elif [[ -e "$hook_dst" ]]; then
+    echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
+  else
+    if [[ "$AE_DRY_RUN" == "true" ]]; then
+      echo "  + pre-commit hook (would create)"
+    else
+      ln -s "$hook_src" "$hook_dst"
+      echo "  + pre-commit hook installed"
+    fi
+  fi
+}


### PR DESCRIPTION
Fixes [DS-58](https://solara6.atlassian.net/browse/DS-58): install.sh's pre-commit step ran `ln -s ... $REPO_DIR/.git/hooks/pre-commit`, which fails with "Not a directory" inside a git worktree where .git is a gitdir-pointer file. The identical block was duplicated in three installers (.claude, .cursor, .opencode).

## Fix
- New shared `scripts/lib/precommit.sh` (`install_precommit_hook`), sourced by all three installers the same way they source `identity.sh`. Resolves the real hooks dir via `git -C "$repo_dir" rev-parse --git-path hooks` (relative results normalized to absolute) - hooks live in the common gitdir for every worktree, which is exactly where git reads them. Also correctly honors `core.hooksPath` where the old hardcoded path did not.
- Behavioral parity for normal checkouts verified branch-by-branch against the old inline block (only additive change: `mkdir -p` on the hooks dir).
- Regression test `bin/tests/test_precommit_worktree.sh` (11/11): real `git worktree add` fixture, asserts .git-is-a-file, no "Not a directory", symlink lands in the shared common gitdir. CI-wired into adapter-sync.yml beside the DS-57 test per #393 precedent.

## Review
Skeptic round 1: approve with one Minor (CI wiring for the new test), fixed in the follow-up commit. Empirically verified: worktree resolution to common gitdir, core.hooksPath handling, cwd-independent normalization, non-repo soft-fail.

Known out-of-scope twin: the three uninstall.sh scripts share the hardcoded path but fail silently (no crash) - follow-up ticket to be filed.

Gates: build-all clean across 11 adapters (fix survives rebuild), shellcheck clean, neighboring bin/tests pass.