### PR TITLE
docs: add trigger-catalog, graphify, and events-log/telemetry pages

### DIFF
--- a/docs/events-log-telemetry.md
+++ b/docs/events-log-telemetry.md
@@ -1,0 +1,168 @@
+<!--
+Purpose: Operator-facing guide to .agentic/events.jsonl - the structured
+         event log that records orchestration boundaries. Covers the base
+         schema, main event types, who writes what, and how agentic-cost
+         consumes the data. Complements docs/identity-telemetry.md (which
+         covers identity setup, not the event data model).
+
+Public API: Operator-facing prose. Entry point for operators who want to
+            understand what is being logged, consume the log themselves,
+            or troubleshoot agentic-cost output.
+            The full V1 event-type schemas live in
+            content/references/events-log.md.
+
+Upstream deps: content/sections/09-events-log.md (writer scope and base
+               schema); content/references/events-log.md (full V1 schemas,
+               per-developer session log, append discipline, PII boundary).
+
+See also: docs/identity-telemetry.md (identity setup and agentic-cost
+          team rollup).
+
+Downstream consumers: docs site root index.
+
+Failure modes: Stale if new event types are added, field names change, or
+               the per-developer session log schema changes. Update alongside
+               content/references/events-log.md.
+
+Performance: Standard.
+-->
+
+# Events log telemetry
+
+`.agentic/events.jsonl` is a per-project structured log of orchestration
+boundaries. It is optional, gitignored, and written locally - no data leaves
+the machine. `agentic-cost` reads it to produce token and wall-time reports.
+
+For identity setup (registering a developer handle so sessions are attributed
+correctly), see [docs/identity-telemetry.md](identity-telemetry.md).
+
+## Base schema
+
+Each line is one JSON object:
+
+```json
+{
+  "ts":      "2026-05-28T12:00:00Z",
+  "phase":   "worker-spawn",
+  "event":   "spawn_start",
+  "agent":   "engineer",
+  "task_id": "task-001",
+  "data":    { ... }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `ts` | yes | ISO8601 UTC timestamp |
+| `phase` | yes | Orchestration phase label (e.g. `worker-spawn`, `session_end`) |
+| `event` | yes | Event type (see below) |
+| `agent` | - | Spawned agent name; `null` when not agent-scoped |
+| `task_id` | - | Correlation id for multi-unit plans; matches `.agentic/tasks.jsonl`; `null` otherwise |
+| `data` | - | Free-form object with event-specific fields |
+
+## Who writes what
+
+**The conductor** is the primary writer. It appends one line at each
+orchestration boundary: worker spawn, worker return, Skeptic finding/sign-off,
+QA result, /wrap completion, finding fix.
+
+**The Stop hook** (`hooks/stop-context.js`) appends a single `session_total`
+event at session exit. This is the only sanctioned non-conductor writer;
+because the conductor turn has already ended when the hook fires, there is no
+contention.
+
+Subagents do not write to `events.jsonl`.
+
+## Event types
+
+### spawn_start
+
+Emitted immediately before an `Agent` tool call for engineer, skeptic, or
+qa-engineer.
+
+Key `data` fields: `tier`, `tool_use_id`, `agent_id` (null at emission;
+Claude Code assigns it after the spawn returns), `session_uuid`.
+
+### spawn_complete
+
+Emitted immediately after an `Agent` tool call returns.
+
+Key `data` fields: `tier`, `tool_use_id`, `agent_id`, `model`,
+`wall_seconds`, `tokens` (`input`, `output`, `cache_creation`, `cache_read`),
+`status`, `session_uuid`.
+
+When `agent == "skeptic"`, additional calibration fields are present:
+`findings_count` (`{critical, major, minor}`), `diff_lines`, `signed_off`,
+`iteration`.
+
+### session_total
+
+Emitted exactly once per session by the Stop hook.
+
+Key `data` fields: `wall_seconds`, summed `tokens`, `spawn_count`,
+`by_agent` rollup (per-agent `spawns`, `wall_seconds`, `tokens_total`).
+
+This event is also mirrored to `.agentic/session-log/<developer_id>.jsonl`
+for team rollup via `agentic-cost team`.
+
+### meta_review_complete
+
+Emitted when a sampled meta-Skeptic returns a divergence report.
+`agent == "skeptic-meta"`.
+
+Key `data` fields: `original_task_id`, `divergence` (`{critical_missed,
+major_missed, minor_missed}`), `agreement`, `session_uuid`.
+
+### tool_failure_workaround
+
+Emitted when the conductor resolves a tool or command failure via retry or
+workaround.
+
+Key `data` fields: `tool` (tool or command name - no args, no secrets),
+`domain_tag` (short domain label), `note` (one sentence describing the
+workaround - no file contents, no output, no secrets), `session_uuid`.
+
+This feeds the skill-candidate detection system. See
+[docs/skill-candidates.md](skill-candidates.md).
+
+## agentic-cost
+
+`agentic-cost` reads `events.jsonl` and the per-developer session logs to
+produce token and wall-time reports.
+
+```bash
+agentic-cost            # current session summary
+agentic-cost team       # per-developer rollup across all committed session logs
+```
+
+Session logs at `.agentic/session-log/<developer_id>.jsonl` are committed to
+git via `/implement-ticket` Phase 8 (when `commit_telemetry: true` and
+identity is confirmed). `agentic-cost team` therefore reflects sessions from
+all developers whose telemetry has landed on the branch via pull after merge.
+
+## Practical notes
+
+**Append discipline.** Plain shell `>>` append. No fsync, no lock file.
+Single-writer-by-protocol means contention is structurally impossible.
+
+**Retention.** Not auto-rotated. Manual `mv events.jsonl events-prev.jsonl`
+if the file grows past concern. Roughly 50 KB per active session.
+
+**PII boundary.** Only structured fields are written. Excluded: prompt
+content, file paths in tool I/O, user messages, finding text, task
+descriptions, commit messages, environment variable values.
+
+**No events.jsonl.** `/wrap` works normally on projects with no events log.
+The log is supplementary signal for the session skeleton, not required.
+
+## Related references
+
+- `content/references/events-log.md` - full V1 event-type schemas with
+  field-level `data` shapes, session-log schema, append discipline,
+  atomicity, retention, and PII boundary
+- `content/sections/09-events-log.md` - writer scope and base schema
+  (the section that events-log.md expands)
+- `docs/identity-telemetry.md` - identity setup and agentic-cost team
+  rollup (the prerequisite for attributed session logs)
+- `docs/skill-candidates.md` - how tool_failure_workaround events feed
+  the skill-candidate detection system

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -59,7 +59,7 @@ Build a graph once from the repo root:
 
 ```bash
 pip install graphifyy
-graphify install          # installs tree-sitter grammars
+graphify install          # graphify setup step
 graphify .                # builds graphify-out/graph.json and GRAPH_REPORT.md
 ```
 

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,0 +1,153 @@
+<!--
+Purpose: Operator-facing guide to the Graphify integration in AE. Explains
+         what graphify does when connected to the methodology, how to enable
+         it (presence-gated - no toggle), what changes at risk classification
+         and investigation time, and the fail-safe behavior when no graph is
+         present.
+
+Public API: Operator-facing prose. Entry point for anyone who wants to
+            understand or enable the graph-assisted risk signal.
+            The authoritative behavioral spec lives in
+            content/references/risk-config-and-tiers.md
+            §Graph-derived risk signal and in content/agents/investigator.md
+            §Graph-assisted blast radius.
+
+Upstream deps: content/references/risk-config-and-tiers.md
+               (graph-derived risk signal, freshness algorithm, autonomous
+               refresh, GRAPHIFY_OUT);
+               content/sections/02-delegation.md
+               (graph-derived escalation rule);
+               content/agents/investigator.md
+               (graphify affected, read-only lock, staleness fallback).
+
+Downstream consumers: docs site root index.
+
+Failure modes: Stale if the graphify v8 report format changes (heading
+               strings for God Nodes / Surprising Connections), or if
+               investigator's graphify affected usage changes. Update
+               alongside content/references/risk-config-and-tiers.md.
+
+Performance: Standard.
+-->
+
+# Graphify integration
+
+When a Graphify knowledge graph is present at the repo root, AE uses it in two
+places: risk classification (the conductor) and blast-radius investigation (the
+investigator agent). Both paths are presence-gated - no config toggle required.
+If no graph exists, behavior is identical to today's non-graph baseline.
+
+## What graphify is
+
+[Graphify](https://github.com/graphifyy/graphifyy) (`pip install graphifyy`)
+builds a code knowledge graph from your repository's source files. It writes
+two artifacts: `graphify-out/graph.json` (the graph database) and
+`GRAPH_REPORT.md` (a human-readable summary at the repo root).
+
+The report's two relevant sections are:
+- **God Nodes** - the highest-degree symbols in your codebase: the core
+  abstractions that everything else connects to.
+- **Surprising Connections** - cross-file couplings that are non-obvious from
+  reading any one file.
+
+AE reads those sections to detect when a proposed change touches a symbol that
+carries more architectural weight than it appears to.
+
+## How to enable it
+
+Build a graph once from the repo root:
+
+```bash
+pip install graphifyy
+graphify install          # installs tree-sitter grammars
+graphify .                # builds graphify-out/graph.json and GRAPH_REPORT.md
+```
+
+That is the entire setup. Once `GRAPH_REPORT.md` exists at the repo root, the
+integration activates on its own. There is no config toggle.
+
+**Keep the graph at the repo root.** If you relocate it via `GRAPHIFY_OUT`,
+the report is no longer found at the repo root and the signal does not fire.
+
+## What changes
+
+### Risk classification
+
+Before classifying any task's risk, the conductor checks whether a fresh
+`GRAPH_REPORT.md` exists at the repo root.
+
+If it does, and the task's target symbol(s) appear in the God Nodes or
+Surprising Connections sections of the report, the conductor treats that as an
+additional Elevated signal. This mechanizes two existing Elevated signals that
+already required human judgment: "Changes to shared utilities (single-file but
+high blast radius)" and "Logic with emergent/non-obvious cross-component
+interactions."
+
+The signal is escalate-only: it can raise a classification toward Elevated,
+never lower one. A change with no other Elevated signals that touches a God
+Node gets classified Elevated. A change already classified Elevated stays
+Elevated regardless.
+
+### Blast-radius investigation
+
+When the investigator agent runs a shared-utility or per-consumer-impact
+analysis, it checks for `graphify-out/graph.json`. If the graph is present, it
+runs:
+
+```bash
+graphify affected "<symbol-or-label>" --depth 2 [--relation <R>]
+```
+
+This is a deterministic graph BFS - read-only, no LLM call. Each result row
+carries the affected node label, BFS depth, relation type, and source
+location. The investigator treats graph hits as leads, not proof, and confirms
+each against the actual file before reporting it as a consumer. When the graph
+is absent, the investigator falls back to `grep -rn` exactly as it does today.
+
+The investigator is read-only: it never runs `graphify update .` or any
+mutating subcommand.
+
+## Freshness and autonomous refresh
+
+The conductor keeps the graph fresh itself. Before each risk classification
+(at most once per session), it checks whether the graph is stale:
+
+- **Primary check**: the `## Graph Freshness` section of `GRAPH_REPORT.md`
+  contains `- Built from commit: ` followed by an 8-character SHA. The graph
+  is fresh only if that SHA matches the first 8 characters of `git rev-parse
+  HEAD` AND the target files have no uncommitted modifications.
+- **Fallback** (no freshness section): compare `GRAPH_REPORT.md`'s mtime
+  against the newest target-source-file mtime. If any source is newer, treat
+  as stale.
+
+When stale, the conductor runs `graphify update .` once from the repo root,
+then reads the refreshed report. This runs at most once per session.
+
+The conductor refreshes only an existing graph. It never runs a from-scratch
+`graphify .` or any destructive path. If no graph exists, it does nothing and
+falls back to non-graph behavior.
+
+If `graphify update .` fails, the conductor proceeds with the existing stale
+graph. Because the signal is escalate-only, a stale graph can only under-fire
+(miss an escalation), never produce a false downgrade. An update failure never
+blocks risk classification.
+
+## Fail-safe summary
+
+| Condition | Behavior |
+|---|---|
+| No graph at repo root | No change from non-graph baseline |
+| Graph present, target symbol not in God Nodes / Surprising Connections | No change |
+| Graph present, target symbol matches | Additional Elevated signal |
+| Graph stale, update fails | Proceed with stale graph (signal may under-fire) |
+| `GRAPHIFY_OUT` relocates the report | Treated as absent; no signal |
+
+## Related references
+
+- `content/references/risk-config-and-tiers.md` §Graph-derived risk signal -
+  full freshness algorithm, format coupling, GRAPHIFY_OUT, and symbol-matching
+  details
+- `content/agents/investigator.md` §Graph-assisted blast radius - `graphify
+  affected` usage, staleness fallback, read-only invariant
+- `content/sections/02-delegation.md` - graph-derived escalation rule in
+  context of the full delegation table

--- a/docs/index.html
+++ b/docs/index.html
@@ -1204,6 +1204,9 @@
       <div class="node node-protocol"><a href="skill-candidates.md" target="_blank" rel="noopener">skill-candidates.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="capability-preflight.md" target="_blank" rel="noopener">capability-preflight.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="wrap-deferred.md" target="_blank" rel="noopener">wrap-deferred.md</a> <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol"><a href="trigger-catalog.md" target="_blank" rel="noopener">trigger-catalog.md</a> <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol"><a href="graphify.md" target="_blank" rel="noopener">graphify.md</a> <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol"><a href="events-log-telemetry.md" target="_blank" rel="noopener">events-log-telemetry.md</a> <span class="load-badge on-demand">on demand</span></div>
     </div>
     <p class="desc">Not auto-loaded. Read on-demand when protocols are triggered (e.g., Elevated risk declared, Skeptic review needed).</p>
   </div>

--- a/docs/trigger-catalog.md
+++ b/docs/trigger-catalog.md
@@ -1,0 +1,156 @@
+<!--
+Purpose: Operator-facing guide to the trigger catalog - the three ways a
+         conductor flow can start and the open-goal loop contract that governs
+         iterative, measured-condition loops. Covers the yolo-guard: triggers
+         fire the conductor, they do not bypass risk classification or Skeptic
+         review.
+
+Public API: Operator-facing prose. Entry point for operators who want to
+            automate AE on CI/CD, scheduled runs, or webhook events, or who
+            want to understand the safety guarantees around automated start.
+            The full internal spec lives in
+            content/references/trigger-catalog.md.
+
+Upstream deps: content/references/trigger-catalog.md (authoritative spec);
+               content/sections/07-cross-session-loop-resume.md
+               (loop-state resume semantics);
+               content/references/skeptic-protocol.md
+               (re-route limits and convergence-failure rules).
+
+Downstream consumers: docs site root index.
+
+Failure modes: Stale if open-goal loop contract, hard-stop rules, or
+               yolo-guard semantics change. Update alongside
+               content/references/trigger-catalog.md.
+
+Performance: Standard.
+-->
+
+# Trigger catalog
+
+Three ways to start a conductor flow, and the safety contract that governs all
+three.
+
+## The three trigger types
+
+**Manual** is the default. The operator invokes `/implement-ticket` directly.
+All conductor behavior applies unchanged. Every other trigger type is an
+extension of this baseline, not a replacement.
+
+**Scheduled** runs the existing conductor flow at a predetermined interval via
+a cron entry, a CI scheduled workflow, or an external `/schedule` skill. AE
+contributes the entry-point contract and risk discipline; the scheduling
+infrastructure is outside AE scope.
+
+**Action-triggered** fires the conductor in response to a repository event -
+PR opened, push to a branch, CI status check going green - via CI or webhook
+at the harness layer. AE contributes the entry-point convention and risk
+discipline; the CI and webhook plumbing is outside AE scope.
+
+All three trigger types enter the conductor at the same point: the start of the
+standard `/implement-ticket` flow. From there, the methodology applies without
+exception.
+
+## Open-goal loops
+
+An open-goal loop is an iterative conductor flow where the operator declares a
+goal condition rather than a fixed list of units. Each iteration produces one
+or more units of work through the standard sequence (architect ->
+orchestration-planner -> engineer -> Skeptic). The loop continues until the
+condition is met or a hard stop fires.
+
+The four required parts:
+
+**Trigger**: one of the three trigger types above starts the loop.
+
+**Action**: the conductor runs `/implement-ticket` with `goal_mode=open_goal`.
+
+**Measured condition**: an operator-declared `goal_condition` string evaluated
+after each Skeptic sign-off iteration. When it is true, the loop exits cleanly.
+Example: `"zero open Critical findings in content/references/"`.
+
+**Hard stop**: the loop exits on whichever fires first:
+- `goal_condition` evaluates to true.
+- Re-route cap reached: 3 fix passes on a single Skeptic finding with it still
+  open. Escalates to the operator per
+  `content/references/skeptic-protocol.md`.
+- Convergence failure: the same Skeptic finding re-raised unchanged after the
+  engineer claimed to fix it. Escalates immediately.
+- A hard blocker: permission denial, missing credential, irreversible action
+  without authorization, or a fundamental scope conflict.
+
+The open-goal loop reuses `loop-state.json`, cross-session resume, and
+clean-exit exactly as documented in
+`content/sections/07-cross-session-loop-resume.md`. No new loop engine is
+introduced.
+
+## The yolo-guard
+
+This section is structural, not advisory.
+
+**A trigger fires the conductor. It does not bypass risk classification or
+Skeptic review.** The conductor receives the trigger as input and then applies
+the standard risk-classification table before spawning any worker. An
+action-triggered flow enters the conductor at the same entry point as a manual
+invocation.
+
+**Each iteration of an open-goal loop is a fresh Elevated-eligible task.** It
+gets a fresh risk declaration. For any Elevated unit, it gets a fresh
+independent Skeptic - not the same Skeptic instance that reviewed the previous
+iteration. `goal_mode=open_goal` relaxes no existing review obligation.
+
+**Auditability.** Each iteration records a `risk_declared` field in
+`loop-state.json` as evidence that risk classification was performed. An
+iteration with no `risk_declared` is a protocol violation.
+
+**What this buys.** The trigger removes the human from the START of each
+iteration, never from the REVIEW. Every unit that goes through an automated
+loop gets the same adversarial Skeptic review as a manually triggered unit.
+Automated start does not imply automated approval.
+
+## Setting one up
+
+Automated triggering is outside AE scope at the harness level, but the
+entry-point contract is simple: invoke the existing `/implement-ticket`
+conductor flow from your CI or scheduler, and the methodology handles
+everything from there.
+
+The following is illustrative only - not production-ready CI. Authentication,
+runner setup, Claude Code invocation method, and secret management are all
+outside AE scope:
+
+```yaml
+# ILLUSTRATIVE ONLY - not production-ready CI.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ae-conductor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run AE conductor (action-triggered)
+        # The trigger invokes the existing /implement-ticket flow.
+        # The conductor applies standard risk classification before
+        # spawning any workers - the trigger does not bypass review.
+        run: |
+          claude --project . /implement-ticket "${{ github.event.pull_request.title }}"
+```
+
+## Companion config toggle
+
+`auto_merge_on_ci_green` (boolean, default `false`) in `.agentic/config.json`
+enables unsupervised merge when an action-triggered flow completes CI-green.
+When `true`, `/implement-ticket` Phase 12 squash-merges the PR after all CI
+checks pass, the PR is marked ready, and no reviewer has requested changes.
+Documented in `content/sections/04-risk-classification.md` §Project config.
+
+## Related references
+
+- `content/references/trigger-catalog.md` - full internal spec: open-goal
+  loop contract, hard-stop rules, yolo-guard, and entry-point examples
+- `content/sections/07-cross-session-loop-resume.md` - loop-state persistence
+  and resume semantics the open-goal loop inherits
+- `content/references/skeptic-protocol.md` - re-route limits and
+  convergence-failure escalation rules


### PR DESCRIPTION
## Summary
Three new operator-facing docs-site pages + nav wiring:
- `docs/trigger-catalog.md` - three trigger types (manual/scheduled/action-triggered), the open-goal loop contract, and the yolo-guard. Source: `content/references/trigger-catalog.md`.
- `docs/graphify.md` - the graphify knowledge-graph integration: presence-gated risk signal (God Nodes / Surprising Connections), `graphify affected` blast-radius, autonomous once-per-session refresh, fail-safe behavior. Built from grounded grep hits across `content/` (risk-config-and-tiers, investigator, delegation).
- `docs/events-log-telemetry.md` - `.agentic/events.jsonl` schema, event types, writer scope, and `agentic-cost` consumption. Sources: `content/references/events-log.md`, `content/sections/09-events-log.md`.
- `docs/index.html` - three nav nodes in the Protocol Documents grid.

## Review
- Skeptic-reviewed (three-dot diff): every claim traced to a named source; graphify page got highest scrutiny (no canonical source doc) - all commands/flags grounded, no inventions. 0 Critical, 0 Major, 1 Minor (ungrounded install-comment gloss) fixed.
- No `content/` files modified.