### PR TITLE
fix(content): correct skill-candidate trigger wording + phantom command; rebuild adapters

### DIFF
--- a/.claude/commands/skill-candidates.md
+++ b/.claude/commands/skill-candidates.md
@@ -4,8 +4,7 @@
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -32,15 +31,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -48,7 +46,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -86,7 +88,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -96,7 +99,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.codex/commands/skill-candidates.md
+++ b/.codex/commands/skill-candidates.md
@@ -2,8 +2,7 @@
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -30,15 +29,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -46,7 +44,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -84,7 +86,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -94,7 +97,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.cursor/commands/skill-candidates.md
+++ b/.cursor/commands/skill-candidates.md
@@ -2,8 +2,7 @@
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -30,15 +29,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -46,7 +44,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -84,7 +86,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -94,7 +97,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.gemini/commands/skill-candidates.toml
+++ b/.gemini/commands/skill-candidates.toml
@@ -8,8 +8,7 @@ prompt = """
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -36,15 +35,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -52,7 +50,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -90,7 +92,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -100,7 +103,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.github/prompts/skill-candidates.prompt.md
+++ b/.github/prompts/skill-candidates.prompt.md
@@ -5,8 +5,7 @@ description: "Read-only view of the skill-candidate backlog. Displays open and d
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -33,15 +32,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -49,7 +47,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -87,7 +89,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -97,7 +100,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -15819,8 +15819,7 @@ Pick the single best match. If multiple apply, use the first match in this list.
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -15847,15 +15846,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -15863,7 +15861,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -15901,7 +15903,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -15911,7 +15914,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.openclaw/skills/skill-candidates/SKILL.md
+++ b/.openclaw/skills/skill-candidates/SKILL.md
@@ -7,8 +7,7 @@ user-invocable: true
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -35,15 +34,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -51,7 +49,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -89,7 +91,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -99,7 +102,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/.opencode/commands/skill-candidates.md
+++ b/.opencode/commands/skill-candidates.md
@@ -6,8 +6,7 @@ agent: build
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -34,15 +33,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -50,7 +48,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -88,7 +90,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -98,7 +101,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/content/commands/skill-candidates.md
+++ b/content/commands/skill-candidates.md
@@ -2,8 +2,7 @@
 
 Read-only view of the skill-candidate backlog. Displays open and dismissed
 candidates detected from recurring workflow friction - each with its domain,
-count, suggested artifact type, and example note. Points at the `skill-creator`
-skill for open items.
+count, suggested artifact type, and example note.
 
 No writes, no agent spawns, no network calls. Always exits 0.
 
@@ -30,15 +29,14 @@ the detector on first promotion) or `dismissed` (set by a human to suppress).
 **First seen:** YYYY-MM-DD
 **Last seen:** YYYY-MM-DD
 **Status:** open
-**Example:** "<data.note from the triggering event>"
+**Example:** "<one sentence from the triggering session>"
 ```
 
 ## What this shows
 
-The backlog is written by the Stop hook's `runSkillCandidateScan` whenever a
-domain tag accumulates >= 3 occurrences across sessions (from
-`tool_failure_workaround` events and `.agentic/learnings.md` entries). Each
-entry carries:
+The backlog is written at wrap time (via `/wrap` Part D LLM extraction and the
+`hooks/lib/skill-candidate-deep-cluster.js` helper) whenever a domain tag
+accumulates >= 3 occurrences across sessions. Each entry carries:
 
 - **Domain** - the `## <domain>` heading (unique key)
 - **Count** - lifetime occurrence count across sessions
@@ -46,7 +44,11 @@ entry carries:
   (routing taxonomy from the detection signal)
 - **Status** - `open` (not yet dismissed) or `dismissed` (operator suppressed)
 - **First seen / Last seen** - ISO date range of the friction signal
-- **Example** - the `data.note` from the triggering event (illustrative only)
+- **Example** - a concrete note from the triggering session (illustrative only)
+
+The wrap-time path is the active detection mechanism. A secondary path via
+`tool_failure_workaround` events in `.agentic/events.jsonl` exists in the
+codebase but is dormant - those events are not emitted in ad-hoc sessions.
 
 ## Grouping by status
 
@@ -84,7 +86,8 @@ OPEN (already surfaced)
 DISMISSED
   (none)
 
-To create a skill for an open item: run /skill-creator <domain>
+To create a skill for an open item: create a skill for the domain manually,
+  or use your usual skill-authoring flow
 To dismiss a candidate: edit .agentic/skill-candidates.md and change
   **Status:** open  to  **Status:** dismissed
 ```
@@ -94,7 +97,7 @@ When `.agentic/skill-candidates.md` is absent:
 ```
 No skill candidates detected yet.
 
-The detector runs at session end (Stop hook) and writes candidates here
+The detector runs at the end of each /wrap call and writes candidates here
 when a domain tag accumulates >= 3 occurrences. Check back after a few
 more sessions, or verify that skill_candidate_detection is true in
 .agentic/config.json.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -68,7 +68,7 @@ it manually.
 | `qa_default_skip` | reserved/inert | reserved | Schema placeholder only; does not alter QA-gate behavior |
 | `model_profile` | `"default"` | `"default"`, `"budget"` | `budget` routes eligible spawns to Tier 1 to reduce cost; **never applies to `security-auditor` or any mandated Tier-3 spawn** |
 | `auto_merge_on_ci_green` | `false` | bool | When `true`, Phase 12 squash-merges after CI green + ready + no change-requests |
-| `capability_preflight_mode` | `"blocking"` | `"advisory"`, `"blocking"` | `advisory` warns and proceeds on a missing dep; `blocking` refuses the spawn. Default is `blocking` (all agent manifests are populated as of P2). Note: METHODOLOGY.md prose says `advisory` - that text is stale; `blocking` is the canonical default. |
+| `capability_preflight_mode` | `"blocking"` | `"advisory"`, `"blocking"` | `advisory` warns and proceeds on a missing dep; `blocking` refuses the spawn. Default is `blocking` (all agent manifests are populated as of P2). |
 | `perceptual_diff_enabled` | `false` | bool | qa-engineer runs pixelmatch against committed baselines |
 | `theme_aware` | `false` | bool | qa-engineer runs scenarios in both light and dark themes |
 | `storybook_enabled` | `false` | bool | qa-engineer targets Storybook iframe for isolated component verification |


### PR DESCRIPTION
## Summary
- `content/commands/skill-candidates.md`: replace stale "Stop hook / tool_failure_workaround events" trigger description with the active wrap-time path (/wrap Part D LLM extraction + `hooks/lib/skill-candidate-deep-cluster.js`); mark the events.jsonl path dormant. Remove the phantom `/skill-creator` call-to-action (AE ships no such command).
- `docs/configuration-reference.md`: remove a self-contradicting note that flagged METHODOLOGY.md's "advisory" default as stale; `content/sections/06-capability-preflight.md` already states `blocking` as of P2.
- Regenerate 8 affected adapter outputs via `scripts/build-all.sh`.

## Review
- Skeptic-reviewed empirically: `build-all.sh` + `git diff --exit-code` = 0 (adapter sync clean), `check-methodology-drift.sh` = 0. Source claims verified against wrap.md Part D + conventions skill-candidate sweep. 0 Critical/Major; 1 Minor (sibling docs still say "Stop hook") deferred as a follow-up doc-sync pass - pre-existing, non-misleading.

## Follow-up (tracked)
- Sibling references (README.md, content/references/risk-config-and-tiers.md, conventions-detail.md, init-project.md, project-scaffolding.yml, docs/components.md) still attribute skill-candidate detection to the Stop hook without the wrap-time-active nuance. Separate doc-sync unit.