### PR TITLE
DS-56: add bin/agentic-feedback home-dir feedback store CLI

### DIFF
--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,6 +1,6 @@
 # bin/
 
-Fourteen CLI entry points (11 Python, 1 Bash, 2 Node) that the agentic-engineering
+Fifteen CLI entry points (12 Python, 1 Bash, 2 Node) that the agentic-engineering
 methodology exposes as PATH-wired commands. Each binary ships with a
 module-manifest docstring (Purpose / Public API / Upstream deps / Downstream
 consumers / Failure modes / Performance) that is the authoritative description
@@ -16,6 +16,7 @@ module-group map, not a duplicate of those manifests.
 | `agentic-disable` | Python | Append the opt-out marker to `AGENTS.md`; optionally update the global config. |
 | `agentic-doctor` | Python | Inspect and repair global install health (symlinks, bin wrappers, hook paths in `settings.json`). |
 | `agentic-emit` | Bash | Append one structured JSON event to `.agentic/events.jsonl` at orchestration boundaries. |
+| `agentic-feedback` | Python | Manage the home-dir feedback store (`~/.agentic/feedback.jsonl`) - append/list/mark operator and agent friction items. |
 | `agentic-help` | Python | Print the static slash-command reference to stdout. Zero file I/O; never fails. |
 | `agentic-identity` | Python | Manage per-developer identity files used by the Stop hook for session telemetry attribution. |
 | `agentic-memory` | Python | Query `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md`; return compact Markdown summaries. |
@@ -37,7 +38,7 @@ module-group map, not a duplicate of those manifests.
 
 ## Downstream consumers
 
-`content/commands/` slash-command specs; adapter install scripts (`.claude/install.sh`, `.codex/install.sh`, etc.) that symlink these onto `PATH`; `hooks/stop-context.js` for `agentic-identity` helpers; Activation preflight Step 6 for `agentic-migrate`.
+`content/commands/` slash-command specs; adapter install scripts (`.claude/install.sh`, `.codex/install.sh`, etc.) that symlink these onto `PATH`; `hooks/stop-context.js` for `agentic-identity` helpers; Activation preflight Step 6 for `agentic-migrate`; `content/commands/wrap.md` Part D.5 and `content/commands/feedback-triage.md` for `agentic-feedback`.
 
 ## Failure-mode discipline
 

--- a/bin/agentic-feedback
+++ b/bin/agentic-feedback
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Purpose: CLI for managing the home-dir feedback store (~/.agentic/feedback.jsonl)
+         used to accumulate operator/agent friction signals (tool friction,
+         process escalations, guardrail fires, operator corrections) captured
+         during /wrap runs across projects, for later triage into tickets or
+         methodology fixes.
+
+Public API:
+  agentic-feedback append --repo <path> --session-uuid <uuid> --file <path-to-json-array>
+  agentic-feedback list [--scope {project,methodology}] [--status {open,triaged,dismissed}]
+                        [--repo <path>]
+  agentic-feedback mark --id <uuid> --status {open,triaged,dismissed}
+  agentic-feedback --help
+
+Data model:
+  ~/.agentic/feedback.jsonl: one JSON object per line.
+  Fields:
+    id                 (CLI-owned) uuid4, assigned on append.
+    ts                 (CLI-owned) UTC ISO8601, assigned on append.
+    repo               caller-supplied via --repo at append time.
+    scope              caller-supplied draft field; one of "project", "methodology".
+    severity           caller-supplied draft field; one of "high", "medium", "low".
+    category           caller-supplied draft field; one of "tool-friction",
+                       "process-escalation", "guardrail-fire", "operator-correction".
+    evidence           caller-supplied draft field; non-empty string.
+    suggested_title    caller-supplied draft field; non-empty string.
+    suggested_body     caller-supplied draft field; non-empty string.
+    status             (CLI-owned) one of "open", "triaged", "dismissed";
+                       assigned "open" on append, changed only via `mark`.
+    session_uuid       caller-supplied via --session-uuid at append time.
+
+  IMPORTANT: id, ts, and status are CLI-owned. On `append`, any id/ts/status
+  keys present in a caller-supplied draft object are IGNORED and overwritten
+  by CLI-assigned values - callers (operators or LLM agents assembling the
+  --file batch) must never be trusted to self-assign these three fields.
+
+  Enums:
+    scope:    project | methodology
+    severity: high | medium | low
+    category: tool-friction | process-escalation | guardrail-fire | operator-correction
+    status:   open | triaged | dismissed
+
+Upstream deps: Python 3 stdlib only (argparse, json, os, sys, uuid, datetime,
+               pathlib). Shared helpers: bin/_lib (acquire_exclusive_lock,
+               atomic_write).
+
+Downstream consumers: content/commands/wrap.md Part D.5 (writes drafts via
+                      `append` at end of session); content/commands/feedback-triage.md
+                      (reads via `list`, updates status via `mark`).
+
+Failure modes:
+  append: per-item soft-fail - an individual draft that fails validation
+    (bad enum value, missing/empty required string field) is skipped with a
+    warning printed to stderr; the batch continues. An empty or all-invalid
+    batch is NOT an error (exit 0, no-op). Exit 1 only on hard errors:
+    --file missing/unreadable, --file not valid JSON, --file not a JSON
+    array, lock acquisition timeout, or a write I/O failure.
+  list: file-absent prints "[]" and exits 0 (not an error). Malformed
+    (non-JSON) lines in the store are skipped silently.
+  mark: exits 1 with a stderr message if the store file is absent or no
+    line matches --id. The rewrite is all-or-nothing via atomic_write - a
+    failure mid-rewrite leaves the original file untouched.
+
+  Locking: all three subcommands acquire the same exclusive LOCK_PATH for
+  their full read/modify/write critical section (append's read+append,
+  list's read, mark's read+rewrite), serializing concurrent invocations -
+  e.g. two projects' /wrap runs calling `append` at the same time, or a
+  `mark` full-file rewrite racing an `append`. acquire_exclusive_lock (from
+  bin/_lib) opens the lock file in 'r' mode and requires it to already
+  exist; every subcommand therefore mkdir -p's the lock file's parent and
+  touch()es the lock file before calling acquire_exclusive_lock.
+
+Performance: Standard. Single-file read + append/rewrite; no indexing. Fine
+  at the scale of an individual developer's accumulated feedback backlog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+import sys as _sys
+import importlib.util as _ilu
+import importlib.machinery as _ilm
+
+_LIB_PATH = Path(__file__).parent / "_lib.py"
+if "_lib" in _sys.modules:
+    _lib_mod = _sys.modules["_lib"]
+else:
+    _loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+    _spec = _ilu.spec_from_loader("_lib", _loader)
+    _lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+    _loader.exec_module(_lib_mod)
+    _sys.modules["_lib"] = _lib_mod
+    del _loader, _spec
+acquire_exclusive_lock = _lib_mod.acquire_exclusive_lock
+atomic_write = _lib_mod.atomic_write
+del _sys, _ilu, _ilm, _lib_mod
+
+FEEDBACK_PATH = Path(os.path.expanduser("~/.agentic/feedback.jsonl"))
+LOCK_PATH = Path(os.path.expanduser("~/.agentic/feedback.jsonl.lock"))
+
+SCOPE_VALUES = ("project", "methodology")
+SEVERITY_VALUES = ("high", "medium", "low")
+CATEGORY_VALUES = ("tool-friction", "process-escalation", "guardrail-fire", "operator-correction")
+STATUS_VALUES = ("open", "triaged", "dismissed")
+
+DRAFT_STRING_FIELDS = ("evidence", "suggested_title", "suggested_body")
+
+
+def _ensure_lock_bootstrap() -> None:
+    """Ensure LOCK_PATH and its parent dir exist before acquire_exclusive_lock.
+
+    acquire_exclusive_lock opens the lock file in 'r' mode and requires it to
+    already exist - mirrors bin/agentic-identity's mkdir+touch bootstrap.
+    """
+    LOCK_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    LOCK_PATH.touch(exist_ok=True)
+
+
+def _read_store() -> list[dict]:
+    """Read FEEDBACK_PATH and return a list of parsed line dicts.
+
+    File-absent returns []. Malformed (non-JSON) lines are skipped silently.
+    """
+    if not FEEDBACK_PATH.is_file():
+        return []
+    rows: list[dict] = []
+    text = FEEDBACK_PATH.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def _validate_draft(draft: dict) -> str | None:
+    """Return None if draft is valid, else a human-readable reason string."""
+    if not isinstance(draft, dict):
+        return "not a JSON object"
+    scope = draft.get("scope")
+    if scope not in SCOPE_VALUES:
+        return f"invalid scope {scope!r} (must be one of {SCOPE_VALUES})"
+    severity = draft.get("severity")
+    if severity not in SEVERITY_VALUES:
+        return f"invalid severity {severity!r} (must be one of {SEVERITY_VALUES})"
+    category = draft.get("category")
+    if category not in CATEGORY_VALUES:
+        return f"invalid category {category!r} (must be one of {CATEGORY_VALUES})"
+    for field in DRAFT_STRING_FIELDS:
+        value = draft.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return f"missing/empty required field {field!r}"
+    return None
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    file_path = Path(args.file)
+    try:
+        raw = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"agentic-feedback: cannot read --file {file_path}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        drafts = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"agentic-feedback: --file {file_path} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(drafts, list):
+        print(f"agentic-feedback: --file {file_path} must contain a JSON array", file=sys.stderr)
+        return 1
+
+    accepted: list[dict] = []
+    for idx, draft in enumerate(drafts):
+        reason = _validate_draft(draft)
+        if reason is not None:
+            print(f"agentic-feedback: skipping draft[{idx}]: {reason}", file=sys.stderr)
+            continue
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # CLI-owned fields (id, ts, status) always overwrite any caller-supplied
+        # values for those keys - never trust operator/LLM-supplied id/ts/status.
+        record = {
+            "id": str(uuid.uuid4()),
+            "ts": now,
+            "repo": args.repo,
+            "scope": draft["scope"],
+            "severity": draft["severity"],
+            "category": draft["category"],
+            "evidence": draft["evidence"],
+            "suggested_title": draft["suggested_title"],
+            "suggested_body": draft["suggested_body"],
+            "status": "open",
+            "session_uuid": args.session_uuid,
+        }
+        accepted.append(record)
+
+    if not accepted:
+        # Empty or all-invalid batch is a clean no-op, not an error.
+        print("agentic-feedback: no valid drafts to append (0 written)")
+        return 0
+
+    _ensure_lock_bootstrap()
+    try:
+        with acquire_exclusive_lock(LOCK_PATH):
+            FEEDBACK_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            lines = "".join(json.dumps(r, separators=(",", ":")) + "\n" for r in accepted)
+            with open(FEEDBACK_PATH, "a", encoding="utf-8") as f:
+                f.write(lines)
+    except RuntimeError as exc:
+        print(f"agentic-feedback: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"agentic-feedback: write failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Appended {len(accepted)} feedback item(s).")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    _ensure_lock_bootstrap()
+    try:
+        with acquire_exclusive_lock(LOCK_PATH):
+            rows = _read_store()
+    except RuntimeError as exc:
+        print(f"agentic-feedback: {exc}", file=sys.stderr)
+        return 1
+
+    if args.scope is not None:
+        rows = [r for r in rows if r.get("scope") == args.scope]
+    if args.status is not None:
+        rows = [r for r in rows if r.get("status") == args.status]
+    if args.repo is not None:
+        rows = [r for r in rows if r.get("repo") == args.repo]
+
+    print(json.dumps(rows, indent=2))
+    return 0
+
+
+def cmd_mark(args: argparse.Namespace) -> int:
+    _ensure_lock_bootstrap()
+    try:
+        with acquire_exclusive_lock(LOCK_PATH):
+            if not FEEDBACK_PATH.is_file():
+                print(
+                    f"agentic-feedback: no feedback store at {FEEDBACK_PATH}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            rows = _read_store()
+            matched = False
+            new_lines: list[str] = []
+            for row in rows:
+                if row.get("id") == args.id:
+                    matched = True
+                    row = dict(row)
+                    row["status"] = args.status
+                new_lines.append(json.dumps(row, separators=(",", ":")))
+
+            if not matched:
+                print(
+                    f"agentic-feedback: no feedback item with id {args.id!r}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            content = "".join(line + "\n" for line in new_lines)
+            try:
+                atomic_write(FEEDBACK_PATH, content, mode=0o600)
+            except Exception as exc:
+                print(f"agentic-feedback: write failed: {exc}", file=sys.stderr)
+                return 1
+    except RuntimeError as exc:
+        print(f"agentic-feedback: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Marked {args.id} as {args.status}.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        prog="agentic-feedback",
+        description="Manage the home-dir feedback store (~/.agentic/feedback.jsonl).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_append = sub.add_parser("append", help="Append validated feedback drafts from a JSON file")
+    p_append.add_argument("--repo", required=True, help="Repo path to stamp on each item")
+    p_append.add_argument("--session-uuid", required=True, help="Session uuid to stamp on each item")
+    p_append.add_argument("--file", required=True, help="Path to a JSON array of draft objects")
+    p_append.set_defaults(func=cmd_append)
+
+    p_list = sub.add_parser("list", help="List feedback items as a JSON array")
+    p_list.add_argument("--scope", choices=SCOPE_VALUES, default=None, help="Filter by scope")
+    p_list.add_argument("--status", choices=STATUS_VALUES, default=None, help="Filter by status")
+    p_list.add_argument("--repo", default=None, help="Filter by repo")
+    p_list.set_defaults(func=cmd_list)
+
+    p_mark = sub.add_parser("mark", help="Update the status of a feedback item by id")
+    p_mark.add_argument("--id", required=True, help="Feedback item id (uuid)")
+    p_mark.add_argument("--status", required=True, choices=STATUS_VALUES, help="New status")
+    p_mark.set_defaults(func=cmd_mark)
+
+    args = p.parse_args(argv[1:])
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/agentic-feedback
+++ b/bin/agentic-feedback
@@ -60,7 +60,16 @@ Failure modes:
     (non-JSON) lines in the store are skipped silently.
   mark: exits 1 with a stderr message if the store file is absent or no
     line matches --id. The rewrite is all-or-nothing via atomic_write - a
-    failure mid-rewrite leaves the original file untouched.
+    failure mid-rewrite leaves the original file untouched. A malformed
+    (non-JSON) line encountered during mark's read is dropped from the
+    rewritten file (as with list) but - unlike list - mark prints a
+    one-line stderr warning naming the line number, since mark's rewrite
+    is destructive and the drop should be visible, not silent. mark also
+    re-canonicalizes every surviving line via json.dumps with compact
+    separators on rewrite, so non-target lines are byte-identical only
+    for lines the CLI itself originally wrote; an externally hand-edited
+    line (different key order, whitespace, etc.) will be re-canonicalized
+    to the CLI's compact form even though its field values are preserved.
 
   Locking: all three subcommands acquire the same exclusive LOCK_PATH for
   their full read/modify/write critical section (append's read+append,
@@ -125,22 +134,34 @@ def _ensure_lock_bootstrap() -> None:
     LOCK_PATH.touch(exist_ok=True)
 
 
-def _read_store() -> list[dict]:
+def _read_store(warn_on_malformed: bool = False) -> list[dict]:
     """Read FEEDBACK_PATH and return a list of parsed line dicts.
 
-    File-absent returns []. Malformed (non-JSON) lines are skipped silently.
+    File-absent returns []. Malformed (non-JSON) lines are skipped.
+
+    When warn_on_malformed is True (used by `mark`'s full-file rewrite,
+    where a skipped line represents a destructive silent drop from the
+    store), a one-line stderr warning naming the 1-based line number is
+    printed for each skipped line. `list`'s read path leaves this False -
+    list is non-destructive, so warning there would be noisier than useful.
     """
     if not FEEDBACK_PATH.is_file():
         return []
     rows: list[dict] = []
     text = FEEDBACK_PATH.read_text(encoding="utf-8")
-    for line in text.splitlines():
+    for lineno, line in enumerate(text.splitlines(), start=1):
         line = line.strip()
         if not line:
             continue
         try:
             rows.append(json.loads(line))
         except json.JSONDecodeError:
+            if warn_on_malformed:
+                print(
+                    f"agentic-feedback: skipping malformed line {lineno} in "
+                    f"{FEEDBACK_PATH.name}",
+                    file=sys.stderr,
+                )
             continue
     return rows
 
@@ -261,7 +282,7 @@ def cmd_mark(args: argparse.Namespace) -> int:
                 )
                 return 1
 
-            rows = _read_store()
+            rows = _read_store(warn_on_malformed=True)
             matched = False
             new_lines: list[str] = []
             for row in rows:

--- a/bin/tests/test_agentic_feedback.py
+++ b/bin/tests/test_agentic_feedback.py
@@ -20,6 +20,15 @@ Test groups:
   8. test_two_sequential_appends_both_land_under_shared_lock - two
      sequential append calls (simulating two projects' /wrap runs) both
      land intact; final file is the union of valid items, one line each.
+  9. test_concurrent_appends_serialize_under_real_multiprocess_contention -
+     genuine cross-process concurrency via multiprocessing.Process: N
+     workers each append many records to the SAME store at once; asserts
+     exact expected line count and that every line is valid, non-torn
+     JSON, proving the fcntl lock actually serializes writers (a version
+     with the lock removed would drop and/or interleave lines).
+  10. test_mark_warns_on_malformed_line_and_drops_it - mark's rewrite
+      prints a stderr warning naming the line number of a malformed line
+      it drops (visibility for a destructive silent skip).
 
 Regression test obligation: content/references/regression-test-obligation.md
 Run with: python3 -m pytest bin/tests/test_agentic_feedback.py -x
@@ -31,6 +40,7 @@ import importlib.machinery
 import importlib.util
 import io
 import json
+import multiprocessing
 import sys
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
@@ -48,6 +58,48 @@ _mod = importlib.util.module_from_spec(_spec)
 _loader.exec_module(_mod)
 
 main = _mod.main
+
+
+def _mp_append_worker(
+    bin_path_str: str,
+    feedback_path_str: str,
+    lock_path_str: str,
+    repo: str,
+    session_uuid: str,
+    batch_path_str: str,
+) -> None:
+    """Multiprocessing worker (module-level, picklable): fresh-imports
+    bin/agentic-feedback in THIS process and patches FEEDBACK_PATH/LOCK_PATH
+    before invoking `append`, then sys.exit()s with main()'s return code.
+
+    Must be defined at module level (not a closure/lambda) so
+    multiprocessing can pickle a reference to it for the child process.
+    Each worker re-imports the CLI module and re-sets FEEDBACK_PATH/
+    LOCK_PATH itself, because a multiprocessing worker does not inherit the
+    parent test process's monkeypatched module globals (the child gets its
+    own copy of the module either way - via re-import under 'spawn' or
+    copy-on-write under 'fork' - so re-setting explicitly here is what
+    makes the worker point at the shared tmp-dir store regardless of which
+    start method the platform uses).
+    """
+    import importlib.machinery as _mp_ilm
+    import importlib.util as _mp_ilu
+    import sys as _mp_sys
+    from pathlib import Path as _MpPath
+
+    loader = _mp_ilm.SourceFileLoader("agentic_feedback_mp_worker", bin_path_str)
+    spec = _mp_ilu.spec_from_loader("agentic_feedback_mp_worker", loader)
+    worker_mod = _mp_ilu.module_from_spec(spec)
+    loader.exec_module(worker_mod)
+
+    worker_mod.FEEDBACK_PATH = _MpPath(feedback_path_str)
+    worker_mod.LOCK_PATH = _MpPath(lock_path_str)
+
+    rc = worker_mod.main([
+        "agentic-feedback", "append",
+        "--repo", repo, "--session-uuid", session_uuid, "--file", batch_path_str,
+    ])
+    _mp_sys.exit(rc)
 
 
 def _patch_paths(tmp_path: Path):
@@ -304,6 +356,108 @@ def test_two_sequential_appends_both_land_under_shared_lock():
         print("PASS test_two_sequential_appends_both_land_under_shared_lock")
 
 
+def test_concurrent_appends_serialize_under_real_multiprocess_contention():
+    """(9) genuine concurrency: N multiprocessing.Process workers each append
+    many records to the SAME store at once. Asserts on COUNT and JSON-validity
+    only (no timing/ordering assertions - deterministic and robust):
+      (a) the final file has exactly the expected total line count, and
+      (b) every line parses as valid JSON (no torn/interleaved half-lines).
+    A version with the fcntl lock removed would be expected to drop and/or
+    interleave lines under this contention - this test proves the lock
+    actually serializes writers, unlike a sequential-call test."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path = tmp_path / "feedback.jsonl"
+        lock_path = tmp_path / "feedback.jsonl.lock"
+
+        n_workers = 4
+        n_per_worker = 25
+        procs = []
+        for w in range(n_workers):
+            drafts = [
+                dict(VALID_DRAFT, evidence=f"worker {w} item {i}")
+                for i in range(n_per_worker)
+            ]
+            batch_path = tmp_path / f"batch-{w}.json"
+            batch_path.write_text(json.dumps(drafts), encoding="utf-8")
+            p = multiprocessing.Process(
+                target=_mp_append_worker,
+                args=(
+                    str(_BIN_PATH), str(feedback_path), str(lock_path),
+                    f"/repo/{w}", f"sess-{w}", str(batch_path),
+                ),
+            )
+            procs.append(p)
+
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=60)
+
+        for w, p in enumerate(procs):
+            assert p.exitcode == 0, f"worker {w} exited with {p.exitcode!r} (expected 0)"
+
+        assert feedback_path.is_file(), "store file must exist after concurrent appends"
+        lines = [ln for ln in feedback_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+        expected_total = n_workers * n_per_worker
+        assert len(lines) == expected_total, (
+            f"Expected exactly {expected_total} lines under lock-serialized "
+            f"contention, got {len(lines)} (a lost/torn write indicates the "
+            f"lock did not serialize the workers)"
+        )
+
+        # Every line must be valid, non-torn JSON - json.loads raises on a
+        # half-written/interleaved line, which a missing lock could produce.
+        ids = set()
+        for line in lines:
+            row = json.loads(line)
+            ids.add(row["id"])
+        assert len(ids) == expected_total, (
+            "every appended item must get a distinct id (no duplicate/corrupted rows)"
+        )
+
+        print("PASS test_concurrent_appends_serialize_under_real_multiprocess_contention")
+
+
+def test_mark_warns_on_malformed_line_and_drops_it():
+    """(10) mark's rewrite prints a stderr warning naming the line number of a
+    malformed line it drops - visibility for what would otherwise be a
+    silent, destructive skip during the full-file rewrite."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        batch_path = _write_batch(tmp_path, [dict(VALID_DRAFT, evidence="good item")])
+        rc, _, _ = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0
+
+        good_line = feedback_path.read_text(encoding="utf-8").rstrip("\n")
+        good_id = json.loads(good_line)["id"]
+
+        # Hand-corrupt the store: append a malformed (non-JSON) line at line 2.
+        with open(feedback_path, "a", encoding="utf-8") as f:
+            f.write("{this is not valid json\n")
+
+        rc, out, err = _run(["mark", "--id", good_id, "--status", "triaged"])
+        assert rc == 0, f"mark should still succeed despite a malformed line: {err}"
+        assert "skipping malformed line 2" in err, (
+            f"Expected a stderr warning naming line 2, got: {err!r}"
+        )
+
+        remaining_lines = [
+            ln for ln in feedback_path.read_text(encoding="utf-8").splitlines() if ln.strip()
+        ]
+        assert len(remaining_lines) == 1, "malformed line must be dropped from the rewrite"
+        row = json.loads(remaining_lines[0])
+        assert row["id"] == good_id
+        assert row["status"] == "triaged"
+
+        print("PASS test_mark_warns_on_malformed_line_and_drops_it")
+
+
 if __name__ == "__main__":
     test_append_valid_and_invalid_mixed()
     test_append_overwrites_caller_supplied_id_ts_status()
@@ -313,4 +467,6 @@ if __name__ == "__main__":
     test_mark_updates_only_target_status()
     test_mark_unknown_id_exits_1_and_leaves_file_unchanged()
     test_two_sequential_appends_both_land_under_shared_lock()
+    test_concurrent_appends_serialize_under_real_multiprocess_contention()
+    test_mark_warns_on_malformed_line_and_drops_it()
     print("All tests passed.")

--- a/bin/tests/test_agentic_feedback.py
+++ b/bin/tests/test_agentic_feedback.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Tests for agentic-feedback: home-dir feedback store CLI.
+
+Test groups:
+  1. test_append_valid_and_invalid_mixed - append writes valid items and
+     skips invalid ones (count + stderr warning).
+  2. test_append_overwrites_caller_supplied_id_ts_status - a draft that tries
+     to supply id/ts/status is ignored; the CLI-assigned values win (m4).
+  3. test_append_empty_array_is_clean_noop - empty --file array is a no-op
+     (exit 0, store file untouched/absent).
+  4. test_list_filters_by_scope_and_status - list applies --scope/--status
+     filters correctly.
+  5. test_list_missing_file_returns_empty_array - list on an absent store
+     prints "[]" and returns 0.
+  6. test_mark_updates_only_target_status - mark changes only the matching
+     line's status; all other fields byte-identical.
+  7. test_mark_unknown_id_exits_1_and_leaves_file_unchanged - mark on an
+     unknown --id exits 1 and does not modify the store.
+  8. test_two_sequential_appends_both_land_under_shared_lock - two
+     sequential append calls (simulating two projects' /wrap runs) both
+     land intact; final file is the union of valid items, one line each.
+
+Regression test obligation: content/references/regression-test-obligation.md
+Run with: python3 -m pytest bin/tests/test_agentic_feedback.py -x
+       or: python3 bin/tests/test_agentic_feedback.py
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load agentic-feedback as a module (no .py extension)
+# ---------------------------------------------------------------------------
+_BIN_PATH = Path(__file__).parent.parent / "agentic-feedback"
+_loader = importlib.machinery.SourceFileLoader("agentic_feedback", str(_BIN_PATH))
+_spec = importlib.util.spec_from_loader("agentic_feedback", _loader)
+if _spec is None:
+    raise RuntimeError(f"Cannot build spec for agentic-feedback from {_BIN_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+main = _mod.main
+
+
+def _patch_paths(tmp_path: Path):
+    """Patch module-level FEEDBACK_PATH/LOCK_PATH to a per-test tmp dir.
+
+    Returns (feedback_path, lock_path). Never touches the developer's real
+    ~/.agentic/feedback.jsonl.
+    """
+    feedback_path = tmp_path / "feedback.jsonl"
+    lock_path = tmp_path / "feedback.jsonl.lock"
+    _mod.FEEDBACK_PATH = feedback_path
+    _mod.LOCK_PATH = lock_path
+    return feedback_path, lock_path
+
+
+def _write_batch(tmp_path: Path, drafts: list) -> Path:
+    batch_path = tmp_path / "batch.json"
+    batch_path.write_text(json.dumps(drafts), encoding="utf-8")
+    return batch_path
+
+
+def _run(argv: list[str]) -> tuple[int, str, str]:
+    """Invoke main() capturing stdout/stderr. Returns (rc, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(["agentic-feedback"] + argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+VALID_DRAFT = {
+    "scope": "project",
+    "severity": "medium",
+    "category": "tool-friction",
+    "evidence": "curl failed in sandbox 3 times",
+    "suggested_title": "curl blocked in sandbox",
+    "suggested_body": "sandbox blocks curl; use ctx_execute instead",
+}
+
+
+def test_append_valid_and_invalid_mixed():
+    """(1) append writes valid items and skips invalid ones."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        drafts = [
+            dict(VALID_DRAFT),
+            {"scope": "bogus-scope", "severity": "medium", "category": "tool-friction",
+             "evidence": "x", "suggested_title": "y", "suggested_body": "z"},
+            {"scope": "project", "severity": "medium", "category": "tool-friction",
+             "evidence": "", "suggested_title": "y", "suggested_body": "z"},
+        ]
+        batch_path = _write_batch(tmp_path, drafts)
+
+        rc, out, err = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0, f"Expected exit 0, got {rc}. stderr={err}"
+        assert "Appended 1" in out, f"Expected 1 appended, got: {out}"
+        assert "skipping draft" in err, f"Expected skip warnings on stderr, got: {err}"
+
+        lines = [l for l in feedback_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1, f"Expected 1 line written, got {len(lines)}"
+
+        print("PASS test_append_valid_and_invalid_mixed")
+
+
+def test_append_overwrites_caller_supplied_id_ts_status():
+    """(2) [m4] id/ts/status in a draft are ignored; CLI-assigned values win."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        malicious_draft = dict(VALID_DRAFT)
+        malicious_draft["id"] = "attacker-supplied-id"
+        malicious_draft["ts"] = "1999-01-01T00:00:00Z"
+        malicious_draft["status"] = "dismissed"
+        batch_path = _write_batch(tmp_path, [malicious_draft])
+
+        rc, out, err = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0, f"Expected exit 0, got {rc}. stderr={err}"
+
+        lines = [l for l in feedback_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["id"] != "attacker-supplied-id", "id must be CLI-assigned, not caller-supplied"
+        assert row["ts"] != "1999-01-01T00:00:00Z", "ts must be CLI-assigned, not caller-supplied"
+        assert row["status"] == "open", f"status must always be 'open' on append, got {row['status']!r}"
+
+        print("PASS test_append_overwrites_caller_supplied_id_ts_status")
+
+
+def test_append_empty_array_is_clean_noop():
+    """(3) empty-array append is a clean no-op (exit 0, no file corruption)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        batch_path = _write_batch(tmp_path, [])
+
+        rc, out, err = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0, f"Expected exit 0 on empty batch, got {rc}. stderr={err}"
+        assert not feedback_path.exists(), "Empty batch must not create the store file"
+
+        print("PASS test_append_empty_array_is_clean_noop")
+
+
+def test_list_filters_by_scope_and_status():
+    """(4) list filters by --scope and --status."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        _patch_paths(tmp_path)
+
+        drafts = [
+            dict(VALID_DRAFT, scope="project", severity="high"),
+            dict(VALID_DRAFT, scope="methodology", severity="low"),
+        ]
+        batch_path = _write_batch(tmp_path, drafts)
+        rc, _, _ = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0
+
+        rc, out, _ = _run(["list", "--scope", "project"])
+        assert rc == 0
+        rows = json.loads(out)
+        assert len(rows) == 1 and rows[0]["scope"] == "project"
+
+        # mark one item triaged, then filter by status
+        target_id = rows[0]["id"]
+        rc, _, _ = _run(["mark", "--id", target_id, "--status", "triaged"])
+        assert rc == 0
+
+        rc, out, _ = _run(["list", "--status", "triaged"])
+        assert rc == 0
+        rows = json.loads(out)
+        assert len(rows) == 1 and rows[0]["id"] == target_id
+
+        rc, out, _ = _run(["list", "--status", "open"])
+        assert rc == 0
+        rows = json.loads(out)
+        assert len(rows) == 1 and rows[0]["scope"] == "methodology"
+
+        print("PASS test_list_filters_by_scope_and_status")
+
+
+def test_list_missing_file_returns_empty_array():
+    """(5) list on an absent store prints '[]' and returns 0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        _patch_paths(tmp_path)
+
+        rc, out, _ = _run(["list"])
+        assert rc == 0
+        assert json.loads(out) == []
+
+        print("PASS test_list_missing_file_returns_empty_array")
+
+
+def test_mark_updates_only_target_status():
+    """(6) mark changes only the matching line's status; all else byte-identical."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        drafts = [dict(VALID_DRAFT, evidence="item A"), dict(VALID_DRAFT, evidence="item B")]
+        batch_path = _write_batch(tmp_path, drafts)
+        rc, _, _ = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0
+
+        before_lines = [json.loads(l) for l in feedback_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        target = next(r for r in before_lines if r["evidence"] == "item A")
+        other = next(r for r in before_lines if r["evidence"] == "item B")
+
+        rc, out, _ = _run(["mark", "--id", target["id"], "--status", "dismissed"])
+        assert rc == 0, out
+
+        after_lines = [json.loads(l) for l in feedback_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        after_target = next(r for r in after_lines if r["id"] == target["id"])
+        after_other = next(r for r in after_lines if r["id"] == other["id"])
+
+        assert after_target["status"] == "dismissed"
+        for key in target:
+            if key == "status":
+                continue
+            assert after_target[key] == target[key], f"field {key!r} changed unexpectedly"
+
+        assert after_other == other, "non-target row must be byte-identical (field-for-field)"
+
+        print("PASS test_mark_updates_only_target_status")
+
+
+def test_mark_unknown_id_exits_1_and_leaves_file_unchanged():
+    """(7) mark on unknown --id exits 1 and does not modify the store."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        batch_path = _write_batch(tmp_path, [dict(VALID_DRAFT)])
+        rc, _, _ = _run([
+            "append", "--repo", "/repo/x", "--session-uuid", "s1", "--file", str(batch_path),
+        ])
+        assert rc == 0
+
+        before = feedback_path.read_text(encoding="utf-8")
+
+        rc, out, err = _run(["mark", "--id", "not-a-real-id", "--status", "dismissed"])
+        assert rc == 1, f"Expected exit 1 for unknown id, got {rc}"
+        assert "no feedback item" in err.lower()
+
+        after = feedback_path.read_text(encoding="utf-8")
+        assert before == after, "File must be unchanged after a failed mark"
+
+        print("PASS test_mark_unknown_id_exits_1_and_leaves_file_unchanged")
+
+
+def test_two_sequential_appends_both_land_under_shared_lock():
+    """(8) two sequential appends (simulating two projects' /wrap runs) both land
+    intact - final file is the union of valid items, one well-formed line each."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        feedback_path, _ = _patch_paths(tmp_path)
+
+        batch1 = _write_batch(tmp_path, [dict(VALID_DRAFT, evidence="repo-a item")])
+        rc1, _, _ = _run([
+            "append", "--repo", "/repo/a", "--session-uuid", "sess-a", "--file", str(batch1),
+        ])
+        assert rc1 == 0
+
+        batch2 = _write_batch(tmp_path, [dict(VALID_DRAFT, evidence="repo-b item")])
+        rc2, _, _ = _run([
+            "append", "--repo", "/repo/b", "--session-uuid", "sess-b", "--file", str(batch2),
+        ])
+        assert rc2 == 0
+
+        lines = [l for l in feedback_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 2, f"Expected 2 lines (union of both appends), got {len(lines)}"
+
+        rows = [json.loads(l) for l in lines]
+        evidences = {r["evidence"] for r in rows}
+        assert evidences == {"repo-a item", "repo-b item"}
+        repos = {r["repo"] for r in rows}
+        assert repos == {"/repo/a", "/repo/b"}
+        # Each line individually well-formed JSON (already implied by json.loads above).
+        ids = {r["id"] for r in rows}
+        assert len(ids) == 2, "Each appended item must get a distinct id"
+
+        print("PASS test_two_sequential_appends_both_land_under_shared_lock")
+
+
+if __name__ == "__main__":
+    test_append_valid_and_invalid_mixed()
+    test_append_overwrites_caller_supplied_id_ts_status()
+    test_append_empty_array_is_clean_noop()
+    test_list_filters_by_scope_and_status()
+    test_list_missing_file_returns_empty_array()
+    test_mark_updates_only_target_status()
+    test_mark_unknown_id_exits_1_and_leaves_file_unchanged()
+    test_two_sequential_appends_both_land_under_shared_lock()
+    print("All tests passed.")


### PR DESCRIPTION
## Summary
Adds `bin/agentic-feedback`, a Python-3-stdlib CLI managing a home-dir feedback store (`~/.agentic/feedback.jsonl`) for auto-detected session-friction signals, plus its regression suite and a `bin/AGENTS.md` doc-sync. Unit 1 of 4 for DS-56 slice 1 (end-of-session feedback capture).

- `append --repo --session-uuid --file <batch.json>`: validates each draft (scope/severity/category enums + non-empty evidence/title/body), per-item soft-fails invalid drafts, and always CLI-assigns `id`/`ts`/`status` (caller-supplied values for those three ignored).
- `list [--scope] [--status] [--repo]`: filters the store; absent file prints `[]`, exit 0.
- `mark --id --status`: `atomic_write` rewrite touching only the target line's status; unknown id exits 1 leaving the file unchanged; warns to stderr on any malformed line dropped during rewrite.
- All three subcommands serialize on a single exclusive lock (mkdir+touch bootstrap before `acquire_exclusive_lock`, mirroring `agentic-identity`) so concurrent `/wrap` runs across projects cannot race.

Skeptic-reviewed (concurrency/data-integrity brief): 0 Critical/Major, 3 Minors folded in (real multiprocess-contention test, `mark` malformed-line stderr visibility, docstring nuance).

## Jira
Part of DS-56.

## Test plan
- [x] `python3 -m pytest bin/tests/test_agentic_feedback.py -x` - 10/10 pass (incl. real multiprocessing contention test)
- [x] HOME-isolated end-to-end smoke (append -> list -> mark -> list); real `~/.agentic/feedback.jsonl` confirmed untouched
- [x] `ruff check bin/agentic-feedback` - only the pre-existing import-shim finding shared with `bin/agentic-identity`
