### PR TITLE
DS-56: resolve _lib through PATH symlink for agentic-feedback

### DIFF
--- a/bin/agentic-feedback
+++ b/bin/agentic-feedback
@@ -95,11 +95,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-feedback ->
+# repo bin/agentic-feedback, as created by install.sh) back to the real
+# bin/ directory so _lib.py is found on a bare `agentic-feedback` invocation.
 import sys as _sys
 import importlib.util as _ilu
 import importlib.machinery as _ilm
 
-_LIB_PATH = Path(__file__).parent / "_lib.py"
+_LIB_PATH = Path(__file__).resolve().parent / "_lib.py"
 if "_lib" in _sys.modules:
     _lib_mod = _sys.modules["_lib"]
 else:

--- a/bin/tests/test_agentic_feedback.py
+++ b/bin/tests/test_agentic_feedback.py
@@ -29,6 +29,11 @@ Test groups:
   10. test_mark_warns_on_malformed_line_and_drops_it - mark's rewrite
       prints a stderr warning naming the line number of a malformed line
       it drops (visibility for a destructive silent skip).
+  11. test_cli_runs_through_path_symlink_resolving_lib - regression guard
+      for the install.sh PATH-symlink invocation path: invokes the CLI as
+      a subprocess through a symlink (mimicking ~/.local/bin/agentic-feedback
+      -> repo bin/agentic-feedback) and asserts it can still locate and
+      load bin/_lib.py rather than raising FileNotFoundError.
 
 Regression test obligation: content/references/regression-test-obligation.md
 Run with: python3 -m pytest bin/tests/test_agentic_feedback.py -x
@@ -41,6 +46,8 @@ import importlib.util
 import io
 import json
 import multiprocessing
+import os
+import subprocess
 import sys
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
@@ -263,6 +270,52 @@ def test_list_missing_file_returns_empty_array():
         print("PASS test_list_missing_file_returns_empty_array")
 
 
+def test_cli_runs_through_path_symlink_resolving_lib():
+    """(11) Regression guard for the install.sh PATH-symlink invocation path.
+
+    install.sh symlinks ~/.local/bin/agentic-feedback -> repo bin/agentic-feedback
+    but never symlinks _lib.py alongside it. When Python resolves __file__ for a
+    symlinked entrypoint it reports the SYMLINK's path, so `Path(__file__).parent`
+    lands in ~/.local/bin/ where _lib.py does not exist. Must invoke via a real
+    subprocess THROUGH the symlink (not an in-process import) because the bug
+    only manifests when the OS/interpreter actually resolves __file__ to a
+    symlink path, which in-process importlib loading (as used by _run() above)
+    never exercises.
+    """
+    real_bin_path = Path(__file__).parent.parent / "agentic-feedback"
+    assert real_bin_path.is_file(), f"expected real CLI at {real_bin_path}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_local_bin = tmp_path / "local-bin"
+        fake_local_bin.mkdir()
+        symlink_path = fake_local_bin / "agentic-feedback"
+        os.symlink(real_bin_path.resolve(), symlink_path)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        env = dict(os.environ)
+        env["HOME"] = str(fake_home)
+
+        result = subprocess.run(
+            [str(symlink_path), "list"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"CLI invoked through PATH symlink failed (rc={result.returncode}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert json.loads(result.stdout.strip()) == []
+        assert "FileNotFoundError" not in result.stderr
+
+        print("PASS test_cli_runs_through_path_symlink_resolving_lib")
+
+
 def test_mark_updates_only_target_status():
     """(6) mark changes only the matching line's status; all else byte-identical."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -464,6 +517,7 @@ if __name__ == "__main__":
     test_append_empty_array_is_clean_noop()
     test_list_filters_by_scope_and_status()
     test_list_missing_file_returns_empty_array()
+    test_cli_runs_through_path_symlink_resolving_lib()
     test_mark_updates_only_target_status()
     test_mark_unknown_id_exits_1_and_leaves_file_unchanged()
     test_two_sequential_appends_both_land_under_shared_lock()


### PR DESCRIPTION
## Summary
Fixes `bin/agentic-feedback` so it works when invoked as a bare `agentic-feedback` command through its `~/.local/bin` PATH symlink.

The `_lib.py` loader shim used `Path(__file__).parent`, which resolves to the symlink's own directory (`~/.local/bin`) where `_lib.py` does not exist (`install.sh` symlinks only `agentic-*`). Fix: `Path(__file__).resolve().parent` follows the symlink to the real repo `bin/`. No-op when not symlinked.

Without this, `/wrap` Part D.5's `agentic-feedback append` shell-out would silently no-op (the feature captures nothing on real installs).

- Adds `test_cli_runs_through_path_symlink_resolving_lib`: real `os.symlink` + `subprocess.run` through the symlink, asserts exit 0 + `[]`. Confirmed to fail with the exact `FileNotFoundError` when the fix is reverted (teeth verified).

Note: the same latent bug affects every other `_lib`-dependent bin (`agentic-identity`, etc.), masked because their call sites soft-fail. Tracked separately as DS-66.

## Jira
Part of DS-56.

## Test plan
- [x] `python3 -m pytest bin/tests/test_agentic_feedback.py -x` - 11/11 pass
- [x] Regression test fails when fix reverted (non-vacuous)
