### PR TITLE
DS-56: add /feedback-triage to command indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ See [ADAPTERS.md](ADAPTERS.md) for how to create adapters for other tools.
 **Agents** (18) - named specialist roles:
 adr-drift-detector, adr-generator, architect, debugger, dependency-auditor, engineer, goal-condition-evaluator, investigator, learning-extractor, learnings-agent, orchestration-planner, perf-analyst, product-discovery, qa-engineer, release-orchestrator, security-auditor, skeptic, wrap-ticket
 
-**Commands** (19) - workflow shortcuts:
-agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`), agentic-disable, agentic-help (static, zero-token command reference listing every slash command), agentic-identity, agentic-status, brief, cleanup-worktrees, implement-ticket, init-project, memory-update, migrate-project, prune-harness, pull-and-install, representation-audit, skeptic, test-suite-comprehension, ticket-status-sync, update-agentic-engineering, wrap
+**Commands** (20) - workflow shortcuts:
+agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`), agentic-disable, agentic-help (static, zero-token command reference listing every slash command), agentic-identity, agentic-status, brief, cleanup-worktrees, feedback-triage (triage captured session friction from `~/.agentic/feedback.jsonl` into tracker tickets), implement-ticket, init-project, memory-update, migrate-project, prune-harness, pull-and-install, representation-audit, skeptic, test-suite-comprehension, ticket-status-sync, update-agentic-engineering, wrap
 
 **Hooks / Plugins** - lifecycle event handlers for risk reminders and session context saving. Claude Code uses native hooks; OpenCode uses a plugin that writes session context when the session becomes idle.
 

--- a/bin/agentic-help
+++ b/bin/agentic-help
@@ -53,6 +53,7 @@ Maintain & curate
   /migrate-project             Apply scaffolding migrations to bring a project up to the current manifest version.
   /cleanup-worktrees           Remove stale subagent and feature worktrees.
   /ticket-status-sync          Reconcile a tracker column with the real PR/branch state.
+  /feedback-triage             Triage captured session friction (~/.agentic/feedback.jsonl) into tracker tickets.
 
 Audit & improve the methodology
   /prune-harness               Propose deletions of rules that are not earning their keep.

--- a/docs/components.md
+++ b/docs/components.md
@@ -40,8 +40,8 @@
 **Agents** (18) - named specialist roles:
 adr-drift-detector, adr-generator, architect, debugger, dependency-auditor, engineer, goal-condition-evaluator, investigator, learning-extractor, learnings-agent, orchestration-planner, perf-analyst, product-discovery, qa-engineer, release-orchestrator, security-auditor, skeptic, wrap-ticket
 
-**Commands** (23) - workflow shortcuts:
-agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`), agentic-disable, agentic-help (static, zero-token command reference listing every slash command), agentic-identity, agentic-status, brief, cleanup-worktrees, configure-team, implement-ticket, init-project, memory-update, migrate-project, prune-harness, pull-and-install, representation-audit, skeptic, skill-candidates, test-suite-comprehension, ticket-status-sync, ticket-triage (batch planner: dependency analysis, lane distribution, paste-ready kickoff prompts; plan-only, no tracker writes), update-agentic-engineering, wrap, wrap-deferred
+**Commands** (24) - workflow shortcuts:
+agentic-cost (token / wall-time rollups from `.agentic/events.jsonl`; opt-in pricing via `~/.agentic/pricing.yml`), agentic-disable, agentic-help (static, zero-token command reference listing every slash command), agentic-identity, agentic-status, brief, cleanup-worktrees, configure-team, feedback-triage (triage captured session friction from `~/.agentic/feedback.jsonl` into tracker tickets), implement-ticket, init-project, memory-update, migrate-project, prune-harness, pull-and-install, representation-audit, skeptic, skill-candidates, test-suite-comprehension, ticket-status-sync, ticket-triage (batch planner: dependency analysis, lane distribution, paste-ready kickoff prompts; plan-only, no tracker writes), update-agentic-engineering, wrap, wrap-deferred
 
 **Hooks / Plugins** - lifecycle event handlers for risk reminders and session context saving. Claude Code uses native hooks; OpenCode uses a plugin that writes session context when the session becomes idle.
 


### PR DESCRIPTION
## Summary
Final unit of DS-56 slice 1: adds `/feedback-triage` to the three hand-maintained command inventories that the adapter build does not auto-generate.

- `bin/agentic-help` - new line under "Maintain & curate".
- `docs/components.md` - added to the Commands list (count 23 -> 24).
- `README.md` - added to the Commands list (count 19 -> 20).

Skeptic-verified: counts match the actual list lengths, description is consistent across all three and with the merged `content/commands/feedback-triage.md`, help tests pass. A broader pre-existing staleness in `docs/index.html` and `CONTRIBUTING.md` command enumerations (unrelated to this change) was found and left for a separate follow-up.

## Jira
Part of DS-56.

## Test plan
- [x] `python3 bin/tests/test_agentic_help.py` - 5/5 pass
- [x] Counts verified against committed list lengths
- [ ] CI
