### PR TITLE
DS-66: resolve _lib and sibling paths through PATH symlinks (5 bins)

### DIFF
--- a/bin/agentic-config
+++ b/bin/agentic-config
@@ -50,7 +50,11 @@ from pathlib import Path
 # (same pattern as bin/tests/test_agentic_status.py:23-42)
 # ---------------------------------------------------------------------------
 
-_BIN_DIR = Path(__file__).parent
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-config ->
+# repo bin/agentic-config, as created by install.sh) back to the real bin/
+# directory so both agentic-status and _lib.py are found on a bare
+# `agentic-config` invocation.
+_BIN_DIR = Path(__file__).resolve().parent
 
 _STATUS_PATH = _BIN_DIR / "agentic-status"
 _status_loader = importlib.machinery.SourceFileLoader("agentic_status", str(_STATUS_PATH))

--- a/bin/agentic-configure
+++ b/bin/agentic-configure
@@ -44,10 +44,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-# _role_spec lives in the same bin/ directory (no .py extension peer)
+# _role_spec lives in the same bin/ directory (no .py extension peer).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-configure ->
+# repo bin/agentic-configure, as created by install.sh) back to the real
+# bin/ directory so _role_spec.py is found on a bare `agentic-configure`
+# invocation.
 import importlib.machinery as _im
 import importlib.util as _ilu
-_rs_path = Path(__file__).parent / "_role_spec.py"
+_rs_path = Path(__file__).resolve().parent / "_role_spec.py"
 _rs_loader = _im.SourceFileLoader("_role_spec", str(_rs_path))
 _rs_spec = _ilu.spec_from_loader("_role_spec", _rs_loader)
 _rs_mod = _ilu.module_from_spec(_rs_spec)  # type: ignore[arg-type]
@@ -131,7 +135,9 @@ def _models_suggestions(models_csv: str) -> dict:
     Returns a suggestions dict (same shape as _gather_roles expects) or {}
     on any failure. Non-fatal: callers fall back to sonnet defaults.
     """
-    agentic_models = Path(__file__).parent / "agentic-models"
+    # .resolve() follows a PATH symlink back to the real bin/ directory so
+    # the sibling agentic-models binary is found on a bare invocation.
+    agentic_models = Path(__file__).resolve().parent / "agentic-models"
     if not agentic_models.is_file():
         return {}
     model_list = [m.strip() for m in models_csv.split(",") if m.strip()]
@@ -197,8 +203,10 @@ def _cmd_team(argv: list[str]) -> int:
 
     Resolves agentic-team as a sibling binary in the same bin/ directory.
     Both binaries must be 0755 co-located (standard install layout).
+    .resolve() follows a PATH symlink back to the real bin/ directory so
+    the sibling agentic-team binary is found on a bare invocation.
     """
-    agentic_team = Path(__file__).parent / "agentic-team"
+    agentic_team = Path(__file__).resolve().parent / "agentic-team"
     if not agentic_team.is_file():
         print(
             "agentic-configure team: agentic-team binary not found at "

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -76,11 +76,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-identity ->
+# repo bin/agentic-identity, as created by install.sh) back to the real
+# bin/ directory so _lib.py is found on a bare `agentic-identity` invocation.
 import sys as _sys
 import importlib.util as _ilu
 import importlib.machinery as _ilm
 
-_LIB_PATH = Path(__file__).parent / "_lib.py"
+_LIB_PATH = Path(__file__).resolve().parent / "_lib.py"
 if "_lib" in _sys.modules:
     _lib_mod = _sys.modules["_lib"]
 else:

--- a/bin/agentic-migrate
+++ b/bin/agentic-migrate
@@ -35,9 +35,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-migrate ->
+# repo bin/agentic-migrate, as created by install.sh) back to the real
+# bin/ directory so _lib.py is found on a bare `agentic-migrate` invocation.
 import sys as _sys
 
-_LIB_PATH = Path(__file__).parent / "_lib.py"
+_LIB_PATH = Path(__file__).resolve().parent / "_lib.py"
 if "_lib" in _sys.modules:
     _lib_mod = _sys.modules["_lib"]
 else:

--- a/bin/agentic-team
+++ b/bin/agentic-team
@@ -83,9 +83,12 @@ except ImportError:
     _HAVE_YAML = False
 
 # ---------------------------------------------------------------------------
-# Load _role_spec from the same bin/ directory (no .py extension sibling)
+# Load _role_spec from the same bin/ directory (no .py extension sibling).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/agentic-team ->
+# repo bin/agentic-team, as created by install.sh) back to the real bin/
+# directory so _role_spec.py is found on a bare `agentic-team` invocation.
 # ---------------------------------------------------------------------------
-_rs_path = Path(__file__).parent / "_role_spec.py"
+_rs_path = Path(__file__).resolve().parent / "_role_spec.py"
 _rs_loader = _im.SourceFileLoader("_role_spec", str(_rs_path))
 _rs_spec = _ilu.spec_from_loader("_role_spec", _rs_loader)
 _rs_mod = _ilu.module_from_spec(_rs_spec)  # type: ignore[arg-type]

--- a/bin/tests/test_bin_symlink_resolution.py
+++ b/bin/tests/test_bin_symlink_resolution.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """
 Shared regression guard (DS-66) for the install.sh PATH-symlink invocation
-path, across every `_lib.py`-dependent python CLI in bin/.
+path, across every python CLI in bin/ that resolves a sibling file or
+sibling binary (bin/_lib.py, bin/_role_spec.py, or another bin/agentic-*
+binary) relative to its own __file__.
 
 install.sh symlinks bin/agentic-* into ~/.local/bin but never symlinks
-_lib.py alongside them. When Python resolves __file__ for a symlinked
+their sibling dependencies (_lib.py, _role_spec.py, other bin/agentic-*
+binaries) alongside them. When Python resolves __file__ for a symlinked
 entrypoint it reports the SYMLINK's path, so a bare `Path(__file__).parent`
-sibling-file lookup lands in ~/.local/bin/ where _lib.py (and, for
-agentic-config, the sibling agentic-status binary) does not exist -
-raising FileNotFoundError at import time, before argument parsing even
-runs. The fix is `Path(__file__).resolve().parent`, which follows the
+sibling-file lookup lands in ~/.local/bin/ where the sibling does not
+exist - raising FileNotFoundError at import time, before argument parsing
+even runs (or, for agentic-configure's --models/team subcommands, at first
+use). The fix is `Path(__file__).resolve().parent`, which follows the
 symlink back to the real bin/ directory (a no-op when not symlinked).
 
 This must be exercised via a real subprocess THROUGH an os.symlink (not an
@@ -18,14 +21,14 @@ actually resolves __file__ to a symlink path - in-process importlib loading
 never exercises it.
 
 `--help` is used as the invocation because argparse imports the module
-(where the _lib shim runs at module scope) before printing usage and
-exiting - exercising the exact bug surface with zero side effects. Note
-bin/agentic-config is a hand-rolled parser (not argparse) that treats
-`--help` as an unrecognized positional and exits 2 with a clean usage
-message - which is fine, since the shim still runs at import time and
-still needs to be verified clean of the symlink-resolution bug; its
-expected exit code is captured separately below rather than assuming 0
-for every CLI.
+(where the sibling-resolution shim runs at module scope) before printing
+usage and exiting - exercising the exact bug surface with zero side
+effects. Note bin/agentic-config is a hand-rolled parser (not argparse)
+that treats `--help` as an unrecognized positional and exits 2 with a
+clean usage message - which is fine, since the shim still runs at import
+time and still needs to be verified clean of the symlink-resolution bug;
+its expected exit code is captured separately below rather than assuming
+0 for every CLI.
 
 Run with: python3 -m pytest bin/tests/test_bin_symlink_resolution.py -x
 """
@@ -44,12 +47,14 @@ REPO_BIN = Path(__file__).resolve().parent.parent
 # (cli name, args, expected exit code)
 # agentic-config has no argparse --help; its hand-rolled parser treats
 # --help as an unrecognized positional and exits 2 with a usage message.
-# The other three are argparse-based and exit 0 on --help.
+# The rest are argparse-based and exit 0 on --help.
 CASES = [
     ("agentic-identity", ["--help"], 0),
     ("agentic-migrate", ["--help"], 0),
     ("agentic-config", ["--help"], 2),
     ("agentic-feedback", ["--help"], 0),
+    ("agentic-configure", ["--help"], 0),
+    ("agentic-team", ["--help"], 0),
 ]
 
 

--- a/bin/tests/test_bin_symlink_resolution.py
+++ b/bin/tests/test_bin_symlink_resolution.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Shared regression guard (DS-66) for the install.sh PATH-symlink invocation
+path, across every `_lib.py`-dependent python CLI in bin/.
+
+install.sh symlinks bin/agentic-* into ~/.local/bin but never symlinks
+_lib.py alongside them. When Python resolves __file__ for a symlinked
+entrypoint it reports the SYMLINK's path, so a bare `Path(__file__).parent`
+sibling-file lookup lands in ~/.local/bin/ where _lib.py (and, for
+agentic-config, the sibling agentic-status binary) does not exist -
+raising FileNotFoundError at import time, before argument parsing even
+runs. The fix is `Path(__file__).resolve().parent`, which follows the
+symlink back to the real bin/ directory (a no-op when not symlinked).
+
+This must be exercised via a real subprocess THROUGH an os.symlink (not an
+in-process import) because the bug only manifests when the OS/interpreter
+actually resolves __file__ to a symlink path - in-process importlib loading
+never exercises it.
+
+`--help` is used as the invocation because argparse imports the module
+(where the _lib shim runs at module scope) before printing usage and
+exiting - exercising the exact bug surface with zero side effects. Note
+bin/agentic-config is a hand-rolled parser (not argparse) that treats
+`--help` as an unrecognized positional and exits 2 with a clean usage
+message - which is fine, since the shim still runs at import time and
+still needs to be verified clean of the symlink-resolution bug; its
+expected exit code is captured separately below rather than assuming 0
+for every CLI.
+
+Run with: python3 -m pytest bin/tests/test_bin_symlink_resolution.py -x
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_BIN = Path(__file__).resolve().parent.parent
+
+# (cli name, args, expected exit code)
+# agentic-config has no argparse --help; its hand-rolled parser treats
+# --help as an unrecognized positional and exits 2 with a usage message.
+# The other three are argparse-based and exit 0 on --help.
+CASES = [
+    ("agentic-identity", ["--help"], 0),
+    ("agentic-migrate", ["--help"], 0),
+    ("agentic-config", ["--help"], 2),
+    ("agentic-feedback", ["--help"], 0),
+]
+
+
+@pytest.mark.parametrize("cli_name,args,expected_rc", CASES)
+def test_cli_runs_through_path_symlink(cli_name: str, args: list[str], expected_rc: int) -> None:
+    real_bin_path = REPO_BIN / cli_name
+    assert real_bin_path.is_file(), f"expected real CLI at {real_bin_path}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_local_bin = tmp_path / "local-bin"
+        fake_local_bin.mkdir()
+        symlink_path = fake_local_bin / cli_name
+        os.symlink(real_bin_path.resolve(), symlink_path)
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        env = dict(os.environ)
+        env["HOME"] = str(fake_home)
+
+        result = subprocess.run(
+            [str(symlink_path), *args],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == expected_rc, (
+            f"{cli_name} invoked through PATH symlink returned unexpected "
+            f"rc={result.returncode} (expected {expected_rc}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "_lib.py" not in result.stderr, (
+            f"{cli_name}: _lib.py sibling-resolution failure through symlink: "
+            f"stderr={result.stderr!r}"
+        )
+        assert "FileNotFoundError" not in result.stderr, (
+            f"{cli_name}: FileNotFoundError through symlink invocation: "
+            f"stderr={result.stderr!r}"
+        )
+        assert "Traceback" not in result.stderr, (
+            f"{cli_name}: unhandled traceback through symlink invocation: "
+            f"stderr={result.stderr!r}"
+        )
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, args, expected_rc in CASES:
+        try:
+            test_cli_runs_through_path_symlink(name, args, expected_rc)
+            print(f"PASS test_cli_runs_through_path_symlink[{name}]")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL test_cli_runs_through_path_symlink[{name}]: {exc}")
+    if failures:
+        raise SystemExit(1)
+    print("All tests passed.")

--- a/bin/tests/test_bin_symlink_resolution.py
+++ b/bin/tests/test_bin_symlink_resolution.py
@@ -58,23 +58,32 @@ CASES = [
 ]
 
 
-@pytest.mark.parametrize("cli_name,args,expected_rc", CASES)
-def test_cli_runs_through_path_symlink(cli_name: str, args: list[str], expected_rc: int) -> None:
+def _symlinked_cli(tmp_path: Path, cli_name: str) -> tuple[Path, dict]:
+    """Create a real os.symlink to bin/<cli_name> under an isolated fake
+    ~/.local/bin, plus an isolated-HOME env dict - the shared setup for
+    every through-symlink invocation in this module (mirrors how
+    install.sh links bin/agentic-* into ~/.local/bin)."""
     real_bin_path = REPO_BIN / cli_name
     assert real_bin_path.is_file(), f"expected real CLI at {real_bin_path}"
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        fake_local_bin = tmp_path / "local-bin"
-        fake_local_bin.mkdir()
-        symlink_path = fake_local_bin / cli_name
+    fake_local_bin = tmp_path / "local-bin"
+    fake_local_bin.mkdir(exist_ok=True)
+    symlink_path = fake_local_bin / cli_name
+    if not symlink_path.exists():
         os.symlink(real_bin_path.resolve(), symlink_path)
 
-        fake_home = tmp_path / "home"
-        fake_home.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
 
-        env = dict(os.environ)
-        env["HOME"] = str(fake_home)
+    env = dict(os.environ)
+    env["HOME"] = str(fake_home)
+    return symlink_path, env
+
+
+@pytest.mark.parametrize("cli_name,args,expected_rc", CASES)
+def test_cli_runs_through_path_symlink(cli_name: str, args: list[str], expected_rc: int) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        symlink_path, env = _symlinked_cli(Path(tmp), cli_name)
 
         result = subprocess.run(
             [str(symlink_path), *args],
@@ -103,6 +112,98 @@ def test_cli_runs_through_path_symlink(cli_name: str, args: list[str], expected_
         )
 
 
+def test_agentic_configure_models_symlink_resolves_agentic_models() -> None:
+    """Regression for DS-66 line ~134 (agentic-configure._models_suggestions).
+
+    `--help` alone gives this site NO teeth: _models_suggestions is only
+    reached when --models is supplied, and its failure mode is SILENT -
+    `if not agentic_models.is_file(): return {}` - so a broken sibling
+    resolution does not raise, error, or change the exit code. It just
+    makes the CLI quietly ignore the requested --models ranking and fall
+    back to the hardcoded 'sonnet' default for every role. Asserting
+    exit 0 alone cannot distinguish "resolved the sibling and ranked
+    opus" from "silently failed to resolve it and fell back to sonnet" -
+    both exit 0. Instead assert the concrete positive signal: with
+    --models opus, the skeptic role must resolve to 'opus' (verified
+    against the unbroken CLI - see class docstring); if it silently
+    falls back it resolves to the 'sonnet' default instead.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        symlink_path, env = _symlinked_cli(tmp_path, "agentic-configure")
+        output_path = tmp_path / "role-models.yml"
+
+        result = subprocess.run(
+            [str(symlink_path), "--non-interactive", "--models", "opus", "--path", str(output_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"agentic-configure --models through symlink failed: rc={result.returncode} "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert output_path.is_file(), f"expected {output_path} to be written"
+        text = output_path.read_text()
+        assert "skeptic: opus" in text, (
+            "agentic-configure --models opus invoked through a PATH symlink silently "
+            "fell back to the sonnet default (sibling agentic-models binary not "
+            f"resolved) instead of ranking the requested model. Written YAML:\n{text}"
+        )
+
+
+def test_agentic_configure_team_symlink_resolves_agentic_team() -> None:
+    """Regression for DS-66 line ~201 (agentic-configure._cmd_team).
+
+    `--help` alone gives this site NO teeth: the `team` subcommand
+    dispatch (and its sibling agentic-team resolution) is only reached
+    via `agentic-configure team ...`. Unlike the --models case this
+    failure is NOT silent - a broken sibling resolution prints
+    "agentic-team binary not found" and exits 2 - but it is still a full
+    functional break of the team subcommand through a symlinked install
+    that a --help-only probe cannot catch. Assert successful delegation:
+    exit 0 and team.yml written with the assigned harness/model (mirrors
+    bin/tests/test_agentic_configure.py::test_configure_team_shim_delegates_to_agentic_team).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        symlink_path, env = _symlinked_cli(tmp_path, "agentic-configure")
+        output_path = tmp_path / "team.yml"
+
+        result = subprocess.run(
+            [
+                str(symlink_path), "team", "--non-interactive",
+                "--assign", "engineer=codex:gpt-5", "--path", str(output_path),
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"agentic-configure team through symlink failed: rc={result.returncode} "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "agentic-team binary not found" not in result.stderr, (
+            f"agentic-configure team: sibling agentic-team resolution failed through "
+            f"symlink: stderr={result.stderr!r}"
+        )
+        assert output_path.is_file(), f"expected {output_path} to be written"
+        text = output_path.read_text()
+        assert "harness: codex" in text and "model: gpt-5" in text, (
+            f"team.yml missing expected assignment; got:\n{text}"
+        )
+
+
+EXTRA_TESTS = [
+    test_agentic_configure_models_symlink_resolves_agentic_models,
+    test_agentic_configure_team_symlink_resolves_agentic_team,
+]
+
+
 if __name__ == "__main__":
     failures = 0
     for name, args, expected_rc in CASES:
@@ -112,6 +213,13 @@ if __name__ == "__main__":
         except AssertionError as exc:
             failures += 1
             print(f"FAIL test_cli_runs_through_path_symlink[{name}]: {exc}")
+    for t in EXTRA_TESTS:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {t.__name__}: {exc}")
     if failures:
         raise SystemExit(1)
     print("All tests passed.")


### PR DESCRIPTION
## Summary
Fixes DS-66: every `bin/` CLI that resolves a sibling file/binary via bare `Path(__file__).parent` was broken when invoked through its `~/.local/bin` PATH symlink (`install.sh` symlinks the CLIs but not their siblings, so `__file__` points at the symlink dir and the sibling isn't found). Masked everywhere by soft-failing call sites - so identity, telemetry, config, and model/team resolution were latently non-functional through bare-command invocation.

Fix: `Path(__file__).resolve().parent` (follows the symlink to the real repo `bin/`; no-op when not symlinked). `agentic-feedback` was the reference (fixed under DS-56).

**5 bins fixed, 6 sites:**
- `agentic-identity`, `agentic-migrate` - `_lib.py` loader shim
- `agentic-config` - `_BIN_DIR` (fixes both `_lib.py` and the `agentic-status` sibling in one change)
- `agentic-configure` - `_role_spec.py` load + `agentic-models` (`--models`) + `agentic-team` (`team`) sibling binaries
- `agentic-team` - `_role_spec.py` load

**Shared regression test** (`test_bin_symlink_resolution.py`): invokes each bin through a real `os.symlink` via subprocess with isolated HOME. Includes teeth for the two silent-failure sites - `agentic-configure --models` (asserts real ranking output `skeptic: opus`, not the silent `sonnet` fallback) and `team` (asserts written YAML). Every fixed site is revert-verified to fail without the fix.

## Jira
Closes DS-66. (Surfaced during DS-56.)

## Test plan
- [x] `python3 -m pytest bin/tests/ -x` - 169 pass
- [x] Teeth confirmed: reverting any of the 6 sites fails its regression case
- [x] Independent grep: zero remaining bare-`.parent` sibling resolutions in production bins
- [ ] CI
