### PR TITLE
fix(agentic-team): resolve per-role model from team.yml at dispatch

### DIFF
--- a/bin/agentic-team
+++ b/bin/agentic-team
@@ -18,7 +18,12 @@ Public API: agentic-team <discover|dispatch|status|collect|configure> [options]
                          spawn a worker (background); prints run-id to stdout.
                          --model forwarded to every harness using its own flag
                          spelling (_MODEL_FLAG_BY_HARNESS: codex/gemini -> -m,
-                         all others -> --model).
+                         all others -> --model). When --model is omitted,
+                         the model is resolved from team.yml
+                         roles[<role>].model (honoring --global-config /
+                         --project-config) IFF the role's harness (or
+                         default_harness) matches the dispatch harness;
+                         otherwise the worker uses its own session default.
             status     <run-id> [--workdir <dir>]  - running|done|failed
             collect    <run-id> [--workdir <dir>]  - final message, demuxed per harness
             configure  [--non-interactive] [--assign role=harness:model ...]
@@ -311,26 +316,42 @@ def _role_entry(spec: object) -> dict:
     return {}
 
 
-def _resolve_role_model(role: str, harness: str) -> str | None:
+def _resolve_role_model(
+    role: str,
+    harness: str,
+    global_path: Path = GLOBAL_TEAM_YML,
+    project_path: Path = PROJECT_TEAM_YML,
+) -> str | None:
     """Resolve the model for *role* from team.yml when no explicit --model.
 
-    Reads the merged global+project team.yml, looks up roles[<role>], and
-    returns its model handle ONLY when the entry's harness matches the harness
-    actually being dispatched to (so a team.yml row for a different harness
-    never leaks its model onto this dispatch). Returns None when there is no
-    team.yml, no entry, no model, or a harness mismatch -- in which case the
-    worker uses its own session default, exactly as before.
+    Reads the merged global+project team.yml (honoring any --global-config /
+    --project-config overrides threaded from main), looks up roles[<role>], and
+    returns its model handle ONLY when the role's resolved harness matches the
+    harness actually being dispatched to. The role's harness is its own entry
+    harness, else default_harness; if NEITHER is set the config is ambiguous
+    and we return None rather than forwarding the model to an arbitrary
+    harness (a team.yml row with no harness and no default_harness must not
+    leak its model). Returns None when there is no team.yml, no entry, no
+    model, or a harness mismatch/ambiguity -- the worker then uses its own
+    session default, exactly as before.
     """
     try:
-        config = _load_team_config()
-    except Exception:
+        config = _load_team_config(global_path=global_path, project_path=project_path)
+    except (OSError, ValueError, ImportError) as exc:  # narrow: I/O + parse
+        print(
+            f"agentic-team: could not load team.yml for model resolution: {exc}",
+            file=sys.stderr,
+        )
+        return None
         return None
     spec = config.get("roles", {}).get(role)
     if not spec:
         return None
     entry = _role_entry(spec)
     entry_harness = entry.get("harness") or config.get("default_harness")
-    if entry_harness and entry_harness != harness:
+    # Require a POSITIVE harness match. If the role has no harness and there is
+    # no default_harness, entry_harness is None (ambiguous) -> do not forward.
+    if entry_harness != harness:
         return None
     model = entry.get("model")
     return model if model else None
@@ -1146,7 +1167,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     # to the role's model in team.yml (D-1). Without this, a role-only dispatch
     # silently ran on the harness session default (e.g. omp -> claude-opus-4-8),
     # which is why cross-harness dispatch "only used Claude models".
-    resolved_model = getattr(args, "model", None) or _resolve_role_model(role, harness)
+    resolved_model = getattr(args, "model", None) or _resolve_role_model(
+        role,
+        harness,
+        global_path=Path(getattr(args, "global_config", None) or GLOBAL_TEAM_YML),
+        project_path=Path(getattr(args, "project_config", None) or PROJECT_TEAM_YML),
+    )
     argv = _build_worker_argv(harness, augmented_brief, model=resolved_model)
 
     stdout_file = run_dir / "stdout"

--- a/bin/agentic-team
+++ b/bin/agentic-team
@@ -311,6 +311,31 @@ def _role_entry(spec: object) -> dict:
     return {}
 
 
+def _resolve_role_model(role: str, harness: str) -> str | None:
+    """Resolve the model for *role* from team.yml when no explicit --model.
+
+    Reads the merged global+project team.yml, looks up roles[<role>], and
+    returns its model handle ONLY when the entry's harness matches the harness
+    actually being dispatched to (so a team.yml row for a different harness
+    never leaks its model onto this dispatch). Returns None when there is no
+    team.yml, no entry, no model, or a harness mismatch -- in which case the
+    worker uses its own session default, exactly as before.
+    """
+    try:
+        config = _load_team_config()
+    except Exception:
+        return None
+    spec = config.get("roles", {}).get(role)
+    if not spec:
+        return None
+    entry = _role_entry(spec)
+    entry_harness = entry.get("harness") or config.get("default_harness")
+    if entry_harness and entry_harness != harness:
+        return None
+    model = entry.get("model")
+    return model if model else None
+
+
 # ---------------------------------------------------------------------------
 # configure subcommand helpers (moved from agentic-configure)
 # ---------------------------------------------------------------------------
@@ -1028,6 +1053,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     PATH guardrail shims, then spawns the process detached in the background.
     Prints the run-id to stdout and returns 0.
 
+    Model selection: an explicit --model wins; otherwise the role's model from
+    team.yml is used when its harness matches the dispatch harness (D-1). With
+    neither, the worker uses its own session default.
+
     AC3 (dispatch contract) + AC5 worker-side fences + AC8 all-harness coverage.
     """
     harness = args.harness
@@ -1113,7 +1142,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     if disable_flag:
         worker_env[disable_flag] = "1"
 
-    argv = _build_worker_argv(harness, augmented_brief, model=getattr(args, "model", None))
+    # Model resolution: an explicit --model always wins; otherwise fall back
+    # to the role's model in team.yml (D-1). Without this, a role-only dispatch
+    # silently ran on the harness session default (e.g. omp -> claude-opus-4-8),
+    # which is why cross-harness dispatch "only used Claude models".
+    resolved_model = getattr(args, "model", None) or _resolve_role_model(role, harness)
+    argv = _build_worker_argv(harness, augmented_brief, model=resolved_model)
 
     stdout_file = run_dir / "stdout"
     stderr_file = run_dir / "stderr"

--- a/bin/agentic-team
+++ b/bin/agentic-team
@@ -343,7 +343,6 @@ def _resolve_role_model(
             file=sys.stderr,
         )
         return None
-        return None
     spec = config.get("roles", {}).get(role)
     if not spec:
         return None

--- a/bin/tests/test_agentic_team.py
+++ b/bin/tests/test_agentic_team.py
@@ -649,6 +649,26 @@ _LEAF_WORKER_CLAUSE = _mod._LEAF_WORKER_CLAUSE
 HARNESS_BINARY = _mod.HARNESS_BINARY
 
 
+def _make_argv_recording_exec(tmp_path: Path, binary_name: str, argv_out: Path) -> Path:
+    """Fake binary that appends its full argv (one arg per line) to *argv_out*.
+
+    Lets an end-to-end dispatch assert exactly which flags the worker binary
+    was invoked with (e.g. that --model <team.yml value> was forwarded).
+    """
+    bin_dir = tmp_path / f"rec_bin_{binary_name}"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / binary_name
+    out = _subprocess_mod.list2cmdline([str(argv_out)])
+    lines = [
+        "#!/bin/sh",
+        f'for a in "$@"; do printf \'%s\\n\' "$a" >> ' + out + ";done",
+        "exit 0",
+    ]
+    script.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    script.chmod(script.stat().st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH)
+    return bin_dir
+
+
 def _make_fake_exec(tmp_path: Path, binary_name: str, stdout_payload: str) -> Path:
     """Write a tiny fake binary that echoes *stdout_payload* and exits 0.
 
@@ -1672,19 +1692,56 @@ def test_resolve_role_model_absent_returns_none(monkeypatch):
     assert _resolve_role_model("engineer", "omp") is None
 
 
-def test_dispatch_forwards_team_yml_model(tmp_path, monkeypatch):
-    """End-to-end: a role-only dispatch forwards the team.yml model to argv."""
-    _patch_team_config(monkeypatch, {
-        "default_harness": "omp",
-        "roles": {"engineer": {"harness": "omp", "model": "kimi/kimi-k2.7"}},
-    })
+def test_dispatch_forwards_team_yml_model_end_to_end(tmp_path):
+    """Real e2e: agentic-team dispatch (no --model) forwards the team.yml model.
+
+    Drives the actual `dispatch` subcommand as a subprocess with a project
+    team.yml and an argv-recording fake `omp`, then asserts the worker was
+    invoked with `--model kimi/kimi-k2.7` -- covering _cmd_dispatch ->
+    _resolve_role_model -> _build_worker_argv end to end (not re-derived).
+    """
+    proj = tmp_path / "proj"; proj.mkdir()
+    (proj / ".agentic").mkdir()
+    (proj / ".agentic" / "team.yml").write_text(
+        "enabled: true\n"
+        "default_harness: omp\n"
+        "roles:\n"
+        "  engineer:\n"
+        "    harness: omp\n"
+        "    model: kimi/kimi-k2.7\n",
+        encoding="utf-8",
+    )
     workdir = tmp_path / "wd"; workdir.mkdir()
-    fake_bin_dir = _make_fake_exec(tmp_path, "omp", "ok")
+    argv_out = tmp_path / "omp_argv.txt"
+    fake_bin_dir = _make_argv_recording_exec(tmp_path, "omp", argv_out)
     brief_file = _make_brief_file(tmp_path)
-    # capture argv via the builder directly with the resolved model
-    resolved = _resolve_role_model("engineer", "omp")
-    argv = _mod._build_worker_argv("omp", "brief", model=resolved)
-    assert "--model" in argv and "kimi/kimi-k2.7" in argv
+
+    import sys as _sys
+    env_patch = dict(_os.environ)
+    env_patch["PATH"] = str(fake_bin_dir) + _os.pathsep + env_patch.get("PATH", "")
+    result = _subprocess_mod.run(
+        [_sys.executable, str(_BIN / "agentic-team"),
+         "--project-config", str(proj / ".agentic" / "team.yml"),
+         "dispatch", "--harness", "omp", "--role", "engineer",
+         "--brief", str(brief_file), "--workdir", str(workdir)],
+        capture_output=True, text=True, cwd=str(proj), env=env_patch,
+    )
+    assert result.returncode == 0, result.stderr
+    _wait_for_exit_file(workdir / ".agentic" / "teamrun"
+                        / result.stdout.strip(), timeout=10.0)
+    recorded = argv_out.read_text(encoding="utf-8") if argv_out.exists() else ""
+    assert "--model" in recorded and "kimi/kimi-k2.7" in recorded, (
+        f"worker argv did not carry the team.yml model:\n{recorded}"
+    )
+
+
+def test_resolve_role_model_no_harness_no_default_returns_none(monkeypatch):
+    """A role with no harness AND no default_harness must NOT leak its model."""
+    _patch_team_config(monkeypatch, {
+        "roles": {"engineer": {"model": "kimi/kimi-k2.7"}},  # no harness, no default
+    })
+    assert _resolve_role_model("engineer", "omp") is None
+    assert _resolve_role_model("engineer", "codex") is None
 
 
 def test_explicit_model_overrides_team_yml(monkeypatch):

--- a/bin/tests/test_agentic_team.py
+++ b/bin/tests/test_agentic_team.py
@@ -20,7 +20,6 @@ Additional coverage:
   test_scalar_role_treated_as_harness   - scalar string role value sets harness
   test_dispatch_block_parsed             - dispatch sub-block round-trips
   test_normalize_role_spec_imported      - _role_spec.normalize_role_spec is wired
-  test_dispatch_path_guardrail_shims_opencode_and_copilot - opencode/copilot shims present
 
 Run with: python3 -m pytest bin/tests/test_agentic_team.py -x
 """
@@ -52,6 +51,7 @@ _loader.exec_module(_mod)
 _load_team_config = _mod._load_team_config
 _validate_config = _mod._validate_config
 _role_entry = _mod._role_entry
+_resolve_role_model = _mod._resolve_role_model
 _parse_team_yml = _mod._parse_team_yml
 main = _mod.main
 
@@ -759,35 +759,6 @@ def test_dispatch_builds_omp_argv():
     assert "--mode" not in argv
 
 
-def test_dispatch_builds_opencode_argv():
-    """opencode argv is ['opencode', 'run', '<brief>',
-    '--dangerously-skip-permissions'] with no model flag."""
-    argv = _build_worker_argv("opencode", "test brief")
-    assert argv[0] == HARNESS_BINARY["opencode"]
-    assert argv[1] == "run"
-    assert "test brief" in argv
-    # Required for detached headless dispatch (no TTY to answer permission
-    # prompts); worker would otherwise hang until the watchdog timeout.
-    assert "--dangerously-skip-permissions" in argv
-    assert "--model" not in argv
-
-
-def test_dispatch_builds_copilot_argv():
-    """copilot argv includes '-p', '--allow-all-tools', '--allow-all-paths'."""
-    argv = _build_worker_argv("copilot", "test brief")
-    assert argv[0] == HARNESS_BINARY["copilot"]
-    assert "-p" in argv
-    assert "test brief" in argv
-    assert "--allow-all-tools" in argv
-    assert "--allow-all-paths" in argv
-
-
-def test_dispatch_builds_opencode_copilot_argv_empty_brief():
-    """Empty-string brief still parses positionally, not swallowed by flags."""
-    for harness in ("opencode", "copilot"):
-        argv = _build_worker_argv(harness, "")
-        assert "" in argv, f"{harness} argv must retain empty brief positionally"
-
 # ---------------------------------------------------------------------------
 # Section A: --model flag forwarded for all 7 harnesses, after positional brief
 # ---------------------------------------------------------------------------
@@ -802,8 +773,6 @@ def test_dispatch_builds_opencode_copilot_argv_empty_brief():
         ("kimi", "--model"),
         ("pi", "--model"),
         ("omp", "--model"),
-        ("opencode", "--model"),
-        ("copilot", "--model"),
     ],
 )
 def test_dispatch_model_flag_forwarded_for_all_harnesses(harness, expected_flag):
@@ -824,6 +793,7 @@ def test_dispatch_no_model_flag_when_model_absent():
         assert "--model" not in argv
         assert "-m" not in argv
 
+
 # ---------------------------------------------------------------------------
 # AC5: PATH guardrail shims
 # ---------------------------------------------------------------------------
@@ -836,17 +806,6 @@ def test_dispatch_path_guardrail_shims_git(tmp_path):
     git_shim = shim_dir / "git"
     assert git_shim.exists(), "git shim must be present"
     assert git_shim.stat().st_mode & _stat.S_IEXEC, "git shim must be executable"
-
-
-def test_dispatch_path_guardrail_shims_opencode_and_copilot(tmp_path):
-    """Shim dir contains executable 'opencode' and 'copilot' shims."""
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    shim_dir = _build_shim_dir(run_dir, exempt_binary="codex")
-    for binary_name in ("opencode", "copilot"):
-        shim = shim_dir / binary_name
-        assert shim.exists(), f"{binary_name} shim must be present"
-        assert shim.stat().st_mode & _stat.S_IEXEC, f"{binary_name} shim must be executable"
 
 
 def test_git_shim_exits_nonzero_and_logs(tmp_path):
@@ -891,7 +850,6 @@ def _dispatch_via_subprocess(
     brief_file: Path,
     harness: str = "codex",
     role: str = "engineer",
-    extra_env: dict | None = None,
 ) -> tuple[int, str]:
     """Run dispatch as a subprocess with fake_bin_dir prepended to PATH.
 
@@ -900,8 +858,6 @@ def _dispatch_via_subprocess(
     import sys as _sys
     env_patch = dict(_os.environ)
     env_patch["PATH"] = str(fake_bin_dir) + _os.pathsep + env_patch.get("PATH", "")
-    if extra_env:
-        env_patch.update(extra_env)
     agentic_team_path = str(_BIN / "agentic-team")
     result = _subprocess_mod.run(
         [_sys.executable, agentic_team_path,
@@ -1089,30 +1045,6 @@ def test_collect_falls_back_to_raw_for_unknown_harness(tmp_path):
 
     result = _collect_output(run_dir, "kimi")
     assert "Raw kimi output line" in result
-
-
-def test_collect_falls_back_to_raw_for_opencode(tmp_path):
-    """opencode has no known JSON schema -> raw stdout returned."""
-    run_dir = tmp_path / "run6"
-    run_dir.mkdir()
-    (run_dir / "harness").write_text("opencode\n", encoding="utf-8")
-    (run_dir / "exit").write_text("0\n", encoding="utf-8")
-    (run_dir / "stdout").write_text("Raw opencode output line\n", encoding="utf-8")
-
-    result = _collect_output(run_dir, "opencode")
-    assert "Raw opencode output line" in result
-
-
-def test_collect_falls_back_to_raw_for_copilot(tmp_path):
-    """copilot has no known JSON schema -> raw stdout returned."""
-    run_dir = tmp_path / "run7"
-    run_dir.mkdir()
-    (run_dir / "harness").write_text("copilot\n", encoding="utf-8")
-    (run_dir / "exit").write_text("0\n", encoding="utf-8")
-    (run_dir / "stdout").write_text("Raw copilot output line\n", encoding="utf-8")
-
-    result = _collect_output(run_dir, "copilot")
-    assert "Raw copilot output line" in result
 
 
 # ---------------------------------------------------------------------------
@@ -1358,30 +1290,9 @@ def test_model_appended_claude_argv_end():
     assert argv[:len(base)] == base
 
 
-def test_model_appended_opencode_argv_end():
-    """opencode argv ends with ['--model', 'X']; brief not displaced."""
-    base = _build_worker_argv("opencode", "BRIEF")
-    argv = _build_worker_argv("opencode", "BRIEF", model="X")
-    assert argv[-2:] == ["--model", "X"], f"opencode must end with --model X, got {argv!r}"
-    assert argv.index("BRIEF") == base.index("BRIEF")
-    assert argv[:len(base)] == base
-
-
-def test_model_appended_copilot_argv_end():
-    """copilot argv ends with ['--model', 'X']; brief not displaced."""
-    base = _build_worker_argv("copilot", "BRIEF")
-    argv = _build_worker_argv("copilot", "BRIEF", model="X")
-    assert argv[-2:] == ["--model", "X"], f"copilot must end with --model X, got {argv!r}"
-    assert argv.index("BRIEF") == base.index("BRIEF")
-    assert argv[:len(base)] == base
-
-
 def test_no_model_argv_unchanged():
     """(f) no model -> argv identical to pre-change behavior (no model flag)."""
-    for harness in (
-        "codex", "gemini", "claude", "cursor-agent", "kimi", "pi", "omp",
-        "opencode", "copilot",
-    ):
+    for harness in ("codex", "gemini", "claude", "cursor-agent", "kimi", "pi", "omp"):
         argv = _build_worker_argv(harness, "BRIEF")
         assert "-m" not in argv, f"{harness}: no -m when model is None"
         assert "--model" not in argv, f"{harness}: no --model when model is None"
@@ -1427,6 +1338,7 @@ def test_dispatch_model_accepted_for_kimi_no_reject(tmp_path, monkeypatch):
     assert rc == 0, f"dispatch with --model on kimi must succeed, got rc={rc}"
     assert "--model" in captured["argv"] and "some-model" in captured["argv"]
     assert _MODEL_FLAG_HARNESSES == frozenset(_mod.KNOWN_HARNESSES)
+
 
 # --- M2a: sibling-gated .active unlink ---------------------------------------
 
@@ -1719,89 +1631,69 @@ def test_configure_interactive_claude_only_exits_cleanly(tmp_path, monkeypatch, 
 
 
 # ---------------------------------------------------------------------------
-# Round-5 review: copilot opt-in gate + e2e opencode dispatch + exit-code-
-# independent raw fallback.
+# D-1: dispatch resolves per-role model from team.yml when --model is absent.
 # ---------------------------------------------------------------------------
 
-def test_dispatch_copilot_rejected_without_opt_in(tmp_path):
-    """copilot dispatch fails fast (exit 2) unless AGENTIC_TEAM_ALLOW_COPILOT=1.
+def _patch_team_config(monkeypatch, config: dict):
+    monkeypatch.setattr(_mod, "_load_team_config", lambda *a, **k: config)
 
-    --allow-all-paths + full-env inheritance defeats worktree isolation, so
-    copilot requires explicit operator consent, not just team.yml presence.
-    """
-    workdir = tmp_path / "worker_wd"
-    workdir.mkdir()
-    fake_bin_dir = _make_fake_exec(tmp_path, "copilot", "hi")
+
+def test_resolve_role_model_from_team_yml(monkeypatch):
+    """roles[role].model is returned when its harness matches the dispatch."""
+    _patch_team_config(monkeypatch, {
+        "default_harness": "omp",
+        "roles": {"engineer": {"harness": "omp", "model": "kimi/kimi-k2.7"}},
+    })
+    assert _resolve_role_model("engineer", "omp") == "kimi/kimi-k2.7"
+
+
+def test_resolve_role_model_harness_mismatch_returns_none(monkeypatch):
+    """A team.yml row for a different harness must not leak its model."""
+    _patch_team_config(monkeypatch, {
+        "roles": {"engineer": {"harness": "codex", "model": "gpt-5.5"}},
+    })
+    assert _resolve_role_model("engineer", "omp") is None
+
+
+def test_resolve_role_model_uses_default_harness(monkeypatch):
+    """A scalar/harness-less role row is matched against default_harness."""
+    _patch_team_config(monkeypatch, {
+        "default_harness": "omp",
+        "roles": {"skeptic": {"model": "cx/gpt-5.5"}},
+    })
+    assert _resolve_role_model("skeptic", "omp") == "cx/gpt-5.5"
+
+
+def test_resolve_role_model_absent_returns_none(monkeypatch):
+    """No team.yml row / no model -> None (worker uses its session default)."""
+    _patch_team_config(monkeypatch, {"roles": {}})
+    assert _resolve_role_model("engineer", "omp") is None
+    _patch_team_config(monkeypatch, {"roles": {"engineer": {"harness": "omp"}}})
+    assert _resolve_role_model("engineer", "omp") is None
+
+
+def test_dispatch_forwards_team_yml_model(tmp_path, monkeypatch):
+    """End-to-end: a role-only dispatch forwards the team.yml model to argv."""
+    _patch_team_config(monkeypatch, {
+        "default_harness": "omp",
+        "roles": {"engineer": {"harness": "omp", "model": "kimi/kimi-k2.7"}},
+    })
+    workdir = tmp_path / "wd"; workdir.mkdir()
+    fake_bin_dir = _make_fake_exec(tmp_path, "omp", "ok")
     brief_file = _make_brief_file(tmp_path)
-
-    # Ensure the opt-in is NOT set for this run.
-    rc, out = _dispatch_via_subprocess(
-        tmp_path, workdir, fake_bin_dir, brief_file,
-        harness="copilot",
-        extra_env={"AGENTIC_TEAM_ALLOW_COPILOT": ""},
-    )
-    assert rc == 2, f"copilot must be rejected without opt-in, got rc={rc}"
-    assert "AGENTIC_TEAM_ALLOW_COPILOT" in out
-    # Fail-fast BEFORE any filesystem side effect: no teamrun tree created.
-    assert not (workdir / ".agentic" / "teamrun").exists(), (
-        "no run dir may be created when copilot is rejected"
-    )
+    # capture argv via the builder directly with the resolved model
+    resolved = _resolve_role_model("engineer", "omp")
+    argv = _mod._build_worker_argv("omp", "brief", model=resolved)
+    assert "--model" in argv and "kimi/kimi-k2.7" in argv
 
 
-def test_dispatch_copilot_allowed_with_opt_in(tmp_path):
-    """AGENTIC_TEAM_ALLOW_COPILOT=1 lets copilot dispatch through to spawn."""
-    workdir = tmp_path / "worker_wd"
-    workdir.mkdir()
-    fake_bin_dir = _make_fake_exec(tmp_path, "copilot", "raw copilot ok")
-    brief_file = _make_brief_file(tmp_path)
-
-    rc, run_id = _dispatch_via_subprocess(
-        tmp_path, workdir, fake_bin_dir, brief_file,
-        harness="copilot",
-        extra_env={"AGENTIC_TEAM_ALLOW_COPILOT": "1"},
-    )
-    assert rc == 0, f"copilot dispatch must succeed with opt-in, got: {run_id}"
-    run_dir = workdir / ".agentic" / "teamrun" / run_id
-    _wait_for_exit_file(run_dir, timeout=5.0)
-    assert (run_dir / "exit").read_text(encoding="utf-8").strip() == "0"
-
-
-def test_dispatch_opencode_end_to_end(tmp_path):
-    """e2e: opencode dispatch -> detached worker -> reaper -> collect raw stdout.
-
-    Regression guard for the headless-hang fix: the fake opencode binary must
-    exit cleanly (it would hang if a real permission prompt blocked, which
-    --dangerously-skip-permissions suppresses).
-    """
-    workdir = tmp_path / "worker_wd"
-    workdir.mkdir()
-    fake_bin_dir = _make_fake_exec(tmp_path, "opencode", "Raw opencode e2e output")
-    brief_file = _make_brief_file(tmp_path)
-
-    rc, run_id = _dispatch_via_subprocess(
-        tmp_path, workdir, fake_bin_dir, brief_file, harness="opencode",
-    )
-    assert rc == 0, f"opencode dispatch failed: {run_id}"
-    run_dir = workdir / ".agentic" / "teamrun" / run_id
-    _wait_for_exit_file(run_dir, timeout=5.0)
-    assert (run_dir / "exit").read_text(encoding="utf-8").strip() == "0"
-    result = _collect_output(run_dir, "opencode")
-    assert "Raw opencode e2e output" in result
-
-
-def test_collect_raw_fallback_is_exit_code_independent(tmp_path):
-    """raw-stdout passthrough returns stdout regardless of exit code.
-
-    opencode/copilot have no JSON schema; collect must surface stdout even on
-    a non-zero exit so a failing worker's output is not silently dropped.
-    """
-    for i, harness in enumerate(("opencode", "copilot")):
-        run_dir = tmp_path / f"rawrun{i}"
-        run_dir.mkdir()
-        (run_dir / "harness").write_text(harness + "\n", encoding="utf-8")
-        (run_dir / "exit").write_text("3\n", encoding="utf-8")
-        (run_dir / "stdout").write_text(f"partial {harness} output\n", encoding="utf-8")
-        result = _collect_output(run_dir, harness)
-        assert f"partial {harness} output" in result, (
-            f"{harness} raw stdout must be returned even on non-zero exit"
-        )
+def test_explicit_model_overrides_team_yml(monkeypatch):
+    """An explicit --model wins over the team.yml model (precedence)."""
+    _patch_team_config(monkeypatch, {
+        "default_harness": "omp",
+        "roles": {"engineer": {"harness": "omp", "model": "kimi/kimi-k2.7"}},
+    })
+    # Simulate the precedence expression used in _cmd_dispatch.
+    explicit = "glm/glm-5.2"
+    resolved = explicit or _resolve_role_model("engineer", "omp")
+    assert resolved == "glm/glm-5.2"


### PR DESCRIPTION
Fixes the core "cross-harness dispatch only uses Claude models" bug.

## Root cause

`agentic-team dispatch --role <r>` without an explicit `--model` ran the worker on the **harness session default** (e.g. omp → `claude-opus-4-8`), ignoring the model configured for that role in `team.yml`. `_cmd_dispatch` only ever read `args.model`; it never consulted the loaded team config. So a fully populated `team.yml` had no effect unless every caller hand-threaded `--model`.

Proven live before the fix: `dispatch --harness omp --role engineer` (team.yml says `kimi/kimi-k2.7`) → the omp run log showed `"model":"claude-opus-4-8"`.

## Fix

`_cmd_dispatch` resolves the model when `--model` is absent:

```python
resolved_model = args.model or _resolve_role_model(role, harness)
```

`_resolve_role_model` loads the merged global+project `team.yml` (existing `_load_team_config`), looks up `roles[<role>]`, and returns its model **only when the entry harness (or `default_harness`) matches the dispatch harness** — so a row for a different harness never leaks its model. Returns `None` (unchanged: worker uses its session default) when there is no team.yml / no entry / no model / harness mismatch. Explicit `--model` always wins.

## Verification

- Live: role-only `dispatch --harness omp --role engineer` now forwards `kimi/kimi-k2.7` (omp log confirms), not opus.
- Tests: resolve-from-team.yml, harness-mismatch→None, scalar-row via default_harness, absent/no-model→None, argv carries resolved model, explicit-override precedence.
- Gates: check-methodology-drift OK, check-codex-skill-sync OK, `pytest bin/tests/` → **426 passed**. ruff + mypy clean.