### PR TITLE
feat(vision): North Star alignment section in PR template + CONTRIBUTING (Layer C)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,19 @@
 
 <!-- One or two sentences on the motivation and the change. -->
 
+## North Star alignment
+
+<!-- Required when this PR touches a methodology-shaping path. See the canonical trigger
+     list in content/agents/skeptic.md step 3.6 - keep this comment in sync with that list.
+     A trivial change (typo, formatting, whitespace, comment-only) on a methodology-shaping
+     path may satisfy this section with a one-line answer, e.g. "N/A - typo/formatting only,
+     no methodology-behavior change." A full pillar/trade-off answer is only expected when the
+     diff actually changes behavior. For PRs that touch no methodology-shaping path at all,
+     write "N/A". -->
+
+- Pillar(s) advanced (see docs/overview/vision.md):
+- Trade-off or pillar this could regress, if any:
+
 ## Related issues
 
 <!-- e.g. Closes #123, Refs #456 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Changes to the methodology itself - conductor rules, the Skeptic protocol, risk 
 - One concern per PR — don't bundle unrelated changes
 - Describe the *why* in the PR body, not just the *what*
 - Test locally before opening: re-run `install.sh`, open a Claude Code session, verify the change works as expected
-- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction) without regressing another, with operator attention as the tie-breaker
+- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another, with operator attention as the tie-breaker. Fill in the PR template's '## North Star alignment' section - required for changes touching a methodology-shaping path (see content/agents/skeptic.md step 3.6); a trivial in-scope change may answer with a one-line N/A. Write "N/A" outright for out-of-scope PRs.
 
 ### Adapter compatibility declaration
 


### PR DESCRIPTION
## Summary

Contributor-facing layer of the vision-alignment enforcement feature: adds a '## North Star alignment' section to the PR template (required for methodology-shaping paths, one-line N/A sanctioned for trivial diffs) and updates the CONTRIBUTING North Star bullet - which also fixes a pre-existing gap where it listed only 3 of the 4 pillars (missing 'works for everyone').

Paired doc-sync edit, single commit. The canonical trigger-path list lives in content/agents/skeptic.md step 3.6 (PR #433); this template comment references it by name.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Works for everyone (harness-agnostic - applies to any contributor filing a PR, agent-driven or hand-edited); guard operator attention (misalignment surfaces in the PR body where the operator reviews).
- Trade-off or pillar this could regress, if any: Low friction - one new PR-body section; mitigated by the explicit one-line-N/A carve-out for trivial and out-of-scope PRs.

## Verification

- Integration Skeptic sign-off (0 Critical, 0 Major) on the combined feature diff
- QA static pass: section placement (after Summary, before Related issues) and CONTRIBUTING 4-pillar text verified against the plan verbatim