### PR TITLE
feat(vision): required North Star alignment field on protocol-change RFC template (Layer E)

### DIFF
--- a/.github/ISSUE_TEMPLATE/protocol_change.yml
+++ b/.github/ISSUE_TEMPLATE/protocol_change.yml
@@ -37,6 +37,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: north_star_alignment
+    attributes:
+      label: North Star alignment
+      description: Which pillar in docs/overview/vision.md does this advance (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone)? Note any pillar it could regress or trade off. (This RFC gate is issue-type-scoped per CONTRIBUTING.md's protocol-change definition - a narrower, distinct gate from the path-based trigger canonical in content/agents/skeptic.md step 3.6, not a duplicate of it.)
+    validations:
+      required: true
+  - type: textarea
     id: backward_compatibility
     attributes:
       label: Backward-compatibility impact


### PR DESCRIPTION
## Summary

Pre-implementation layer of the vision-alignment enforcement feature: protocol-change RFCs now require a North Star alignment answer (which pillar advanced, any trade-off) before the RFC can be filed. Issue-type-scoped gate, distinct from the path-based trigger list - references it by name, does not duplicate it.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Guard operator attention (the alignment question is answered before implementation work starts, where course-correction is cheapest); works for everyone (GitHub-native, harness-agnostic).
- Trade-off or pillar this could regress, if any: Low friction - one required field on a template that already gates the highest-leverage methodology changes; proportional to the stakes of that change class.

## Verification

- YAML parses (PyYAML); field placed between motivation and backward_compatibility with validations.required: true
- Post-merge: rendered issue-form check (GitHub renders forms from the default branch only)
- Integration Skeptic sign-off (0 Critical, 0 Major)