### PR TITLE
QA test: vision-alignment-check red-X path (throwaway - do not merge)

### DIFF
--- a/bin/agentic-status
+++ b/bin/agentic-status
@@ -636,3 +636,4 @@ def main(_argv: list[str]) -> int:
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))
+# qa-test: vision-alignment-check red-X scenario (throwaway)


### PR DESCRIPTION
QA verification PR for DS vision-alignment enforcement feature (PRs #433-436). This PR intentionally omits the '## North Star alignment' section entirely to verify vision-alignment-check fails with the ::error:: annotation on a methodology-affecting path (bin/agentic-status). Throwaway - will be closed after evidence capture, do not merge.