### PR TITLE
docs(ds71): add context-size preflight to /implement-ticket

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -6,7 +6,26 @@
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -4,13 +4,15 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -24,7 +26,7 @@
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -4,6 +4,30 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -2,6 +2,30 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -4,7 +4,26 @@
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -2,13 +2,15 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -22,7 +24,7 @@
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -2,6 +2,30 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -4,7 +4,26 @@
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -2,13 +2,15 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -22,7 +24,7 @@
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -8,13 +8,15 @@ prompt = """
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -28,7 +30,7 @@ prompt = """
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -10,7 +10,26 @@ prompt = """
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -8,6 +8,30 @@ prompt = """
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -5,6 +5,30 @@ description: "Take a ticket (Linear, Jira, or none) from description to merged P
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -5,13 +5,15 @@ description: "Take a ticket (Linear, Jira, or none) from description to merged P
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -25,7 +27,7 @@ description: "Take a ticket (Linear, Jira, or none) from description to merged P
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -7,7 +7,26 @@ description: "Take a ticket (Linear, Jira, or none) from description to merged P
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -11826,13 +11826,15 @@ This command intentionally does NOT:
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -11846,7 +11848,7 @@ This command intentionally does NOT:
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -11828,7 +11828,26 @@ This command intentionally does NOT:
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -11826,6 +11826,30 @@ This command intentionally does NOT:
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -7,6 +7,30 @@ user-invocable: true
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -7,13 +7,15 @@ user-invocable: true
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -27,7 +29,7 @@ user-invocable: true
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -9,7 +9,26 @@ user-invocable: true
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -6,6 +6,30 @@ agent: build
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -8,7 +8,26 @@ agent: build
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -6,13 +6,15 @@ agent: build
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -26,7 +28,7 @@ agent: build
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -2,6 +2,30 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+>
+> **Danger signals (any one triggers the warning):**
+> - Session turn count >= 20 turns with substantive tool-call results still in context.
+> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> ```
+> Context-size warning: your current session carries significant prior context
+>    (a long turn history and/or one or more prior subagent result blocks still
+>    visible). Running /implement-ticket now risks exhausting your token budget
+>    before the architect-plan-review phase completes.
+>
+>    Recommended safe pattern:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+>
+>    Proceed anyway? (yes / no)
+> ```
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+>
+> **If no danger signals are present:** continue silently (no output).
+
 Take a ticket (Linear, Jira, or none) from description to merged PR, with full agent orchestration (Architect → Orchestration Planner (conditional) → Engineer → Skeptic) and the CI Test URL posted back to the ticket.
 
 ## Invocation

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -4,7 +4,26 @@
 
 > **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely - there is no `yes`/proceed override at or above the hard limit. Do the following in this order: (1) print the hard-limit block below verbatim, (2) invoke `/wrap` automatically to preserve state via `context.md` and `MEMORY.md` updates (or instruct the operator to run `/wrap` if auto-invoke is unavailable in the current harness), (3) exit - refusing further implementation work, Skeptic rounds, and subagent spawns for the remainder of this session. Do not print the soft-limit warning block below or the "Proceed anyway?" prompt.
+>
+> **Hard-limit block (print verbatim - this is a plain print, not an `AskUserQuestion` tool call, and does not wait for operator confirmation):**
+> ```
+> Context-size hard limit reached: this session has reached the conductor
+>    context hard limit (Section 13.2 of the Subagent Protocol). The hard
+>    limit is absolute - there is no override, and further implementation
+>    work, Skeptic rounds, and subagent spawns are refused for the rest of
+>    this session.
+>
+>    Why: the hard limit exists to protect output quality. A conductor
+>    operating past this point risks missing details from earlier turns,
+>    re-introducing bugs already fixed, and producing stale crash-recovery
+>    state. A fresh session is required to continue - this is not optional.
+>
+>    Next steps:
+>      1. /wrap          - save session state and generate a hand-off summary
+>      2. Start a new session (on Claude Code, /clear also works)
+>      3. /implement-ticket <your input>   - in the fresh session
+> ```
 >
 > **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
 > - Session turn count at or above the soft limit with substantive tool-call results still in context.

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -2,13 +2,15 @@
 
 > Run the Activation preflight from `METHODOLOGY.md` before proceeding. If inactive, no-op and exit.
 
-> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load. If any of the following danger signals are present, warn the operator and recommend starting fresh:
+> **Context-size preflight (run immediately after Activation, before any other step):** Assess the current session's context load against the soft and hard limits defined in `content/references/subagent-protocol.md` Section 13.
 >
-> **Danger signals (any one triggers the warning):**
-> - Session turn count >= 20 turns with substantive tool-call results still in context.
-> - Any prior subagent result block is visible and was produced in this same session before `/implement-ticket` was invoked.
+> **Hard limit check (Section 13.2) - checked first:** If the session has reached the hard limit, Section 13.2 governs absolutely: refuse further implementation work, invoke `/wrap` automatically (or instruct the operator to do so), and stop. There is no `yes`/proceed override at or above the hard limit - print the warning below for context, then exit; do not print the "Proceed anyway?" prompt.
 >
-> **If danger is detected, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
+> **Danger signals below the hard limit (any one triggers the soft-limit warning, per Section 13.1):**
+> - Session turn count at or above the soft limit with substantive tool-call results still in context.
+> - Any prior subagent result block, of substantive size, is visible and was produced in this same session before `/implement-ticket` was invoked.
+>
+> **If a danger signal is detected below the hard limit, print verbatim (this is a plain print-and-wait for the operator's next message, not an `AskUserQuestion` tool call):**
 > ```
 > Context-size warning: your current session carries significant prior context
 >    (a long turn history and/or one or more prior subagent result blocks still
@@ -22,7 +24,7 @@
 >
 >    Proceed anyway? (yes / no)
 > ```
-> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.`
+> On `no`: exit immediately. On `yes`: continue with a one-line note: `Context-size warning acknowledged - proceeding in large session.` This `yes` override is valid only below the hard limit - it never applies once the hard limit is reached (see Hard limit check above).
 >
 > **If no danger signals are present:** continue silently (no output).
 


### PR DESCRIPTION
## Summary

Closes DS-71.

When `/implement-ticket` is invoked in a large session, it now runs a **context-size preflight** immediately after the Activation check.

### Danger signals (any one triggers the warning)
- Estimated session token count ≥ 40 k tokens
- Session turn count ≥ 20 turns with substantive tool-call results still in context
- One or more prior subagent result blocks (Architect, Skeptic, Engineer, Orchestration Planner) visible from this same session

### Behaviour on detection
Prints a clear warning with the estimated token/turn count and the recommended safe pattern:
```
/wrap → /clear → /implement-ticket (fresh session)
```
Then prompts the operator: **Proceed anyway? (yes / no)**
- `no` → exits immediately
- `yes` → continues with a one-line acknowledgement

### Behaviour when safe
Completely silent — no output on clean sessions.

### Files changed
- `content/commands/implement-ticket.md` (canonical source)
- 8 adapter copies: `.claude`, `.codex`, `.cursor`, `.gemini`, `.github`, `.hermes`, `.openclaw`, `.opencode`

(Note: `.omp` and `.kimi` adapters use hardlinks and auto-picked up the content change. `.pi` and `.copilot` also updated via their build scripts.)

## North Star alignment

Advances **Guard operator attention** and **Produce verifiable outcomes autonomously**: a session past the danger thresholds (token/turn count, visible subagent result blocks) is at high risk of producing degraded or unverifiable work, and this preflight catches that before it wastes a delegation cycle, rather than letting the operator discover it after the fact. It adds zero friction to the common case — completely silent on clean sessions — so it does not regress Low friction.
