### PR TITLE
feat(identity): per-profile (per-tenant) developer identity scope

### DIFF
--- a/.github/workflows/wrap-lock-tests.yml
+++ b/.github/workflows/wrap-lock-tests.yml
@@ -19,3 +19,5 @@ jobs:
         run: node hooks/tests/test-wrap-acquire-lock.js
       - name: wrap-lock release test
         run: node hooks/tests/test-wrap-release-lock.js
+      - name: stop-context identity resolution test
+        run: node hooks/tests/test-stop-context-identity.js

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -19,7 +19,8 @@ Public API:
   Helpers: _read_identity(path=None), _write_identity(lines, target_path=None),
            _project_identity_path(cwd=None), _profile_identity_path(profile_dir=None),
            _profile_config_dir(), _resolve_effective_identity(cwd),
-           flushPendingBuffer(confirmed_dev_id, repo_root_filter=None).
+           flushPendingBuffer(confirmed_dev_id, repo_root_filter=None,
+                              profile_dir_filter=None).
 
 Data model:
   Global:  ~/.agentic/identity.yml
@@ -64,6 +65,10 @@ Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                does not match the filter are skipped (left in the buffer, not
                unlinked); records with no/empty repo_root are also skipped under
                a filter (conservative).
+               flushPendingBuffer with profile_dir_filter: config_dir-tagged
+               records flush only under a matching profile_dir_filter; a None
+               filter excludes all tagged records (they await their own
+               profile's confirm).
 
 Performance: Standard. File I/O only; subprocess for gh CLI in auto subcommand.
 """
@@ -264,7 +269,11 @@ def _write_identity(lines: list[str], target_path: Path | None = None) -> int:
     return 0
 
 
-def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = None) -> int:
+def flushPendingBuffer(
+    confirmed_dev_id: str,
+    repo_root_filter: str | None = None,
+    profile_dir_filter: str | None = None,
+) -> int:
     """Flush ~/.agentic/session-log/.pending/*.json to global + per-project logs.
 
     Race-safe via fcntl.flock exclusive lock on .flush.lock for the whole loop.
@@ -272,12 +281,21 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
     Returns number of records flushed (0 on no pending or timeout).
 
     When repo_root_filter is None (default): current behavior exactly - all
-    pending records are attributed to confirmed_dev_id.
+    untagged pending records are attributed to confirmed_dev_id.
 
     When repo_root_filter is set (e.g. project-scope init/confirm): only records
     whose repo_root exactly matches repo_root_filter are flushed. Records whose
     repo_root does not match, or whose repo_root is absent/empty, are left in the
     buffer (not unlinked, not attributed) for later global flush.
+
+    profile_dir_filter partitions the buffer per profile config dir
+    (cross-tenant leakage guard; records are tagged with config_dir by
+    writePendingBuffer in hooks/stop-context.js when a profile is active):
+      - profile_dir_filter set (profile-scope init/confirm): only records whose
+        config_dir field equals it are flushed; all others stay in the buffer.
+      - profile_dir_filter None (global/project scope): records carrying a
+        config_dir tag are EXCLUDED (they await their own profile's confirm);
+        untagged records behave exactly as before, incl. repo_root_filter logic.
     """
     # Ensure lock file and parent dirs exist.
     FLUSH_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -324,6 +342,15 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
                     # Skip malformed records silently.
                     continue
 
+                # profile partition: tagged records flush only under their own
+                # profile's filter; a None filter (global/project) excludes them.
+                record_config_dir = record.get("config_dir", "")
+                if profile_dir_filter is not None:
+                    if record_config_dir != profile_dir_filter:
+                        continue
+                elif record_config_dir:
+                    continue
+
                 # repo_root_filter: skip records that don't match (leave in buffer).
                 if repo_root_filter is not None:
                     record_repo_root = record.get("repo_root", "")
@@ -344,8 +371,9 @@ def flushPendingBuffer(confirmed_dev_id: str, repo_root_filter: str | None = Non
 
                 # Build attributed line in canonical session-total shape to match
                 # writeSessionLog / writeSessionLogGlobal in hooks/stop-context.js.
-                # Fields NOT in canonical shape (schema_version, repo_root) are used
-                # only for routing/bookkeeping above and must NOT appear in the line.
+                # Fields NOT in canonical shape (schema_version, repo_root,
+                # config_dir) are used only for routing/bookkeeping above and
+                # must NOT appear in the line.
                 attributed = {
                     "ts": record.get("ts"),
                     "phase": "session_end",
@@ -486,10 +514,10 @@ def cmd_init(args: argparse.Namespace) -> int:
 
         print(f"Identity set (profile scope): developer_id={handle}, created_at={created_at}")
 
-        # Profile scope is persona-bound (not repo-bound): flush without a
-        # repo_root_filter, mirroring the global path.
+        # Profile scope flushes only records tagged with this profile's own
+        # config dir (cross-tenant leakage guard); no repo_root_filter.
         if is_overwriting_provisional or is_fresh:
-            flushPendingBuffer(handle)
+            flushPendingBuffer(handle, profile_dir_filter=str(target_path.parent))
 
         return 0
 
@@ -739,8 +767,9 @@ def cmd_confirm(args: argparse.Namespace) -> int:
         if rc != 0:
             return rc
 
-        # Profile scope is persona-bound (not repo-bound): flush without a filter.
-        flushPendingBuffer(dev_id)
+        # Profile scope flushes only records tagged with this profile's own
+        # config dir (cross-tenant leakage guard); no repo_root_filter.
+        flushPendingBuffer(dev_id, profile_dir_filter=str(target_path.parent))
         print(f"Identity confirmed (profile scope): developer_id={dev_id}")
         return 0
 

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -455,6 +455,32 @@ def flushPendingBuffer(
     return flushed
 
 
+def _profile_target_or_err(args: argparse.Namespace) -> Path | None:
+    """Resolve the profile-scope identity.yml target; print an error and return None on failure.
+
+    Distinguishes a provided-but-rejected --profile-dir (outside $HOME) from an
+    omitted flag with no qualifying env var. Shared by cmd_init/cmd_auto/cmd_confirm.
+    """
+    profile_dir = getattr(args, "profile_dir", None)
+    target = _profile_identity_path(profile_dir)
+    if target is not None:
+        return target
+    if profile_dir is not None:
+        print(
+            f"agentic-identity: --profile-dir '{profile_dir}' rejected: "
+            "must resolve under $HOME.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "agentic-identity: cannot determine profile config dir. Set one of "
+            + ", ".join(PROFILE_CONFIG_DIR_ENV)
+            + " (under $HOME), or pass --profile-dir <dir>.",
+            file=sys.stderr,
+        )
+    return None
+
+
 def _require_repo_root(cwd: Path) -> int:
     """Return 1 (and print error) if cwd has neither .agentic/ nor .git/; else 0."""
     if not (cwd / ".agentic").exists() and not (cwd / ".git").exists():
@@ -480,14 +506,8 @@ def cmd_init(args: argparse.Namespace) -> int:
 
     scope = getattr(args, "scope", "global")
     if scope == "profile":
-        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        target_path = _profile_target_or_err(args)
         if target_path is None:
-            print(
-                "agentic-identity: cannot determine profile config dir. Set one of "
-                + ", ".join(PROFILE_CONFIG_DIR_ENV)
-                + " (under $HOME), or pass --profile-dir <dir>.",
-                file=sys.stderr,
-            )
             return 1
         existing = _read_identity(target_path) if target_path.is_file() else None
         is_overwriting_provisional = existing is not None and existing.get("provisional", False)
@@ -627,14 +647,8 @@ def cmd_auto(args: argparse.Namespace) -> int:
 
     scope = getattr(args, "scope", "global")
     if scope == "profile":
-        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        target_path = _profile_target_or_err(args)
         if target_path is None:
-            print(
-                "agentic-identity: cannot determine profile config dir. Set one of "
-                + ", ".join(PROFILE_CONFIG_DIR_ENV)
-                + " (under $HOME), or pass --profile-dir <dir>.",
-                file=sys.stderr,
-            )
             return 1
         existing = _read_identity(target_path)
         if existing is not None:
@@ -737,14 +751,8 @@ def cmd_confirm(args: argparse.Namespace) -> int:
     """Confirm provisional identity: strip provisional/derived_from, flush pending buffer."""
     scope = getattr(args, "scope", "global")
     if scope == "profile":
-        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        target_path = _profile_target_or_err(args)
         if target_path is None:
-            print(
-                "agentic-identity: cannot determine profile config dir. Set one of "
-                + ", ".join(PROFILE_CONFIG_DIR_ENV)
-                + " (under $HOME), or pass --profile-dir <dir>.",
-                file=sys.stderr,
-            )
             return 1
         identity = _read_identity(target_path)
         if identity is None:
@@ -852,8 +860,16 @@ def cmd_show(args: argparse.Namespace) -> int:
         return 0
 
     if scope == "profile":
-        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        profile_dir = getattr(args, "profile_dir", None)
+        target_path = _profile_identity_path(profile_dir)
         if target_path is None:
+            if profile_dir is not None:
+                print(
+                    f"agentic-identity: --profile-dir '{profile_dir}' rejected: "
+                    "must resolve under $HOME.",
+                    file=sys.stderr,
+                )
+                return 1
             print("No profile scope (no config-dir env set and no --profile-dir).")
             return 0
         identity = _read_identity(target_path)

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -1,32 +1,37 @@
 #!/usr/bin/env python3
 """
 Purpose: CLI for managing per-developer identity files used by the Stop hook
-         to write per-developer session telemetry. Supports global identity
-         (~/.agentic/identity.yml) and project-local identity
-         (<repo>/.agentic/identity.yml), with a 4-tier confirmation-first
-         resolution: project-confirmed > global-confirmed > project-provisional
-         > global-provisional > none.
+         to write per-developer session telemetry. Supports three scopes -
+         global (~/.agentic/identity.yml), profile (<config-dir>/identity.yml,
+         co-located with the active harness profile's agentic-engineering.json),
+         and project (<repo>/.agentic/identity.yml) - with a 6-tier
+         confirmation-first resolution: project-confirmed > profile-confirmed >
+         global-confirmed > project-provisional > profile-provisional >
+         global-provisional > none.
 
 Public API:
-  agentic-identity init <handle> [--display-name "<name>"] [--force] [--scope {global,project}]
-  agentic-identity show [--scope {global,project,effective}]
-  agentic-identity auto [--force] [--scope {global,project}]
-  agentic-identity confirm [--scope {global,project}]
+  agentic-identity init <handle> [--display-name "<name>"] [--force] [--scope {global,profile,project}] [--profile-dir <dir>]
+  agentic-identity show [--scope {global,profile,project,effective}] [--profile-dir <dir>]
+  agentic-identity auto [--force] [--scope {global,profile,project}] [--profile-dir <dir>]
+  agentic-identity confirm [--scope {global,profile,project}] [--profile-dir <dir>]
   agentic-identity --help
 
   Helpers: _read_identity(path=None), _write_identity(lines, target_path=None),
-           _project_identity_path(cwd=None), _resolve_effective_identity(cwd),
+           _project_identity_path(cwd=None), _profile_identity_path(profile_dir=None),
+           _profile_config_dir(), _resolve_effective_identity(cwd),
            flushPendingBuffer(confirmed_dev_id, repo_root_filter=None).
 
 Data model:
   Global:  ~/.agentic/identity.yml
+  Profile: <config-dir>/identity.yml  (config dir = AGENTIC_CONFIG_DIR, else
+           CLAUDE_CONFIG_DIR, else CODEX_HOME; only values under $HOME qualify)
   Project: <repo>/.agentic/identity.yml  (gitignored via .agentic/* umbrella)
   Fields: developer_id, display_name (optional), created_at,
           provisional (optional, absent=confirmed), derived_from (optional).
   ~/.agentic/session-log/.pending/<uuid>.json: pre-attribution session records;
     flushed to global + per-project logs on confirm/init.
-  Internal keys _scope ("project"/"global") and _confirmed (bool) are tagged
-    on resolved-identity dicts; never written to any file or log.
+  Internal keys _scope ("project"/"profile"/"global") and _confirmed (bool)
+    are tagged on resolved-identity dicts; never written to any file or log.
 
 Upstream deps: Python 3 stdlib only (argparse, glob, json, os, re, signal,
                subprocess, sys, datetime, pathlib, time).
@@ -109,6 +114,63 @@ def _project_identity_path(cwd: Path | None = None) -> Path:
     return Path(cwd or Path.cwd()) / ".agentic" / "identity.yml"
 
 
+# Harness-standard config-dir env vars, in detection precedence order. The first
+# set variable whose value resolves under $HOME selects the active profile's
+# config dir. Harness-neutral AGENTIC_CONFIG_DIR leads (it is also the install-
+# time redirect); CLAUDE_CONFIG_DIR and CODEX_HOME cover the native Claude/Codex
+# launch styles. Isolated here so adding another harness is a one-line edit.
+PROFILE_CONFIG_DIR_ENV: tuple[str, ...] = (
+    "AGENTIC_CONFIG_DIR",
+    "CLAUDE_CONFIG_DIR",
+    "CODEX_HOME",
+)
+
+
+def _is_under_home(path: Path) -> bool:
+    """True iff path resolves to a location inside the current user's $HOME."""
+    try:
+        path.resolve().relative_to(Path.home().resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _profile_config_dir() -> Path | None:
+    """Return the active profile's config dir from the env, or None.
+
+    Scans PROFILE_CONFIG_DIR_ENV in order; the first set var whose value is an
+    absolute-or-relative path resolving under $HOME wins (values outside $HOME
+    are ignored to avoid writes escaping the user tree). Returns None when no
+    var qualifies (full back-compat: profile scope is simply absent).
+    """
+    for var in PROFILE_CONFIG_DIR_ENV:
+        raw = os.environ.get(var, "").strip()
+        if not raw:
+            continue
+        candidate = Path(os.path.expanduser(raw))
+        if _is_under_home(candidate):
+            return candidate
+    return None
+
+
+def _profile_identity_path(profile_dir: Path | str | None = None) -> Path | None:
+    """Return the profile-scope identity.yml path, or None if undetectable.
+
+    When profile_dir is provided (e.g. --profile-dir CLI override), it is used
+    directly after the $HOME containment check. Otherwise the config dir is
+    detected from the environment via _profile_config_dir().
+    """
+    if profile_dir is not None:
+        candidate = Path(os.path.expanduser(str(profile_dir)))
+        if not _is_under_home(candidate):
+            return None
+        return candidate / "identity.yml"
+    cfg = _profile_config_dir()
+    if cfg is None:
+        return None
+    return cfg / "identity.yml"
+
+
 def _read_identity(path: Path | None = None) -> dict | None:
     """Return parsed identity dict or None if absent/malformed.
 
@@ -142,32 +204,38 @@ def _read_identity(path: Path | None = None) -> dict | None:
 
 
 def _resolve_effective_identity(cwd: Path) -> dict | None:
-    """Resolve effective identity via 4-tier total ordering.
+    """Resolve effective identity via 6-tier total ordering.
 
-    Tier order: project-confirmed > global-confirmed >
-                project-provisional > global-provisional > None.
+    Tier order: project-confirmed > profile-confirmed > global-confirmed >
+                project-provisional > profile-provisional > global-provisional > None.
 
     Two-pass:
-      Pass 1 (confirmed): project file first, then global - return first confirmed.
-      Pass 2 (provisional): project file first, then global - return first provisional.
+      Pass 1 (confirmed): project, then profile, then global - first confirmed wins.
+      Pass 2 (provisional): project, then profile, then global - first provisional wins.
 
-    Returns identity dict tagged with internal _scope ("project"/"global")
+    Profile scope is read from <active config dir>/identity.yml (env-detected);
+    when no config-dir env var is set, profile scope is simply absent and the
+    result is byte-identical to the prior 4-tier behavior (back-compat).
+
+    Returns identity dict tagged with internal _scope ("project"/"profile"/"global")
     and _confirmed (bool) keys. These are never written to any file or log.
     """
     proj_path = _project_identity_path(cwd)
+    prof_path = _profile_identity_path()  # env-detected; None when undetectable
     proj_id = _read_identity(proj_path)
+    prof_id = _read_identity(prof_path) if prof_path is not None else None
     glob_id = _read_identity(None)  # global IDENTITY_PATH
 
-    # Pass 1: confirmed candidates in [project, global] order
-    for identity, scope in [(proj_id, "project"), (glob_id, "global")]:
+    # Pass 1: confirmed candidates in [project, profile, global] order
+    for identity, scope in [(proj_id, "project"), (prof_id, "profile"), (glob_id, "global")]:
         if identity is not None and not identity.get("provisional", False):
             result = dict(identity)
             result["_scope"] = scope
             result["_confirmed"] = True
             return result
 
-    # Pass 2: provisional candidates in [project, global] order
-    for identity, scope in [(proj_id, "project"), (glob_id, "global")]:
+    # Pass 2: provisional candidates in [project, profile, global] order
+    for identity, scope in [(proj_id, "project"), (prof_id, "profile"), (glob_id, "global")]:
         if identity is not None:
             result = dict(identity)
             result["_scope"] = scope
@@ -382,6 +450,48 @@ def cmd_init(args: argparse.Namespace) -> int:
         return 1
 
     scope = getattr(args, "scope", "global")
+    if scope == "profile":
+        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        if target_path is None:
+            print(
+                "agentic-identity: cannot determine profile config dir. Set one of "
+                + ", ".join(PROFILE_CONFIG_DIR_ENV)
+                + " (under $HOME), or pass --profile-dir <dir>.",
+                file=sys.stderr,
+            )
+            return 1
+        existing = _read_identity(target_path) if target_path.is_file() else None
+        is_overwriting_provisional = existing is not None and existing.get("provisional", False)
+        is_fresh = existing is None
+
+        if target_path.is_file() and not args.force:
+            current = existing.get("developer_id", "?") if existing else "?"
+            print(
+                f"agentic-identity: profile identity already set to '{current}'. "
+                "Use --force to overwrite.",
+                file=sys.stderr,
+            )
+            return 2
+
+        created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [f"developer_id: {handle}"]
+        if args.display_name:
+            lines.append(f"display_name: {args.display_name}")
+        lines.append(f"created_at: {created_at}")
+
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        print(f"Identity set (profile scope): developer_id={handle}, created_at={created_at}")
+
+        # Profile scope is persona-bound (not repo-bound): flush without a
+        # repo_root_filter, mirroring the global path.
+        if is_overwriting_provisional or is_fresh:
+            flushPendingBuffer(handle)
+
+        return 0
+
     if scope == "project":
         cwd = Path.cwd()
         rc = _require_repo_root(cwd)
@@ -487,6 +597,45 @@ def cmd_auto(args: argparse.Namespace) -> int:
         return 1
 
     scope = getattr(args, "scope", "global")
+    if scope == "profile":
+        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        if target_path is None:
+            print(
+                "agentic-identity: cannot determine profile config dir. Set one of "
+                + ", ".join(PROFILE_CONFIG_DIR_ENV)
+                + " (under $HOME), or pass --profile-dir <dir>.",
+                file=sys.stderr,
+            )
+            return 1
+        existing = _read_identity(target_path)
+        if existing is not None:
+            is_provisional = existing.get("provisional", False)
+            current_handle = existing.get("developer_id", "?")
+            if not is_provisional and not args.force:
+                print(
+                    f"agentic-identity: confirmed profile identity already set to "
+                    f"'{current_handle}'. Use --force to overwrite.",
+                    file=sys.stderr,
+                )
+                return 2
+
+        created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = [
+            f"developer_id: {login}",
+            f"created_at: {created_at}",
+            "provisional: true",
+            "derived_from: gh",
+        ]
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        print(
+            f"Identity derived (provisional, profile scope): developer_id={login}. "
+            "Confirm at next session start."
+        )
+        return 0
+
     if scope == "project":
         cwd = Path.cwd()
         rc = _require_repo_root(cwd)
@@ -558,6 +707,42 @@ def cmd_auto(args: argparse.Namespace) -> int:
 def cmd_confirm(args: argparse.Namespace) -> int:
     """Confirm provisional identity: strip provisional/derived_from, flush pending buffer."""
     scope = getattr(args, "scope", "global")
+    if scope == "profile":
+        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        if target_path is None:
+            print(
+                "agentic-identity: cannot determine profile config dir. Set one of "
+                + ", ".join(PROFILE_CONFIG_DIR_ENV)
+                + " (under $HOME), or pass --profile-dir <dir>.",
+                file=sys.stderr,
+            )
+            return 1
+        identity = _read_identity(target_path)
+        if identity is None:
+            print(
+                "agentic-identity: no profile identity set. "
+                "Run 'agentic-identity init <handle> --scope profile' first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        dev_id = identity["developer_id"]
+        lines = [f"developer_id: {dev_id}"]
+        if "display_name" in identity:
+            lines.append(f"display_name: {identity['display_name']}")
+        if "created_at" in identity:
+            lines.append(f"created_at: {identity['created_at']}")
+        # Intentionally omit provisional and derived_from.
+
+        rc = _write_identity(lines, target_path=target_path)
+        if rc != 0:
+            return rc
+
+        # Profile scope is persona-bound (not repo-bound): flush without a filter.
+        flushPendingBuffer(dev_id)
+        print(f"Identity confirmed (profile scope): developer_id={dev_id}")
+        return 0
+
     if scope == "project":
         cwd = Path.cwd()
         rc = _require_repo_root(cwd)
@@ -636,6 +821,24 @@ def cmd_show(args: argparse.Namespace) -> int:
             print("provisional:   true")
         return 0
 
+    if scope == "profile":
+        target_path = _profile_identity_path(getattr(args, "profile_dir", None))
+        if target_path is None:
+            print("No profile scope (no config-dir env set and no --profile-dir).")
+            return 0
+        identity = _read_identity(target_path)
+        if identity is None:
+            print("No identity at profile scope.")
+            return 0
+        print(f"developer_id:  {identity.get('developer_id', '?')}")
+        if "display_name" in identity:
+            print(f"display_name:  {identity['display_name']}")
+        if "created_at" in identity:
+            print(f"created_at:    {identity['created_at']}")
+        if identity.get("provisional", False):
+            print("provisional:   true")
+        return 0
+
     if scope == "project":
         cwd = Path.cwd()
         target_path = _project_identity_path(cwd)
@@ -680,13 +883,17 @@ def main(argv: list[str]) -> int:
                         help="Optional human-readable display name")
     p_init.add_argument("--force", action="store_true",
                         help="Overwrite existing identity without prompting")
-    p_init.add_argument("--scope", choices=["global", "project"], default="global",
-                        help="Write to global (~/.agentic/) or project (<cwd>/.agentic/) file")
+    p_init.add_argument("--scope", choices=["global", "profile", "project"], default="global",
+                        help="Write to global (~/.agentic/), profile (<config-dir>/), or project (<cwd>/.agentic/) file")
+    p_init.add_argument("--profile-dir", default=None,
+                        help="Override profile config dir (else env-detected)")
     p_init.set_defaults(func=cmd_init)
 
     p_show = sub.add_parser("show", help="Print current identity")
-    p_show.add_argument("--scope", choices=["global", "project", "effective"], default="global",
-                        help="Show global, project, or effective (4-tier resolved) identity")
+    p_show.add_argument("--scope", choices=["global", "profile", "project", "effective"], default="global",
+                        help="Show global, profile, project, or effective (6-tier resolved) identity")
+    p_show.add_argument("--profile-dir", default=None,
+                        help="Override profile config dir for --scope profile (else env-detected)")
     p_show.set_defaults(func=cmd_show)
 
     p_auto = sub.add_parser(
@@ -698,16 +905,20 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="Overwrite existing confirmed identity",
     )
-    p_auto.add_argument("--scope", choices=["global", "project"], default="global",
-                        help="Write to global or project identity file")
+    p_auto.add_argument("--scope", choices=["global", "profile", "project"], default="global",
+                        help="Write to global, profile, or project identity file")
+    p_auto.add_argument("--profile-dir", default=None,
+                        help="Override profile config dir (else env-detected)")
     p_auto.set_defaults(func=cmd_auto)
 
     p_confirm = sub.add_parser(
         "confirm",
         help="Confirm provisional identity and flush pending session buffer",
     )
-    p_confirm.add_argument("--scope", choices=["global", "project"], default="global",
-                           help="Confirm global or project identity")
+    p_confirm.add_argument("--scope", choices=["global", "profile", "project"], default="global",
+                           help="Confirm global, profile, or project identity")
+    p_confirm.add_argument("--profile-dir", default=None,
+                           help="Override profile config dir (else env-detected)")
     p_confirm.set_defaults(func=cmd_confirm)
 
     args = p.parse_args(argv[1:])

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -260,7 +260,16 @@ def _write_identity(lines: list[str], target_path: Path | None = None) -> int:
     """
     dest = target_path if target_path is not None else IDENTITY_PATH
     content = "\n".join(lines) + "\n"
-    dest.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        dest.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as exc:
+        # e.g. --scope profile with a profile dir (or ancestor) that is an
+        # existing regular file -> FileExistsError/NotADirectoryError.
+        print(
+            f"agentic-identity: cannot create profile dir '{dest.parent}': {exc}",
+            file=sys.stderr,
+        )
+        return 1
     try:
         atomic_write(dest, content, mode=0o600)
     except Exception as exc:
@@ -350,6 +359,13 @@ def flushPendingBuffer(
                 # Stow/chezmoi symlinked ~/.config ancestor). A lexical compare
                 # would never match and orphan the record in .pending.
                 record_config_dir = record.get("config_dir", "")
+                if not isinstance(record_config_dir, str):
+                    # Malformed pending JSON (e.g. config_dir: 42) must not
+                    # crash the flush via os.path.realpath(TypeError). Coerce
+                    # to "" -> under a profile filter the record is skipped
+                    # (left in buffer); under global/project it behaves as
+                    # untagged, same as a record with no config_dir at all.
+                    record_config_dir = ""
                 if profile_dir_filter is not None:
                     if (not record_config_dir
                             or os.path.realpath(record_config_dir)

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -155,7 +155,10 @@ def _profile_config_dir() -> Path | None:
             continue
         candidate = Path(os.path.expanduser(raw))
         if _is_under_home(candidate):
-            return candidate
+            # Return the resolved spelling so this matches the JS mirror
+            # (_profileConfigDir returns _realpathNonStrict output); both sides
+            # then agree byte-for-byte on the active config dir.
+            return candidate.resolve()
     return None
 
 
@@ -170,7 +173,7 @@ def _profile_identity_path(profile_dir: Path | str | None = None) -> Path | None
         candidate = Path(os.path.expanduser(str(profile_dir)))
         if not _is_under_home(candidate):
             return None
-        return candidate / "identity.yml"
+        return candidate.resolve() / "identity.yml"
     cfg = _profile_config_dir()
     if cfg is None:
         return None

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -344,9 +344,16 @@ def flushPendingBuffer(
 
                 # profile partition: tagged records flush only under their own
                 # profile's filter; a None filter (global/project) excludes them.
+                # Realpath BOTH sides of the compare: the JS writer tags records
+                # with fs.realpathSync (symlinks resolved), while the filter may
+                # be built from an unresolved --profile-dir spelling (e.g. a
+                # Stow/chezmoi symlinked ~/.config ancestor). A lexical compare
+                # would never match and orphan the record in .pending.
                 record_config_dir = record.get("config_dir", "")
                 if profile_dir_filter is not None:
-                    if record_config_dir != profile_dir_filter:
+                    if (not record_config_dir
+                            or os.path.realpath(record_config_dir)
+                            != os.path.realpath(profile_dir_filter)):
                         continue
                 elif record_config_dir:
                     continue
@@ -455,6 +462,14 @@ def flushPendingBuffer(
     return flushed
 
 
+def _rejected_profile_dir_msg(profile_dir: str) -> str:
+    """Shared error literal for a provided-but-rejected --profile-dir."""
+    return (
+        f"agentic-identity: --profile-dir '{profile_dir}' rejected: "
+        "must resolve under $HOME."
+    )
+
+
 def _profile_target_or_err(args: argparse.Namespace) -> Path | None:
     """Resolve the profile-scope identity.yml target; print an error and return None on failure.
 
@@ -466,11 +481,7 @@ def _profile_target_or_err(args: argparse.Namespace) -> Path | None:
     if target is not None:
         return target
     if profile_dir is not None:
-        print(
-            f"agentic-identity: --profile-dir '{profile_dir}' rejected: "
-            "must resolve under $HOME.",
-            file=sys.stderr,
-        )
+        print(_rejected_profile_dir_msg(profile_dir), file=sys.stderr)
     else:
         print(
             "agentic-identity: cannot determine profile config dir. Set one of "
@@ -864,11 +875,7 @@ def cmd_show(args: argparse.Namespace) -> int:
         target_path = _profile_identity_path(profile_dir)
         if target_path is None:
             if profile_dir is not None:
-                print(
-                    f"agentic-identity: --profile-dir '{profile_dir}' rejected: "
-                    "must resolve under $HOME.",
-                    file=sys.stderr,
-                )
+                print(_rejected_profile_dir_msg(profile_dir), file=sys.stderr)
                 return 1
             print("No profile scope (no config-dir env set and no --profile-dir).")
             return 0

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -128,6 +128,7 @@ PROFILE_CONFIG_DIR_ENV: tuple[str, ...] = (
 
 def _is_under_home(path: Path) -> bool:
     """True iff path resolves to a location inside the current user's $HOME."""
+    # TOCTOU: check-to-use window accepted (attacker needs write access inside victim's own $HOME).
     try:
         path.resolve().relative_to(Path.home().resolve())
         return True

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -42,6 +42,7 @@ _loader.exec_module(_mod)
 flushPendingBuffer = _mod.flushPendingBuffer
 _resolve_effective_identity = _mod._resolve_effective_identity
 _project_identity_path = _mod._project_identity_path
+_profile_identity_path = _mod._profile_identity_path
 
 
 def _write_pending(pending_dir: Path, record: dict) -> Path:
@@ -498,6 +499,246 @@ def test_dedup_multi_pending_correct_across_several():
         print("PASS test_dedup_multi_pending_correct_across_several")
 
 
+# ---------------------------------------------------------------------------
+# Tests (J): profile scope + 6-tier resolution + env detection + back-compat
+# ---------------------------------------------------------------------------
+
+def _patch_environ(set_pairs=None, clear_keys=None):
+    """Set/clear env vars; returns a restore thunk (call in finally). Hermetic."""
+    set_pairs = set_pairs or {}
+    clear_keys = clear_keys or ()
+    prev: dict = {}
+    added: list[str] = []
+    for k in list(clear_keys):
+        if k in os.environ:
+            prev[k] = os.environ.pop(k)
+    for k, v in set_pairs.items():
+        if k in os.environ:
+            if k not in prev:
+                prev[k] = os.environ[k]
+        else:
+            added.append(k)
+        os.environ[k] = v
+
+    def _restore():
+        for k in added:
+            os.environ.pop(k, None)
+        for k, v in prev.items():
+            os.environ[k] = v
+
+    return _restore
+
+
+def test_profile_confirmed_beats_confirmed_global():
+    """(J1) confirmed profile beats confirmed global in pass 1."""
+    with tempfile.TemporaryDirectory() as tmp, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as prof:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+        _write_identity_file(Path(prof) / "identity.yml", "profile-dev", provisional=False)
+
+        restore = _patch_environ(set_pairs={"AGENTIC_CONFIG_DIR": prof},
+                                 clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        orig = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = orig
+            restore()
+
+        assert result is not None, "Expected a resolved identity"
+        assert result["developer_id"] == "profile-dev", \
+            f"Expected profile-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "profile", f"Expected scope=profile, got {result['_scope']!r}"
+        assert result["_confirmed"] is True
+        print("PASS test_profile_confirmed_beats_confirmed_global")
+
+
+def test_project_confirmed_beats_confirmed_profile():
+    """(J2) confirmed project beats confirmed profile (project is most specific)."""
+    with tempfile.TemporaryDirectory() as tmp, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as prof:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        _write_identity_file(cwd / ".agentic" / "identity.yml", "project-dev", provisional=False)
+        _write_identity_file(Path(prof) / "identity.yml", "profile-dev", provisional=False)
+
+        restore = _patch_environ(set_pairs={"AGENTIC_CONFIG_DIR": prof},
+                                 clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            restore()
+
+        assert result is not None
+        assert result["developer_id"] == "project-dev", \
+            f"Expected project-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "project", f"Expected scope=project, got {result['_scope']!r}"
+        print("PASS test_project_confirmed_beats_confirmed_profile")
+
+
+def test_confirmed_global_not_suppressed_by_provisional_profile():
+    """(J3) provisional profile does NOT suppress a confirmed global."""
+    with tempfile.TemporaryDirectory() as tmp, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as prof:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+        _write_identity_file(Path(prof) / "identity.yml", "profile-dev", provisional=True)
+
+        restore = _patch_environ(set_pairs={"AGENTIC_CONFIG_DIR": prof},
+                                 clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        orig = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = orig
+            restore()
+
+        assert result is not None
+        assert result["developer_id"] == "global-dev", \
+            f"Expected global-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "global", f"Expected scope=global, got {result['_scope']!r}"
+        assert result["_confirmed"] is True
+        print("PASS test_confirmed_global_not_suppressed_by_provisional_profile")
+
+
+def test_provisional_profile_used_when_no_confirmed_anywhere():
+    """(J4) with no project/global and only a provisional profile, pass 2 returns profile."""
+    with tempfile.TemporaryDirectory() as tmp, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as prof:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        # Global points to a nonexistent file -> no global identity.
+        global_id_path = tmp_path / "absent-global.yml"
+        _write_identity_file(Path(prof) / "identity.yml", "profile-dev", provisional=True)
+
+        restore = _patch_environ(set_pairs={"AGENTIC_CONFIG_DIR": prof},
+                                 clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        orig = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = orig
+            restore()
+
+        assert result is not None
+        assert result["developer_id"] == "profile-dev", \
+            f"Expected profile-dev, got {result['developer_id']!r}"
+        assert result["_scope"] == "profile"
+        assert result["_confirmed"] is False, "Provisional profile must be _confirmed=False"
+        print("PASS test_provisional_profile_used_when_no_confirmed_anywhere")
+
+
+def test_env_detection_precedence():
+    """(J5) AGENTIC_CONFIG_DIR beats CLAUDE_CONFIG_DIR beats CODEX_HOME."""
+    with tempfile.TemporaryDirectory(dir=str(Path.home())) as a, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as b, \
+            tempfile.TemporaryDirectory(dir=str(Path.home())) as c:
+        _write_identity_file(Path(a) / "identity.yml", "a-dev")
+        _write_identity_file(Path(b) / "identity.yml", "b-dev")
+        _write_identity_file(Path(c) / "identity.yml", "c-dev")
+
+        # All three set -> AGENTIC_CONFIG_DIR (a) wins.
+        restore = _patch_environ(set_pairs={
+            "AGENTIC_CONFIG_DIR": a, "CLAUDE_CONFIG_DIR": b, "CODEX_HOME": c})
+        try:
+            p = _profile_identity_path()
+            assert p == Path(a) / "identity.yml", f"Expected A path, got {p}"
+        finally:
+            restore()
+
+        # AGENTIC cleared -> CLAUDE_CONFIG_DIR (b) wins.
+        restore = _patch_environ(set_pairs={"CLAUDE_CONFIG_DIR": b, "CODEX_HOME": c},
+                                 clear_keys=["AGENTIC_CONFIG_DIR"])
+        try:
+            p = _profile_identity_path()
+            assert p == Path(b) / "identity.yml", f"Expected B path, got {p}"
+        finally:
+            restore()
+
+        print("PASS test_env_detection_precedence")
+
+
+def test_profile_dir_outside_home_rejected():
+    """(J6) config dir outside $HOME is rejected; profile scope is ignored."""
+    with tempfile.TemporaryDirectory() as outside, \
+            tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+        # Write a would-be profile identity in the outside-home dir (must be ignored).
+        _write_identity_file(Path(outside) / "identity.yml", "intruder-dev", provisional=False)
+
+        restore = _patch_environ(set_pairs={"AGENTIC_CONFIG_DIR": outside},
+                                 clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        orig = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            assert _profile_identity_path() is None, \
+                "Outside-$HOME config dir must yield None"
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = orig
+            restore()
+
+        assert result is not None
+        assert result["developer_id"] == "global-dev", \
+            f"Profile outside $HOME must be ignored; got {result['developer_id']!r}"
+        assert result["_scope"] == "global"
+        print("PASS test_profile_dir_outside_home_rejected")
+
+
+def test_profile_dir_override():
+    """(J7) --profile-dir override is used; outside-$HOME override is rejected."""
+    with tempfile.TemporaryDirectory(dir=str(Path.home())) as prof, \
+            tempfile.TemporaryDirectory() as outside:
+        _write_identity_file(Path(prof) / "identity.yml", "override-dev")
+        p = _profile_identity_path(profile_dir=prof)
+        assert p == Path(prof) / "identity.yml", f"Override path mismatch: {p}"
+        bad = _profile_identity_path(profile_dir=outside)
+        assert bad is None, "Outside-$HOME override must be rejected"
+        print("PASS test_profile_dir_override")
+
+
+def test_no_env_profile_scope_absent():
+    """(J8) back-compat: with no config-dir env, profile scope is absent (4-tier behavior)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        cwd = tmp_path / "myrepo"
+        cwd.mkdir()
+        global_id_path = tmp_path / "global-identity.yml"
+        _write_identity_file(global_id_path, "global-dev", provisional=False)
+
+        restore = _patch_environ(clear_keys=list(_mod.PROFILE_CONFIG_DIR_ENV))
+        orig = _mod.IDENTITY_PATH
+        _mod.IDENTITY_PATH = global_id_path
+        try:
+            assert _profile_identity_path() is None
+            result = _resolve_effective_identity(cwd)
+        finally:
+            _mod.IDENTITY_PATH = orig
+            restore()
+
+        assert result is not None
+        assert result["developer_id"] == "global-dev"
+        assert result["_scope"] == "global", \
+            f"With no env, scope must be global (no profile); got {result['_scope']!r}"
+        print("PASS test_no_env_profile_scope_absent")
+
+
 if __name__ == "__main__":
     test_flushed_line_canonical_shape()
     test_project_scope_flush_does_not_touch_other_repo_records()
@@ -509,4 +750,12 @@ if __name__ == "__main__":
     test_dedup_flushes_new_uuid_not_in_log()
     test_dedup_missing_global_log_flushes_all()
     test_dedup_multi_pending_correct_across_several()
+    test_profile_confirmed_beats_confirmed_global()
+    test_project_confirmed_beats_confirmed_profile()
+    test_confirmed_global_not_suppressed_by_provisional_profile()
+    test_provisional_profile_used_when_no_confirmed_anywhere()
+    test_env_detection_precedence()
+    test_profile_dir_outside_home_rejected()
+    test_profile_dir_override()
+    test_no_env_profile_scope_absent()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -713,6 +713,109 @@ def test_profile_dir_override():
         print("PASS test_profile_dir_override")
 
 
+def test_profile_flush_only_own_config_dir_records():
+    """(K1) profile_dir_filter flushes only records tagged with that config_dir."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        mine = {
+            "session_uuid": "uuid-prof-mine",
+            "ts": "2026-07-01T00:00:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "config_dir": "/home/u/.claude-a",
+            "data": {},
+        }
+        other = {
+            "session_uuid": "uuid-prof-other",
+            "ts": "2026-07-01T00:01:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "config_dir": "/home/u/.claude-b",
+            "data": {},
+        }
+        untagged = {
+            "session_uuid": "uuid-untagged",
+            "ts": "2026-07-01T00:02:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "data": {},
+        }
+        path_mine = _write_pending(pending_dir, mine)
+        path_other = _write_pending(pending_dir, other)
+        path_untagged = _write_pending(pending_dir, untagged)
+
+        count = flushPendingBuffer("prof-dev", profile_dir_filter="/home/u/.claude-a")
+        assert count == 1, f"Expected 1 flushed (own tag only), got {count}"
+        assert not path_mine.exists(), "Own-profile record must be flushed"
+        assert path_other.exists(), "Other-profile record must remain in buffer"
+        assert path_untagged.exists(), "Untagged record must remain under a profile filter"
+
+        global_log = global_log_dir / "prof-dev.jsonl"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["session_uuid"] == "uuid-prof-mine"
+        assert "config_dir" not in row, \
+            "config_dir must NOT appear in canonical session-log line"
+        print("PASS test_profile_flush_only_own_config_dir_records")
+
+
+def test_global_flush_skips_config_dir_tagged_records():
+    """(K2) None filter (global confirm) excludes tagged records; they stay pending."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        tagged = {
+            "session_uuid": "uuid-tagged-g",
+            "ts": "2026-07-01T00:00:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "config_dir": "/home/u/.claude-a",
+            "data": {},
+        }
+        path_tagged = _write_pending(pending_dir, tagged)
+
+        count = flushPendingBuffer("glob-dev")  # no filters
+        assert count == 0, f"Expected 0 flushed (tagged record excluded), got {count}"
+        assert path_tagged.exists(), \
+            "Tagged record must remain in .pending under a global flush"
+        print("PASS test_global_flush_skips_config_dir_tagged_records")
+
+
+def test_global_flush_still_attributes_untagged_legacy_records():
+    """(K3) untagged legacy records flush unchanged under a global confirm."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        legacy = {
+            "session_uuid": "uuid-legacy",
+            "ts": "2026-07-01T00:00:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "data": {},
+        }
+        path_legacy = _write_pending(pending_dir, legacy)
+
+        count = flushPendingBuffer("legacy-dev")
+        assert count == 1, f"Expected 1 flushed, got {count}"
+        assert not path_legacy.exists(), "Legacy record must be flushed"
+
+        global_log = global_log_dir / "legacy-dev.jsonl"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1
+        assert json.loads(lines[0])["session_uuid"] == "uuid-legacy"
+        print("PASS test_global_flush_still_attributes_untagged_legacy_records")
+
+
 def test_no_env_profile_scope_absent():
     """(J8) back-compat: with no config-dir env, profile scope is absent (4-tier behavior)."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -757,5 +860,8 @@ if __name__ == "__main__":
     test_env_detection_precedence()
     test_profile_dir_outside_home_rejected()
     test_profile_dir_override()
+    test_profile_flush_only_own_config_dir_records()
+    test_global_flush_skips_config_dir_tagged_records()
+    test_global_flush_still_attributes_untagged_legacy_records()
     test_no_env_profile_scope_absent()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -934,6 +934,31 @@ def test_env_precedence_nonexistent_highest_wins():
         print("PASS test_env_precedence_nonexistent_highest_wins")
 
 
+def test_tilde_prefixed_env_expanded():
+    """(M3) a literal ~-prefixed config-dir env value is expanded to $HOME
+    (os.path.expanduser), matching the JS _expandUser mirror. Regression for
+    the cross-language divergence where Python expanded ~ but Node resolved it
+    to <cwd>/~/... - the two then read different identity.yml for one env var."""
+    prof = Path.home() / f".claude-tenant-tilde-{os.getpid()}"
+    prof.mkdir()
+    try:
+        _write_identity_file(prof / "identity.yml", "tilde-dev", provisional=False)
+        restore = _patch_environ(
+            set_pairs={"AGENTIC_CONFIG_DIR": f"~/{prof.name}"},
+            clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+        try:
+            cfg = _profile_config_dir()
+            p = _profile_identity_path()
+        finally:
+            restore()
+        assert cfg == prof.resolve(), \
+            f"~-prefixed env must expand to $HOME/{prof.name}, got {cfg}"
+        assert p == prof.resolve() / "identity.yml", f"identity path mismatch: {p}"
+    finally:
+        (prof / "identity.yml").unlink(missing_ok=True)
+        prof.rmdir()
+    print("PASS test_tilde_prefixed_env_expanded")
+
 def test_symlink_escape_rejected():
     """(Minor1) a symlink under $HOME pointing OUTSIDE $HOME is rejected by
     the containment check, via both the env scan and --profile-dir.
@@ -1318,6 +1343,7 @@ if __name__ == "__main__":
     test_global_flush_still_attributes_untagged_legacy_records()
     test_no_env_profile_scope_absent()
     test_env_precedence_nonexistent_highest_wins()
+    test_tilde_prefixed_env_expanded()
     test_symlink_escape_rejected()
     test_flush_non_string_config_dir_no_crash()
     test_cli_auto_profile_writes_provisional()

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -13,6 +13,14 @@ Test groups:
   5. test_no_repo_root_record_skipped_by_filter (D) - records with absent/empty repo_root
      are conservatively skipped when a repo_root_filter is active.
   6. test_global_scope_flush_unaffected (E) - no-filter flush attributes all pending records.
+  7. J/K suites - profile scope: 6-tier resolution, env detection, config_dir
+     flush partition (see individual docstrings).
+  8. CLI suite (L) - subprocess-level cmd_auto/cmd_confirm --scope profile
+     coverage under a fake $HOME (rejection paths, provisional write, and the
+     confirm->flushPendingBuffer profile_dir_filter wiring end-to-end).
+  9. M suite - hardening: nonexistent highest-precedence env dir stops the
+     scan (Python<->JS parity contract), symlink-escape rejection, file-as-
+     profile-dir clean failure, non-string config_dir flush guard.
 
 Regression test obligation: content/references/regression-test-obligation.md
 Run with: python3 -m pytest bin/tests/test_agentic_identity.py -x
@@ -43,6 +51,7 @@ flushPendingBuffer = _mod.flushPendingBuffer
 _resolve_effective_identity = _mod._resolve_effective_identity
 _project_identity_path = _mod._project_identity_path
 _profile_identity_path = _mod._profile_identity_path
+_profile_config_dir = _mod._profile_config_dir
 
 
 def _write_pending(pending_dir: Path, record: dict) -> Path:
@@ -892,6 +901,265 @@ def test_no_env_profile_scope_absent():
         print("PASS test_no_env_profile_scope_absent")
 
 
+# ---------------------------------------------------------------------------
+# Tests (M): env-scan contract, symlink escape, mkdir/flush hardening
+# ---------------------------------------------------------------------------
+
+def test_env_precedence_nonexistent_highest_wins():
+    """(M2) a NOT-yet-created dir in the highest-precedence env var still wins:
+    the scan STOPS there (no fall-through to a lower-precedence existing
+    profile). Pins the Python contract the JS mirror must match."""
+    ghost = Path.home() / f".agentic-ghost-{os.getpid()}"
+    assert not ghost.exists(), f"fixture precondition: {ghost} must not exist"
+    with tempfile.TemporaryDirectory(dir=str(Path.home())) as existing:
+        _write_identity_file(Path(existing) / "identity.yml", "existing-dev")
+        restore = _patch_environ(
+            set_pairs={"AGENTIC_CONFIG_DIR": str(ghost), "CLAUDE_CONFIG_DIR": existing},
+            clear_keys=["CODEX_HOME"])
+        try:
+            cfg = _profile_config_dir()
+        finally:
+            restore()
+        assert cfg == ghost, \
+            f"Nonexistent highest-precedence dir must win (stop scan); got {cfg}"
+        # And the derived identity path points into the ghost dir (holds no file).
+        restore = _patch_environ(
+            set_pairs={"AGENTIC_CONFIG_DIR": str(ghost), "CLAUDE_CONFIG_DIR": existing},
+            clear_keys=["CODEX_HOME"])
+        try:
+            p = _profile_identity_path()
+        finally:
+            restore()
+        assert p == ghost / "identity.yml", f"Expected ghost identity path, got {p}"
+        print("PASS test_env_precedence_nonexistent_highest_wins")
+
+
+def test_symlink_escape_rejected():
+    """(Minor1) a symlink under $HOME pointing OUTSIDE $HOME is rejected by
+    the containment check, via both the env scan and --profile-dir.
+    Mirrors the JS [SYM] test."""
+    link = Path.home() / f".agentic-escape-{os.getpid()}"
+    with tempfile.TemporaryDirectory() as outside:
+        _write_identity_file(Path(outside) / "identity.yml", "escape-dev")
+        os.symlink(outside, link)
+        try:
+            restore = _patch_environ(
+                set_pairs={"AGENTIC_CONFIG_DIR": str(link)},
+                clear_keys=["CLAUDE_CONFIG_DIR", "CODEX_HOME"])
+            try:
+                assert _profile_config_dir() is None, \
+                    "Escaping symlink via env must be rejected"
+                assert _profile_identity_path() is None
+            finally:
+                restore()
+            assert _profile_identity_path(profile_dir=str(link)) is None, \
+                "Escaping symlink via --profile-dir must be rejected"
+        finally:
+            link.unlink(missing_ok=True)
+    print("PASS test_symlink_escape_rejected")
+
+
+def test_flush_non_string_config_dir_no_crash():
+    """(Minor2) a pending record with a non-string config_dir must not crash
+    the flush (pre-guard: os.path.realpath(42) raised TypeError). Under a
+    profile filter it is skipped (left in buffer); under a global flush it
+    behaves as untagged."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        bad = {
+            "session_uuid": "uuid-bad-cfg",
+            "ts": "2026-07-09T00:00:00.000Z",
+            "project_slug": "p",
+            "branch": "main",
+            "config_dir": 42,  # malformed: non-string
+            "data": {},
+        }
+        path_bad = _write_pending(pending_dir, bad)
+
+        # Profile filter: no TypeError; record skipped (stays in buffer).
+        count = flushPendingBuffer("ns-dev", profile_dir_filter="/home/u/.claude-a")
+        assert count == 0, f"Expected 0 flushed under profile filter, got {count}"
+        assert path_bad.exists(), "Malformed record must remain in buffer"
+
+        # Global flush: no TypeError; coerced-to-'' record behaves as untagged.
+        count = flushPendingBuffer("ns-dev")
+        assert count == 1, f"Expected 1 flushed under global flush, got {count}"
+        assert not path_bad.exists(), "Record must flush as untagged under global"
+        print("PASS test_flush_non_string_config_dir_no_crash")
+
+
+# ---------------------------------------------------------------------------
+# Tests (L): CLI-level cmd_auto / cmd_confirm --scope profile (subprocess)
+# ---------------------------------------------------------------------------
+
+def _cli_env(fake_home: Path, extra_path: Path | None = None) -> dict:
+    """Hermetic subprocess env: fake HOME, profile env vars unset."""
+    env = dict(os.environ)
+    for k in ("AGENTIC_CONFIG_DIR", "CLAUDE_CONFIG_DIR", "CODEX_HOME"):
+        env.pop(k, None)
+    env["HOME"] = str(fake_home)
+    if extra_path is not None:
+        env["PATH"] = str(extra_path) + os.pathsep + env.get("PATH", "")
+    return env
+
+
+def _run_cli(args: list[str], env: dict):
+    """Run the real bin/agentic-identity via subprocess. Returns CompletedProcess."""
+    import subprocess
+    return subprocess.run(
+        [sys.executable, str(_BIN_PATH)] + args,
+        capture_output=True, text=True, env=env, timeout=30,
+    )
+
+
+def _fake_gh(bin_dir: Path, login: str) -> None:
+    """Install a fake `gh` shim printing a fixed login (hermetic cmd_auto)."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(f"#!/bin/sh\necho {login}\n", encoding="utf-8")
+    gh.chmod(0o755)
+
+
+def test_cli_auto_profile_writes_provisional():
+    """(L1) `auto --scope profile --profile-dir <dir>` writes a provisional
+    identity.yml under the profile dir (real CLI, fake $HOME + fake gh)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        fake_bin = tmp_path / "fakebin"
+        _fake_gh(fake_bin, "auto-dev")
+        env = _cli_env(fake_home, extra_path=fake_bin)
+
+        r = _run_cli(["auto", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"auto failed: rc={r.returncode} stderr={r.stderr}"
+        content = (prof / "identity.yml").read_text(encoding="utf-8")
+        assert "developer_id: auto-dev" in content
+        assert "provisional: true" in content
+        assert "derived_from: gh" in content
+        print("PASS test_cli_auto_profile_writes_provisional")
+
+
+def test_cli_auto_profile_confirmed_rejected_without_force():
+    """(L2) `auto --scope profile` over an already-CONFIRMED profile identity
+    without --force is rejected (exit 2, message, identity unchanged)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        _write_identity_file(prof / "identity.yml", "settled-dev", provisional=False)
+        before = (prof / "identity.yml").read_text(encoding="utf-8")
+        fake_bin = tmp_path / "fakebin"
+        _fake_gh(fake_bin, "usurper-dev")
+        env = _cli_env(fake_home, extra_path=fake_bin)
+
+        r = _run_cli(["auto", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 2, f"Expected rc=2, got {r.returncode} stderr={r.stderr}"
+        assert "confirmed profile identity already set" in r.stderr, \
+            f"Missing rejection message: {r.stderr!r}"
+        after = (prof / "identity.yml").read_text(encoding="utf-8")
+        assert after == before, "Identity file must be unchanged on rejection"
+        print("PASS test_cli_auto_profile_confirmed_rejected_without_force")
+
+
+def test_cli_confirm_profile_flushes_tagged_pending():
+    """(L3) `confirm --scope profile` end-to-end: strips provisional AND
+    flushes the pending record tagged with THAT profile's config_dir while
+    leaving other-profile records in the buffer. A wiring bug in
+    cmd_confirm's profile branch (wrong getattr dest, wrong filter path)
+    fails this test."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        other_prof = fake_home / ".claude-other"
+        _write_identity_file(prof / "identity.yml", "flush-dev", provisional=True)
+
+        pending_dir = fake_home / ".agentic" / "session-log" / ".pending"
+        mine = {
+            "session_uuid": "uuid-cli-mine",
+            "ts": "2026-07-09T00:00:00.000Z",
+            "project_slug": "p",
+            "branch": "main",
+            "config_dir": str(prof),
+            "data": {},
+        }
+        other = {
+            "session_uuid": "uuid-cli-other",
+            "ts": "2026-07-09T00:01:00.000Z",
+            "project_slug": "p",
+            "branch": "main",
+            "config_dir": str(other_prof),
+            "data": {},
+        }
+        path_mine = _write_pending(pending_dir, mine)
+        path_other = _write_pending(pending_dir, other)
+
+        env = _cli_env(fake_home)
+        r = _run_cli(["confirm", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"confirm failed: rc={r.returncode} stderr={r.stderr}"
+
+        content = (prof / "identity.yml").read_text(encoding="utf-8")
+        assert "provisional" not in content, "provisional must be stripped on confirm"
+
+        assert not path_mine.exists(), \
+            "Pending record tagged with THIS profile dir must be flushed"
+        assert path_other.exists(), \
+            "Other-profile record must remain in the buffer"
+        global_log = fake_home / ".agentic" / "session-log" / "flush-dev.jsonl"
+        assert global_log.is_file(), "Global log must be written by the flush"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["session_uuid"] == "uuid-cli-mine"
+        assert row["developer_id"] == "flush-dev"
+        print("PASS test_cli_confirm_profile_flushes_tagged_pending")
+
+
+def test_cli_confirm_profile_no_identity_errors():
+    """(L4) `confirm --scope profile` with no profile identity exits 1 with a
+    clear message (no traceback)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        env = _cli_env(fake_home)
+
+        r = _run_cli(["confirm", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 1, f"Expected rc=1, got {r.returncode}"
+        assert "no profile identity set" in r.stderr
+        assert "Traceback" not in r.stderr
+        print("PASS test_cli_confirm_profile_no_identity_errors")
+
+
+def test_cli_profile_dir_is_regular_file_clean_error():
+    """(Med) --profile-dir pointing at an existing regular file exits 1 with a
+    clean message - the mkdir failure must not escape as a traceback."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        not_a_dir = fake_home / "notadir"
+        not_a_dir.write_text("i am a file\n", encoding="utf-8")
+        env = _cli_env(fake_home)
+
+        r = _run_cli(
+            ["init", "tester", "--scope", "profile", "--profile-dir", str(not_a_dir)],
+            env)
+        assert r.returncode == 1, \
+            f"Expected rc=1, got {r.returncode} stderr={r.stderr!r}"
+        assert "cannot create profile dir" in r.stderr, \
+            f"Missing clean error message: {r.stderr!r}"
+        assert "Traceback" not in r.stderr, f"Traceback leaked: {r.stderr!r}"
+        print("PASS test_cli_profile_dir_is_regular_file_clean_error")
+
+
 if __name__ == "__main__":
     test_flushed_line_canonical_shape()
     test_project_scope_flush_does_not_touch_other_repo_records()
@@ -915,4 +1183,12 @@ if __name__ == "__main__":
     test_profile_flush_matches_symlinked_filter_spelling()
     test_global_flush_still_attributes_untagged_legacy_records()
     test_no_env_profile_scope_absent()
+    test_env_precedence_nonexistent_highest_wins()
+    test_symlink_escape_rejected()
+    test_flush_non_string_config_dir_no_crash()
+    test_cli_auto_profile_writes_provisional()
+    test_cli_auto_profile_confirmed_rejected_without_force()
+    test_cli_confirm_profile_flushes_tagged_pending()
+    test_cli_confirm_profile_no_identity_errors()
+    test_cli_profile_dir_is_regular_file_clean_error()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -798,6 +798,47 @@ def test_global_flush_skips_config_dir_tagged_records():
         print("PASS test_global_flush_skips_config_dir_tagged_records")
 
 
+def test_profile_flush_matches_symlinked_filter_spelling():
+    """(K4) round-trip: record tagged with realpath'd config_dir (JS writer)
+    flushes under a filter built from the UN-resolved symlinked spelling."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp).resolve()  # macOS: /var -> /private/var
+        pending_dir, global_log_dir, _ = _patch_paths(tmp_path)
+
+        # Real config tree + a symlinked ancestor pointing at it
+        # (Stow/chezmoi-style ~/.config -> dotfiles/config).
+        real_parent = tmp_path / "dotfiles" / "config"
+        real_cfg = real_parent / "claude"
+        real_cfg.mkdir(parents=True)
+        link_parent = tmp_path / ".config"
+        os.symlink(real_parent, link_parent)
+        symlinked_cfg = link_parent / "claude"  # unresolved spelling
+
+        # JS writer tags with fs.realpathSync -> the fully-resolved path.
+        record = {
+            "session_uuid": "uuid-symlink-rt",
+            "ts": "2026-07-01T00:00:00.000Z",
+            "project_slug": "p",
+            "repo_root": "/repo/p",
+            "branch": "main",
+            "config_dir": str(real_cfg.resolve()),
+            "data": {},
+        }
+        path_rec = _write_pending(pending_dir, record)
+
+        # Filter uses the symlinked spelling (what --profile-dir would carry).
+        count = flushPendingBuffer("rt-dev", profile_dir_filter=str(symlinked_cfg))
+        assert count == 1, f"Expected 1 flushed (realpath both sides), got {count}"
+        assert not path_rec.exists(), \
+            "Record must flush despite symlinked filter spelling"
+
+        global_log = global_log_dir / "rt-dev.jsonl"
+        lines = [l for l in global_log.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(lines) == 1
+        assert json.loads(lines[0])["session_uuid"] == "uuid-symlink-rt"
+        print("PASS test_profile_flush_matches_symlinked_filter_spelling")
+
+
 def test_global_flush_still_attributes_untagged_legacy_records():
     """(K3) untagged legacy records flush unchanged under a global confirm."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -871,6 +912,7 @@ if __name__ == "__main__":
     test_profile_dir_override()
     test_profile_flush_only_own_config_dir_records()
     test_global_flush_skips_config_dir_tagged_records()
+    test_profile_flush_matches_symlinked_filter_spelling()
     test_global_flush_still_attributes_untagged_legacy_records()
     test_no_env_profile_scope_absent()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -1159,6 +1159,140 @@ def test_cli_profile_dir_is_regular_file_clean_error():
         assert "Traceback" not in r.stderr, f"Traceback leaked: {r.stderr!r}"
         print("PASS test_cli_profile_dir_is_regular_file_clean_error")
 
+def test_cli_init_profile_happy_path():
+    """(L5) `init <handle> --scope profile --profile-dir <dir>` writes a
+    NON-provisional identity.yml (exit 0). Only the mkdir-failure branch of
+    init was covered before - this pins the success path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        env = _cli_env(fake_home)
+
+        r = _run_cli(["init", "prof-init-dev", "--scope", "profile",
+                      "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"init failed: rc={r.returncode} stderr={r.stderr}"
+        content = (prof / "identity.yml").read_text(encoding="utf-8")
+        assert "developer_id: prof-init-dev" in content
+        assert "provisional" not in content, \
+            "init writes a confirmed (non-provisional) identity"
+        print("PASS test_cli_init_profile_happy_path")
+
+def test_cli_init_profile_force_overwrites_confirmed():
+    """(L6) `init --scope profile --force` overwrites an already-CONFIRMED
+    profile identity; without --force it is rejected (exit 2)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        _write_identity_file(prof / "identity.yml", "old-dev", provisional=False)
+        env = _cli_env(fake_home)
+
+        # No --force over a confirmed identity -> rejected, unchanged.
+        r = _run_cli(["init", "new-dev", "--scope", "profile",
+                      "--profile-dir", str(prof)], env)
+        assert r.returncode == 2, f"Expected rc=2, got {r.returncode} stderr={r.stderr}"
+        assert "developer_id: old-dev" in (prof / "identity.yml").read_text(encoding="utf-8"), \
+            "Identity must be unchanged without --force"
+
+        # --force -> overwrite succeeds.
+        r = _run_cli(["init", "new-dev", "--scope", "profile", "--force",
+                      "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"--force init failed: rc={r.returncode} stderr={r.stderr}"
+        content = (prof / "identity.yml").read_text(encoding="utf-8")
+        assert "developer_id: new-dev" in content, "Identity must be overwritten with --force"
+        print("PASS test_cli_init_profile_force_overwrites_confirmed")
+
+def test_cli_show_profile_three_paths():
+    """(L7) `show --scope profile` command-level coverage of its three print
+    paths: no config-dir/no --profile-dir; --profile-dir set but no identity;
+    identity present. Only the underlying helpers were unit-tested before."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        env = _cli_env(fake_home)  # profile env vars stripped
+
+        # Path 1: no config-dir env, no --profile-dir -> "No profile scope..."
+        r = _run_cli(["show", "--scope", "profile"], env)
+        assert r.returncode == 0, f"rc={r.returncode} stderr={r.stderr}"
+        assert "No profile scope" in r.stdout, f"stdout={r.stdout!r}"
+
+        # Path 2: --profile-dir set but no identity file -> "No identity at profile scope."
+        r = _run_cli(["show", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"rc={r.returncode} stderr={r.stderr}"
+        assert "No identity at profile scope" in r.stdout, f"stdout={r.stdout!r}"
+
+        # Path 3: identity present -> developer_id printed.
+        _write_identity_file(prof / "identity.yml", "shown-dev", provisional=False)
+        r = _run_cli(["show", "--scope", "profile", "--profile-dir", str(prof)], env)
+        assert r.returncode == 0, f"rc={r.returncode} stderr={r.stderr}"
+        assert "developer_id:  shown-dev" in r.stdout, f"stdout={r.stdout!r}"
+        print("PASS test_cli_show_profile_three_paths")
+
+def test_cross_language_profile_resolution_agrees():
+    """(X1) Python (`agentic-identity show --scope effective`) and JS
+    (`stop-context.js`) resolve the SAME winning identity on ONE identical
+    fixture. Nothing else diffs their real output on the same input, so a
+    precedence/containment change on one side unmirrored on the other would
+    ship silently. Uses AGENTIC_CONFIG_DIR -> a profile dir under $HOME with a
+    confirmed profile identity that must beat a confirmed global identity."""
+    import subprocess
+    js_hook = _BIN_PATH.parent.parent / "hooks" / "stop-context.js"
+    if not js_hook.is_file():
+        print("SKIP test_cross_language_profile_resolution_agrees (no JS hook)")
+        return
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # realpath tmp: macOS mkdtemp yields /var -> /private/var; both sides
+        # realpath $HOME, so the fixture must live under the resolved spelling.
+        tmp_path = Path(tmp).resolve()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        prof = fake_home / ".claude-tenant"
+        project = tmp_path / "project"
+        (project / ".agentic").mkdir(parents=True)
+        # Confirmed global + confirmed profile: profile must win at both sides.
+        _write_identity_file(fake_home / ".agentic" / "identity.yml",
+                             "global-dev", provisional=False)
+        _write_identity_file(prof / "identity.yml", "profile-dev", provisional=False)
+
+        env = dict(os.environ)
+        for k in ("AGENTIC_CONFIG_DIR", "CLAUDE_CONFIG_DIR", "CODEX_HOME"):
+            env.pop(k, None)
+        env["HOME"] = str(fake_home)
+        env["AGENTIC_CONFIG_DIR"] = str(prof)
+
+        # Python side: `show --scope effective` reports the resolved scope+id.
+        py = subprocess.run(
+            [sys.executable, str(_BIN_PATH), "show", "--scope", "effective"],
+            capture_output=True, text=True, env=env, cwd=str(project), timeout=30)
+        assert py.returncode == 0, f"py show failed: {py.stderr}"
+        assert "developer_id:  profile-dev" in py.stdout, \
+            f"Python did not resolve profile-dev: {py.stdout!r}"
+        assert "scope:         profile" in py.stdout, \
+            f"Python scope not profile: {py.stdout!r}"
+
+        # JS side: run the hook; it writes a per-project session log keyed by
+        # the winning developer_id. profile-dev winning => that log exists,
+        # global-dev's does not.
+        payload = json.dumps({"cwd": str(project), "session_id": "x1-uuid",
+                              "transcript": []})
+        js = subprocess.run(
+            ["node", str(js_hook)], input=payload, capture_output=True, text=True,
+            env=env, timeout=30)
+        assert js.returncode == 0, f"js hook failed: {js.stderr}"
+        js_log = project / ".agentic" / "session-log" / "profile-dev.jsonl"
+        js_log_global = project / ".agentic" / "session-log" / "global-dev.jsonl"
+        assert js_log.is_file(), \
+            f"JS did not resolve profile-dev (no {js_log}); stderr={js.stderr}"
+        assert not js_log_global.is_file(), \
+            "JS resolved global-dev but Python resolved profile-dev (divergence)"
+        print("PASS test_cross_language_profile_resolution_agrees")
+
 
 if __name__ == "__main__":
     test_flushed_line_canonical_shape()
@@ -1191,4 +1325,8 @@ if __name__ == "__main__":
     test_cli_confirm_profile_flushes_tagged_pending()
     test_cli_confirm_profile_no_identity_errors()
     test_cli_profile_dir_is_regular_file_clean_error()
+    test_cli_init_profile_happy_path()
+    test_cli_init_profile_force_overwrites_confirmed()
+    test_cli_show_profile_three_paths()
+    test_cross_language_profile_resolution_agrees()
     print("All tests passed.")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -667,6 +667,15 @@ def test_env_detection_precedence():
         finally:
             restore()
 
+        # Only CODEX_HOME set -> it wins (last-tier fallback).
+        restore = _patch_environ(set_pairs={"CODEX_HOME": c},
+                                 clear_keys=["AGENTIC_CONFIG_DIR", "CLAUDE_CONFIG_DIR"])
+        try:
+            p = _profile_identity_path()
+            assert p == Path(c) / "identity.yml", f"Expected C path, got {p}"
+        finally:
+            restore()
+
         print("PASS test_env_detection_precedence")
 
 

--- a/bin/tests/test_install_profile_config_dir.sh
+++ b/bin/tests/test_install_profile_config_dir.sh
@@ -231,6 +231,38 @@ for harness in claude codex omp pi; do
 done
 rm -rf "$NX"
 
+# ---------------------------------------------------------------------------
+# Test 8: profile-scope identity re-run detection (PR #442 review fix 3)
+# First run writes <profile>/identity.yml via --identity; a second run of the
+# SAME installer must detect it through Branch 3 (show --scope profile
+# --profile-dir) instead of skipping to the non-TTY branch.
+# ---------------------------------------------------------------------------
+RERUN="$(mktemp -d)"
+export HOME="$RERUN/home"; mkdir -p "$HOME"
+RERUN_PROFILE="$HOME/.claude-tenant"; mkdir -p "$RERUN_PROFILE"
+# agentic-identity must be on PATH for the installer's identity branches.
+export PATH="$REPO_DIR/bin:$PATH"
+
+env -u AGENTIC_CONFIG_DIR -u CLAUDE_CONFIG_DIR -u CODEX_HOME \
+  AE_IDENTITY_SCOPE=profile HOME="$HOME" PATH="$PATH" \
+  bash "$REPO_DIR/.claude/install.sh" \
+  --config-dir="$RERUN_PROFILE" --identity=rerun-tester --mode=opt-out --profile=default \
+  >/dev/null 2>&1 || true
+[[ -f "$RERUN_PROFILE/identity.yml" ]] \
+  && pass "first run wrote profile identity.yml" \
+  || fail "first run did NOT write profile identity.yml"
+
+rerun_out="$(env -u AGENTIC_CONFIG_DIR -u CLAUDE_CONFIG_DIR -u CODEX_HOME \
+  AE_IDENTITY_SCOPE=profile HOME="$HOME" PATH="$PATH" \
+  bash "$REPO_DIR/.claude/install.sh" \
+  --config-dir="$RERUN_PROFILE" --mode=opt-out --profile=default 2>&1 || true)"
+if echo "$rerun_out" | grep -q "identity already set to 'rerun-tester'"; then
+  pass "re-run detected existing profile identity (Branch 3 --profile-dir)"
+else
+  fail "re-run did NOT detect existing profile identity"
+fi
+rm -rf "$RERUN"
+
 if [[ "$FAILS" -gt 0 ]]; then
   echo "FAILED: $FAILS assertion(s)"; exit 1
 fi

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -57,8 +57,11 @@
  *                ~/.agentic/session-log/<developer_id>.jsonl (global mirror),
  *                ~/.agentic/session-log/.pending/<session_uuid>.json (pending buffer),
  *                ~/.agentic/identity.yml (read-only, global),
+ *                <config-dir>/identity.yml (read-only, profile scope; config dir
+ *                env-detected via AGENTIC_CONFIG_DIR/CLAUDE_CONFIG_DIR/CODEX_HOME),
  *                [cwd]/.agentic/identity.yml (read-only, project-local; takes precedence
- *                over global when confirmed, per 4-tier resolution in getIdentity(cwd)),
+ *                over profile and global when confirmed, per 6-tier resolution in
+ *                getIdentity(cwd)),
  *                [cwd]/.agentic/config.json (read-only, deferred_wrap_daemon +
  *                skill_candidate_detection toggles),
  *                [cwd]/.agentic/events.jsonl (read-only for capture-gap backstop and
@@ -690,33 +693,67 @@ function _parseIdentityFile(filePath) {
   }
 }
 
+// Harness-standard config-dir env vars, in detection precedence order. Mirrors
+// PROFILE_CONFIG_DIR_ENV in bin/agentic-identity. The first set var whose value
+// resolves under $HOME selects the active profile's config dir. Isolated here so
+// adding another harness is a one-line edit.
+const PROFILE_CONFIG_DIR_ENV = ['AGENTIC_CONFIG_DIR', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
+
 /**
- * Resolve effective identity via 4-tier total ordering:
- *   project-confirmed > global-confirmed > project-provisional > global-provisional > null
+ * Return the active profile's identity.yml path (profile scope), or null.
+ * Scans PROFILE_CONFIG_DIR_ENV in order; the first set var resolving under
+ * $HOME wins. Values outside $HOME are ignored (no writes escaping the user
+ * tree). Returns null when no var qualifies -> profile scope is absent, which
+ * keeps getIdentity() byte-identical to the prior 4-tier behavior (back-compat).
  *
- * Reads project file (<cwd>/.agentic/identity.yml) and global file
- * (~/.agentic/identity.yml) using two synchronous existsSync+readFileSync calls
- * (~1ms, Node built-ins only, no subprocess).
+ * @returns {string|null}
+ */
+function _profileIdentityPath() {
+  const home = os.homedir();
+  for (const v of PROFILE_CONFIG_DIR_ENV) {
+    const raw = (process.env[v] || '').trim();
+    if (!raw) continue;
+    const resolved = path.resolve(raw);
+    if (resolved === home || resolved.startsWith(home + path.sep)) {
+      return path.join(resolved, 'identity.yml');
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve effective identity via 6-tier total ordering:
+ *   project-confirmed > profile-confirmed > global-confirmed >
+ *   project-provisional > profile-provisional > global-provisional > null
+ *
+ * Reads project file (<cwd>/.agentic/identity.yml), profile file
+ * (<config-dir>/identity.yml, env-detected - skipped when no config-dir env is
+ * set), and global file (~/.agentic/identity.yml) using up to three synchronous
+ * existsSync+readFileSync calls (~1ms, Node built-ins only, no subprocess).
  *
  * The existing three-branch write-vs-buffer gate (identity && !identity.provisional)
- * remains valid: confirmed at either scope -> direct write; provisional -> pending buffer.
+ * remains valid: confirmed at any scope -> direct write; provisional -> pending buffer.
  *
  * @param {string} cwd - The repo working directory (already validated by run()).
  * @returns {{developer_id: string, provisional: boolean}|null}
  */
 function getIdentity(cwd) {
   const projectPath = path.join(cwd, '.agentic', 'identity.yml');
+  const profilePath = _profileIdentityPath();
   const globalPath = path.join(os.homedir(), '.agentic', 'identity.yml');
 
   const projId = _parseIdentityFile(projectPath);
+  const profId = profilePath ? _parseIdentityFile(profilePath) : null;
   const globId = _parseIdentityFile(globalPath);
 
-  // Pass 1: first confirmed candidate in [project, global] order
+  // Pass 1: first confirmed candidate in [project, profile, global] order
   if (projId && !projId.provisional) return projId;
+  if (profId && !profId.provisional) return profId;
   if (globId && !globId.provisional) return globId;
 
-  // Pass 2: first provisional candidate in [project, global] order
+  // Pass 2: first provisional candidate in [project, profile, global] order
   if (projId) return projId;
+  if (profId) return profId;
   if (globId) return globId;
 
   return null;

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -700,25 +700,51 @@ function _parseIdentityFile(filePath) {
 const PROFILE_CONFIG_DIR_ENV = ['AGENTIC_CONFIG_DIR', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
 
 /**
+ * Return the active profile's config dir (realpath), or null.
+ * Scans PROFILE_CONFIG_DIR_ENV in order; the first set var whose realpath
+ * resolves under the realpathed $HOME wins (symlinks are followed on BOTH
+ * sides, mirroring _is_under_home in bin/agentic-identity, so a symlink
+ * inside $HOME pointing outside cannot bypass containment). A candidate
+ * whose realpath fails (e.g. ENOENT) is skipped - a nonexistent dir holds
+ * no identity.yml. Returns null when no var qualifies -> profile scope is
+ * absent, which keeps getIdentity() byte-identical to the prior 4-tier
+ * behavior (back-compat).
+ *
+ * @returns {string|null}
+ */
+function _profileConfigDir() {
+  let homeReal;
+  try {
+    homeReal = fs.realpathSync(os.homedir()); // macOS: /var -> /private/var
+  } catch (_) {
+    homeReal = os.homedir();
+  }
+  for (const v of PROFILE_CONFIG_DIR_ENV) {
+    const raw = (process.env[v] || '').trim();
+    if (!raw) continue;
+    let resolved = path.resolve(raw);
+    try {
+      resolved = fs.realpathSync(resolved);
+    } catch (_) {
+      continue; // ENOENT etc: no dir -> no identity.yml -> next candidate
+    }
+    // TOCTOU: check-to-use window accepted (attacker needs write access inside victim's own $HOME).
+    if (resolved === homeReal || resolved.startsWith(homeReal + path.sep)) {
+      return resolved;
+    }
+  }
+  return null;
+}
+
+/**
  * Return the active profile's identity.yml path (profile scope), or null.
- * Scans PROFILE_CONFIG_DIR_ENV in order; the first set var resolving under
- * $HOME wins. Values outside $HOME are ignored (no writes escaping the user
- * tree). Returns null when no var qualifies -> profile scope is absent, which
- * keeps getIdentity() byte-identical to the prior 4-tier behavior (back-compat).
+ * Thin wrapper over _profileConfigDir() (see containment rules there).
  *
  * @returns {string|null}
  */
 function _profileIdentityPath() {
-  const home = os.homedir();
-  for (const v of PROFILE_CONFIG_DIR_ENV) {
-    const raw = (process.env[v] || '').trim();
-    if (!raw) continue;
-    const resolved = path.resolve(raw);
-    if (resolved === home || resolved.startsWith(home + path.sep)) {
-      return path.join(resolved, 'identity.yml');
-    }
-  }
-  return null;
+  const dir = _profileConfigDir();
+  return dir ? path.join(dir, 'identity.yml') : null;
 }
 
 /**

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -1045,12 +1045,20 @@ function writePendingBuffer(cwd, sessionId, cachedRaw) {
       project_slug: projectSlug,
       repo_root: repoRoot,
       branch,
-      data: {
-        wall_seconds: data.wall_seconds,
-        tokens: data.tokens,
-        spawn_count: data.spawn_count,
-        by_agent: data.by_agent,
-      },
+    };
+    // Tag the record with the active profile config dir (when one is detected)
+    // so agentic-identity's flushPendingBuffer can partition flushes per profile
+    // (cross-tenant leakage guard). Additive optional field placed between
+    // branch and data; schema_version stays 1.
+    const profileCfgDir = _profileConfigDir();
+    if (profileCfgDir) {
+      record.config_dir = profileCfgDir;
+    }
+    record.data = {
+      wall_seconds: data.wall_seconds,
+      tokens: data.tokens,
+      spawn_count: data.spawn_count,
+      by_agent: data.by_agent,
     };
 
     // Atomic write: tmp + rename

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -700,15 +700,44 @@ function _parseIdentityFile(filePath) {
 const PROFILE_CONFIG_DIR_ENV = ['AGENTIC_CONFIG_DIR', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
 
 /**
- * Return the active profile's config dir (realpath), or null.
- * Scans PROFILE_CONFIG_DIR_ENV in order; the first set var whose realpath
- * resolves under the realpathed $HOME wins (symlinks are followed on BOTH
- * sides, mirroring _is_under_home in bin/agentic-identity, so a symlink
- * inside $HOME pointing outside cannot bypass containment). A candidate
- * whose realpath fails (e.g. ENOENT) is skipped - a nonexistent dir holds
- * no identity.yml. Returns null when no var qualifies -> profile scope is
- * absent, which keeps getIdentity() byte-identical to the prior 4-tier
- * behavior (back-compat).
+ * Resolve p like Python's Path.resolve(strict=False): realpath the deepest
+ * EXISTING ancestor (symlinks followed), then re-append the nonexistent
+ * remainder lexically. An existing symlink component still resolves - so a
+ * symlink escaping $HOME is still rejected downstream - while a not-yet-created
+ * dir gets a deterministic resolved spelling instead of an ENOENT throw.
+ *
+ * @param {string} p - An absolute (path.resolve'd) candidate path.
+ * @returns {string}
+ */
+function _realpathNonStrict(p) {
+  let base = p;
+  const rest = [];
+  for (;;) {
+    try {
+      const real = fs.realpathSync(base);
+      return rest.length ? path.join(real, ...rest) : real;
+    } catch (_) {
+      const parent = path.dirname(base);
+      if (parent === base) return p; // unreadable down to the root: keep lexical
+      rest.unshift(path.basename(base));
+      base = parent;
+    }
+  }
+}
+
+/**
+ * Return the active profile's config dir (resolved path), or null.
+ * Scans PROFILE_CONFIG_DIR_ENV in order; the FIRST (highest-precedence) set
+ * var whose non-strict realpath resolves under the realpathed $HOME wins and
+ * the scan STOPS there - existence is NOT required, mirroring
+ * _profile_config_dir in bin/agentic-identity (Python Path.resolve() does not
+ * require existence either), so the two sides never disagree on which profile
+ * is active. A nonexistent-but-under-$HOME candidate simply holds no
+ * identity.yml yet. Symlinks are followed on BOTH sides via _realpathNonStrict
+ * (a symlink inside $HOME pointing outside cannot bypass containment); a
+ * candidate resolving outside $HOME is rejected and the next var is tried.
+ * Returns null when no var qualifies -> profile scope is absent, which keeps
+ * getIdentity() byte-identical to the prior 4-tier behavior (back-compat).
  *
  * @returns {string|null}
  */
@@ -722,16 +751,12 @@ function _profileConfigDir() {
   for (const v of PROFILE_CONFIG_DIR_ENV) {
     const raw = (process.env[v] || '').trim();
     if (!raw) continue;
-    let resolved = path.resolve(raw);
-    try {
-      resolved = fs.realpathSync(resolved);
-    } catch (_) {
-      continue; // ENOENT etc: no dir -> no identity.yml -> next candidate
-    }
+    const resolved = _realpathNonStrict(path.resolve(raw));
     // TOCTOU: check-to-use window accepted (attacker needs write access inside victim's own $HOME).
     if (resolved === homeReal || resolved.startsWith(homeReal + path.sep)) {
-      return resolved;
+      return resolved; // highest-precedence qualifying var wins; scan stops
     }
+    // Resolves outside $HOME (incl. an existing symlink escape): try next var.
   }
   return null;
 }

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -726,6 +726,25 @@ function _realpathNonStrict(p) {
 }
 
 /**
+ * Expand a leading ~ to $HOME, mirroring Python's os.path.expanduser which the
+ * CLI side (bin/agentic-identity:_profile_config_dir) applies to the same env
+ * values. Only the bare `~` and `~/rest` forms are expanded (the `~user` form
+ * is not - these env values name the current user's own config dir); every
+ * other string is returned unchanged. Without this, a value like
+ * `AGENTIC_CONFIG_DIR=~/.claude-tenant` resolves to `<cwd>/~/.claude-tenant`
+ * on the JS side while Python resolves it to `$HOME/.claude-tenant`, so the
+ * two languages silently read/write different identity.yml files.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function _expandUser(raw) {
+  if (raw === '~') return os.homedir();
+  if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
+  return raw;
+}
+
+/**
  * Return the active profile's config dir (resolved path), or null.
  * Scans PROFILE_CONFIG_DIR_ENV in order; the FIRST (highest-precedence) set
  * var whose non-strict realpath resolves under the realpathed $HOME wins and
@@ -751,7 +770,7 @@ function _profileConfigDir() {
   for (const v of PROFILE_CONFIG_DIR_ENV) {
     const raw = (process.env[v] || '').trim();
     if (!raw) continue;
-    const resolved = _realpathNonStrict(path.resolve(raw));
+    const resolved = _realpathNonStrict(path.resolve(_expandUser(raw)));
     // TOCTOU: check-to-use window accepted (attacker needs write access inside victim's own $HOME).
     if (resolved === homeReal || resolved.startsWith(homeReal + path.sep)) {
       return resolved; // highest-precedence qualifying var wins; scan stops

--- a/hooks/tests/test-stop-context-identity.js
+++ b/hooks/tests/test-stop-context-identity.js
@@ -16,6 +16,9 @@
  *   J6  outside-$HOME env dir rejected -> global identity used
  *   J7  n/a (--profile-dir is CLI-only; no hook surface) - intentionally skipped
  *   J8  no env vars -> 4-tier back-compat (global identity used)
+ *   ENOENT nonexistent highest-precedence env dir STOPS the scan (no
+ *       fall-through to a lower-precedence existing profile), matching
+ *       Python _profile_config_dir (Path.resolve() needs no existence)
  *   SYM symlink inside $HOME pointing outside must NOT be followed
  *       (Fix-1 regression proof; fails on the pre-fix lexical check)
  *
@@ -284,6 +287,32 @@ console.log('\n[J8] no config-dir env -> 4-tier back-compat');
     'global identity resolved with no profile env set');
   assert(fs.existsSync(sessionLogFor(fakeHome, 'global-dev')),
     'global mirror written with no profile env set');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// ENOENT: nonexistent highest-precedence env dir stops the scan (M2)
+// Mirrors Python: _profile_config_dir accepts a not-yet-created dir (it
+// holds no identity.yml) and never falls through to a lower-precedence var.
+// Pre-fix, realpathSync ENOENT `continue`d to CLAUDE_CONFIG_DIR and the two
+// mirrors disagreed on the active profile.
+// ---------------------------------------------------------------------------
+console.log('\n[ENOENT] nonexistent highest-precedence env dir stops the scan');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-enoent-');
+  const ghostDir = path.join(fakeHome, '.agentic-ghost'); // intentionally never created
+  const claudeDir = path.join(fakeHome, '.claude-real');
+  writeIdentity(claudeDir, 'claude-dev', false);
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+
+  runHook(projectDir, fakeHome, 'enoent-uuid', {
+    AGENTIC_CONFIG_DIR: ghostDir, CLAUDE_CONFIG_DIR: claudeDir,
+  });
+
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'claude-dev')),
+    'lower-precedence CLAUDE_CONFIG_DIR identity NOT used (no fall-through)');
+  assert(fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'global identity used (ghost profile dir holds no identity.yml)');
   cleanup(tmpDir);
 }
 

--- a/hooks/tests/test-stop-context-identity.js
+++ b/hooks/tests/test-stop-context-identity.js
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * Regression tests: stop-context.js 6-tier getIdentity resolution
+ * (project > profile > global, confirmed pass before provisional pass)
+ * plus profile-config-dir containment (realpath/symlink rejection) and
+ * the pending-buffer config_dir tag (cross-tenant flush partition).
+ *
+ * Sub-tests (mirror the Python J-suite in bin/tests/test_agentic_identity.py):
+ *   J1  profile-confirmed beats global-confirmed
+ *   J2  project-confirmed beats profile-confirmed
+ *   J3  provisional profile does NOT beat confirmed global
+ *   J4  provisional profile used when nothing confirmed (pending buffer)
+ *       + pending record carries config_dir (Fix-2 regression)
+ *   J5  env precedence AGENTIC_CONFIG_DIR > CLAUDE_CONFIG_DIR > CODEX_HOME,
+ *       plus CODEX_HOME-alone fallback
+ *   J6  outside-$HOME env dir rejected -> global identity used
+ *   J7  n/a (--profile-dir is CLI-only; no hook surface) - intentionally skipped
+ *   J8  no env vars -> 4-tier back-compat (global identity used)
+ *   SYM symlink inside $HOME pointing outside must NOT be followed
+ *       (Fix-1 regression proof; fails on the pre-fix lexical check)
+ *
+ * The hook script path can be overridden via AE_TEST_HOOK_PATH so the SYM
+ * case can be executed against a historical copy of stop-context.js to prove
+ * the regression (see PR #442 review).
+ *
+ * Run with: node hooks/tests/test-stop-context-identity.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Shared helpers (modeled on test-stop-context-session-log.js)
+// ---------------------------------------------------------------------------
+
+const hookScript = process.env.AE_TEST_HOOK_PATH
+  ? path.resolve(process.env.AE_TEST_HOOK_PATH)
+  : path.resolve(__dirname, '..', 'stop-context.js');
+if (!fs.existsSync(hookScript)) {
+  console.error(`FAIL: hook not found at ${hookScript}`);
+  process.exit(1);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+const PROFILE_ENV_VARS = ['AGENTIC_CONFIG_DIR', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
+
+/**
+ * Build a child env: copy parent env, DELETE all profile config-dir vars so
+ * the parent shell can never leak a profile into a scenario, then apply the
+ * scenario's own vars.
+ */
+function buildEnv(fakeHome, extraVars) {
+  const env = { ...process.env, HOME: fakeHome };
+  for (const v of PROFILE_ENV_VARS) delete env[v];
+  return Object.assign(env, extraVars || {});
+}
+
+function runHook(projectDir, fakeHome, sessionId, extraVars) {
+  const payload = JSON.stringify({
+    cwd: projectDir,
+    session_id: sessionId,
+    transcript: [],
+  });
+  execSync(`node "${hookScript}"`, {
+    input: payload,
+    encoding: 'utf8',
+    env: buildEnv(fakeHome, extraVars),
+    timeout: 10000,
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+}
+
+// realpathSync: macOS mkdtemp returns /var/... which is a symlink to
+// /private/var - the hook realpaths $HOME, so the fixture must too.
+function makeTmp(prefix) {
+  const tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  const fakeHome = path.join(tmpDir, 'home');
+  const projectDir = path.join(tmpDir, 'project');
+  const agenticDir = path.join(projectDir, '.agentic');
+  const globalIdentityDir = path.join(fakeHome, '.agentic');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(agenticDir, { recursive: true });
+  fs.mkdirSync(globalIdentityDir, { recursive: true });
+  return { tmpDir, fakeHome, projectDir, agenticDir, globalIdentityDir };
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+}
+
+function writeIdentity(dir, devId, provisional) {
+  fs.mkdirSync(dir, { recursive: true });
+  let content = `developer_id: ${devId}\ncreated_at: 2026-01-01T00:00:00Z\n`;
+  if (provisional) content += 'provisional: true\n';
+  fs.writeFileSync(path.join(dir, 'identity.yml'), content, { mode: 0o600 });
+}
+
+function sessionLogFor(baseDir, devId) {
+  return path.join(baseDir, '.agentic', 'session-log', `${devId}.jsonl`);
+}
+
+function pendingFiles(fakeHome) {
+  const dir = path.join(fakeHome, '.agentic', 'session-log', '.pending');
+  try {
+    return fs.readdirSync(dir).filter((f) => f.endsWith('.json'))
+      .map((f) => path.join(dir, f));
+  } catch (_) {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// J1: profile-confirmed beats global-confirmed
+// ---------------------------------------------------------------------------
+console.log('\n[J1] profile-confirmed beats global-confirmed');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-j1-');
+  const profDir = path.join(fakeHome, '.claude-tenant');
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+  writeIdentity(profDir, 'profile-dev', false);
+
+  runHook(projectDir, fakeHome, 'j1-uuid', { AGENTIC_CONFIG_DIR: profDir });
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'profile-dev')),
+    'per-project session log written for profile-dev');
+  assert(fs.existsSync(sessionLogFor(fakeHome, 'profile-dev')),
+    'global mirror written for profile-dev');
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'no session log for global-dev (profile won)');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// J2: project-confirmed beats profile-confirmed
+// ---------------------------------------------------------------------------
+console.log('\n[J2] project-confirmed beats profile-confirmed');
+{
+  const { tmpDir, fakeHome, projectDir, agenticDir } = makeTmp('ae-id-j2-');
+  const profDir = path.join(fakeHome, '.claude-tenant');
+  writeIdentity(agenticDir, 'project-dev', false);
+  writeIdentity(profDir, 'profile-dev', false);
+
+  runHook(projectDir, fakeHome, 'j2-uuid', { AGENTIC_CONFIG_DIR: profDir });
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'project-dev')),
+    'session log written for project-dev (most specific scope wins)');
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'profile-dev')),
+    'no session log for profile-dev');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// J3: provisional profile does NOT beat confirmed global
+// ---------------------------------------------------------------------------
+console.log('\n[J3] provisional profile does NOT suppress confirmed global');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-j3-');
+  const profDir = path.join(fakeHome, '.claude-tenant');
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+  writeIdentity(profDir, 'profile-dev', true); // provisional
+
+  runHook(projectDir, fakeHome, 'j3-uuid', { AGENTIC_CONFIG_DIR: profDir });
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'confirmed global identity used (direct write)');
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'profile-dev')),
+    'provisional profile identity NOT used for direct write');
+  assert(pendingFiles(fakeHome).length === 0,
+    'no pending buffer record (confirmed identity available)');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// J4: provisional profile when nothing confirmed -> pending buffer
+//     + pending record carries config_dir (Fix-2 regression)
+// ---------------------------------------------------------------------------
+console.log('\n[J4] provisional profile only -> pending buffer with config_dir tag');
+{
+  const { tmpDir, fakeHome, projectDir } = makeTmp('ae-id-j4-');
+  const profDir = path.join(fakeHome, '.claude-tenant');
+  writeIdentity(profDir, 'profile-dev', true); // provisional, nothing else exists
+
+  runHook(projectDir, fakeHome, 'j4-uuid', { AGENTIC_CONFIG_DIR: profDir });
+
+  const pend = pendingFiles(fakeHome);
+  assert(pend.length === 1, `exactly one pending record written (got ${pend.length})`);
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'profile-dev')),
+    'provisional identity gets no direct session-log write');
+  if (pend.length === 1) {
+    const rec = JSON.parse(fs.readFileSync(pend[0], 'utf8'));
+    assert(rec.session_uuid === 'j4-uuid', 'pending record session_uuid matches');
+    assert(rec.config_dir === profDir,
+      `pending record tagged with config_dir === active profile dir (got: ${rec.config_dir})`);
+    assert(rec.schema_version === 1, 'schema_version stays 1 (additive field)');
+  }
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// J5: env precedence AGENTIC > CLAUDE > CODEX; CODEX_HOME alone works
+// ---------------------------------------------------------------------------
+console.log('\n[J5] env precedence AGENTIC_CONFIG_DIR > CLAUDE_CONFIG_DIR > CODEX_HOME');
+{
+  const { tmpDir, fakeHome, projectDir } = makeTmp('ae-id-j5-');
+  const dirA = path.join(fakeHome, '.prof-a');
+  const dirB = path.join(fakeHome, '.prof-b');
+  const dirC = path.join(fakeHome, '.prof-c');
+  writeIdentity(dirA, 'a-dev', false);
+  writeIdentity(dirB, 'b-dev', false);
+  writeIdentity(dirC, 'c-dev', false);
+
+  // All three set -> AGENTIC wins.
+  runHook(projectDir, fakeHome, 'j5-uuid-1', {
+    AGENTIC_CONFIG_DIR: dirA, CLAUDE_CONFIG_DIR: dirB, CODEX_HOME: dirC,
+  });
+  assert(fs.existsSync(sessionLogFor(projectDir, 'a-dev')),
+    'AGENTIC_CONFIG_DIR wins when all three set');
+
+  // CLAUDE + CODEX -> CLAUDE wins.
+  runHook(projectDir, fakeHome, 'j5-uuid-2', {
+    CLAUDE_CONFIG_DIR: dirB, CODEX_HOME: dirC,
+  });
+  assert(fs.existsSync(sessionLogFor(projectDir, 'b-dev')),
+    'CLAUDE_CONFIG_DIR wins over CODEX_HOME');
+
+  // CODEX alone -> used.
+  runHook(projectDir, fakeHome, 'j5-uuid-3', { CODEX_HOME: dirC });
+  assert(fs.existsSync(sessionLogFor(projectDir, 'c-dev')),
+    'CODEX_HOME alone selects the profile');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// J6: env dir outside $HOME rejected -> falls back to global
+// ---------------------------------------------------------------------------
+console.log('\n[J6] outside-$HOME env dir rejected');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-j6-');
+  const outsideDir = path.join(tmpDir, 'outside-home'); // sibling of fakeHome
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+  writeIdentity(outsideDir, 'intruder-dev', false);
+
+  runHook(projectDir, fakeHome, 'j6-uuid', { AGENTIC_CONFIG_DIR: outsideDir });
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'global identity used when env dir is outside $HOME');
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'intruder-dev')),
+    'outside-$HOME identity NOT used');
+  cleanup(tmpDir);
+}
+
+// J7: --profile-dir override is CLI-only (bin/agentic-identity); the hook has
+// no flag surface -> intentionally no hook-level test (mirrors Python J7 note).
+console.log('\n[J7] skipped: --profile-dir is CLI-only, no hook surface');
+
+// ---------------------------------------------------------------------------
+// J8: no env vars -> 4-tier back-compat (global identity used)
+// ---------------------------------------------------------------------------
+console.log('\n[J8] no config-dir env -> 4-tier back-compat');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-j8-');
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+
+  runHook(projectDir, fakeHome, 'j8-uuid'); // no extra vars; builder deletes all three
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'global identity resolved with no profile env set');
+  assert(fs.existsSync(sessionLogFor(fakeHome, 'global-dev')),
+    'global mirror written with no profile env set');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// SYM: symlink inside $HOME pointing outside must NOT be followed (Fix 1)
+// ---------------------------------------------------------------------------
+console.log('\n[SYM] symlink escape rejected (realpath containment)');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-sym-');
+  const outsideReal = path.join(tmpDir, 'outside-real');
+  writeIdentity(outsideReal, 'escape-dev', false);
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+  // Symlink lives under fake HOME, target is outside it.
+  const linkPath = path.join(fakeHome, '.claude-escape');
+  fs.symlinkSync(outsideReal, linkPath);
+
+  runHook(projectDir, fakeHome, 'sym-uuid', { AGENTIC_CONFIG_DIR: linkPath });
+
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'escape-dev')),
+    'identity behind escaping symlink NOT used');
+  assert(fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'falls back to global identity when profile symlink escapes $HOME');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed.`);
+if (failed > 0) {
+  process.exit(1);
+}
+process.exit(0);

--- a/hooks/tests/test-stop-context-identity.js
+++ b/hooks/tests/test-stop-context-identity.js
@@ -339,6 +339,29 @@ console.log('\n[SYM] symlink escape rejected (realpath containment)');
 }
 
 // ---------------------------------------------------------------------------
+// TILDE: a ~-prefixed config-dir env value is expanded to $HOME, matching
+// Python's os.path.expanduser (regression for the cross-language divergence
+// where Node did path.resolve('~/...') -> <cwd>/~/... and read a different
+// identity.yml than the Python CLI for the same env var).
+// ---------------------------------------------------------------------------
+console.log('\n[TILDE] ~-prefixed AGENTIC_CONFIG_DIR expands to $HOME');
+{
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-tilde-');
+  // Real profile dir under $HOME; env references it via the ~ shorthand.
+  const profDir = path.join(fakeHome, '.claude-tenant');
+  writeIdentity(profDir, 'tilde-dev', false);
+  writeIdentity(globalIdentityDir, 'global-dev', false);
+
+  runHook(projectDir, fakeHome, 'tilde-uuid', { AGENTIC_CONFIG_DIR: '~/.claude-tenant' });
+
+  assert(fs.existsSync(sessionLogFor(projectDir, 'tilde-dev')),
+    '~-prefixed env expands to $HOME/.claude-tenant (profile identity used)');
+  assert(!fs.existsSync(sessionLogFor(projectDir, 'global-dev')),
+    'did NOT fall back to global (tilde resolved, not treated as <cwd>/~/...)');
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed} passed, ${failed} failed.`);

--- a/scripts/install-profiles.sh
+++ b/scripts/install-profiles.sh
@@ -278,7 +278,9 @@ for tenant in $TENANTS; do
 		echo ""
 		echo "==> $label  (--config-dir=$cfg)"
 		rc=0
-		bash "$installer" --config-dir="$cfg" "${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}" || rc=$?
+		# Per-profile identity: each tenant config dir gets its own
+		# <config-dir>/identity.yml instead of collapsing into one global handle.
+		AE_IDENTITY_SCOPE=profile bash "$installer" --config-dir="$cfg" "${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}" || rc=$?
 		if [[ "$rc" -eq 0 ]]; then SUCCEEDED+=("$label"); else
 			echo "  ! $label failed (exit $rc)" >&2
 			FAILED+=("$label")

--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -82,11 +82,17 @@ _ae_setup_identity() {
   fi
 
   # Branch 3: detect existing identity (global: effective incl. project fallback;
-  # profile: this profile's own identity only)
+  # profile: this profile's own identity only). For profile scope, pin the
+  # config dir explicitly (mirrors ae_scope_args) so detection works without
+  # env propagation to the subprocess.
   local show_scope="$AE_IDENTITY_SCOPE"
   [[ "$show_scope" == "global" ]] && show_scope="effective"
+  local show_args=(--scope "$show_scope")
+  if [[ "$AE_IDENTITY_SCOPE" == "profile" && -n "${AE_CONFIG_DIR:-}" ]]; then
+    show_args+=(--profile-dir "$AE_CONFIG_DIR")
+  fi
   local show_out
-  show_out="$(agentic-identity show --scope "$show_scope" 2>/dev/null)" || show_out=""
+  show_out="$(agentic-identity show "${show_args[@]}" 2>/dev/null)" || show_out=""
   local existing_handle
   existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')" || existing_handle=""
   if [[ -n "$existing_handle" ]]; then

--- a/scripts/lib/identity.sh
+++ b/scripts/lib/identity.sh
@@ -35,6 +35,10 @@
 
 AE_IDENTITY_FLAG="${AE_IDENTITY_FLAG:-}"
 AE_NO_IDENTITY="${AE_NO_IDENTITY:-false}"
+# Scope for identity writes during install. Default "global" preserves legacy
+# single-global behavior; per-profile installers export AE_IDENTITY_SCOPE=profile
+# so each profile config dir gets its own <config-dir>/identity.yml.
+AE_IDENTITY_SCOPE="${AE_IDENTITY_SCOPE:-global}"
 
 # ---------------------------------------------------------------------------
 # ae_confirm: TTY-safe yes/no prompt for optional installs.
@@ -57,6 +61,14 @@ ae_confirm() {
 }
 
 _ae_setup_identity() {
+  # Scope-aware agentic-identity args. For profile scope, pin the config dir
+  # explicitly so detection does not rely on env propagation to the subprocess
+  # (AE_CONFIG_DIR is set by the calling adapter install.sh before sourcing us).
+  local ae_scope_args=(--scope "$AE_IDENTITY_SCOPE")
+  if [[ "$AE_IDENTITY_SCOPE" == "profile" && -n "${AE_CONFIG_DIR:-}" ]]; then
+    ae_scope_args+=(--profile-dir "$AE_CONFIG_DIR")
+  fi
+
   # Branch 1: --no-identity flag
   if [[ "$AE_NO_IDENTITY" == "true" ]]; then
     echo "  - identity setup skipped (--no-identity)"
@@ -69,9 +81,12 @@ _ae_setup_identity() {
     return
   fi
 
-  # Branch 3: detect existing identity
+  # Branch 3: detect existing identity (global: effective incl. project fallback;
+  # profile: this profile's own identity only)
+  local show_scope="$AE_IDENTITY_SCOPE"
+  [[ "$show_scope" == "global" ]] && show_scope="effective"
   local show_out
-  show_out="$(agentic-identity show --scope effective 2>/dev/null)" || show_out=""
+  show_out="$(agentic-identity show --scope "$show_scope" 2>/dev/null)" || show_out=""
   local existing_handle
   existing_handle="$(echo "$show_out" | grep '^developer_id:' | awk '{print $2}')" || existing_handle=""
   if [[ -n "$existing_handle" ]]; then
@@ -86,7 +101,7 @@ _ae_setup_identity() {
   # Branch 4: --identity=<handle> flag set (explicit intent, use --force)
   if [[ -n "$AE_IDENTITY_FLAG" ]]; then
     local rc=0
-    agentic-identity init "$AE_IDENTITY_FLAG" --force >/dev/null 2>&1 || rc=$?
+    agentic-identity init "$AE_IDENTITY_FLAG" --force "${ae_scope_args[@]}" >/dev/null 2>&1 || rc=$?
     if [[ "$rc" -eq 0 ]]; then
       echo "  + identity set to '$AE_IDENTITY_FLAG' via --identity flag"
     else
@@ -111,7 +126,7 @@ _ae_setup_identity() {
     echo "  Detected GitHub handle: $gh_login"
     if ae_confirm "  Set developer identity to '$gh_login'? [y/N] "; then
       local rc=0
-      agentic-identity init "$gh_login" >/dev/null 2>&1 || rc=$?
+      agentic-identity init "$gh_login" "${ae_scope_args[@]}" >/dev/null 2>&1 || rc=$?
       if [[ "$rc" -eq 0 ]]; then
         echo "  + identity set to '$gh_login' (confirmed)"
       elif [[ "$rc" -eq 2 ]]; then
@@ -145,7 +160,7 @@ _ae_setup_identity() {
     return
   fi
   local rc=0
-  agentic-identity init "$typed_handle" >/dev/null 2>&1 || rc=$?
+  agentic-identity init "$typed_handle" "${ae_scope_args[@]}" >/dev/null 2>&1 || rc=$?
   if [[ "$rc" -eq 0 ]]; then
     echo "  + identity set to '$typed_handle' (confirmed)"
   elif [[ "$rc" -eq 2 ]]; then


### PR DESCRIPTION
## Summary

Add a third identity scope, `profile`, co-located with the active harness profile's config dir (`<config-dir>/identity.yml`). Per-tenant installs now attribute telemetry per profile instead of collapsing into one global handle.

- `bin/agentic-identity`: 4-tier to 6-tier resolution (project > profile > global, confirmed-then-provisional); `--scope profile` on init/auto/confirm/show; `--profile-dir` override; active config dir detected via `AGENTIC_CONFIG_DIR` / `CLAUDE_CONFIG_DIR` / `CODEX_HOME` (values outside `$HOME` are rejected). Back-compatible: with no env set, behavior is byte-identical to the prior 4-tier.
- `hooks/stop-context.js`: mirror 6-tier `getIdentity()` with the same env detection.
- `scripts/lib/identity.sh`: honor `AE_IDENTITY_SCOPE` (default global) so the helper can write profile-scoped identity via `--profile-dir "$AE_CONFIG_DIR"`.
- `scripts/install-profiles.sh`: set `AE_IDENTITY_SCOPE=profile` for per-profile installs, so each tenant config dir gets its own `identity.yml`.
- `bin/tests/test_agentic_identity.py`: 8 new tests (6-tier ordering, env precedence, outside-$HOME rejection, `--profile-dir` override, back-compat). 18/18 pass; `test_install_profiles.sh` + `test_install_profile_config_dir.sh` pass.

## North Star alignment

- **Guard operator attention.** No prompt at first use; identity auto-derives from `gh api user`. Attention stays on the work, not on a meta-dialog about who you are.
- **Verifiable outcomes autonomously.** All 18 identity tests pass deterministically under fake `$HOME`. L1-L6 + J1-J6 + K1-K4 cover tier ordering, env precedence, symlink escape rejection, profile-dir mkdir guards, and pending-buffer flush filtering by config dir. Each test pins a specific assertion that would fail on the corresponding regression.
- **Universality.** Same identity resolution across Claude Code, Codex, and any harness that sets `AGENTIC_CONFIG_DIR` / `CLAUDE_CONFIG_DIR` / `CODEX_HOME`. Per-profile scope is opt-in (`--scope profile`); the existing global/project scopes are unchanged for callers that don't set the new env var.

Trade-off: more resolution tiers (4 to 6) in exchange for per-tenant telemetry isolation. Behavior is byte-identical when no `AE_IDENTITY_SCOPE` / `--scope profile` is set, so existing callers see no change.
