### PR TITLE
docs(ds52): add story-size preflight and token-reduction callout to /ticket-triage

### DIFF
--- a/.claude/commands/ticket-triage.md
+++ b/.claude/commands/ticket-triage.md
@@ -118,7 +118,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -126,26 +126,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/.claude/commands/ticket-triage.md
+++ b/.claude/commands/ticket-triage.md
@@ -118,13 +118,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -219,14 +247,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.codex/commands/ticket-triage.md
+++ b/.codex/commands/ticket-triage.md
@@ -116,7 +116,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -124,26 +124,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/.codex/commands/ticket-triage.md
+++ b/.codex/commands/ticket-triage.md
@@ -116,13 +116,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -217,14 +245,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.cursor/commands/ticket-triage.md
+++ b/.cursor/commands/ticket-triage.md
@@ -116,7 +116,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -124,26 +124,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/.cursor/commands/ticket-triage.md
+++ b/.cursor/commands/ticket-triage.md
@@ -116,13 +116,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -217,14 +245,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.gemini/commands/ticket-triage.toml
+++ b/.gemini/commands/ticket-triage.toml
@@ -122,7 +122,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -130,26 +130,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/.gemini/commands/ticket-triage.toml
+++ b/.gemini/commands/ticket-triage.toml
@@ -122,13 +122,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -223,14 +251,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.github/prompts/ticket-triage.prompt.md
+++ b/.github/prompts/ticket-triage.prompt.md
@@ -119,13 +119,42 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3-4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -220,14 +249,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -17313,13 +17313,42 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3-4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -17414,14 +17443,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.openclaw/skills/ticket-triage/SKILL.md
+++ b/.openclaw/skills/ticket-triage/SKILL.md
@@ -121,13 +121,42 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3-4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -222,14 +251,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/.opencode/commands/ticket-triage.md
+++ b/.opencode/commands/ticket-triage.md
@@ -120,7 +120,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -128,26 +128,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/.opencode/commands/ticket-triage.md
+++ b/.opencode/commands/ticket-triage.md
@@ -120,13 +120,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -221,14 +249,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 

--- a/content/commands/ticket-triage.md
+++ b/content/commands/ticket-triage.md
@@ -116,7 +116,7 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table; no distribution rule consumes it, and estimate-aware lane sizing is a deferred default. Only `story_points` and Linear `estimate` trigger the story-size preflight below - `timeestimate` is Jira's time-tracking field (denominated in seconds), display-only, and is never compared against the preflight threshold.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
@@ -124,26 +124,27 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
 
-> **Story-size preflight** — runs once, immediately after all metadata is collected.
+> **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
-> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number) AND that is not `terminal: true` or `in_progress: true` (those are deferred / excluded from lane assignment regardless of size - warning them here would flag tickets that never reach `/implement-ticket`), check:
 > - **≥ 5 points:** print the following warning (once per oversized ticket):
 >   ```
->   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>   ⚠ [DS-XX] Est: N pts - large story. Recommend decomposing into ≤ 3-point sub-tickets
 >     before running /implement-ticket. A single 5+ point story can exhaust the context
 >     window before the loop completes. Split strategy: one sub-ticket per independent
 >     deliverable; use /ticket-triage on the sub-set to re-sequence.
 >   ```
 >   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
 >
-> - **3–4 points:** no warning. `context_risk` is unset.
+> - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
 > 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
 >    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    operation producing > 20 lines - they reduce context consumption by ~98%
+>    (see content/rules/code-standards.md §Context Window Management).
 >    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```

--- a/content/commands/ticket-triage.md
+++ b/content/commands/ticket-triage.md
@@ -116,13 +116,41 @@ Conductor-direct (no subagent). For each entry in `normalized_input.entries[]`, 
 - **Jira:** `mcp__mcp-atlassian__jira_get_issue` - capture `priority`, `status`, `story_points` (or `timeestimate`), `labels`, `components`, `assignee`, and `issuelinks` (blocks / is-blocked-by / relates-to).
 - **Linear:** `mcp__linear__get_issue` - capture `priority`, `state`, `estimate`, `labels`, `assignee`, and relations (blocks / blocked-by / related).
 
-The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates only the display-only "Est" column in the Phase 4a per-ticket summary table. No distribution rule consumes it; estimate-aware lane sizing is a deferred default.
+The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) populates the display-only "Est" column in the Phase 4a per-ticket summary table AND triggers the story-size preflight below.
 
 **Soft-fail per ticket:** on any fetch error, mark `fetch_failed: true` on that entry and proceed. Fetch-failed tickets are treated as independent (no known deps, no known metadata) in all downstream phases.
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
 **In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+
+> **Story-size preflight** — runs once, immediately after all metadata is collected.
+>
+> For each ticket whose estimate is available (`story_points` or Linear `estimate` is a number), check:
+> - **≥ 5 points:** print the following warning (once per oversized ticket):
+>   ```
+>   ⚠ [DS-XX] Est: N pts — large story. Recommend decomposing into ≤ 3-point sub-tickets
+>     before running /implement-ticket. A single 5+ point story can exhaust the context
+>     window before the loop completes. Split strategy: one sub-ticket per independent
+>     deliverable; use /ticket-triage on the sub-set to re-sequence.
+>   ```
+>   Then append a `context_risk: high` flag to that entry. Lane assignment proceeds normally; the operator decides whether to decompose.
+>
+> - **3–4 points:** no warning. `context_risk` is unset.
+> - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
+>
+> **Token-reduction reminder** — if any `context_risk: high` ticket is lane-assigned (not deferred), append this one-time callout at the end of the story-size preflight output:
+> ```
+> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
+>    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
+>    operation producing > 20 lines — they reduce context consumption by ~98%.
+>    If context fills mid-session, /wrap → /clear → re-invoke /implement-ticket
+>    with the remaining ticket IDs to continue in a fresh window.
+> ```
+>
+> **Silent on clean sets:** if no ticket has `context_risk: high`, print nothing. No output on safe sessions.
+>
+> The `context_risk` flags are display-only; no distribution rule consumes them.
 
 `[phase: ticket-triage | phase=metadata]`
 
@@ -217,14 +245,15 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
-     Display-only; no distribution rule consumes it. -->
+     Display-only; no distribution rule consumes it.
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
 
-| Ticket | Priority | Status | Est | Lane | Notes |
-|--------|----------|--------|-----|------|-------|
-| A | High | To Do | 3 | Lane 1 | |
-| B | Med | To Do | 2 | Lane 1 | blocked by A |
-| C | High | To Do | - | Lane 2 | |
-| ... | | | | | |
+| Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
+|--------|----------|--------|-----|---|------|-------|
+| A | High | To Do | 3 | | Lane 1 | |
+| B | Med | To Do | 2 | | Lane 1 | blocked by A |
+| C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| ... | | | | | | |
 
 ## Dependency notes
 


### PR DESCRIPTION
## DS-52 - Large Stories Burn Context Window Before Loop Starts

### What changed

Added a **Story-size preflight** block to `/ticket-triage` Phase 1, running once immediately after all ticket metadata is collected.

**Trigger:** any ticket with a `story_points` or Linear `estimate` >= 5 (Jira's `timeestimate` field is seconds-denominated and display-only; it never triggers this preflight). Tickets marked `terminal: true` or `in_progress: true` are excluded from the scan - they are deferred or removed from lane assignment regardless of size.

**On detection (per oversized ticket):**
- Prints a `⚠ [TICKET-ID] Est: N pts - large story` warning with a concrete split recommendation (decompose into <= 3-point sub-tickets, re-triage the sub-set)
- Sets a `context_risk: high` flag on the entry (display-only; no lane distribution rule consumes it)
- If any ticket has `context_risk: high`: appends a one-time token-reduction reminder pointing operators to `ctx_*` context-mode tools (~98% context savings vs raw shell output, see `content/rules/code-standards.md` §Context Window Management) and the `/wrap -> /clear -> re-invoke` mid-session reset pattern

**Silent on clean sets:** no output when no ticket exceeds the threshold.

**Artifact:** added a `⚠` column to the Phase 4a per-ticket summary table skeleton so `⚠ large` surfaces visually in triage artifacts for oversized tickets.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): **Guard operator attention.** The preflight is silent on clean sets - it prints nothing unless a ticket actually needs decomposing, so it does not tax attention in the common case. When it does fire, it surfaces one concrete decision (decompose or proceed) rather than a status dump.
- Trade-off or pillar this could regress, if any: adds one more recurring operator-facing output type to a core command. Mitigated by the silent-on-clean-sets behavior above; a set with no oversized tickets sees zero additional output.

### Files changed

`content/commands/ticket-triage.md`, rebuilt across all 11 adapters: full copies regenerated for `.claude`, `.codex`, `.cursor`, `.gemini`, `.opencode`, `.github/prompts`, `.hermes`, `.openclaw`; `.kimi`, `.omp`, `.pi` symlink/read `content/` directly and show no diff; `.copilot` regenerated with no drift.

### Testing

Docs-only change - no behavioral logic, no state writes, no adapter build scripts modified.
