### PR TITLE
fix(build): glob content/templates/.agentic seeds so new templates propagate to adapters

### DIFF
--- a/.claude/build.sh
+++ b/.claude/build.sh
@@ -78,10 +78,11 @@ else
   ln "$SCAFFOLDING_SRC" "$SCAFFOLDING_DST"
 fi
 
-# templates/: hardlink .agentic seed files
+# templates/: hardlink .agentic seed files (glob so new templates auto-propagate)
 mkdir -p "$SKILL_DST/templates/.agentic"
-for tmpl_name in config.json learnings.md; do
-  TMPL_SRC="$CONTENT/templates/.agentic/$tmpl_name"
+for TMPL_SRC in "$CONTENT"/templates/.agentic/*; do
+  [[ -f "$TMPL_SRC" ]] || continue
+  tmpl_name="$(basename "$TMPL_SRC")"
   TMPL_DST="$SKILL_DST/templates/.agentic/$tmpl_name"
   if [[ -e "$TMPL_DST" ]] && [[ "$(get_inode "$TMPL_SRC")" == "$(get_inode "$TMPL_DST")" ]]; then
     :

--- a/.claude/skills/agentic-engineering/templates/.agentic/skill-candidates.md
+++ b/.claude/skills/agentic-engineering/templates/.agentic/skill-candidates.md
@@ -1,0 +1,34 @@
+# Skill Candidates
+
+Recurring workflow friction detected across sessions. Each entry represents a
+domain that has accumulated enough occurrences to warrant considering a new
+skill. Detection signal: `tool_failure_workaround` events (by `domain_tag`) and
+`.agentic/learnings.md` entries (by `Domain`), threshold >= 3 across sessions.
+
+Classification rules and routing taxonomy are in
+`content/commands/skill-candidates.md`. The detector is in
+`hooks/lib/skill-candidate-detector.js`.
+
+## Entry format
+
+Each candidate uses this exact format. The `## <domain>` heading is the unique
+key (no separate id field). `Status` is set to `open` by the detector; a human
+edits it to `dismissed` to suppress future session-start notices.
+
+```markdown
+## <domain>
+**Count:** <lifetime occurrence count>
+**Suggested artifact:** command | named-agent | preset | lint-rule
+**First seen:** YYYY-MM-DD
+**Last seen:** YYYY-MM-DD
+**Status:** open
+**Example:** "<data.note from the triggering event>"
+```
+
+Do not hand-edit `Count`, `First seen`, or `Last seen` - they are maintained by
+the detector. To dismiss a candidate, change `**Status:** open` to
+`**Status:** dismissed`.
+
+## Candidates
+
+<!-- Entries appended by wrap-time detector (/wrap Part D + skill-candidate-deep-cluster.js). -->

--- a/.codex/build.sh
+++ b/.codex/build.sh
@@ -166,8 +166,9 @@ echo "Rebuilt references/ hardlinks"
 # project-scaffolding.yml and templates/: hardlink into .codex/skill/ so agentic-migrate can find them
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$SKILL_DST/project-scaffolding.yml"
 mkdir -p "$SKILL_DST/templates/.agentic"
-for tmpl_name in config.json learnings.md; do
-  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$SKILL_DST/templates/.agentic/$tmpl_name"
+for tmpl_src in "$CONTENT"/templates/.agentic/*; do
+  [[ -f "$tmpl_src" ]] || continue
+  hardlink_from_content "$tmpl_src" "$SKILL_DST/templates/.agentic/$(basename "$tmpl_src")"
 done
 echo "Rebuilt skill/project-scaffolding.yml and templates/"
 

--- a/.codex/skill/templates/.agentic/skill-candidates.md
+++ b/.codex/skill/templates/.agentic/skill-candidates.md
@@ -1,0 +1,34 @@
+# Skill Candidates
+
+Recurring workflow friction detected across sessions. Each entry represents a
+domain that has accumulated enough occurrences to warrant considering a new
+skill. Detection signal: `tool_failure_workaround` events (by `domain_tag`) and
+`.agentic/learnings.md` entries (by `Domain`), threshold >= 3 across sessions.
+
+Classification rules and routing taxonomy are in
+`content/commands/skill-candidates.md`. The detector is in
+`hooks/lib/skill-candidate-detector.js`.
+
+## Entry format
+
+Each candidate uses this exact format. The `## <domain>` heading is the unique
+key (no separate id field). `Status` is set to `open` by the detector; a human
+edits it to `dismissed` to suppress future session-start notices.
+
+```markdown
+## <domain>
+**Count:** <lifetime occurrence count>
+**Suggested artifact:** command | named-agent | preset | lint-rule
+**First seen:** YYYY-MM-DD
+**Last seen:** YYYY-MM-DD
+**Status:** open
+**Example:** "<data.note from the triggering event>"
+```
+
+Do not hand-edit `Count`, `First seen`, or `Last seen` - they are maintained by
+the detector. To dismiss a candidate, change `**Status:** open` to
+`**Status:** dismissed`.
+
+## Candidates
+
+<!-- Entries appended by wrap-time detector (/wrap Part D + skill-candidate-deep-cluster.js). -->

--- a/.cursor/build.sh
+++ b/.cursor/build.sh
@@ -80,8 +80,9 @@ done
 CURSOR_DIR="$REPO_DIR/.cursor"
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$CURSOR_DIR/project-scaffolding.yml"
 mkdir -p "$CURSOR_DIR/templates/.agentic"
-for tmpl_name in config.json learnings.md; do
-  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$CURSOR_DIR/templates/.agentic/$tmpl_name"
+for tmpl_src in "$CONTENT"/templates/.agentic/*; do
+  [[ -f "$tmpl_src" ]] || continue
+  hardlink_from_content "$tmpl_src" "$CURSOR_DIR/templates/.agentic/$(basename "$tmpl_src")"
 done
 
 echo "Cursor adapter build complete."

--- a/.cursor/templates/.agentic/skill-candidates.md
+++ b/.cursor/templates/.agentic/skill-candidates.md
@@ -1,0 +1,34 @@
+# Skill Candidates
+
+Recurring workflow friction detected across sessions. Each entry represents a
+domain that has accumulated enough occurrences to warrant considering a new
+skill. Detection signal: `tool_failure_workaround` events (by `domain_tag`) and
+`.agentic/learnings.md` entries (by `Domain`), threshold >= 3 across sessions.
+
+Classification rules and routing taxonomy are in
+`content/commands/skill-candidates.md`. The detector is in
+`hooks/lib/skill-candidate-detector.js`.
+
+## Entry format
+
+Each candidate uses this exact format. The `## <domain>` heading is the unique
+key (no separate id field). `Status` is set to `open` by the detector; a human
+edits it to `dismissed` to suppress future session-start notices.
+
+```markdown
+## <domain>
+**Count:** <lifetime occurrence count>
+**Suggested artifact:** command | named-agent | preset | lint-rule
+**First seen:** YYYY-MM-DD
+**Last seen:** YYYY-MM-DD
+**Status:** open
+**Example:** "<data.note from the triggering event>"
+```
+
+Do not hand-edit `Count`, `First seen`, or `Last seen` - they are maintained by
+the detector. To dismiss a candidate, change `**Status:** open` to
+`**Status:** dismissed`.
+
+## Candidates
+
+<!-- Entries appended by wrap-time detector (/wrap Part D + skill-candidate-deep-cluster.js). -->

--- a/.gemini/build.sh
+++ b/.gemini/build.sh
@@ -404,8 +404,9 @@ echo "Built ${#generated_agents[@]} agent files in .gemini/agents/"
 # project-scaffolding.yml and templates/: hardlink so agentic-migrate can resolve from adapter
 hardlink_from_content "$CONTENT/project-scaffolding.yml" "$GEMINI_DIR/project-scaffolding.yml"
 mkdir -p "$GEMINI_DIR/templates/.agentic"
-for tmpl_name in config.json learnings.md; do
-  hardlink_from_content "$CONTENT/templates/.agentic/$tmpl_name" "$GEMINI_DIR/templates/.agentic/$tmpl_name"
+for tmpl_src in "$CONTENT"/templates/.agentic/*; do
+  [[ -f "$tmpl_src" ]] || continue
+  hardlink_from_content "$tmpl_src" "$GEMINI_DIR/templates/.agentic/$(basename "$tmpl_src")"
 done
 echo "Rebuilt project-scaffolding.yml and templates/"
 

--- a/.gemini/templates/.agentic/skill-candidates.md
+++ b/.gemini/templates/.agentic/skill-candidates.md
@@ -1,0 +1,34 @@
+# Skill Candidates
+
+Recurring workflow friction detected across sessions. Each entry represents a
+domain that has accumulated enough occurrences to warrant considering a new
+skill. Detection signal: `tool_failure_workaround` events (by `domain_tag`) and
+`.agentic/learnings.md` entries (by `Domain`), threshold >= 3 across sessions.
+
+Classification rules and routing taxonomy are in
+`content/commands/skill-candidates.md`. The detector is in
+`hooks/lib/skill-candidate-detector.js`.
+
+## Entry format
+
+Each candidate uses this exact format. The `## <domain>` heading is the unique
+key (no separate id field). `Status` is set to `open` by the detector; a human
+edits it to `dismissed` to suppress future session-start notices.
+
+```markdown
+## <domain>
+**Count:** <lifetime occurrence count>
+**Suggested artifact:** command | named-agent | preset | lint-rule
+**First seen:** YYYY-MM-DD
+**Last seen:** YYYY-MM-DD
+**Status:** open
+**Example:** "<data.note from the triggering event>"
+```
+
+Do not hand-edit `Count`, `First seen`, or `Last seen` - they are maintained by
+the detector. To dismiss a candidate, change `**Status:** open` to
+`**Status:** dismissed`.
+
+## Candidates
+
+<!-- Entries appended by wrap-time detector (/wrap Part D + skill-candidate-deep-cluster.js). -->


### PR DESCRIPTION
## Summary
Four adapter `build.sh` scripts (`.claude`, `.cursor`, `.codex`, `.gemini`) hardcoded a `config.json learnings.md` list when hardlinking `.agentic` seed templates into adapter template dirs. The tracked seed `content/templates/.agentic/skill-candidates.md` was never propagated, so `bin/agentic-migrate` v4 scaffolding hit its missing-template branch, returned exit 3, and never stamped `scaffolding_version` - a silent break for every project on a machine.

Replace each hardcoded loop with a glob over `content/templates/.agentic/*` guarded by `[[ -f ]] || continue`, preserving each script's own hardlink + inode-equality semantics and destination variable (two variants: inline `ln`+inode in `.claude/build.sh`; the `hardlink_from_content` helper in the other three). Future seed templates now auto-propagate, so this bug class cannot recur.

## Changes
- 4 build scripts: hardcoded template list -> glob.
- 4 regenerated adapter artifacts: `skill-candidates.md` now committed under `.claude`/`.codex`/`.cursor`/`.gemini` `templates/.agentic/` (adapter-sync CI only diffs tracked files, so the seed must be committed or the fix is inert for bare-pull consumers).

## North Star alignment
Advances **Low friction (P3)** and **Works for everyone (P4)**: removes a silent, per-machine breakage in v4 scaffolding; new seed templates now propagate to every adapter automatically, so no maintainer must remember to update four hardcoded lists - portable by construction. Also advances **Verifiable outcomes (P2)**: eliminates a silent-failure class (errored-but-no-stderr, exit 3 with no version stamp), so migration cleanly applies (exit 0) or is a real, visible error.

Trade-off (named plainly): the glob trades an explicit two-item allow-list for "propagate whatever is in the dir" (Skeptic Minor). Low-risk - `agentic-migrate` only seeds manifest-listed files, and `content/templates/.agentic/` is curated to seeds only. No pillar materially regressed; the attention test improves (one fewer silent break for the operator to notice and hand-fix).

## Review
- Fresh independent Skeptic: semantics preserved per-variant, glob-safe under `set -euo pipefail` (no `nullglob`/`dotglob`), `hardlink_from_content(src,dst)` signature confirmed, 4-adapter scope correct (the other 7 adapters have no such loop). Functionally verified by running builds in an isolated worktree.
- Skeptic Major ("regenerated artifacts must be committed") resolved: `skill-candidates.md` is tracked in all 4 adapter dirs in this PR; `check-adapter-sync` passes.

## Test plan
- [x] `bash -n` on all four scripts passes
- [x] Full `build-all` regenerates cleanly; `git status` shows only the 4 scripts + 4 new seeds, no unrelated churn
- [x] CI: adapter-sync, methodology-drift, codex-skill-sync, DCO green