### PR TITLE
docs(site): install section with video walkthrough up front, fix AE_DEST_DIR install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This clones the repo into `DinoStack/` inside your current directory, runs the i
 
 ```bash
 # Install to ~/tools/DinoStack instead of the current directory
-AE_DEST_DIR=~/tools/DinoStack curl -fsSL https://docs.dinostack.ai/install.sh | bash
+curl -fsSL https://docs.dinostack.ai/install.sh | AE_DEST_DIR=~/tools/DinoStack bash
 ```
 
 **Pass flags through to the installer** (e.g. to set activation mode without prompts):

--- a/docs/index.html
+++ b/docs/index.html
@@ -955,7 +955,7 @@
   <div class="note">
     <strong>Variants</strong>
     <ul>
-      <li>Custom install location - set <code>AE_DEST_DIR</code>: <code>AE_DEST_DIR=~/tools/DinoStack curl -fsSL https://docs.dinostack.ai/install.sh | bash</code></li>
+      <li>Custom install location - set <code>AE_DEST_DIR</code>: <code>curl -fsSL https://docs.dinostack.ai/install.sh | AE_DEST_DIR=~/tools/DinoStack bash</code></li>
       <li>Opt-in activation with no prompts: <code>curl -fsSL https://docs.dinostack.ai/install.sh | bash -s -- --mode=opt-in</code></li>
       <li>Already installed? Bootstrap detects an existing install and aborts, printing the update-in-place command instead of creating a second clone.</li>
     </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -776,6 +776,33 @@
     font-weight: 500;
   }
 
+  /* ── Video embed ── */
+  .video-embed { margin: 20px 0 4px; }
+  .video-embed-frame {
+    position: relative;
+    aspect-ratio: 16 / 9;
+    width: 100%;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--bg-surface);
+    box-shadow: 0 18px 44px rgba(2, 5, 12, 0.5);
+  }
+  .video-embed-frame iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  .video-embed-caption {
+    margin: 10px 0 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    letter-spacing: 0.01em;
+  }
+
   strong { font-weight: 700; color: var(--text-bright); }
 
   /* ── Table — dark zebra ── */
@@ -869,12 +896,13 @@
   <div class="side-nav-brand">
     <img class="side-nav-logo" src="images/dinostack-logo.svg" alt="DinoStack" />
   </div>
-  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jul 10, 2026
+  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jul 15, 2026
   <hr class="side-nav-divider">
+  <a href="#install"><span class="nav-dot" style="background: var(--cyan);"></span> Install</a>
+  <a href="#updating"><span class="nav-dot" style="background: var(--cyan);"></span> Updating</a>
   <a href="#decks"><span class="nav-dot" style="background: var(--text-muted);"></span> Slide Decks</a>
   <a href="#infographics"><span class="nav-dot" style="background: var(--gold);"></span> Infographics</a>
   <a href="#signals"><span class="nav-dot" style="background: var(--gold);"></span> Is It Working?</a>
-  <a href="#updating"><span class="nav-dot" style="background: var(--cyan);"></span> Updating</a>
   <a href="#config"><span class="nav-dot" style="background: var(--cyan);"></span> Configuration</a>
   <a href="#protocols"><span class="nav-dot" style="background: var(--violet);"></span> Protocol Rules</a>
   <a href="#protocol-deep-dive"><span class="nav-dot" style="background: var(--violet);"></span> Protocol Deep Dive</a>
@@ -905,6 +933,76 @@
   <p class="repo-link"><a href="https://github.com/Space-Dinosaurs/DinoStack" target="_blank" rel="noopener noreferrer">github.com/Space-Dinosaurs/DinoStack</a></p>
   <p class="epigraph">Operator attention is the scarce resource. Agents aren't. This architecture is an attempt to run as much of the process without you as possible - so the attention you do spend goes where judgment is load-bearing.</p>
   <p class="compat-note">Built around Claude Code. <code>AGENTS.md</code> is the cross-tool standard - Codex reads it natively; Claude Code loads it via a <code>CLAUDE.md</code> containing <code>@AGENTS.md</code> and <code>@MEMORY.md</code> import lines. The patterns translate to any agentic framework.</p>
+</div>
+
+<!-- ═══ INSTALL: One command to get started ═══ -->
+<div id="install" class="section config-layer">
+  <div class="section-title"><h2>Install</h2><h3>One command. Everything else is optional.</h3></div>
+  <p class="desc">One line clones the repo into <code>DinoStack/</code> inside your current directory, runs the installer, and writes the install path to <code>~/.agentic/agentic-engineering-config.json</code> so update tooling (<code>agentic-update</code>, <code>/update-agentic-engineering</code>) knows where to find it. Prerequisites: <code>git</code> and <code>python3</code> - <code>node</code> is optional, needed only for the update TUI.</p>
+
+  <div class="code-block">
+    <span class="cb-label">one-liner install</span>
+    <span class="cb-prompt">$ </span><span class="cb-cmd">curl</span> <span class="cb-flag">-fsSL</span> <span class="cb-path">https://docs.dinostack.ai/install.sh</span> <span class="cb-op">|</span> <span class="cb-cmd">bash</span>
+  </div>
+
+  <div class="video-embed">
+    <div class="video-embed-frame">
+      <iframe src="https://www.youtube-nocookie.com/embed/kGUIXqixnyw" title="How to Install DinoStack and Complete Your First Ticket" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+    </div>
+    <p class="video-embed-caption">Walkthrough: installing DinoStack and completing your first ticket, end to end.</p>
+  </div>
+
+  <div class="note">
+    <strong>Variants</strong>
+    <ul>
+      <li>Custom install location - set <code>AE_DEST_DIR</code>: <code>AE_DEST_DIR=~/tools/DinoStack curl -fsSL https://docs.dinostack.ai/install.sh | bash</code></li>
+      <li>Opt-in activation with no prompts: <code>curl -fsSL https://docs.dinostack.ai/install.sh | bash -s -- --mode=opt-in</code></li>
+      <li>Already installed? Bootstrap detects an existing install and aborts, printing the update-in-place command instead of creating a second clone.</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ═══ UPDATING: Keep DinoStack current ═══ -->
+<div id="updating" class="section config-layer">
+  <div class="section-title"><h2>Updating</h2><h3>Keep DinoStack current with one command.</h3></div>
+  <p class="desc">Run <code>agentic-update</code> from any directory, no arguments. It pulls the latest <code>main</code>, rebuilds adapters only when something changed under <code>content/</code>, <code>hooks/</code>, <code>bin/</code>, or the build scripts, resets the version-check cache, and runs <code>agentic-doctor --fix</code> to repair drifted symlinks or hooks. No TTY required.</p>
+  <table style="width: 100%; border-collapse: collapse; font-size: 14.5px; margin: 16px 0;">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border-subtle);">
+        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 22%;">Path</th>
+        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 42%;">Command</th>
+        <th style="text-align: left; padding: 10px 12px; color: var(--text-muted); width: 36%;">When</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">Shell <span style="color: var(--text-muted); font-size: 0.85em;">(recommended)</span></td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-update</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Default; from any directory, no TTY</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">In-session</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>/pull-and-install</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Inside Claude Code, any project</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">TUI</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>./update.sh</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Interactive adapter selection</td>
+      </tr>
+      <tr style="border-bottom: 1px solid var(--border-faint);">
+        <td style="padding: 10px 12px; vertical-align: top;">CI / scripts</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>git pull &amp;&amp; ./install-all.sh</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Non-interactive</td>
+      </tr>
+      <tr>
+        <td style="padding: 10px 12px; vertical-align: top;">Repair drift</td>
+        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-doctor --fix</code></td>
+        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Fix broken symlinks/hooks (e.g. after moving the repo)</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="desc">Full details: <a href="updating.md">updating.md</a></p>
 </div>
 
 <nav id="decks" class="deck-index" aria-label="Slide decks">
@@ -981,49 +1079,6 @@
   <div class="note" style="margin-top: 12px;">
     <strong>Tuning Skeptic overhead:</strong> the default profile works for most projects. Add <code>agentic-engineering-profile: relaxed</code> to a project's <code>AGENTS.md</code> for faster iteration with less review, or <code>strict</code> when correctness is paramount. See <a href="#profiles">Risk Profiles</a> for the full breakdown.
   </div>
-</div>
-
-<!-- ═══ UPDATING: Keep DinoStack current ═══ -->
-<div id="updating" class="section config-layer">
-  <div class="section-title"><h2>Updating</h2><h3>Keep DinoStack current with one command.</h3></div>
-  <p class="desc">Run <code>agentic-update</code> from any directory, no arguments. It pulls the latest <code>main</code>, rebuilds adapters only when something changed under <code>content/</code>, <code>hooks/</code>, <code>bin/</code>, or the build scripts, resets the version-check cache, and runs <code>agentic-doctor --fix</code> to repair drifted symlinks or hooks. No TTY required.</p>
-  <table style="width: 100%; border-collapse: collapse; font-size: 14.5px; margin: 16px 0;">
-    <thead>
-      <tr style="border-bottom: 1px solid var(--border-subtle);">
-        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 22%;">Path</th>
-        <th style="text-align: left; padding: 10px 12px; color: var(--cyan); width: 42%;">Command</th>
-        <th style="text-align: left; padding: 10px 12px; color: var(--text-muted); width: 36%;">When</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr style="border-bottom: 1px solid var(--border-faint);">
-        <td style="padding: 10px 12px; vertical-align: top;">Shell <span style="color: var(--text-muted); font-size: 0.85em;">(recommended)</span></td>
-        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-update</code></td>
-        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Default; from any directory, no TTY</td>
-      </tr>
-      <tr style="border-bottom: 1px solid var(--border-faint);">
-        <td style="padding: 10px 12px; vertical-align: top;">In-session</td>
-        <td style="padding: 10px 12px; vertical-align: top;"><code>/pull-and-install</code></td>
-        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Inside Claude Code, any project</td>
-      </tr>
-      <tr style="border-bottom: 1px solid var(--border-faint);">
-        <td style="padding: 10px 12px; vertical-align: top;">TUI</td>
-        <td style="padding: 10px 12px; vertical-align: top;"><code>./update.sh</code></td>
-        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Interactive adapter selection</td>
-      </tr>
-      <tr style="border-bottom: 1px solid var(--border-faint);">
-        <td style="padding: 10px 12px; vertical-align: top;">CI / scripts</td>
-        <td style="padding: 10px 12px; vertical-align: top;"><code>git pull &amp;&amp; ./install-all.sh</code></td>
-        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Non-interactive</td>
-      </tr>
-      <tr>
-        <td style="padding: 10px 12px; vertical-align: top;">Repair drift</td>
-        <td style="padding: 10px 12px; vertical-align: top;"><code>agentic-doctor --fix</code></td>
-        <td style="padding: 10px 12px; color: var(--text-muted); vertical-align: top;">Fix broken symlinks/hooks (e.g. after moving the repo)</td>
-      </tr>
-    </tbody>
-  </table>
-  <p class="desc">Full details: <a href="updating.md">updating.md</a></p>
 </div>
 
 <!-- ═══ LAYER 1: Configuration Files ═══ -->


### PR DESCRIPTION
## Summary
- Add a new `#install` section to the docs site as the first content on the page - above the slide-deck index - with the one-liner install command, prereqs, an embedded walkthrough video ("How to Install DinoStack and Complete Your First Ticket", youtube-nocookie iframe, lazy-loaded), and a variants note (AE_DEST_DIR custom location, --mode=opt-in, rogue-clone guard).
- Move the existing `#updating` section up to sit directly after `#install`, still above the slide decks. Content moved verbatim; `id` preserved so existing anchors keep working. Side nav reordered to match; "Last updated" bumped to Jul 15, 2026.
- Fix a real bug found during adversarial review: the documented custom-install command `AE_DEST_DIR=<path> curl ... | bash` binds the env var to `curl`, not the `bash` right of the pipe, so bootstrap.sh never saw it and silently installed to `$PWD/DinoStack`. Corrected to `curl ... | AE_DEST_DIR=<path> bash` in both README.md and the docs page (empirically verified the var now reaches bash). No other instance of the broken form exists in the repo.

## Verification
- Every command claim on the page re-verified against the repo: `docs/vercel.json` `/install.sh` redirect -> `bootstrap.sh`, `bin/agentic-update`, `update.sh`, `install-all.sh`, `/pull-and-install` command file, `agentic-doctor --fix`, prereqs (git/python3).
- HTML parse check clean; div balance unchanged vs main; single `id="install"`/`id="updating"`; `.section` styling confirmed unscoped to `.diagram` so the relocated sections render and animate correctly.
- Skeptic review: 1 Major raised (the AE_DEST_DIR pipe bug), fixed, re-verified, sign-off granted.

## North Star alignment
Docs-only change (docs site page + README install instructions). No methodology-shaping trigger paths touched.
