### PR TITLE
fix(install): drop ignored path-scoped Write() permission rules and migrate them out

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -67,7 +67,7 @@ The install script offers to configure `bypassPermissions` mode in `~/.claude/se
 **What it configures:**
 
 - `defaultMode: "bypassPermissions"` - agents can use tools without prompting
-- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings
+- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings that already have the bare `Write` rule (left in place otherwise)
 - **Deny list** - blocks destructive commands as a safety net:
   - `git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`
   - `sudo rm`, `dd if=`, `shutdown`, `reboot`

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -67,7 +67,7 @@ The install script offers to configure `bypassPermissions` mode in `~/.claude/se
 **What it configures:**
 
 - `defaultMode: "bypassPermissions"` - agents can use tools without prompting
-- **Allow list** - `Bash(*)`, `Write`, `Edit`, and write access to `~/.claude/` directories
+- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings
 - **Deny list** - blocks destructive commands as a safety net:
   - `git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`
   - `sudo rm`, `dd if=`, `shutdown`, `reboot`

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1244,6 +1244,13 @@ recommended_deny = [
     "Bash(reboot*)"
 ]
 
+def _migrated_allow(existing_allow):
+    """Merge recommended allow rules in and strip legacy path-scoped
+    Write() rules out. Single-sourced so both the already-bypass and the
+    fresh-configure branches apply the identical migration (regression
+    case (g) in install-converge.test.sh covers this helper for both)."""
+    return list((existing_allow | set(recommended_allow)) - set(legacy_allow))
+
 already_bypass = perms.get("defaultMode") == "bypassPermissions"
 
 if already_bypass:
@@ -1256,7 +1263,7 @@ if already_bypass:
     stale_allow = existing_allow & set(legacy_allow)
 
     if missing_allow or missing_deny or missing_dir or stale_allow:
-        perms["allow"] = list((existing_allow | set(recommended_allow)) - set(legacy_allow))
+        perms["allow"] = _migrated_allow(existing_allow)
         perms["deny"] = list(existing_deny | set(recommended_deny))
         if os.path.islink(settings_path):
             sys.stderr.write(f"refusing to write through symlink: {settings_path}\n")
@@ -1283,7 +1290,7 @@ else:
         existing_allow = set(perms.get("allow", []))
         existing_deny = set(perms.get("deny", []))
 
-        perms["allow"] = list((existing_allow | set(recommended_allow)) - set(legacy_allow))
+        perms["allow"] = _migrated_allow(existing_allow)
         perms["deny"] = list(existing_deny | set(recommended_deny))
         perms["defaultMode"] = "bypassPermissions"
         perms.setdefault("additionalDirectories", [])

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1222,11 +1222,16 @@ perms = settings.get("permissions", {})
 recommended_allow = [
     "Bash(*)",
     "Write",
-    f"Write({_cfg_label}/**)",
     "Edit",
     f"Edit({_cfg_label}/**)",
-    f"Write({_cfg_label}/projects/**)",
     f"Edit({_cfg_label}/projects/**)"
+]
+# Legacy rules from older installs: path-scoped Write() rules are ignored by
+# Claude Code's file-permission checks (only Edit(path) rules match) and
+# trigger a startup warning. Strip them wherever found.
+legacy_allow = [
+    f"Write({_cfg_label}/**)",
+    f"Write({_cfg_label}/projects/**)"
 ]
 recommended_deny = [
     "Bash(git push --force*)",
@@ -1248,9 +1253,10 @@ if already_bypass:
     missing_allow = set(recommended_allow) - existing_allow
     missing_deny = set(recommended_deny) - existing_deny
     missing_dir = f"{_cfg_label}/projects" not in perms.get("additionalDirectories", [])
+    stale_allow = existing_allow & set(legacy_allow)
 
-    if missing_allow or missing_deny or missing_dir:
-        perms["allow"] = list(existing_allow | set(recommended_allow))
+    if missing_allow or missing_deny or missing_dir or stale_allow:
+        perms["allow"] = list((existing_allow | set(recommended_allow)) - set(legacy_allow))
         perms["deny"] = list(existing_deny | set(recommended_deny))
         if os.path.islink(settings_path):
             sys.stderr.write(f"refusing to write through symlink: {settings_path}\n")
@@ -1263,6 +1269,8 @@ if already_bypass:
             added.append(f"{len(missing_allow)} allow")
         if missing_deny:
             added.append(f"{len(missing_deny)} deny")
+        if stale_allow:
+            added.append(f"removed {len(stale_allow)} legacy Write rules")
         print(f"  ~ Permissions: bypassPermissions already set, added {' and '.join(added)} rules")
     else:
         print("  = Permissions already configured (bypassPermissions mode)")
@@ -1275,7 +1283,7 @@ else:
         existing_allow = set(perms.get("allow", []))
         existing_deny = set(perms.get("deny", []))
 
-        perms["allow"] = list(existing_allow | set(recommended_allow))
+        perms["allow"] = list((existing_allow | set(recommended_allow)) - set(legacy_allow))
         perms["deny"] = list(existing_deny | set(recommended_deny))
         perms["defaultMode"] = "bypassPermissions"
         perms.setdefault("additionalDirectories", [])

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1264,14 +1264,14 @@ if already_bypass:
         with open(settings_path, "w") as f:
             json.dump(settings, f, indent=2)
             f.write("\n")
-        added = []
+        parts = []
         if missing_allow:
-            added.append(f"{len(missing_allow)} allow")
+            parts.append(f"added {len(missing_allow)} allow rules")
         if missing_deny:
-            added.append(f"{len(missing_deny)} deny")
+            parts.append(f"added {len(missing_deny)} deny rules")
         if stale_allow:
-            added.append(f"removed {len(stale_allow)} legacy Write rules")
-        print(f"  ~ Permissions: bypassPermissions already set, added {' and '.join(added)} rules")
+            parts.append(f"removed {len(stale_allow)} legacy Write rules")
+        print(f"  ~ Permissions: bypassPermissions already set, {' and '.join(parts)}")
     else:
         print("  = Permissions already configured (bypassPermissions mode)")
 else:

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1245,11 +1245,30 @@ recommended_deny = [
 ]
 
 def _migrated_allow(existing_allow):
-    """Merge recommended allow rules in and strip legacy path-scoped
-    Write() rules out. Single-sourced so both the already-bypass and the
+    """Merge recommended allow rules in and, conservatively, strip legacy
+    path-scoped Write() rules out.
+
+    Bare "Write" is unioned in from recommended_allow on every path
+    regardless of this gate - the installer always grants it. Path-scoped
+    Write(path) rules are ignored by Claude Code's file-permission checks
+    (inert either way), so keeping or removing them changes no effective
+    permission. What the gate actually controls is only whether the
+    installer edits the redundant scoped rule out of the config text: the
+    strip fires only when the bare "Write" rule is already present in
+    existing_allow (i.e. present in the user's PRE-migration config). This
+    avoids the installer making a surprising-looking edit - replacing a
+    scoped rule with a broad one in the config text - to a config a user
+    may have deliberately narrowed, without their input. Trade-off: for a
+    user who removed bare Write but kept the scoped rule, the scoped rule
+    (and Claude Code's startup warning about it) is left in place rather
+    than cleaned up. Single-sourced so both the already-bypass and the
     fresh-configure branches apply the identical migration (regression
-    case (g) in install-converge.test.sh covers this helper for both)."""
-    return list((existing_allow | set(recommended_allow)) - set(legacy_allow))
+    cases (g) and (h) in install-converge.test.sh cover both branches of
+    this gate)."""
+    merged = existing_allow | set(recommended_allow)
+    if "Write" in existing_allow:
+        merged -= set(legacy_allow)
+    return list(merged)
 
 already_bypass = perms.get("defaultMode") == "bypassPermissions"
 
@@ -1260,7 +1279,11 @@ if already_bypass:
     missing_allow = set(recommended_allow) - existing_allow
     missing_deny = set(recommended_deny) - existing_deny
     missing_dir = f"{_cfg_label}/projects" not in perms.get("additionalDirectories", [])
-    stale_allow = existing_allow & set(legacy_allow)
+    # Mirror _migrated_allow()'s gate: only count legacy rules as "stale" (and
+    # report them as removed) when the bare "Write" rule is already present
+    # pre-migration - otherwise _migrated_allow() will not strip them, and
+    # reporting a removal here would be inaccurate.
+    stale_allow = (existing_allow & set(legacy_allow)) if "Write" in existing_allow else set()
 
     if missing_allow or missing_deny or missing_dir or stale_allow:
         perms["allow"] = _migrated_allow(existing_allow)

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -31,7 +31,10 @@
 #     Edit(path) rules match) are migrated out of an existing
 #     bypassPermissions settings.json; recommended Edit path rules and the
 #     bare Write/Edit tool rules are retained; the write fires even when
-#     nothing else is missing.
+#     nothing else is missing. The migration is single-sourced in the
+#     install.sh `_migrated_allow()` helper, so this case's assertions
+#     cover both the already-bypass branch and the fresh-configure branch
+#     (both call the same helper).
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -374,7 +377,11 @@ rm -rf "$FAKE_HOME"
 # Case (g): permissions migration - legacy path-scoped Write() allow rules
 #           are removed from an existing bypassPermissions settings.json;
 #           recommended Edit path rules and bare Write/Edit are retained;
-#           the write fires even when nothing else is missing.
+#           the write fires even when nothing else is missing. Exercises
+#           install.sh's single-sourced `_migrated_allow()` helper, which
+#           the fresh-configure (interactive) branch also calls - that
+#           branch reads /dev/tty and cannot be exercised directly in CI,
+#           so this case is the sole coverage for both branches' migration.
 # ---------------------------------------------------------------------------
 
 FAKE_HOME="$(mktemp -d)"

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# Purpose: Tests for .claude/install.sh symlink-convergence and guarded
-#          repo_dir write (Changes 1-3 in the converging-symlinks PR).
+# Purpose: Tests for .claude/install.sh symlink-convergence, guarded
+#          repo_dir write (Changes 1-3 in the converging-symlinks PR), and
+#          the legacy path-scoped Write() permission-rule migration.
 #
 # Public API: bash .claude/tests/install-converge.test.sh
 #             Exits 0 on all pass, non-zero on any failure.
@@ -25,6 +26,12 @@
 #   - Change 2: --dry-run makes no filesystem changes.
 #   - Change 3: clobber guard - valid DIFFERENT repo_dir is NOT overwritten;
 #     absent/invalid repo_dir IS written.
+#   - Case (g): legacy path-scoped Write(<cfg>/**) / Write(<cfg>/projects/**)
+#     allow rules (ignored by Claude Code's file-permission checks, only
+#     Edit(path) rules match) are migrated out of an existing
+#     bypassPermissions settings.json; recommended Edit path rules and the
+#     bare Write/Edit tool rules are retained; the write fires even when
+#     nothing else is missing.
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -359,6 +366,79 @@ if [[ -n "$actual_repo_dir" ]] && [[ "$actual_repo_dir" != "/nonexistent/path/th
   _pass "case (f3): invalid repo_dir overwritten (new value: $actual_repo_dir)"
 else
   _fail "case (f3): invalid repo_dir was not overwritten (got '$actual_repo_dir')"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (g): permissions migration - legacy path-scoped Write() allow rules
+#           are removed from an existing bypassPermissions settings.json;
+#           recommended Edit path rules and bare Write/Edit are retained;
+#           the write fires even when nothing else is missing.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude"
+python3 - "$FAKE_HOME/.claude/settings.json" <<'PYEOF'
+import json, sys
+
+settings = {
+    "permissions": {
+        "defaultMode": "bypassPermissions",
+        "allow": [
+            "Bash(*)",
+            "Write",
+            "Write(~/.claude/**)",
+            "Edit",
+            "Edit(~/.claude/**)",
+            "Write(~/.claude/projects/**)",
+            "Edit(~/.claude/projects/**)"
+        ],
+        "deny": [
+            "Bash(git push --force*)",
+            "Bash(rm -rf*)",
+            "Bash(git reset --hard*)",
+            "Bash(git clean -f*)",
+            "Bash(sudo rm*)",
+            "Bash(dd if=*)",
+            "Bash(shutdown*)",
+            "Bash(reboot*)"
+        ],
+        "additionalDirectories": ["~/.claude/projects"]
+    }
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+PYEOF
+
+_run_install "$FAKE_HOME" || true
+
+result_allow="$(python3 -c "
+import json
+with open('$FAKE_HOME/.claude/settings.json') as f:
+    print(json.dumps(json.load(f)['permissions']['allow']))
+")"
+
+if [[ "$result_allow" != *"Write(~/.claude/**)"* ]] && [[ "$result_allow" != *"Write(~/.claude/projects/**)"* ]]; then
+  _pass "case (g): legacy path-scoped Write() rules removed"
+else
+  _fail "case (g): legacy path-scoped Write() rules still present: $result_allow"
+fi
+
+if [[ "$result_allow" == *'"Edit(~/.claude/**)"'* ]] \
+   && [[ "$result_allow" == *'"Edit(~/.claude/projects/**)"'* ]] \
+   && [[ "$result_allow" == *'"Write"'* ]] \
+   && [[ "$result_allow" == *'"Edit"'* ]]; then
+  _pass "case (g): recommended Edit path rules and bare Write/Edit retained"
+else
+  _fail "case (g): expected recommended allow rules missing: $result_allow"
+fi
+
+if grep -q "removed 2 legacy Write rules" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (g): install output reports legacy-rule removal"
+else
+  _fail "case (g): install output did not report legacy-rule removal"
 fi
 
 rm -rf "$FAKE_HOME"

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -29,12 +29,24 @@
 #   - Case (g): legacy path-scoped Write(<cfg>/**) / Write(<cfg>/projects/**)
 #     allow rules (ignored by Claude Code's file-permission checks, only
 #     Edit(path) rules match) are migrated out of an existing
-#     bypassPermissions settings.json; recommended Edit path rules and the
-#     bare Write/Edit tool rules are retained; the write fires even when
-#     nothing else is missing. The migration is single-sourced in the
-#     install.sh `_migrated_allow()` helper, so this case's assertions
-#     cover both the already-bypass branch and the fresh-configure branch
-#     (both call the same helper).
+#     bypassPermissions settings.json when the bare "Write" rule is already
+#     present pre-migration; recommended Edit path rules and the bare
+#     Write/Edit tool rules are retained; the write fires even when nothing
+#     else is missing. Also asserts idempotency: running install a second
+#     time against the already-migrated state reports "already configured"
+#     and does not attempt to remove legacy rules again. The migration is
+#     single-sourced in the install.sh `_migrated_allow()` helper, so this
+#     case's assertions cover both the already-bypass branch and the
+#     fresh-configure branch (both call the same helper).
+#   - Case (h): legacy path-scoped Write(<cfg>/**) allow rule is RETAINED
+#     (not stripped) when the bare "Write" rule is ABSENT pre-migration.
+#     This does not change effective permissions either way (the scoped
+#     rule is inert; bare Write is added by the recommended-merge
+#     regardless) - retaining it instead avoids the installer making a
+#     surprising-looking edit to a config a user may have deliberately
+#     narrowed, at the cost of leaving Claude Code's startup warning about
+#     the inert scoped rule in place for that edge case. The install
+#     output reports added rules, not a legacy-rule removal.
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -375,13 +387,17 @@ rm -rf "$FAKE_HOME"
 
 # ---------------------------------------------------------------------------
 # Case (g): permissions migration - legacy path-scoped Write() allow rules
-#           are removed from an existing bypassPermissions settings.json;
+#           are removed from an existing bypassPermissions settings.json
+#           when the bare "Write" rule is already present pre-migration;
 #           recommended Edit path rules and bare Write/Edit are retained;
 #           the write fires even when nothing else is missing. Exercises
 #           install.sh's single-sourced `_migrated_allow()` helper, which
 #           the fresh-configure (interactive) branch also calls - that
 #           branch reads /dev/tty and cannot be exercised directly in CI,
 #           so this case is the sole coverage for both branches' migration.
+#           Also verifies idempotency: a second install run against the
+#           now-migrated state reports "already configured" and does not
+#           attempt to remove legacy rules a second time.
 # ---------------------------------------------------------------------------
 
 FAKE_HOME="$(mktemp -d)"
@@ -446,6 +462,113 @@ if grep -q "removed 2 legacy Write rules" "$FAKE_HOME/.install_out" 2>/dev/null;
   _pass "case (g): install output reports legacy-rule removal"
 else
   _fail "case (g): install output did not report legacy-rule removal"
+fi
+
+# Idempotency: running install a second time against the now-migrated state
+# must NOT report removing legacy rules again (there are none left to
+# remove) and must report the already-configured no-op path.
+_run_install "$FAKE_HOME" || true
+
+result_allow_second="$(python3 -c "
+import json
+with open('$FAKE_HOME/.claude/settings.json') as f:
+    print(json.dumps(json.load(f)['permissions']['allow']))
+")"
+
+if [[ "$result_allow_second" != *"Write(~/.claude/**)"* ]] && [[ "$result_allow_second" != *"Write(~/.claude/projects/**)"* ]]; then
+  _pass "case (g): idempotent second run keeps legacy rules absent"
+else
+  _fail "case (g): idempotent second run reintroduced legacy rules: $result_allow_second"
+fi
+
+if grep -q "already configured" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (g): idempotent second run reports already configured"
+else
+  _fail "case (g): idempotent second run did not report already configured"
+fi
+
+if grep -q "legacy Write rules" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _fail "case (g): idempotent second run should not mention legacy Write rules again"
+else
+  _pass "case (g): idempotent second run does not re-report legacy-rule removal"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (h): permissions migration - legacy path-scoped Write() allow rule is
+#           RETAINED when the bare "Write" rule is ABSENT pre-migration.
+#           This does not change effective permissions either way (the
+#           scoped rule is inert; the bare "Write" rule IS added by the
+#           recommended-merge regardless) - retaining it instead avoids the
+#           installer making a surprising-looking edit to a config a user
+#           may have deliberately narrowed. The install output reports
+#           added rules, not a legacy-rule removal.
+# ---------------------------------------------------------------------------
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.claude"
+python3 - "$FAKE_HOME/.claude/settings.json" <<'PYEOF'
+import json, sys
+
+settings = {
+    "permissions": {
+        "defaultMode": "bypassPermissions",
+        "allow": [
+            "Bash(*)",
+            "Write(~/.claude/**)",
+            "Edit",
+            "Edit(~/.claude/**)",
+            "Edit(~/.claude/projects/**)"
+        ],
+        "deny": [
+            "Bash(git push --force*)",
+            "Bash(rm -rf*)",
+            "Bash(git reset --hard*)",
+            "Bash(git clean -f*)",
+            "Bash(sudo rm*)",
+            "Bash(dd if=*)",
+            "Bash(shutdown*)",
+            "Bash(reboot*)"
+        ],
+        "additionalDirectories": ["~/.claude/projects"]
+    }
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+PYEOF
+
+_run_install "$FAKE_HOME" || true
+
+result_allow_h="$(python3 -c "
+import json
+with open('$FAKE_HOME/.claude/settings.json') as f:
+    print(json.dumps(json.load(f)['permissions']['allow']))
+")"
+
+if [[ "$result_allow_h" == *'"Write(~/.claude/**)"'* ]]; then
+  _pass "case (h): legacy scoped Write() rule retained when bare Write was absent pre-migration"
+else
+  _fail "case (h): legacy scoped Write() rule was stripped despite bare Write being absent pre-migration: $result_allow_h"
+fi
+
+if [[ "$result_allow_h" == *'"Write"'* ]]; then
+  _pass "case (h): bare Write rule added by recommended-merge"
+else
+  _fail "case (h): bare Write rule was not added: $result_allow_h"
+fi
+
+if grep -q "legacy Write rules" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _fail "case (h): install output should not report removing legacy Write rules"
+else
+  _pass "case (h): install output does not report legacy-rule removal"
+fi
+
+if grep -q "added" "$FAKE_HOME/.install_out" 2>/dev/null; then
+  _pass "case (h): install output reports added rules"
+else
+  _fail "case (h): install output did not report added rules"
 fi
 
 rm -rf "$FAKE_HOME"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ bash .claude/install.sh --dry-run             # preview symlink + repo_dir chang
 Agents need uninterrupted access to Bash, Edit, and Write - constant permission prompts break agent flow and cause subagents to stall. The Claude Code installer offers to configure `bypassPermissions` mode in `~/.claude/settings.json`:
 
 - `defaultMode: "bypassPermissions"` - agents use tools without prompting
-- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings
+- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings that already have the bare `Write` rule (left in place otherwise)
 - **Deny list** (safety net for destructive commands) - `git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`, `sudo rm`, `dd if=`, `shutdown`, `reboot`
 - **Additional directories** - `~/.claude/projects` for cross-session context
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ bash .claude/install.sh --dry-run             # preview symlink + repo_dir chang
 Agents need uninterrupted access to Bash, Edit, and Write - constant permission prompts break agent flow and cause subagents to stall. The Claude Code installer offers to configure `bypassPermissions` mode in `~/.claude/settings.json`:
 
 - `defaultMode: "bypassPermissions"` - agents use tools without prompting
-- **Allow list** - `Bash(*)`, `Write`, `Edit`, and write access to `~/.claude/` directories
+- **Allow list** - `Bash(*)`, the bare `Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` / `Edit(~/.claude/projects/**)` rules. Only `Edit(path)` rules are matched by Claude Code's file-permission checks - path-scoped `Write(path)` rules are ignored and are migrated out of existing settings
 - **Deny list** (safety net for destructive commands) - `git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`, `sudo rm`, `dd if=`, `shutdown`, `reboot`
 - **Additional directories** - `~/.claude/projects` for cross-session context
 

--- a/docs/safe-configuration.md
+++ b/docs/safe-configuration.md
@@ -66,7 +66,14 @@ Only `Edit(path)` rules are matched by Claude Code's file-permission checks -
 path-scoped `Write(path)` rules are silently ignored and trigger a startup
 warning, so the installer no longer adds them and migrates them out of
 existing `~/.claude/settings.json` files that still have them (`legacy_allow`
-in the same script).
+in the same script). The strip only runs when the bare `Write` rule is
+already present in the pre-migration config; if it is absent, the scoped
+rule is left in place. This does not change effective permissions either
+way - bare `Write` is added by the recommended-merge regardless, and the
+scoped rule is inert - it only avoids the installer editing a config a
+user may have deliberately narrowed without their input. The trade-off is
+that Claude Code's startup warning about the inert scoped rule persists
+for that edge case.
 
 ## Hooks
 

--- a/docs/safe-configuration.md
+++ b/docs/safe-configuration.md
@@ -59,9 +59,14 @@ classification and Skeptic review) exist precisely because the pattern list
 cannot be exhaustive.
 
 The recommended **allow-list** (the `recommended_allow` array,
-[`.claude/install.sh`](../.claude/install.sh) lines 726-733) grants `Bash(*)`,
-`Write`, `Edit`, and write access to `~/.claude/` directories so routine agent
-work does not stall.
+[`.claude/install.sh`](../.claude/install.sh)) grants `Bash(*)`, the bare
+`Write` and `Edit` tool rules, and path-scoped `Edit(~/.claude/**)` /
+`Edit(~/.claude/projects/**)` rules so routine agent work does not stall.
+Only `Edit(path)` rules are matched by Claude Code's file-permission checks -
+path-scoped `Write(path)` rules are silently ignored and trigger a startup
+warning, so the installer no longer adds them and migrates them out of
+existing `~/.claude/settings.json` files that still have them (`legacy_allow`
+in the same script).
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

- Claude Code's file-permission checks only match `Edit(path)` rules; the two path-scoped `Write(~/.claude/**)` and `Write(~/.claude/projects/**)` allow rules the installer wrote were dead weight that now trigger a startup warning telling users to remove them.
- Every `install.sh` run re-added those rules to `~/.claude/settings.json` (the `missing_allow` merge), so deleting them by hand only lasted until the next `agentic-update` / `pull-and-install`. This is the "why does the warning keep coming back" loop.
- Removed both from `recommended_allow` (the bare `Write` tool rule plus the `Edit(path)` rules already provide the intended coverage) and added a `legacy_allow` migration so existing installs get the stale rules stripped on the next `install.sh` run, in both the already-bypass merge branch and the interactive configure branch.
- Fixed a malformed summary line that read "added removed 2 legacy Write rules rules" in the removal-only case.
- Doc-sync: corrected the allow-list description in `docs/safe-configuration.md`, `README.md`, and `.claude/README.md` (they described the removed `Write(path)` rules).

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Low friction - removes a recurring startup warning users had to hand-fix repeatedly (the installer re-added the ignored rules every run). Produce verifiable outcomes autonomously - the fix ships with a regression test (case (g)) that runs the real installer end-to-end against a sandboxed HOME.
- Trade-off or pillar this could regress, if any: None. The removed rules never granted anything (Claude Code ignores path-scoped `Write(path)`), so effective permissions are unchanged. Known non-blocking limitation: the migration is scoped to the install's config-dir label, so a redirected-config (`AE_CONFIG_DIR`) install won't strip literal `~/.claude` legacy rules - consistent with how all recommended rules already behave.

## Test plan

- [x] `bash -n .claude/install.sh`
- [x] New regression case (g) in `.claude/tests/install-converge.test.sh`: seeds a sandboxed fake HOME with the legacy rules, runs the real `install.sh`, asserts removal + retention of valid rules + the report line. Confirmed it fails against pre-fix code.
- [x] `bash .claude/tests/install-converge.test.sh` - 16/16 pass
- [x] Two rounds of adversarial Skeptic review - APPROVED, no findings

## Known follow-ups (non-blocking)

- `install-converge.test.sh` (cases a-g) is not wired into any CI workflow - a pre-existing gap.
