### PR TITLE
fix(hooks): abdication guard misses permission question followed by declarative text

### DIFF
--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -158,6 +158,14 @@ _NEGATIVE_GATE_PATTERNS = re.compile(
 )
 
 
+# Sentence boundary: split right after a terminator (./?/!) that is followed
+# by whitespace. Deliberately naive (does not special-case abbreviations or
+# numbered-list markers like "1.") - false splits only produce extra sentence
+# chunks, they never merge a question with unrelated text, so they cannot
+# cause a false negative or false positive here.
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.?!])\s+")
+
+
 def _is_abdication(text: str) -> bool:
     """Return True if the tail of text looks like a permission-seeking abdication.
 
@@ -172,17 +180,25 @@ def _is_abdication(text: str) -> bool:
     if _NEGATIVE_GATE_PATTERNS.search(tail):
         return False
 
-    # Require a permission phrase.
+    # Require a permission phrase somewhere in the tail (cheap pre-filter
+    # before the more expensive sentence segmentation below).
     if not _PERMISSION_PHRASES.search(tail):
         return False
 
-    # Require the final non-empty sentence to end with "?".
-    lines = tail.splitlines()
-    # Scan backwards for a non-empty line ending with "?"
-    for line in reversed(lines):
-        stripped = line.strip()
-        if stripped:
-            return stripped.endswith("?")
+    # Sentence-granularity check: the SAME sentence must both end with "?"
+    # AND contain a permission phrase. A permission-seeking question followed
+    # by trailing declarative sentences ("Want me to file this? Learnings
+    # captured.") must still fire - checking only the final line missed this
+    # because trailing text pushed the question mark off the last line.
+    # Conversely, a permission phrase appearing in one (non-question)
+    # sentence while an unrelated "?" appears in a later sentence must NOT
+    # fire.
+    for sentence in _SENTENCE_SPLIT_RE.split(tail):
+        stripped = sentence.strip()
+        if not stripped:
+            continue
+        if stripped.endswith("?") and _PERMISSION_PHRASES.search(stripped):
+            return True
 
     return False
 

--- a/hooks/tests/test-enforce-no-abdication.py
+++ b/hooks/tests/test-enforce-no-abdication.py
@@ -376,6 +376,82 @@ def build_cases(tmp_dir: str) -> list[tuple[str, str, str, dict | None]]:
         None,
     ))
 
+    # --- Sentence-granularity regression (line-vs-sentence false negative) ---
+    # REGRESSION: the exact failing shape reported against the pre-fix hook.
+    # _is_abdication used to check only the final non-empty LINE for a
+    # trailing "?". A permission-seeking question followed by declarative
+    # sentences on the same line (or subsequent lines) defeated it because
+    # the last line ended in "." rather than "?".
+    trailing_declaratives_dir = os.path.join(tmp_dir, "trailing_declaratives_cwd")
+    os.makedirs(trailing_declaratives_dir, exist_ok=True)
+    make_config_file(trailing_declaratives_dir, enabled=True)
+    cases.append((
+        "REGRESSION: permission question + trailing declaratives on same line -> BLOCK",
+        make_payload(
+            trailing_declaratives_dir,
+            last_assistant_message=(
+                "Two pre-existing bugs surfaced during QA:\n"
+                "1. An operator hits an infinite redirect loop on a gated page.\n"
+                "2. App-wide WCAG AA form-hint contrast debt.\n\n"
+                "Want me to file those two as Linear tickets? Learnings captured "
+                "to memory. Awaiting the deploy confirmation."
+            ),
+        ),
+        "BLOCK",
+        None,
+    ))
+
+    # Non-regression: a permission question with NO trailing text must still
+    # fire (sentence-splitting must not weaken the original detection path).
+    no_trailing_dir = os.path.join(tmp_dir, "no_trailing_cwd")
+    os.makedirs(no_trailing_dir, exist_ok=True)
+    make_config_file(no_trailing_dir, enabled=True)
+    cases.append((
+        "Permission question with no trailing text -> BLOCK (no regression)",
+        make_payload(
+            no_trailing_dir,
+            last_assistant_message="I've finished the analysis. Should I proceed with the fix?",
+        ),
+        "BLOCK",
+        None,
+    ))
+
+    # Trailing declarative text with NO permission question anywhere -> ALLOW.
+    no_permission_dir = os.path.join(tmp_dir, "no_permission_cwd")
+    os.makedirs(no_permission_dir, exist_ok=True)
+    make_config_file(no_permission_dir, enabled=True)
+    cases.append((
+        "Trailing declaratives, no permission question -> ALLOW",
+        make_payload(
+            no_permission_dir,
+            last_assistant_message=(
+                "Filed the two tickets as DS-100 and DS-101. Learnings captured "
+                "to memory. Awaiting the deploy confirmation."
+            ),
+        ),
+        "ALLOW",
+        None,
+    ))
+
+    # Precision guard: a permission phrase in a non-question sentence, with an
+    # unrelated "?" appearing in a LATER sentence, must NOT fire. Same-sentence
+    # co-occurrence is required, not mere tail co-presence.
+    precision_dir = os.path.join(tmp_dir, "precision_cwd")
+    os.makedirs(precision_dir, exist_ok=True)
+    make_config_file(precision_dir, enabled=True)
+    cases.append((
+        "Precision: permission phrase and unrelated later '?' in different sentences -> ALLOW",
+        make_payload(
+            precision_dir,
+            last_assistant_message=(
+                "Should I proceed was my first instinct, but I went ahead and "
+                "shipped it myself. Did the CI run finish yet?"
+            ),
+        ),
+        "ALLOW",
+        None,
+    ))
+
     return cases
 
 


### PR DESCRIPTION
## Problem
`enforce-no-abdication.py` (`_is_abdication`) only checked whether the **last non-empty line** ends with `?`. A permission-seeking question followed by any declarative sentence(s) on the same line slipped through as a false negative.

Observed shape (allowed the stop, should have blocked):
> Want me to file those two as Linear tickets? Learnings captured to memory. Awaiting the deploy confirmation.

`want me to` matches and the negative gate is clear, but the line ends with `.`, so the guard returned `False` and let the abdication through.

## Fix
Detect the permission question at **sentence** granularity instead of line granularity. The same sentence must both end with `?` and contain a permission phrase, so trailing declarative sentences no longer defeat detection. The Tier-2 negative gate, permission-phrase pre-filter, counter/loop-guard, config gating, and fail-open behavior are all unchanged.

## Verification
- 4 new regression cases in `hooks/tests/test-enforce-no-abdication.py`, including the exact failing shape (pre-fix: ALLOW; post-fix: BLOCK) and a same-tail precision guard (permission phrase in one sentence, unrelated `?` in a later sentence -> ALLOW).
- Full suite: 67 pass, 0 fail. Pre-fix failure independently confirmed by Skeptic on the two substantive cases.
- ruff clean on the hook; no adapter/build sync needed (hook is wired by absolute path, not duplicated).

## North Star alignment
- **Pillar: enforcement floors stay effective.** This closes a mechanical evasion of the abdication guard - a permission-seeking question followed by declarative filler. The guard is a universal enforcement backstop; a backstop that is trivially defeated by phrasing is not doing its job. Restoring its effectiveness serves the "written for the weakest supported model" floor (MEMORY 2026-07-02).
- **Trade-off:** broadening last-line -> last-sentence introduces a bounded new false-positive surface (a permission question quoted as a non-final sentence in a past-work report can now fire). This is within the guard's documented precision-bias tradeoff ("recoverable but annoying"), is capped by the CAP=2 loop guard, and self-corrects. Accepted as the cost of closing the false negative.
- **Universality:** no operator/tracker/harness identity baked in; pure stdlib classifier logic, behaves identically for any user.

## Reviewer notes (Skeptic, non-blocking Minors)
- Broadening line->sentence means a permission question quoted as a **non-final** sentence in a past-work report can now fire (bounded by CAP=2, self-corrects, within the guard's documented precision-bias tradeoff).
- Residual by-design false negatives remain acceptable: `?)`/`?'` endings, no-whitespace-after-`?`, full-width `？`.