### PR TITLE
fix: make temp-file cleanup the responsibility of the creating agent

### DIFF
--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -1972,6 +1972,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.claude/commands/implement-ticket.md
+++ b/.claude/commands/implement-ticket.md
@@ -1972,7 +1972,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1980,8 +1980,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -784,6 +784,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/.codex/agents/perf-analyst.toml
+++ b/.codex/agents/perf-analyst.toml
@@ -70,7 +70,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -111,16 +111,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -382,7 +388,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -111,6 +111,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -131,7 +142,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -371,7 +382,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1970,7 +1970,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1978,8 +1978,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.codex/commands/implement-ticket.md
+++ b/.codex/commands/implement-ticket.md
@@ -1970,6 +1970,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1970,7 +1970,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1978,8 +1978,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.cursor/commands/implement-ticket.md
+++ b/.cursor/commands/implement-ticket.md
@@ -1970,6 +1970,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -143,6 +143,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -784,6 +784,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/.gemini/agents/perf-analyst.md
+++ b/.gemini/agents/perf-analyst.md
@@ -71,7 +71,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -112,6 +112,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -132,7 +143,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -372,7 +383,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -112,16 +112,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -383,7 +389,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -1976,7 +1976,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1984,8 +1984,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.gemini/commands/implement-ticket.toml
+++ b/.gemini/commands/implement-ticket.toml
@@ -1976,6 +1976,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.github/agents/perf-analyst.md
+++ b/.github/agents/perf-analyst.md
@@ -67,7 +67,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/.github/agents/qa-engineer.md
+++ b/.github/agents/qa-engineer.md
@@ -108,16 +108,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -379,7 +385,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.github/agents/qa-engineer.md
+++ b/.github/agents/qa-engineer.md
@@ -108,6 +108,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -128,7 +139,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -368,7 +379,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -788,6 +788,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -1973,6 +1973,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.github/prompts/implement-ticket.prompt.md
+++ b/.github/prompts/implement-ticket.prompt.md
@@ -1973,7 +1973,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1981,8 +1981,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -810,6 +810,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy
@@ -8139,7 +8141,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 
@@ -8597,6 +8599,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -8617,7 +8630,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -8857,7 +8870,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -13920,6 +13933,18 @@ Clean up temp dir:
 
 ```bash
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
+```
+
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -8599,16 +8599,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -8870,7 +8876,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 
@@ -13935,7 +13941,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -13943,8 +13949,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -784,6 +784,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/.openclaw/skills/agent-perf-analyst/SKILL.md
+++ b/.openclaw/skills/agent-perf-analyst/SKILL.md
@@ -67,7 +67,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/.openclaw/skills/agent-qa-engineer/SKILL.md
+++ b/.openclaw/skills/agent-qa-engineer/SKILL.md
@@ -108,16 +108,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -379,7 +385,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.openclaw/skills/agent-qa-engineer/SKILL.md
+++ b/.openclaw/skills/agent-qa-engineer/SKILL.md
@@ -108,6 +108,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -128,7 +139,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -368,7 +379,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -1975,7 +1975,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1983,8 +1983,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.openclaw/skills/implement-ticket/SKILL.md
+++ b/.openclaw/skills/implement-ticket/SKILL.md
@@ -1975,6 +1975,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/.opencode/agents/perf-analyst.md
+++ b/.opencode/agents/perf-analyst.md
@@ -72,7 +72,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -113,6 +113,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -133,7 +144,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -373,7 +384,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -113,16 +113,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -384,7 +390,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -1974,7 +1974,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1982,8 +1982,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/.opencode/commands/implement-ticket.md
+++ b/.opencode/commands/implement-ticket.md
@@ -1974,6 +1974,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/content/agents/perf-analyst.md
+++ b/content/agents/perf-analyst.md
@@ -72,7 +72,7 @@ Choose profiling tools appropriate to the runtime:
 - **HTTP endpoints**: `wrk`, `hey`, `ab`, `autocannon`, or `hyperfine` for command-line benchmarks.
 - **Generic**: `hyperfine` for command-level benchmarking across any language.
 
-If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree.
+If none of these are available, write a minimal timing wrapper in `/tmp/` and run it via Bash. Do not modify files in the project tree. Delete any `/tmp/` profiling scripts you created before returning.
 
 Instrument at the boundary first (the entry point), then narrow inward to find the hotspot. Do not instrument every function - start coarse and refine.
 

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -113,6 +113,17 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+
+```bash
+if [ "$OVERALL_RESULT" != "PASS" ]; then
+  rm -f /tmp/qa_*.png 2>/dev/null || true
+fi
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
+```
+
+The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+
 **Applying project knowledge:**
 
 If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallback) contains a `## Knowledge` section, read all entries before starting pre-flight. Apply them automatically:
@@ -133,7 +144,7 @@ If the resolved qa.md (`.agentic/qa.md` preferred, legacy `.claude/qa.md` fallba
 
 ## Workflow
 
-> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional.
+> **Teardown obligation.** Once you have opened an `agent-browser` session, you MUST run the teardown from the Dev server section (`agent-browser close --all`) before returning - including on any BLOCKED, INCONCLUSIVE, or early-exit return in the steps and scenario sections below. The teardown is unconditional. This also includes the temp-file cleanup block: delete `/tmp/qa_*` (except PASS screenshots) and `/tmp/qa_devserver.log` on every exit path.
 
 ### 1. Pre-flight
 
@@ -373,7 +384,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/content/agents/qa-engineer.md
+++ b/content/agents/qa-engineer.md
@@ -113,16 +113,22 @@ kill $(lsof -ti:<port>) 2>/dev/null || true      # kill the dev server
 
 The `|| true` guards ensure an already-closed session or unbound port never errors the run. Playwright needs no separate teardown: the `with sync_playwright()` context manager plus `browser.close()` in the Playwright snippet below handles it.
 
-**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Delete all `/tmp/qa_*` files and `/tmp/qa_devserver.log` on every exit path **except** when the overall result is PASS. On PASS, leave `/tmp/qa_*.png` screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete `/tmp/qa_devserver.log` even on PASS - it is not consumed by Phase 8.5. Run in teardown after the browser/dev-server steps above:
+**Temp-file cleanup.** `qa-engineer` is responsible for the temp files it creates. Run this in teardown after the browser/dev-server steps above, choosing the branch that matches the result you are about to report:
 
-```bash
-if [ "$OVERALL_RESULT" != "PASS" ]; then
+- If the result you are reporting is **PASS**: do NOT delete `/tmp/qa_*.png`. Leave the screenshots in place so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Still delete the dev-server log:
+
+  ```bash
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
+
+- For any other result (**FAIL**, **PARTIAL**, **BLOCKED**, **INCONCLUSIVE**, or error): delete both the screenshots and the dev-server log:
+
+  ```bash
   rm -f /tmp/qa_*.png 2>/dev/null || true
-fi
-rm -f /tmp/qa_devserver.log 2>/dev/null || true
-```
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+  ```
 
-The `|| true` guards ensure a missing file never errors the run. `OVERALL_RESULT` is the final result reported in the output (`PASS`, `FAIL`, `PARTIAL`, or `BLOCKED`).
+The `|| true` guards ensure a missing file never errors the run. The agent decides which branch to take based on the top-line result it is about to report; do not rely on a shell variable.
 
 **Applying project knowledge:**
 
@@ -384,7 +390,7 @@ Always capture:
 - After each key interaction or state change
 - Any failure state
 
-Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
+Screenshot files remain in `/tmp/` on PASS so `/implement-ticket` Phase 8.5 can copy them to the `qa-evidence` branch. Delete them on all other exit paths during teardown. **Note:** Screenshot and diff-image paths referenced in this report may be stale after teardown. On non-PASS exits, `qa-engineer` deletes `/tmp/qa_*` files as part of temp-file cleanup. The paths remain in the report for reference only. Reference screenshot paths in the Evidence field of each criterion. Also populate the `## Screenshot Evidence JSON` block described in §Output format so that downstream consumers can parse screenshot metadata without scraping the human-readable list.
 
 ## Output format
 

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1970,7 +1970,7 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
-Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Guard with `|| true` so Phase 8.5 remains soft-fail.
 
 ```bash
 if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
@@ -1978,8 +1978,13 @@ if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
     SRC_PATH=$(echo "$entry" | jq -r '.path')
     rm -f "$SRC_PATH" 2>/dev/null || true
   done
-  rm -f /tmp/qa_devserver.log 2>/dev/null || true
 fi
+```
+
+Also delete `/tmp/qa_devserver.log` if it exists. Run this unconditionally at the end of Phase 8.5, regardless of whether screenshots were consumed:
+
+```bash
+rm -f /tmp/qa_devserver.log 2>/dev/null || true
 ```
 
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`

--- a/content/commands/implement-ticket.md
+++ b/content/commands/implement-ticket.md
@@ -1970,6 +1970,18 @@ Clean up temp dir:
 rm -rf "$SCREENSHOTS_SRC" 2>/dev/null || true
 ```
 
+Clean up the original `/tmp/qa_*` source files that were consumed. Run this unconditionally after the copy loop and temp-dir cleanup, but only when `QA_SCREENSHOT_PATHS` is non-empty. Use the parsed paths so only copied files are deleted. Also delete `/tmp/qa_devserver.log` if it exists. Guard with `|| true` so Phase 8.5 remains soft-fail.
+
+```bash
+if [ "${#QA_SCREENSHOT_PATHS[@]}" -gt 0 ]; then
+  for entry in "${QA_SCREENSHOT_PATHS[@]}"; do
+    SRC_PATH=$(echo "$entry" | jq -r '.path')
+    rm -f "$SRC_PATH" 2>/dev/null || true
+  done
+  rm -f /tmp/qa_devserver.log 2>/dev/null || true
+fi
+```
+
 Emit breadcrumb: `[phase: qa-evidence | screenshots=<N> | urls=<M> | branch=qa-evidence]`
 
 ---

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -138,6 +138,8 @@ git branch -d <branch-name>
 
 **Multi-session support:** Multiple Claude Code sessions can work on different features simultaneously. Each session operates on its own branch. Isolation worktrees are additionally protected across sessions by the harness itself: Claude Code locks (`git worktree lock`) each isolation worktree while its agent is running, so git refuses the non-force removal and branch-deletion commands this methodology uses against it from any concurrent session; the lock releases when the agent finishes. This coordination is harness behavior (see Claude Code's own worktree documentation), not a mechanism the conductor or methodology adds.
 
+**Temp-file ownership.** Agents that write temp files are responsible for deleting them in teardown. If a downstream phase consumes the temp files, the consuming phase deletes the originals after consumption.
+
 **Superseding an open PR's work means close + rebase, never bundle.** If your branch's work makes another open PR's commits unnecessary or subsumed, close that PR citing the superseding one and rebase your branch clean of its commits - do not merge or cherry-pick the superseded PR's commits into your own branch. A branch whose history contains another open PR's head commit is exactly the pattern an advisory review-rigor CI check flags where configured; treat the flag as confirmation to close + rebase, not to proceed.
 
 ## Context Economy

--- a/docs/index.html
+++ b/docs/index.html
@@ -896,7 +896,7 @@
   <div class="side-nav-brand">
     <img class="side-nav-logo" src="images/dinostack-logo.svg" alt="DinoStack" />
   </div>
-  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jul 18, 2026
+  <div style="font-size:0.65em; color:var(--text-muted); margin:-4px 20px 6px;">Last updated: Jul 19, 2026
   <hr class="side-nav-divider">
   <a href="#install"><span class="nav-dot" style="background: var(--cyan);"></span> Install</a>
   <a href="#updating"><span class="nav-dot" style="background: var(--cyan);"></span> Updating</a>


### PR DESCRIPTION
Updates temp-file cleanup ownership across the methodology:

- qa-engineer deletes /tmp/qa_* and /tmp/qa_devserver.log on non-PASS exits, preserving PASS screenshots for /implement-ticket Phase 8.5.
- /implement-ticket Phase 8.5 deletes consumed source screenshot files and the devserver log after copying to qa-evidence.
- perf-analyst deletes ephemeral /tmp/ profiling scripts before returning.
- Adds a temp-file ownership convention note to content/rules/conventions.md.
- Regenerates all adapter copies via scripts/build-all.sh.

## North Star alignment

- **Works for everyone:** temp-file cleanup is delegated to the agent that creates the files, so no operator-specific cleanup scripts or harness hooks are required. The change degrades gracefully - if a phase that consumes temp files fails to clean up, the next run's filenames are timestamped and non-conflicting.
- **Minimal blast radius:** PASS screenshots are preserved only long enough for Phase 8.5 to copy them; everything else is deleted on teardown. The convention is stated once in content/rules/conventions.md and applied locally by each agent.

Signed-off-by: skeptic <tyson@spacedinosaurs.com>