### PR TITLE
chore: add CODEOWNERS designating @tysonhummel as sole code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS
+#
+# The designated code owner for this repo. Combined with the `main` branch
+# ruleset's `require_code_owner_review: true` + `required_approving_review_count: 1`,
+# this means every PR to `main` requires exactly one approving review and it must
+# come from @tysonhummel. A contributor with write access can then merge their own
+# PR once that approval is present (subject to required status checks and
+# `require_last_push_approval`).
+#
+# Note: GitHub never permits self-approval, so a PR authored by @tysonhummel must be
+# merged via admin bypass (that account is a ruleset bypass actor).
+
+* @tysonhummel


### PR DESCRIPTION
Adds `.github/CODEOWNERS` naming @tysonhummel as the code owner for all paths.

Paired with a `main` ruleset change (applied separately) to `required_approving_review_count: 1` + `require_code_owner_review: true`, this makes every PR require exactly one approving review that must come from @tysonhummel. A write-access contributor can then merge their own PR once that approval is present, subject to required status checks and `require_last_push_approval`.

Admin bypass on the ruleset is preserved.

Adapters: None (governance/config; no `content/` change).

Signed-off-by present per DCO.