### PR TITLE
fix(hooks): guard the hooks subsystem against PEP 604 import crash on Python 3.9

### DIFF
--- a/hooks/enforce-background-spawn.py
+++ b/hooks/enforce-background-spawn.py
@@ -122,6 +122,8 @@ Performance: < 5 ms per call (in-memory JSON parse + optional YAML parse of two
              small config files + optional stat/proc check, no network I/O).
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/hooks/tests/test-enforce-no-abdication.py
+++ b/hooks/tests/test-enforce-no-abdication.py
@@ -28,6 +28,8 @@ Test coverage:
   - Smoke: clean payload -> empty stdout
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/hooks/tests/test-enforce-orchestrator-singularity.py
+++ b/hooks/tests/test-enforce-orchestrator-singularity.py
@@ -6,6 +6,8 @@ Each case pipes a JSON payload (or malformed string) into the hook via stdin
 and asserts ALLOW (exit 0, no deny output) or DENY (exit 0, deny in stdout).
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/hooks/tests/test-enforce-tier.py
+++ b/hooks/tests/test-enforce-tier.py
@@ -6,6 +6,8 @@ Each case pipes a JSON payload (or malformed string) into the hook via stdin
 and asserts ALLOW (exit 0, no deny output) or DENY (exit 0, deny in stdout).
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/hooks/tests/test-hooks-pep604-guard.py
+++ b/hooks/tests/test-hooks-pep604-guard.py
@@ -1,0 +1,239 @@
+# Run with: python3 hooks/tests/test-hooks-pep604-guard.py
+"""
+Regression guard for the whole hooks subsystem's PEP 604 / Python 3.9
+import-time crash class.
+
+CPython evaluates function and variable annotations EAGERLY at def-time
+unless the module carries `from __future__ import annotations` (PEP 563).
+PEP 604 union syntax (`X | None`) on a builtin type in annotation position
+raises `TypeError` the instant such a module is imported under Python
+3.8/3.9 - before main(), before any try/except fail-open guard. This bites
+ONLY on 3.8/3.9; 3.10+ interprets `X | None` as a runtime `types.UnionType`
+and never crashes, so a purely dynamic "run the file and check exit code"
+test would pass silently on any 3.10+ CI runner (this project's
+hooks-python-tests CI job runs Python 3.11) and fail to protect 3.9 users.
+
+Scope: this guard covers BOTH top-level hooks/*.py (the hooks themselves,
+e.g. hooks/enforce-background-spawn.py) AND hooks/tests/*.py (the test
+helper files, e.g. hooks/tests/test-enforce-tier.py - these carry their own
+`run_hook(payload, extra_env: dict | None = None)`-style helper signatures
+and are just as import-time-fragile as the hooks they test). hooks/lib/ is
+excluded by construction (the two globs below never reach it) - it
+currently has no .py files at all (only .js/.sh), so there is nothing to
+scan there; if a .py file is ever added to hooks/lib/, it is NOT covered by
+this guard and would need its own inclusion.
+
+This test is therefore STATIC and version-independent: it parses every
+covered file with `ast`, and for any module that does NOT declare
+`from __future__ import annotations`, walks the WHOLE tree (function
+parameter/return annotations and variable annotations, at
+module/class/nested-function scope - all of which are eagerly evaluated at
+def-time) looking for a BinOp using the `|` operator (PEP 604 union) in
+annotation position. Any hit is a regression regardless of which Python
+version runs this test.
+
+A secondary runtime smoke check (executes each covered file with empty
+stdin and asserts no import-time traceback under the CURRENT interpreter)
+is included as a belt-and-suspenders check, but it is NOT the primary
+guard - it cannot detect the bug when this test itself runs under
+Python 3.10+. The smoke check excludes THIS file from its own subprocess
+loop (see _smoke_targets()) - including it would spawn a copy of this
+script as a subprocess, which would then try to smoke-test itself again,
+recursing without termination.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+
+HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..")
+TESTS_DIR = os.path.join(HOOKS_DIR, "tests")
+SELF_PATH = os.path.realpath(__file__)
+
+
+def _hook_files():
+    """Top-level hooks/*.py files only (not hooks/tests/, not hooks/lib/)."""
+    return sorted(
+        f for f in os.listdir(HOOKS_DIR)
+        if f.endswith(".py") and os.path.isfile(os.path.join(HOOKS_DIR, f))
+    )
+
+
+def _test_files():
+    """hooks/tests/*.py files (the test helpers, including this guard
+    itself - static scanning is safe for self-inclusion; the runtime smoke
+    loop excludes self separately, see _smoke_targets())."""
+    return sorted(
+        f for f in os.listdir(TESTS_DIR)
+        if f.endswith(".py") and os.path.isfile(os.path.join(TESTS_DIR, f))
+    )
+
+
+def _scanned_files():
+    """Combined, deduped (label, absolute_path) pairs covering top-level
+    hooks/*.py and hooks/tests/*.py.
+
+    Dedup is by resolved absolute path: the two directories are disjoint
+    today, so no file can currently match both globs, but a future layout
+    change (e.g. a re-export or symlink) must not cause a file to be
+    double-counted by this guard. First-seen label wins (hooks/*.py is
+    scanned before hooks/tests/*.py)."""
+    seen = {}
+    for fname in _hook_files():
+        abspath = os.path.realpath(os.path.join(HOOKS_DIR, fname))
+        seen.setdefault(abspath, fname)
+    for fname in _test_files():
+        abspath = os.path.realpath(os.path.join(TESTS_DIR, fname))
+        seen.setdefault(abspath, os.path.join("tests", fname))
+    pairs = [(label, path) for path, label in seen.items()]
+    pairs.sort(key=lambda pair: pair[0])
+    return pairs
+
+
+def _smoke_targets(scanned):
+    """*scanned* minus this guard's own file - included in the static AST
+    scan (safe, no execution) but excluded from the runtime subprocess
+    loop (self-invocation would recurse without termination)."""
+    return [(label, path) for label, path in scanned if path != SELF_PATH]
+
+
+def _module_has_future_annotations(tree):
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
+def _iter_annotation_nodes(tree):
+    """Yield (annotation_ast_node, description) for every EAGERLY-EVALUATED
+    annotation in the module: function parameter/return annotations (at any
+    scope, including nested functions - ast.walk covers all of them) and
+    variable annotations (ast.AnnAssign, at module/class/function scope)."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            arg_group = (
+                list(node.args.posonlyargs)
+                + list(node.args.args)
+                + list(node.args.kwonlyargs)
+            )
+            for arg in arg_group:
+                if arg.annotation is not None:
+                    yield arg.annotation, f"{node.name}() param '{arg.arg}'"
+            for special in (node.args.vararg, node.args.kwarg):
+                if special is not None and special.annotation is not None:
+                    yield special.annotation, f"{node.name}() param '{special.arg}'"
+            if node.returns is not None:
+                yield node.returns, f"{node.name}() return annotation"
+        elif isinstance(node, ast.AnnAssign):
+            yield node.annotation, "variable annotation"
+
+
+def _contains_bitor(annotation_node):
+    """True if a PEP 604 `X | Y` BinOp appears anywhere within
+    *annotation_node* (covers nested generics like `dict[str, int | None]`)."""
+    for sub in ast.walk(annotation_node):
+        if isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.BitOr):
+            return True
+    return False
+
+
+def find_pep604_violations(path):
+    """Return a list of human-readable violation strings for *path*, or an
+    empty list if the module is safe on Python 3.8/3.9."""
+    with open(path, "r", encoding="utf-8") as f:
+        source = f.read()
+    tree = ast.parse(source, filename=path)
+    if _module_has_future_annotations(tree):
+        return []  # annotations deferred to strings - never eagerly evaluated
+    violations = []
+    for annotation_node, description in _iter_annotation_nodes(tree):
+        if _contains_bitor(annotation_node):
+            violations.append(
+                f"{os.path.basename(path)}:{annotation_node.lineno}: "
+                f"{description} uses PEP 604 '|' syntax without "
+                "'from __future__ import annotations' - crashes on Python 3.8/3.9"
+            )
+    return violations
+
+
+def run_file_smoke(path):
+    """Secondary belt-and-suspenders check: run *path* with empty stdin
+    under the CURRENT interpreter and confirm no import-time traceback.
+    For hooks/*.py this exercises main() with a no-op payload (fail-open
+    exit 0). For hooks/tests/*.py this runs the file's own test suite
+    (stdin is unused by these files, so it just executes normally) - which
+    additionally confirms the file reaches its assertions rather than
+    dying at import, per the task's stated preference. NOTE: this does NOT
+    catch the PEP 604 bug when this guard itself runs under Python 3.10+
+    (see module docstring) - it is not the primary guard."""
+    result = subprocess.run(
+        [sys.executable, path],
+        input="",
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stderr
+
+
+hook_files = _hook_files()
+test_files = _test_files()
+
+if not hook_files:
+    print(
+        "ERROR: glob hooks/*.py matched zero files - discovery is broken, not clean",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if not test_files:
+    print(
+        "ERROR: glob hooks/tests/*.py matched zero files - discovery is broken, not clean",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+scanned = _scanned_files()
+smoke_targets = _smoke_targets(scanned)
+failed = 0
+
+print(
+    f"Static AST guard: {len(scanned)} file(s) "
+    f"({len(hook_files)} in hooks/, {len(test_files)} in hooks/tests/)"
+)
+for label, path in scanned:
+    violations = find_pep604_violations(path)
+    ok = len(violations) == 0
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] {label}")
+    for v in violations:
+        print(f"         {v}")
+
+print()
+print(
+    f"Runtime smoke check (secondary, python {sys.version.split()[0]}; "
+    f"{len(smoke_targets)} file(s), excludes this guard's own file to avoid "
+    "self-invocation recursion; does not catch the bug on Python 3.10+):"
+)
+for label, path in smoke_targets:
+    rc, stderr = run_file_smoke(path)
+    ok = (rc == 0) and ("Traceback" not in stderr)
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] {label}")
+    if not ok:
+        print(f"         rc:     {rc}")
+        print(f"         stderr: {stderr!r}")
+
+total = len(scanned) + len(smoke_targets)
+print()
+if failed == 0:
+    print(f"All {total} checks passed.")
+    sys.exit(0)
+else:
+    print(f"{failed}/{total} checks FAILED.")
+    sys.exit(1)


### PR DESCRIPTION
## Summary

`hooks/enforce-background-spawn.py` crashed at **import time on Python 3.9**, so the `Task`/`Agent` `PreToolUse` hook dumped a traceback on every spawn (non-blocking, but the background-spawn enforcement it provides was silently dead everywhere the hook is wired).

Root cause: line 226 used PEP 604 union syntax (`str | None`) in a return annotation. CPython evaluates annotations eagerly at def-time unless the module carries `from __future__ import annotations` (PEP 563); on 3.9 the `|`-on-types operator does not exist, so the module raised `TypeError` the instant it loaded, before `main()` and before any fail-open guard. Introduced by `f6206cf8` (DS-70) when the team-routing helper `_resolve_role_harness` was added. The sibling `enforce-tier.py` already carries the future-import and documents exactly why.

## Changes

- **Fix (4 files, one line each):** add `from __future__ import annotations` to `enforce-background-spawn.py` and to 3 sibling test helpers that carried the identical unguarded PEP 604 pattern in their own `run_hook()` signatures and crashed the same way when run directly on 3.9 (`test-enforce-no-abdication.py`, `test-enforce-orchestrator-singularity.py`, `test-enforce-tier.py`). No logic changed. Mirrors the existing `enforce-tier.py` pattern; compatible with 3.8/3.9/3.10+ alike.
- **Regression guard (new):** `hooks/tests/test-hooks-pep604-guard.py` statically parses every `hooks/*.py` and `hooks/tests/*.py` with `ast` and flags any eagerly-evaluated PEP 604 union in annotation position when a module lacks the future-import. The check is **version-independent** on purpose: a plain "run the file and check exit code" test passes silently on 3.10+ (CI runs 3.11) and would leave 3.9 users unprotected. A secondary runtime smoke check is included (self-excluded from its own subprocess loop to avoid recursion).

## Verification

- Reproduced the exact `TypeError` pre-fix and confirmed clean load post-fix on Python 3.9.6.
- Full `hooks/tests/test-*.py` suite green on 3.9.6 (6 files, 95 assertions); the new guard passes 23/23.
- Guard fails on the pre-fix tree (independently reproduced in a throwaway worktree at the base commit) and passes on the fixed tree - a genuine, specific regression signal.
- No CI wiring change needed: `.github/workflows/bin-tests.yml`'s `hooks-python-tests` job already globs `hooks/tests/test-*.py` (under Python 3.11), so the guard runs automatically.

## Known limitation (follow-up, not blocking)

The guard covers **annotation-position** unions only. A value-position type alias (`X = int | None`, `X: TypeAlias = int | None`) also crashes at import on 3.9 but slips past, because distinguishing a type-alias union from a legitimate bitwise-or in value position is not reliably decidable statically without false positives. There are **zero current triggers** in the tree; this is a distinct bug class from the one fixed. Tracked as a follow-up.

## Reviewer note

After merge, this machine's (and any operator's) live hook snapshot must be refreshed (`bash .claude/install.sh`) for running sessions to pick up the fix - the wired copy is the deployed snapshot, not the checkout.

Test plan
- [x] Crash reproduced pre-fix (`TypeError: unsupported operand type(s) for |`) on 3.9.6
- [x] Clean load post-fix (exit 0, no traceback)
- [x] New guard fails on reverted tree, passes on fixed tree
- [x] Full hook test suite passes on 3.9.6
- [x] Realistic Agent spawn payload passes through (exit 0, no deny)

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): **Pillar 4 (works for everyone)** - the hooks now load on Python 3.8/3.9/3.10+ instead of only 3.10+; a hook that crashes on 3.9 is exactly the "works only for some setups" regression the vision names, and this restores portability. **Pillar 2 (verifiable outcomes)** - the globally-wired enforcement hook actually runs again (it was dead-on-import on 3.9), and a version-independent CI guard now makes the bug class checkable. **Pillar 1 (guard attention)** - removes the traceback spam emitted on every spawn.
- Trade-off or pillar this could regress, if any: None material. Adds ~247 lines of self-contained test/guard code that runs in existing CI; no runtime behavior change beyond preventing the crash (Skeptic-confirmed the annotation deferral is behaviorally inert here). The guard's known annotation-position-only scope is documented above as a follow-up, not a regression.

## Review rigor

- Brief / Plan path: N/A - single Elevated unit (debugger-diagnosed hook compat fix); no Brief required per AE risk classification.
- Skeptic rounds (tier): 1 round, Tier 2 (fresh independent Skeptic). Verdict: approved.
- Findings summary: 0 Critical, 0 Major, 1 Minor (guard covers annotation-position unions only; value-position type-alias unions uncaught - zero current triggers, deferred as follow-up). Skeptic independently reproduced the pre-fix crash in a throwaway worktree and confirmed the fix is behaviorally inert beyond stopping the crash.
