### PR TITLE
ci: wire orphaned shell test suites into bin-tests

### DIFF
--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -42,3 +42,55 @@ jobs:
             exit 1
           fi
           echo "Ran $count Python hook test files"
+  # Discovers and runs shell-based test suites no other workflow covers: the
+  # bin/tests/test_*.sh convention plus 4 orphaned *.test.sh files scattered
+  # across other dirs (different naming convention, previously unwired anywhere).
+  bin-sh-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+      - name: run shell bin tests
+        run: |
+          set -e
+          # bin/tests/test_codex_hooks_resolve.sh is also run by adapter-sync.yml -
+          # intentional double coverage, not an exclusion candidate.
+          files=(bin/tests/test_*.sh)
+          orphans=(
+            tests/bootstrap-guard.test.sh
+            scripts/test/repo-dir.test.sh
+            .claude/tests/install-converge.test.sh
+            .cursor/tests/install-converge.test.sh
+          )
+          for f in "${orphans[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "ERROR: expected orphaned test file '$f' not found - it may have been renamed or moved" >&2
+              exit 1
+            fi
+            files+=("$f")
+          done
+          count=0
+          for f in "${files[@]}"; do
+            case "$f" in
+              __no_quarantined_tests_yet__)
+                # QUARANTINE mechanism (precedent: DS-89 in hooks-sh-tests, see
+                # hooks-tests.yml): if a test in this job proves flaky, add a case
+                # arm here matching its path, `continue`, and a one-line reason
+                # comment referencing the tracking ticket.
+                continue
+                ;;
+            esac
+            echo "::group::$f"
+            bash "$f"
+            echo "::endgroup::"
+            count=$((count+1))
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: discovery matched zero runnable files - discovery is broken, not clean" >&2
+            exit 1
+          fi
+          echo "Ran $count shell bin test files"


### PR DESCRIPTION
## What

Adds a `bin-sh-tests` job to `.github/workflows/bin-tests.yml` that discovers and runs 17 shell test suites no workflow currently executes:
- 13 `bin/tests/test_*.sh` (underscore convention; pytest never discovers these)
- 4 orphaned `*.test.sh` in scattered dirs: `tests/bootstrap-guard.test.sh`, `scripts/test/repo-dir.test.sh`, `.claude/tests/install-converge.test.sh`, `.cursor/tests/install-converge.test.sh`

## Why

These suites (SSRF guards, installer convergence, symlink safety, hooks-snapshot behavior) were written but gated nothing in CI - the recurring "tests present, never run" review finding. Job mirrors the existing `hooks-sh-tests` pattern (glob loop + quarantine `case` + zero-match guard).

## Verification

- All 17 pass locally (`Ran 17 files, fail=0`).
- Fails closed: a non-zero test exit fails the job; a broken `bin/tests/test_*.sh` glob hard-fails (unexpanded literal) rather than masking green.
- Independent Skeptic review: 0 Critical / 0 Major / 4 Minor (cosmetic).

## Rollout

Job lands as a non-required check first. After it reports green in real CI here, it will be promoted to a required status check on the `main` ruleset.

Adapters: None (CI-only; no `content/` change).

Signed-off-by present per DCO.