### PR TITLE
feat(hooks): shippable-edit guard, committed + fail-open + rebuild-proof (DS-94)

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -809,6 +809,37 @@ for file_matcher in ("Write", "Edit"):
         f"PreToolUse({file_matcher}) planning-artifact advisory hook",
     )
 
+# ---- PreToolUse shippable-edit guard (Write + Edit + MultiEdit matchers) ---
+# Denies a conductor-direct (agent_id absent) Write/Edit/MultiEdit against a
+# shippable file inside the DinoStack checkout; allows the same edit from an
+# engineer subagent (agent_id present). Mechanically backstops METHODOLOGY
+# §Git Workflow's shippable/exempt classifier for the conductor (DS-94).
+# Fully fail-open on any error. Kill-switch: AE_SHIPPABLE_GUARD_DISABLE=1.
+# Wired on "Write", "Edit", and "MultiEdit" matchers; same idempotent
+# upsert pattern as the planning-artifact block above.
+ENFORCE_SHIPPABLE_CMD = f"python3 {hooks_root}/hooks/enforce-shippable-edit.py"
+
+for file_matcher in ("Write", "Edit", "MultiEdit"):
+    # Find or create a matcher block for this tool name.
+    ptu_shippable_block = None
+    for block in ptu_list:
+        if block.get("matcher") == file_matcher:
+            ptu_shippable_block = block
+            break
+
+    if ptu_shippable_block is None:
+        ptu_shippable_block = {"matcher": file_matcher, "hooks": []}
+        ptu_list.append(ptu_shippable_block)
+
+    ptu_shippable_block.setdefault("hooks", [])
+
+    upsert_hook(
+        ptu_shippable_block["hooks"],
+        "enforce-shippable-edit.py",
+        {"type": "command", "command": ENFORCE_SHIPPABLE_CMD, "timeout": 5},
+        f"PreToolUse({file_matcher}) shippable-edit guard hook",
+    )
+
 # Symlink guard: never write through a symlink (open("w") follows it and truncates
 # the real target). PoC verified: symlinking settings.json to a victim file and
 # running installer overwrites the victim's content through the link.
@@ -820,6 +851,39 @@ with open(settings_path, "w") as f:
     f.write("\n")
 
 print("  settings.json written.")
+
+# ---- Anti-orphan check: warn (non-fatal) on any hook command referencing a
+# script path that does not exist on disk. Catches drift such as a hook
+# wired against a moved/renamed/deleted script. Scoped to tokens containing
+# "/hooks/" that end in .py, .js, or .sh, to avoid false-positiving on the
+# echo-based risk-classification hook commands (which have no script path).
+def _find_orphaned_hook_scripts(obj):
+    orphans = []
+
+    def _walk(node):
+        if isinstance(node, list):
+            for item in node:
+                _walk(item)
+        elif isinstance(node, dict):
+            cmd = node.get("command")
+            if isinstance(cmd, str):
+                for token in cmd.split():
+                    if "/hooks/" in token and token.endswith((".py", ".js", ".sh")):
+                        if not os.path.exists(token):
+                            orphans.append(token)
+            for v in node.values():
+                if isinstance(v, (dict, list)):
+                    _walk(v)
+
+    _walk(obj)
+    return orphans
+
+_orphans = _find_orphaned_hook_scripts(settings)
+if _orphans:
+    print()
+    for _orphan in sorted(set(_orphans)):
+        print("  !! ORPHANED HOOK: " + _orphan + " referenced in " + settings_path + " does not exist on disk")
+    print("  !! Non-fatal - re-run install.sh after the hook script is restored, or remove the stale entry.")
 PYEOF
 
 # ---------------------------------------------------------------------------

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -746,6 +746,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/.cursor/rules/conventions.mdc
+++ b/.cursor/rules/conventions.mdc
@@ -105,6 +105,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -746,6 +746,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -750,6 +750,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -772,6 +772,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/.kimi/AGENTS.md
+++ b/.kimi/AGENTS.md
@@ -746,6 +746,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/bin/agentic-doctor
+++ b/bin/agentic-doctor
@@ -4,10 +4,14 @@ Purpose: Inspect global agentic-engineering install health and (with --fix)
          converge drift. Checks that managed symlinks under ~/.claude resolve
          into the canonical repo_dir, that ~/.local/bin/ wrappers exist for
          each bin/agentic-* script, that hook commands in ~/.claude/settings.json
-         point into repo_dir, and that the repo_dir pre-commit hook is wired.
-         With --fix, re-points ours-to-own broken/stale symlinks and rewrites
-         hook paths in settings.json (atomic read-merge-write). Never invokes
-         install.sh, never touches real files or foreign symlinks.
+         point into repo_dir, that every managed hook script referenced in
+         settings.json actually exists on disk (orphaned-hook detection),
+         and that the repo_dir pre-commit hook is wired. With --fix,
+         re-points ours-to-own broken/stale symlinks and rewrites hook paths
+         in settings.json (atomic read-merge-write); the orphaned-hook check
+         is read-only (FAIL only, no --fix repair - the fix is restoring the
+         script or re-running install.sh). Never invokes install.sh, never
+         touches real files or foreign symlinks.
 
 Public API: agentic-doctor [--fix] [--dry-run] [--cross-harness] [--json]
             --cross-harness: also validate the cross-harness team stack
@@ -90,6 +94,7 @@ MANAGED_HOOK_BASENAMES: frozenset[str] = frozenset([
     "enforce-askuserquestion-default.py",
     "enforce-background-spawn.py",
     "enforce-orchestrator-singularity.py",
+    "enforce-shippable-edit.py",
     "post-tool-use-capture-nudge.js",
     "session-end-wrap.js",
     "session-start-version-check.sh",
@@ -506,6 +511,55 @@ def _atomic_patch_settings(
         doc.mark_unfixable(settings_path)
 
 
+def check_hook_scripts_exist(doc: Doctor) -> None:
+    """FAIL each managed hook script referenced in settings.json that is
+    missing on disk (an orphaned hook wiring - e.g. a moved, renamed, or
+    deleted script). Read-only: never repointed or removed by --fix; the
+    fix for a missing script is restoring the file or re-running install.sh
+    to re-wire against a corrected path, not a doctor-side patch.
+    """
+    settings_path = _settings_path()
+    if not settings_path.exists():
+        doc.skip("hook_scripts", settings_path, "settings.json not found")
+        return
+
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        doc.fail("hook_scripts", f"could not parse {settings_path}: {exc}")
+        return
+
+    missing: set[str] = set()
+
+    def _walk(obj: object) -> None:
+        if isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+        elif isinstance(obj, dict):
+            cmd = obj.get("command")
+            if isinstance(cmd, str):
+                for token in cmd.split():
+                    if "/hooks/" not in token or not token.endswith((".py", ".js", ".sh")):
+                        continue
+                    basename = os.path.basename(token)
+                    if basename not in MANAGED_HOOK_BASENAMES:
+                        continue
+                    if not os.path.exists(token):
+                        missing.add(token)
+            for v in obj.values():
+                if isinstance(v, (dict, list)):
+                    _walk(v)
+
+    _walk(data)
+
+    if not missing:
+        doc.ok("hook_scripts", f"{settings_path}: all managed hook scripts exist on disk")
+        return
+
+    for token in sorted(missing):
+        doc.fail("hook_scripts", f"{token} referenced in {settings_path} does not exist on disk")
+
+
 # ---------------------------------------------------------------------------
 # Check (d): ~/.local/bin/<name> symlinks for each bin/agentic-* script
 # ---------------------------------------------------------------------------
@@ -876,13 +930,16 @@ def main() -> int:
     # (c) hook paths in settings.json
     check_hook_paths(doc)
 
-    # (d) ~/.local/bin wrappers
+    # (d) managed hook scripts exist on disk (orphaned-hook detection)
+    check_hook_scripts_exist(doc)
+
+    # (e) ~/.local/bin wrappers
     check_local_bin_symlinks(doc)
 
-    # (e) git pre-commit hook
+    # (f) git pre-commit hook
     check_git_precommit(doc)
 
-    # (f) cross-harness team stack (opt-in via --cross-harness)
+    # (g) cross-harness team stack (opt-in via --cross-harness)
     if args.cross_harness:
         check_cross_harness(doc)
 

--- a/bin/tests/test_agentic_doctor.sh
+++ b/bin/tests/test_agentic_doctor.sh
@@ -376,6 +376,99 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
+# Test 7: check_hook_scripts_exist FAILs on a managed hook command whose
+# script does not exist on disk (orphaned-hook detection, DS-94).
+# ---------------------------------------------------------------------------
+setup_fixture
+
+mkdir -p "$FAKE_REPO/hooks"
+# One managed hook script that DOES exist on disk...
+cat > "$FAKE_REPO/hooks/enforce-orchestrator-singularity.py" <<'EOF'
+# fixture stub
+EOF
+# ...and settings.json references it plus a second managed hook basename
+# whose script is MISSING from disk.
+cat > "$TEMP_HOME/.claude/settings.json" <<EOF
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {"type": "command", "command": "python3 $FAKE_REPO/hooks/enforce-orchestrator-singularity.py", "timeout": 5},
+          {"type": "command", "command": "python3 $FAKE_REPO/hooks/enforce-shippable-edit.py", "timeout": 5}
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+invoke_doctor
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if echo "$OUT" | grep -q "^FAIL hook_scripts:.*enforce-shippable-edit.py.*does not exist on disk"; then
+  _pass "T7 hook_scripts: missing managed hook script reported as FAIL"
+else
+  _fail "T7 hook_scripts: expected FAIL for missing enforce-shippable-edit.py\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "FAIL hook_scripts:.*enforce-orchestrator-singularity.py"; then
+  _fail "T7 hook_scripts: enforce-orchestrator-singularity.py exists on disk and must NOT be reported as FAIL\n$OUT"
+else
+  _pass "T7 hook_scripts: existing managed hook script not falsely flagged"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 8: check_hook_scripts_exist reports OK when every referenced managed
+# hook script exists on disk.
+# ---------------------------------------------------------------------------
+setup_fixture
+
+mkdir -p "$FAKE_REPO/hooks"
+cat > "$FAKE_REPO/hooks/enforce-orchestrator-singularity.py" <<'EOF'
+# fixture stub
+EOF
+cat > "$FAKE_REPO/hooks/enforce-shippable-edit.py" <<'EOF'
+# fixture stub
+EOF
+cat > "$TEMP_HOME/.claude/settings.json" <<EOF
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {"type": "command", "command": "python3 $FAKE_REPO/hooks/enforce-orchestrator-singularity.py", "timeout": 5},
+          {"type": "command", "command": "python3 $FAKE_REPO/hooks/enforce-shippable-edit.py", "timeout": 5}
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+invoke_doctor
+OUT=$(cat "$TEMP_HOME/.out")
+
+if echo "$OUT" | grep -q "^OK hook_scripts:.*all managed hook scripts exist on disk"; then
+  _pass "T8 hook_scripts: all-present case reports OK"
+else
+  _fail "T8 hook_scripts: expected OK hook_scripts line when all scripts exist\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "^FAIL hook_scripts:"; then
+  _fail "T8 hook_scripts: unexpected FAIL hook_scripts line when all scripts exist\n$OUT"
+else
+  _pass "T8 hook_scripts: no FAIL hook_scripts lines when all scripts exist"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/content/rules/conventions.md
+++ b/content/rules/conventions.md
@@ -100,6 +100,8 @@ Read `content/references/conventions-detail.md` §The Intent Layer for the artif
 3. conductor-direct PRINT/DECISION/RESOLVER-EXECUTION -> EXEMPT.
 4. any other tracked-file write -> SHIPPABLE -> delegate to worktree-isolated engineer (Trivial: no Skeptic/no brief; Elevated: full Worker+Skeptic).
 
+**Mechanical backstop (Claude Code, DinoStack checkout only).** A PreToolUse hook (`hooks/enforce-shippable-edit.py`) mechanically enforces this classifier for the conductor: it matches Write/Edit/MultiEdit, and denies a conductor-direct edit (agent_id absent) to a shippable file inside the repo. Exempt: `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (the sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch: `AE_SHIPPABLE_GUARD_DISABLE=1`. Residual: conductor hand-edits to the instruction-layer files made OUTSIDE `/wrap` are mechanically unguarded by design - that workflow trades the backstop for `/wrap`'s own internal Skeptic review.
+
 **Base branch resolution** - resolve `BASE_BRANCH` in this order and cache the result for the session:
 1. **Explicit declaration wins.** If the project declares a base/integration branch via a `BASE_BRANCH:` line in `AGENTS.md`, use it. Highest priority.
 2. Else if a local `develop` branch exists - use `develop`.

--- a/hooks/enforce-shippable-edit.py
+++ b/hooks/enforce-shippable-edit.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Purpose: PreToolUse hook that mechanically backstops the METHODOLOGY
+         §Git Workflow shippable/exempt classifier for the CONDUCTOR: it
+         denies a Write/Edit/MultiEdit issued directly by the main conductor
+         session (agent_id absent) against a shippable file inside the
+         DinoStack checkout, while ALLOWING the same edit from an engineer
+         subagent (agent_id present). This converts the prose rule
+         "the conductor never edits shippable artifacts directly" into a
+         hard gate on Claude Code, mirroring how enforce-orchestrator-
+         singularity.py backstops the sole-orchestrator invariant.
+
+         Predecessor note (DS-94): an earlier version of this guard was
+         never committed and crashed-to-block (raised an uncaught exception
+         on a missing repo-root file), which took down Write/Edit globally
+         for the whole session. This version is committed, snapshot-
+         included (installed via the session-stable hooks snapshot per
+         DS-54), and structurally incapable of blocking on internal error -
+         every code path that is not an affirmative, fully-resolved "this
+         is a conductor-direct shippable edit inside this repo" match falls
+         through to allow.
+
+         Accepted limitations (intentional, not oversights):
+         - Residual: conductor hand-edits to the instruction-layer files
+           (AGENTS.md / MEMORY.md / CLAUDE.md) made OUTSIDE the /wrap
+           command are mechanically UNGUARDED by design - this hook exempts
+           those basenames unconditionally. The instruction layer trades
+           this backstop for the sanctioned /wrap conductor-write workflow,
+           which performs its own internal Skeptic review (see wrap.md).
+           A conductor that hand-edits AGENTS.md outside /wrap is not
+           caught here; that discipline remains a prose rule.
+         - NotebookEdit is intentionally NOT matched. Its payload shape
+           (notebook_path, not tool_input.file_path) differs from
+           Write/Edit/MultiEdit, notebook surface area in this repo is
+           near-zero, and the fail-open direction of skipping an
+           unmatched tool is always the safe default for this hook.
+         - Kill-switch: AE_SHIPPABLE_GUARD_DISABLE=1 disables the guard for
+           the rare conductor-direct scaffold-repair write (e.g. hand-
+           patching a corrupted .agentic/ file that happens to sit outside
+           the .agentic/** exemption due to a symlink quirk).
+
+Trigger: PreToolUse on tool_name in {"Write", "Edit", "MultiEdit"}.
+
+Public API: Run as a Claude Code PreToolUse hook (matcher: "Write", "Edit",
+            or "MultiEdit"). Reads JSON from stdin, writes hookSpecificOutput
+            JSON to stdout only when denying, exits 0 always.
+
+Upstream deps: Python 3 stdlib only (json, os, sys, pathlib). Reads
+               <hooks-dir>/../.snapshot-meta.json (optional; DS-54 session-
+               stable snapshot metadata) to resolve the live repo root when
+               running from a snapshot copy instead of the checkout itself.
+
+Downstream consumers: Claude Code hook runner (PreToolUse event for Write,
+                      Edit, and MultiEdit). Wired via ~/.claude/settings.json
+                      by .claude/install.sh (three matcher blocks: "Write",
+                      "Edit", "MultiEdit"). Referenced by bin/agentic-doctor
+                      (MANAGED_HOOK_BASENAMES) and content/rules/
+                      conventions.md §Git Workflow.
+
+Failure modes: FAIL-OPEN IS THE WHOLE POINT. Every failure mode below
+               resolves to sys.exit(0) with no deny output:
+    - Malformed/empty stdin: fail-open.
+    - Kill-switch (AE_SHIPPABLE_GUARD_DISABLE=1): fail-open immediately,
+      before reading stdin.
+    - agent_id present at the top level (a subagent, e.g. an engineer
+      Worker): fail-open (ALLOW) - subagents are the sanctioned writers of
+      shippable files.
+    - Non-Write/Edit/MultiEdit tool_name: passthrough (exit 0).
+    - Missing/non-dict tool_input, missing/blank file_path: fail-open.
+    - repo_root unresolvable (no snapshot meta and the hook's own directory
+      is not a real dir), or target path resolution raises: fail-open (the
+      raise is caught by the outer try/except).
+    - target resolves outside repo_root: fail-open (not this repo's
+      concern).
+    - target is under .agentic/**, docs/planning/**, or is named
+      AGENTS.md/MEMORY.md/CLAUDE.md at any depth: fail-open (exempt by the
+      classifier).
+    - Any other unexpected exception anywhere in the body: caught by the
+      outer try/except, fail-open.
+               The single deny path requires ALL of: no kill-switch, valid
+               JSON, matcher tool, no agent_id, valid tool_input.file_path,
+               a resolvable repo_root, a target inside repo_root, and the
+               target NOT matching any exemption.
+
+Performance: < 2 ms per call (in-memory JSON parse, a handful of path
+             operations, optional single small JSON file read for
+             .snapshot-meta.json, no network).
+"""
+
+# Kill-switch + recovery:
+#   To temporarily disable this guard:
+#     1. Set AE_SHIPPABLE_GUARD_DISABLE=1 in your environment, then restart
+#        Claude Code so the hook process inherits the variable.
+#     2. Alternatively, remove the "enforce-shippable-edit" entries from the
+#        Write/Edit/MultiEdit PreToolUse blocks in ~/.claude/settings.json,
+#        then restart.
+#   To re-enable: unset the variable (or re-run .claude/install.sh).
+#
+# agent_id semantics (per official Claude Code hooks docs,
+# https://code.claude.com/docs/en/hooks):
+#   "Present only when the hook fires inside a subagent call."
+#   - Main/conductor session: agent_id is ABSENT from the payload.
+#   - Subagent session (e.g. an engineer Worker): agent_id is PRESENT.
+#   Therefore: deny only when agent_id is ABSENT (or blank) at the TOP
+#   LEVEL of the parsed JSON (NOT inside tool_input) - i.e. only the
+#   conductor is ever a deny candidate.
+
+import json
+import os
+import sys
+from pathlib import Path
+
+DENY_MESSAGE_TEMPLATE = (
+    "Shippable-edit guard: the conductor must not edit shippable files "
+    "directly ({path}). Delegate this edit to a worktree-isolated engineer "
+    "subagent (see METHODOLOGY Git Workflow). Exempt: .agentic/**, "
+    "docs/planning/**, paths outside the repo. Kill-switch: "
+    "AE_SHIPPABLE_GUARD_DISABLE=1."
+)
+
+INSTRUCTION_LAYER_BASENAMES = {"AGENTS.md", "MEMORY.md", "CLAUDE.md"}
+
+
+def _resolve_repo_root() -> str | None:
+    """Resolve the live repo root, preferring DS-54 snapshot metadata.
+
+    When this hook is invoked from the session-stable hooks snapshot
+    (AE_HOOKS_SNAPSHOT_DIR wiring in install.sh), <snapshot>/hooks/ is a
+    copy, not the checkout - .snapshot-meta.json's source_repo_dir points
+    back at the real checkout. Falls back to the hook's own grandparent
+    directory (../../ from hooks/enforce-shippable-edit.py) when no
+    snapshot metadata is present, i.e. running directly from the checkout.
+    Returns None (never raises) when neither resolution yields a directory.
+    """
+    here = Path(__file__).resolve().parent.parent
+    meta_path = here / ".snapshot-meta.json"
+    if meta_path.is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            meta = None
+        if isinstance(meta, dict):
+            source_repo_dir = meta.get("source_repo_dir")
+            if isinstance(source_repo_dir, str) and source_repo_dir.strip():
+                candidate = os.path.realpath(source_repo_dir)
+                if os.path.isdir(candidate):
+                    return candidate
+    candidate = str(here)
+    if os.path.isdir(candidate):
+        return candidate
+    return None
+
+
+def main() -> None:
+    # Kill-switch: fail-open immediately before touching stdin.
+    if os.environ.get("AE_SHIPPABLE_GUARD_DISABLE") == "1":
+        sys.exit(0)
+
+    try:
+        try:
+            data = json.load(sys.stdin)
+        except Exception:
+            sys.exit(0)
+
+        if not isinstance(data, dict):
+            sys.exit(0)
+
+        tool_name = data.get("tool_name")
+        if tool_name not in ("Write", "Edit", "MultiEdit"):
+            sys.exit(0)
+
+        # agent_id present (non-empty string) at the TOP LEVEL means this is
+        # a subagent (e.g. an engineer Worker) - always allow.
+        agent_id = data.get("agent_id")
+        if isinstance(agent_id, str) and agent_id.strip():
+            sys.exit(0)
+
+        tool_input = data.get("tool_input")
+        if not isinstance(tool_input, dict):
+            sys.exit(0)
+
+        file_path = tool_input.get("file_path")
+        if not (isinstance(file_path, str) and file_path.strip()):
+            sys.exit(0)
+        file_path = file_path.strip()
+
+        repo_root = _resolve_repo_root()
+        if not repo_root:
+            sys.exit(0)
+
+        # Resolve the target: join with cwd first if relative. Any failure
+        # here is caught by the outer except -> fail-open.
+        cwd = data.get("cwd", "")
+        if not os.path.isabs(file_path):
+            joined = os.path.join(cwd, file_path) if cwd else file_path
+        else:
+            joined = file_path
+        target = os.path.realpath(joined)
+
+        rel = os.path.relpath(target, repo_root)
+        if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+            # Outside the repo entirely - not this hook's concern.
+            sys.exit(0)
+
+        parts = rel.split(os.sep)
+
+        # Exemption 1: .agentic/** (conductor sole-writer).
+        if parts and parts[0] == ".agentic":
+            sys.exit(0)
+
+        # Exemption 2: docs/planning/** (Briefs/Plans/ADRs).
+        if len(parts) >= 2 and parts[0] == "docs" and parts[1] == "planning":
+            sys.exit(0)
+
+        # Exemption 3: instruction-layer basenames, any depth - the
+        # sanctioned /wrap conductor-write workflow.
+        if os.path.basename(target) in INSTRUCTION_LAYER_BASENAMES:
+            sys.exit(0)
+
+        # Everything else tracked inside the repo is a shippable file the
+        # conductor must not edit directly - deny.
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": DENY_MESSAGE_TEMPLATE.format(
+                            path=target
+                        ),
+                    }
+                }
+            )
+        )
+        sys.exit(0)
+
+    except Exception:
+        # Defense-in-depth: any unexpected error exits 0 (fail-open). This
+        # is the exact failure mode the predecessor version got wrong.
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/enforce-shippable-edit.py
+++ b/hooks/enforce-shippable-edit.py
@@ -49,6 +49,12 @@ Upstream deps: Python 3 stdlib only (json, os, sys, pathlib). Reads
                <hooks-dir>/../.snapshot-meta.json (optional; DS-54 session-
                stable snapshot metadata) to resolve the live repo root when
                running from a snapshot copy instead of the checkout itself.
+               `from __future__ import annotations` keeps the file importable
+               on Python 3.8/3.9 (PEP 604 `str | None` hints would otherwise
+               raise TypeError at module import time, before the kill-switch
+               and outer try/except can catch it - see enforce-tier.py's
+               manifest for the same trap; macOS system python3 is 3.9 and is
+               the documented supported floor).
 
 Downstream consumers: Claude Code hook runner (PreToolUse event for Write,
                       Edit, and MultiEdit). Wired via ~/.claude/settings.json
@@ -104,6 +110,8 @@ Performance: < 2 ms per call (in-memory JSON parse, a handful of path
 #   Therefore: deny only when agent_id is ABSENT (or blank) at the TOP
 #   LEVEL of the parsed JSON (NOT inside tool_input) - i.e. only the
 #   conductor is ever a deny candidate.
+
+from __future__ import annotations
 
 import json
 import os

--- a/hooks/tests/test-enforce-shippable-edit.py
+++ b/hooks/tests/test-enforce-shippable-edit.py
@@ -1,0 +1,332 @@
+# Run with: python3 hooks/tests/test-enforce-shippable-edit.py
+"""
+Unit tests for hooks/enforce-shippable-edit.py.
+
+Each case pipes a JSON payload (or malformed string) into the hook via
+stdin and asserts ALLOW (exit 0, no deny in stdout) or DENY (exit 0,
+permissionDecision "deny" in stdout, reason mentions the guard + path).
+
+The fail-open matrix is the primary invariant under test: this hook must
+NEVER crash-to-block (the failure mode the predecessor version had). Every
+case in FAIL_OPEN_CASES asserts is_allow() - none of them may deny, and
+none may exit non-zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HOOK_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "enforce-shippable-edit.py"
+)
+
+# Real repo root: hooks/tests/../.. from this test file's location.
+REPO_ROOT = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+
+
+def run_hook(payload: str, extra_env: dict | None = None, cwd: str | None = None) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    env.pop("AE_SHIPPABLE_GUARD_DISABLE", None)  # clean slate per test
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        [sys.executable, HOOK_PATH],
+        input=payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def is_allow(returncode: int, stdout: str) -> bool:
+    """ALLOW: exit 0 and no deny decision in stdout."""
+    if returncode != 0:
+        return False
+    if not stdout.strip():
+        return True
+    try:
+        obj = json.loads(stdout)
+        decision = obj.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        return decision != "deny"
+    except Exception:
+        return True  # unparseable output -> not a deny
+
+
+def is_deny(returncode: int, stdout: str) -> tuple[bool, str]:
+    """DENY: exit 0, permissionDecision == deny. Returns (ok, reason)."""
+    if returncode != 0:
+        return False, ""
+    try:
+        obj = json.loads(stdout)
+        hso = obj.get("hookSpecificOutput", {})
+        decision = hso.get("permissionDecision", "")
+        reason = hso.get("permissionDecisionReason", "")
+        return decision == "deny", reason
+    except Exception:
+        return False, ""
+
+
+def make_payload(tool_name: str, file_path: str, agent_id: str | None = None, cwd: str = "") -> str:
+    obj: dict = {"tool_name": tool_name, "tool_input": {"file_path": file_path}, "cwd": cwd}
+    if agent_id is not None:
+        obj["agent_id"] = agent_id
+    return json.dumps(obj)
+
+
+failed = 0
+total = 0
+
+
+def check_allow(label: str, payload: str, extra_env: dict | None = None) -> None:
+    global failed, total
+    total += 1
+    rc, stdout, stderr = run_hook(payload, extra_env)
+    ok = is_allow(rc, stdout)
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] {label}")
+    if not ok:
+        print(f"         payload:  {payload!r}")
+        print(f"         rc:       {rc}")
+        print(f"         stdout:   {stdout!r}")
+        print(f"         stderr:   {stderr!r}")
+
+
+def check_deny(label: str, payload: str, extra_env: dict | None = None, must_contain: tuple[str, ...] = ()) -> None:
+    global failed, total
+    total += 1
+    rc, stdout, stderr = run_hook(payload, extra_env)
+    ok, reason = is_deny(rc, stdout)
+    if ok:
+        for token in must_contain:
+            if token not in reason:
+                ok = False
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] {label}")
+    if not ok:
+        print(f"         payload:  {payload!r}")
+        print(f"         rc:       {rc}")
+        print(f"         stdout:   {stdout!r}")
+        print(f"         stderr:   {stderr!r}")
+        print(f"         reason:   {reason!r}")
+        print(f"         must_contain: {must_contain!r}")
+
+
+# ---------------------------------------------------------------------------
+# 1. FAIL-OPEN matrix - none of these may ever deny.
+# ---------------------------------------------------------------------------
+print("-- fail-open matrix --")
+
+check_allow("empty stdin", "")
+check_allow("malformed JSON", "not-json-at-all{{{{")
+check_allow("JSON but not an object", json.dumps([1, 2, 3]))
+check_allow(
+    "missing tool_input",
+    json.dumps({"tool_name": "Write"}),
+)
+check_allow(
+    "missing file_path",
+    json.dumps({"tool_name": "Write", "tool_input": {}}),
+)
+check_allow(
+    "blank file_path",
+    json.dumps({"tool_name": "Write", "tool_input": {"file_path": "   "}}),
+)
+check_allow(
+    "non-matcher tool (Read)",
+    make_payload("Read", os.path.join(REPO_ROOT, "content", "foo.md")),
+)
+check_allow(
+    "file_path that makes realpath raise (embedded null byte)",
+    make_payload("Write", os.path.join(REPO_ROOT, "content", "\x00bad")),
+)
+_relcwd_dir = os.path.realpath(tempfile.mkdtemp())
+check_allow(
+    "relative file_path + cwd (joins cleanly, resolves outside repo) -> ALLOW",
+    make_payload("Edit", os.path.join("content", "foo.md"), cwd=_relcwd_dir),
+)
+
+# ---------------------------------------------------------------------------
+# 2. Subagent (agent_id present) editing a shippable path -> ALLOW.
+# ---------------------------------------------------------------------------
+print("-- subagent allow --")
+check_allow(
+    "subagent (agent_id set) editing shippable content/foo.md -> ALLOW",
+    make_payload(
+        "Write",
+        os.path.join(REPO_ROOT, "content", "foo.md"),
+        agent_id="engineer-abc123",
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# 3. Kill-switch -> ALLOW even on a shippable path with no agent_id.
+# ---------------------------------------------------------------------------
+print("-- kill-switch --")
+check_allow(
+    "AE_SHIPPABLE_GUARD_DISABLE=1 on shippable path -> ALLOW",
+    make_payload("Write", os.path.join(REPO_ROOT, "content", "foo.md")),
+    extra_env={"AE_SHIPPABLE_GUARD_DISABLE": "1"},
+)
+
+# ---------------------------------------------------------------------------
+# 4. Exemptions -> ALLOW (conductor, no agent_id, matcher tool).
+# ---------------------------------------------------------------------------
+print("-- exemptions --")
+check_allow(
+    ".agentic/x.json -> ALLOW",
+    make_payload("Write", os.path.join(REPO_ROOT, ".agentic", "x.json")),
+)
+check_allow(
+    "docs/planning/x.md -> ALLOW",
+    make_payload("Write", os.path.join(REPO_ROOT, "docs", "planning", "x.md")),
+)
+check_allow(
+    "bin/AGENTS.md -> ALLOW",
+    make_payload("Edit", os.path.join(REPO_ROOT, "bin", "AGENTS.md")),
+)
+check_allow(
+    "hooks/AGENTS.md -> ALLOW",
+    make_payload("Edit", os.path.join(REPO_ROOT, "hooks", "AGENTS.md")),
+)
+check_allow(
+    "AGENTS.md (repo root) -> ALLOW",
+    make_payload("Edit", os.path.join(REPO_ROOT, "AGENTS.md")),
+)
+check_allow(
+    "MEMORY.md (repo root) -> ALLOW",
+    make_payload("Edit", os.path.join(REPO_ROOT, "MEMORY.md")),
+)
+check_allow(
+    "CLAUDE.md (repo root) -> ALLOW",
+    make_payload("Edit", os.path.join(REPO_ROOT, "CLAUDE.md")),
+)
+_outside_dir = os.path.realpath(tempfile.mkdtemp())
+check_allow(
+    "path outside the repo -> ALLOW",
+    make_payload("Write", os.path.join(_outside_dir, "x.md")),
+)
+
+# ---------------------------------------------------------------------------
+# 5. Conductor BLOCKED positive: agent_id absent, Write/Edit/MultiEdit,
+#    shippable path inside the repo -> DENY.
+# ---------------------------------------------------------------------------
+print("-- conductor blocked (positive) --")
+_target = os.path.join(REPO_ROOT, "content", "foo.md")
+check_deny(
+    "Write, no agent_id, content/foo.md -> DENY",
+    make_payload("Write", _target),
+    must_contain=("Shippable-edit guard", _target),
+)
+check_deny(
+    "Edit, no agent_id, content/foo.md -> DENY",
+    make_payload("Edit", _target),
+    must_contain=("Shippable-edit guard", _target),
+)
+check_deny(
+    "MultiEdit, no agent_id, content/foo.md -> DENY",
+    make_payload("MultiEdit", _target),
+    must_contain=("Shippable-edit guard", _target),
+)
+check_deny(
+    "Write, null agent_id, content/foo.md -> DENY",
+    make_payload("Write", _target, agent_id=None),
+    must_contain=("Shippable-edit guard", _target),
+)
+check_deny(
+    "Write, empty-string agent_id, content/foo.md -> DENY",
+    make_payload("Write", _target, agent_id=""),
+    must_contain=("Shippable-edit guard", _target),
+)
+
+# ---------------------------------------------------------------------------
+# 6. DS-54 snapshot-meta resolution: hook run from a fake "snapshot" copy
+#    with .snapshot-meta.json pointing at a separate fake source_repo_dir
+#    must resolve repo_root through the metadata, not through its own
+#    on-disk location.
+# ---------------------------------------------------------------------------
+print("-- snapshot-meta resolution --")
+
+
+def _run_snapshot_case() -> None:
+    global failed, total
+    fake_source = os.path.realpath(tempfile.mkdtemp())
+    os.makedirs(os.path.join(fake_source, "content"), exist_ok=True)
+    os.makedirs(os.path.join(fake_source, ".agentic"), exist_ok=True)
+
+    snapshot_dir = os.path.realpath(tempfile.mkdtemp())
+    snapshot_hooks_dir = os.path.join(snapshot_dir, "hooks")
+    os.makedirs(snapshot_hooks_dir, exist_ok=True)
+    with open(HOOK_PATH, "r", encoding="utf-8") as src:
+        hook_source = src.read()
+    snapshot_hook_path = os.path.join(snapshot_hooks_dir, "enforce-shippable-edit.py")
+    with open(snapshot_hook_path, "w", encoding="utf-8") as dst:
+        dst.write(hook_source)
+
+    meta_path = os.path.join(snapshot_dir, ".snapshot-meta.json")
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump({"source_repo_dir": fake_source, "source_hash": "x", "snapshotted_at": "x"}, f)
+
+    def _run_from_snapshot(payload: str) -> tuple[int, str, str]:
+        env = os.environ.copy()
+        env.pop("AE_SHIPPABLE_GUARD_DISABLE", None)
+        result = subprocess.run(
+            [sys.executable, snapshot_hook_path],
+            input=payload,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    # (a) shippable path under fake_source/content/ -> DENY (repo root
+    #     resolved via .snapshot-meta.json, not the snapshot dir itself).
+    total += 1
+    shippable_target = os.path.join(fake_source, "content", "bar.md")
+    rc, stdout, stderr = _run_from_snapshot(
+        make_payload("Write", shippable_target)
+    )
+    ok, reason = is_deny(rc, stdout)
+    ok = ok and "Shippable-edit guard" in reason and shippable_target in reason
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] snapshot-meta redirect: shippable path under source_repo_dir -> DENY")
+    if not ok:
+        print(f"         rc={rc} stdout={stdout!r} stderr={stderr!r}")
+
+    # (b) .agentic/ path under fake_source -> ALLOW (exemption still
+    #     applies after the redirect).
+    total += 1
+    exempt_target = os.path.join(fake_source, ".agentic", "bar.json")
+    rc, stdout, stderr = _run_from_snapshot(make_payload("Write", exempt_target))
+    ok = is_allow(rc, stdout)
+    status = "PASS" if ok else "FAIL"
+    if not ok:
+        failed += 1
+    print(f"  [{status}] snapshot-meta redirect: .agentic/ path under source_repo_dir -> ALLOW")
+    if not ok:
+        print(f"         rc={rc} stdout={stdout!r} stderr={stderr!r}")
+
+
+_run_snapshot_case()
+
+# ---------------------------------------------------------------------------
+print()
+if failed == 0:
+    print(f"All {total} tests passed.")
+    sys.exit(0)
+else:
+    print(f"{failed}/{total} tests FAILED.")
+    sys.exit(1)

--- a/hooks/tests/test-hooks-py39-safe.py
+++ b/hooks/tests/test-hooks-py39-safe.py
@@ -1,0 +1,150 @@
+# Run with: python3 hooks/tests/test-hooks-py39-safe.py
+"""
+Regression guard: every hooks/enforce-*.py file must stay importable on
+Python 3.8/3.9 (macOS system python3 is 3.9 and is the documented
+supported floor for these hooks).
+
+A PEP 604 union annotation (`X | Y`, e.g. `str | None`) used in a function
+signature or variable annotation is evaluated at MODULE IMPORT TIME on
+Python 3.8/3.9 unless the module carries `from __future__ import
+annotations` (PEP 563), which defers annotation evaluation to strings.
+Without the future import, a PEP 604 union raises TypeError at import -
+before any hook's kill-switch or outer try/except can catch it - which
+crashes-to-block a PreToolUse hook (the exact failure mode DS-94 exists to
+prevent; see hooks/enforce-shippable-edit.py's manifest and MEMORY.md).
+
+This test statically scans every hooks/enforce-*.py file with `ast`: for
+each module, it finds `X | Y` (ast.BinOp with ast.BitOr) inside an
+annotation context (function argument annotations, function return
+annotations, variable annotations) and FAILS if that module lacks
+`from __future__ import annotations`. This guards every current and future
+sibling hook against the same regression class, not just this one line.
+"""
+
+from __future__ import annotations
+
+import ast
+import glob
+import os
+import sys
+
+HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..")
+TARGET_GLOB = os.path.join(HOOKS_DIR, "enforce-*.py")
+
+
+def has_future_annotations(tree: ast.Module) -> bool:
+    """True if the module's (leading) import block includes
+    `from __future__ import annotations`."""
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
+def _contains_bitor(node: ast.AST) -> bool:
+    """True if `node` (an annotation expression subtree) contains a
+    `X | Y` BinOp anywhere within it."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.BitOr):
+            return True
+    return False
+
+
+def find_unguarded_unions(path: str) -> list[str]:
+    """Return a list of human-readable descriptions of PEP 604 union
+    annotations found in `path` that would crash at import on Python
+    3.8/3.9 because the module lacks `from __future__ import annotations`.
+
+    Empty list means: either no PEP 604 unions in annotation position, or
+    the module has the future import (safe either way).
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        source = f.read()
+
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError as exc:
+        # A file that doesn't even parse on the AST's own Python version is
+        # a separate problem this test isn't scoped to diagnose - surface
+        # it distinctly rather than silently passing.
+        return [f"SyntaxError parsing {path}: {exc}"]
+
+    if has_future_annotations(tree):
+        return []  # annotations are deferred to strings - always safe.
+
+    findings: list[str] = []
+
+    for node in ast.walk(tree):
+        # Function argument + return annotations.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            all_args = (
+                list(node.args.posonlyargs)
+                + list(node.args.args)
+                + list(node.args.kwonlyargs)
+            )
+            if node.args.vararg:
+                all_args.append(node.args.vararg)
+            if node.args.kwarg:
+                all_args.append(node.args.kwarg)
+
+            for arg in all_args:
+                if arg.annotation is not None and _contains_bitor(arg.annotation):
+                    findings.append(
+                        f"{path}:{arg.lineno}: parameter '{arg.arg}' of "
+                        f"'{node.name}' has an unguarded PEP 604 union annotation"
+                    )
+
+            if node.returns is not None and _contains_bitor(node.returns):
+                findings.append(
+                    f"{path}:{node.lineno}: return annotation of '{node.name}' "
+                    "has an unguarded PEP 604 union annotation"
+                )
+
+        # Variable annotations (module- or function-scoped).
+        elif isinstance(node, ast.AnnAssign):
+            if node.annotation is not None and _contains_bitor(node.annotation):
+                target = (
+                    node.target.id
+                    if isinstance(node.target, ast.Name)
+                    else ast.dump(node.target)
+                )
+                findings.append(
+                    f"{path}:{node.lineno}: variable annotation '{target}' "
+                    "has an unguarded PEP 604 union annotation"
+                )
+
+    return findings
+
+
+def main() -> int:
+    targets = sorted(glob.glob(TARGET_GLOB))
+    if not targets:
+        print("  [FAIL] no hooks/enforce-*.py files found - glob misconfigured?")
+        return 1
+
+    failed = 0
+    total = 0
+    for path in targets:
+        total += 1
+        findings = find_unguarded_unions(path)
+        rel = os.path.relpath(path, os.path.join(HOOKS_DIR, ".."))
+        if findings:
+            failed += 1
+            print(f"  [FAIL] {rel}")
+            for finding in findings:
+                print(f"         {finding}")
+        else:
+            print(f"  [PASS] {rel}")
+
+    print()
+    if failed == 0:
+        print(f"All {total} hooks/enforce-*.py files are Python 3.8/3.9-safe.")
+        return 0
+    else:
+        print(f"{failed}/{total} hooks/enforce-*.py files have unguarded PEP 604 unions.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Recreates the shippable-edit guard as a committed, fail-open PreToolUse hook. Fixes DS-94.

## Background
The prior guard existed only as an uncommitted local artifact wired into settings.json. A snapshot rebuild orphaned the script; its FileNotFoundError crash then hard-blocked Write/Edit in every session globally. This version is committed, snapshot-included, and structurally incapable of blocking on internal error.

## What it does
`hooks/enforce-shippable-edit.py` (PreToolUse on Write/Edit/MultiEdit): blocks the CONDUCTOR (agent_id absent) from directly editing shippable files inside the DinoStack checkout; ALLOWS engineer subagents (agent_id present). Exempts `.agentic/**`, `docs/planning/**`, the instruction-layer basenames `AGENTS.md`/`MEMORY.md`/`CLAUDE.md` at any depth (sanctioned `/wrap` conductor-write path), and paths outside the repo. Fail-open on any error. Kill-switch `AE_SHIPPABLE_GUARD_DISABLE=1`.

## Design guarantees
- **Fail-open is absolute.** Kill-switch read before any try; all logic inside an outer try/except that exits 0; the single deny is reached only on a confident positive classification. Verified by independent adversarial execution (empty stdin, malformed JSON, null bytes, missing fields, binary blobs) - every case exits 0 with no deny.
- **Python 3.8/3.9 import-safe.** `from __future__ import annotations` guards the PEP 604 union hint (macOS system python3 is 3.9). A new class-wide regression test (`test-hooks-py39-safe.py`) scans all 7 `enforce-*.py` hooks and fails on any bare `X | Y` annotation without the future import.
- **Cannot be silently orphaned again.** Rides the existing `cp -R hooks` snapshot step; install.sh adds a non-fatal anti-orphan check; `agentic-doctor` gains a managed-hook script-existence check.

## Exemption rationale (reviewed)
The instruction-layer basenames are exempt because `/wrap` (the sanctioned conductor flow that writes them) performs its own internal Skeptic review. Residual accepted limitation, documented in the hook manifest and conventions.md: conductor hand-edits to those files OUTSIDE `/wrap` are unguarded.

## Tests
- `hooks/tests/test-enforce-shippable-edit.py` - 26 cases: full fail-open matrix, subagent-allow, kill-switch, every exemption, conductor-blocked positive (mutation-tested: de-fanging the deny path fails 6 cases).
- `hooks/tests/test-hooks-py39-safe.py` - import-safety scan across all enforce-*.py.
- `bin/tests/test_agentic_doctor.sh` - +2 cases for the orphan check.

## Review
Architect plan (Opus) + plan Skeptic + Tier-3 implementation Skeptic, all with independent execution. The Tier-3 review caught a Critical import-crash that would have re-caused the global outage on Python < 3.10; fixed and re-verified.

## Rollout note
Does not touch live settings. The guard goes live only when install.sh is next run; open sessions should be restarted after that (hooks reload from disk).

## North Star alignment

**Universality ("works for everyone"):** the guard bakes in no operator-specific identity or path. It self-locates the repo root at runtime (via the session-stable snapshot metadata, else its own location) and applies only inside that checkout; edits anywhere else are exempt. A teammate with a different checkout, a different clone path, or a different machine gets identical behavior with zero configuration. It is fail-open by construction, so even a misconfigured or missing hook never breaks a teammate's editing - the failure direction is always "allow", never "block".

**Enforcement floor, not a model-dependent dial:** this mechanically enforces an already-documented behavioral rule (the shippable/exempt classifier in conventions.md §Git Workflow). It is written for the weakest supported runtime (Python 3.8/3.9 import-safe) and adds no model-capability assumption. Consistent with the principle that enforcement floors stay universal.

**Trade-off, stated:** the instruction-layer basenames (AGENTS.md/MEMORY.md/CLAUDE.md) are exempt at any depth because /wrap is their sanctioned conductor-writer with its own internal Skeptic review. The accepted residual: conductor hand-edits to those files made outside /wrap are mechanically unguarded. Documented in the hook manifest and conventions.md. NotebookEdit is intentionally unmatched (fail-open direction, near-zero surface).