### PR TITLE
feat(protocol): ticket-rework detection, notice, and escalation (U2)

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2330,7 +2330,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2394,7 +2394,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -281,6 +281,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -849,6 +850,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -874,6 +931,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -988,6 +1057,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1285,10 +1387,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2131,6 +2240,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -857,22 +857,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -884,7 +893,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -934,13 +945,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1499,7 +1514,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1667,7 +1684,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1720,7 +1737,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2256,27 +2273,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -828,6 +828,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -951,13 +986,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1737,7 +1792,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2275,16 +2332,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.codex/commands/ds-implement-ticket.md
+++ b/.codex/commands/ds-implement-ticket.md
@@ -826,6 +826,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -949,13 +984,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1735,7 +1790,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2273,16 +2330,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.codex/commands/ds-implement-ticket.md
+++ b/.codex/commands/ds-implement-ticket.md
@@ -2328,7 +2328,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2392,7 +2392,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.codex/commands/ds-implement-ticket.md
+++ b/.codex/commands/ds-implement-ticket.md
@@ -855,22 +855,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -882,7 +891,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -932,13 +943,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1497,7 +1512,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1665,7 +1682,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1718,7 +1735,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2254,27 +2271,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.codex/commands/ds-implement-ticket.md
+++ b/.codex/commands/ds-implement-ticket.md
@@ -279,6 +279,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -847,6 +848,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -872,6 +929,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -986,6 +1055,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1283,10 +1385,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2129,6 +2238,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -826,6 +826,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -949,13 +984,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1735,7 +1790,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2273,16 +2330,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2328,7 +2328,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2392,7 +2392,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -855,22 +855,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -882,7 +891,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -932,13 +943,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1497,7 +1512,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1665,7 +1682,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1718,7 +1735,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2254,27 +2271,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -279,6 +279,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -847,6 +848,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -872,6 +929,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -986,6 +1055,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1283,10 +1385,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2129,6 +2238,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2334,7 +2334,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2398,7 +2398,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \\
       --arg qs "${QA_STATUS:-}" \\
       --argjson uc "$TRL_UNITS" \\
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -861,22 +861,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -888,7 +897,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -938,13 +949,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1503,7 +1518,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1671,7 +1688,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1724,7 +1741,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2260,27 +2277,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \\| `Low` \\| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -285,6 +285,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -853,6 +854,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -878,6 +935,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -992,6 +1061,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1289,10 +1391,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2135,6 +2244,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \\
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \\
+      --arg tid "$TICKET_ID" \\
+      --argjson pr "$TRL_PR_NUMBER" \\
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \\
+      --arg br "$BRANCH_NAME" \\
+      --arg rc "$RISK_CLASS" \\
+      --arg sr "${TRL_ROUNDS:-}" \\
+      --arg qs "${QA_STATUS:-}" \\
+      --argjson uc "$TRL_UNITS" \\
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -832,6 +832,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -955,13 +990,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1741,7 +1796,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2279,16 +2336,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \\| `Low` \\| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \\| `Low` \\| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2331,7 +2331,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2395,7 +2395,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -282,6 +282,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -850,6 +851,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -875,6 +932,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -989,6 +1058,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1286,10 +1388,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2132,6 +2241,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -858,22 +858,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -885,7 +894,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -935,13 +946,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1500,7 +1515,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1668,7 +1685,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1721,7 +1738,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2257,27 +2274,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -829,6 +829,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -952,13 +987,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1738,7 +1793,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2276,16 +2333,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12945,22 +12945,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -12972,7 +12981,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -13022,13 +13033,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -13587,7 +13602,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -13755,7 +13772,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -13808,7 +13825,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -14344,27 +14361,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12369,6 +12369,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -12937,6 +12938,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -12962,6 +13019,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -13076,6 +13145,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -13373,10 +13475,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -14219,6 +14328,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12916,6 +12916,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -13039,13 +13074,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -13825,7 +13880,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -14363,16 +14420,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14418,7 +14418,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -14482,7 +14482,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -860,22 +860,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -887,7 +896,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -937,13 +948,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1502,7 +1517,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1670,7 +1687,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1723,7 +1740,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2259,27 +2276,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -831,6 +831,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -954,13 +989,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1740,7 +1795,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2278,16 +2335,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2333,7 +2333,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2397,7 +2397,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -284,6 +284,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -852,6 +853,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -877,6 +934,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -991,6 +1060,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1288,10 +1390,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2134,6 +2243,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -830,6 +830,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -953,13 +988,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1739,7 +1794,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2277,16 +2334,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -859,22 +859,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -886,7 +895,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -936,13 +947,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1501,7 +1516,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1669,7 +1686,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1722,7 +1739,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2258,27 +2275,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -283,6 +283,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -851,6 +852,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -876,6 +933,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -990,6 +1059,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1287,10 +1389,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2133,6 +2242,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2332,7 +2332,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2396,7 +2396,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/bin/tests/test_ticket_rework_ledger.sh
+++ b/bin/tests/test_ticket_rework_ledger.sh
@@ -71,6 +71,7 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 # is renamed the extraction fails loudly rather than testing a stale copy.
 WRITE_MARKER='# Phase 9: ticket-rework ledger write'
 READ_MARKER='# Phase 1: ticket-rework detection'
+RESET_MARKER='# Phase 1: per-ticket variable reset'
 
 _extract() { # _extract <marker> <outfile>
   python3 - "$SPEC" "$1" "$2" <<'PY'
@@ -102,7 +103,14 @@ if ! _extract "$READ_MARKER" "$READ_BLOCK"; then
 fi
 _pass "extracted Phase 1 detection block from the shipped spec"
 
-for b in "$WRITE_BLOCK" "$READ_BLOCK"; do
+RESET_BLOCK="$TMP_ROOT/reset.sh"
+if ! _extract "$RESET_MARKER" "$RESET_BLOCK"; then
+  _fail "could not extract the Phase 1 per-ticket reset block from the spec"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+_pass "extracted Phase 1 per-ticket reset block from the shipped spec"
+
+for b in "$WRITE_BLOCK" "$READ_BLOCK" "$RESET_BLOCK"; do
   if bash -n "$b" 2>/dev/null; then
     _pass "extracted block parses: $(basename "$b")"
   else
@@ -206,6 +214,71 @@ _eq "foreign ticket rounds not inherited" "$(_field '.skeptic_rounds|type')" "nu
 
 # ===========================================================================
 echo ""
+echo "--- Major B: batch carry-over in ONE shell scope (the real conductor shape) ---"
+# Every fixture above builds a fresh env per invocation, which CANNOT model the
+# actual failure: the conductor carries ONE variable scope across a whole batch.
+# This block runs two tickets in a single `bash -c` with no env reset between
+# them, exactly as the conductor does, and applies the spec's own reset block at
+# the top of ticket 2 - the mechanism under test.
+: > .agentic/ticket-ledger.jsonl
+printf '{"ticket_id":"DS-87","loop_state":{"phase":"skeptic","iteration":3}}' > .agentic/loop-state.json
+
+BATCH_OUT=$(env GH_REPO=o/r REWORK_DETECTION=true bash -c '
+  # ---- ticket 1: Elevated. Sets all three variables on its own path. ----
+  RISK_CLASS="Elevated"; SKEPTIC_ROUNDS=3; QA_STATUS="PASS"
+  TICKET_ID="DS-87"; BRANCH_NAME="feature/ds-87"; FAKE_GH_PR=458
+  export FAKE_GH_PR
+  source "'"$WRITE_BLOCK"'"
+
+  # ---- ticket 2: Trivial. Reaches neither Phase 6 nor Phase 6b. ----
+  # The spec reset runs first, then only what a Trivial ticket actually sets.
+  source "'"$RESET_BLOCK"'"
+  RISK_CLASS="Trivial"; QA_STATUS="skipped:Trivial path"   # Phase 2 declaration
+  TICKET_ID="DS-91"; BRANCH_NAME="fix/ds-91"; FAKE_GH_PR=462
+  export FAKE_GH_PR
+  source "'"$WRITE_BLOCK"'"
+')
+
+t1=$(head -1 .agentic/ticket-ledger.jsonl)
+t2=$(tail -1 .agentic/ticket-ledger.jsonl)
+_eq "batch t1 records its own rounds"       "$(echo "$t1" | jq -r .skeptic_rounds)"      "3"
+_eq "batch t1 records its own qa_status"    "$(echo "$t1" | jq -r .qa_status)"           "PASS"
+_eq "batch t2 does NOT inherit rounds"      "$(echo "$t2" | jq -r '.skeptic_rounds|type')" "null"
+_eq "batch t2 does NOT inherit PASS"        "$(echo "$t2" | jq -r .qa_status)"           "skipped:Trivial path"
+_eq "batch t2 does NOT inherit risk_class"  "$(echo "$t2" | jq -r .risk_class)"          "Trivial"
+_eq "batch t2 is its own ticket"            "$(echo "$t2" | jq -r .ticket_id)"           "DS-91"
+
+# The reset is what makes the Phase 9 disk fallback REACHABLE. Without it,
+# SKEPTIC_ROUNDS is still 3 from ticket 1, the `[ -z "$TRL_ROUNDS" ]` gate is
+# false, and the ticket_id/phase guards never execute. Prove the guards run:
+# loop-state.json still says DS-87/skeptic/3, and ticket 2 must still get null.
+_eq "disk fallback ran and its ticket_id guard rejected the foreign record" \
+    "$(echo "$t2" | jq -r '.skeptic_rounds|type')" "null"
+
+# Isolate the RESET itself. Above, ticket 2 sets QA_STATUS explicitly (modelling
+# the Phase 2 declaration), so that assertion would hold even with no reset at
+# all. Here ticket 2 sets NOTHING beyond its identity: any non-empty field can
+# only have come from ticket 1. This is the assertion that fails without the
+# reset block, independent of whether any later definition site fires.
+: > .agentic/ticket-ledger.jsonl
+env GH_REPO=o/r REWORK_DETECTION=true bash -c '
+  RISK_CLASS="Elevated"; SKEPTIC_ROUNDS=3; QA_STATUS="PASS"
+  TICKET_ID="DS-87"; BRANCH_NAME="feature/ds-87"; FAKE_GH_PR=458
+  export FAKE_GH_PR
+  source "'"$WRITE_BLOCK"'"
+
+  source "'"$RESET_BLOCK"'"      # <- the mechanism under test, and nothing else
+  TICKET_ID="DS-91"; BRANCH_NAME="fix/ds-91"; FAKE_GH_PR=462
+  export FAKE_GH_PR
+  source "'"$WRITE_BLOCK"'"
+' >/dev/null 2>&1
+bare=$(tail -1 .agentic/ticket-ledger.jsonl)
+_eq "reset alone neutralises qa_status carry-over"  "$(echo "$bare" | jq -r '.qa_status|type')"      "null"
+_eq "reset alone neutralises rounds carry-over"     "$(echo "$bare" | jq -r '.skeptic_rounds|type')" "null"
+_eq "reset alone neutralises risk_class carry-over" "$(echo "$bare" | jq -r .risk_class)"            ""
+
+# ===========================================================================
+echo ""
 echo "--- Phase 9 skip conditions: no record written ---"
 : > .agentic/ticket-ledger.jsonl
 _write REWORK_DETECTION=false TICKET_ID=DS-94 BRANCH_NAME=b GH_REPO=o/r RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=999
@@ -300,8 +373,32 @@ _present "both non-QA paths documented as writing the rationale" \
          'Both non-QA paths .* write the rationale, not null'
 _present "Phase 6b skip branch sets QA_STATUS" \
          'QA_STATUS="skipped:<rationale>"'
-_present "Phase 6b clean exit sets QA_STATUS" \
-         'QA_STATUS. to the qa-engineer.s result verdict'
+_present "Phase 6b PASS exit sets QA_STATUS" \
+         'QA_STATUS="PASS"'
+_present "every other terminal QA verdict sets QA_STATUS (incl. INCONCLUSIVE)" \
+         'QA_STATUS="INCONCLUSIVE"'
+
+# Major A: the contract above is only real if a Trivial ticket can REACH a
+# definition site. Phase 6b is unreachable on the Trivial path, so a
+# Phase-6b-only definition satisfies the prose and still writes null. Pin the
+# mechanism, not just the promise: the Trivial rationale must be set at the
+# Phase 2 declaration, which is on the Trivial path.
+_present "a Trivial-REACHABLE QA_STATUS definition site exists (Phase 2 declaration)" \
+         'QA_STATUS="skipped:Trivial path"'
+_present "the Phase 2 declaration subsection is unconditional" \
+         '### Risk classification declaration \(unconditional'
+_present "spec states why Phase 6b alone is insufficient for Trivial" \
+         'only point in the command a Trivial ticket can record that rationale'
+
+echo ""
+echo "--- Major B (prose): per-ticket reset must exist and cover all three ---"
+_present "per-ticket reset section exists" \
+         '### Per-ticket variable reset'
+_present "reset clears RISK_CLASS"    'RISK_CLASS=""'
+_present "reset clears SKEPTIC_ROUNDS" 'SKEPTIC_ROUNDS=""'
+_present "reset clears QA_STATUS"      'QA_STATUS=""'
+_present "reset explains it makes the disk fallback reachable" \
+         'makes the Phase 9 disk fallback .*reachable'
 
 echo ""
 echo "--- Major 2 (prose): SKEPTIC_ROUNDS captured before Phase 6b overwrites ---"

--- a/bin/tests/test_ticket_rework_ledger.sh
+++ b/bin/tests/test_ticket_rework_ledger.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-# Purpose: Regression guard for the ticket-rework alert's two executable
-#          blocks in content/commands/ds-implement-ticket.md - the Phase 9
-#          ledger write and the Phase 1 detection read. The blocks are
-#          EXTRACTED FROM THE SHIPPED SPEC and executed, not copied here, so
-#          this test fails if the spec's bash drifts from the behaviour the
-#          spec's own prose promises.
+# Purpose: Regression guard for the ticket-rework alert's THREE executable
+#          blocks in content/commands/ds-implement-ticket.md:
+#            1. the Phase 1 per-ticket variable reset  (RESET_MARKER)
+#            2. the Phase 1 detection read             (READ_MARKER)
+#            3. the Phase 9 ledger write               (WRITE_MARKER)
+#          All three are EXTRACTED FROM THE SHIPPED SPEC by their marker
+#          comment and executed, not copied here, so this test fails if the
+#          spec's bash drifts from the behaviour the spec's own prose
+#          promises. Each marker is part of the contract - see Failure modes.
 #
 #          Each fixture below pins a defect found in Skeptic review of the
-#          originating PR, so a future edit that reintroduces one fails here:
+#          originating PR, so a future edit that reintroduces one fails here.
+#          Review round 1:
 #            - qa_status must carry the skip rationale on BOTH non-QA paths
 #              (Trivial, and Elevated with qa_skip), never a bare null. A
 #              null renders "n/a" in the operator notice, which says QA was
@@ -15,15 +19,31 @@
 #            - skeptic_rounds must be the SKEPTIC round count, not the QA
 #              loop's. Phase 6b overwrites loop-state.json with
 #              phase:qa, iteration:1 before Phase 9 runs.
-#            - skeptic_rounds must not be inherited from another ticket.
-#              loop-state.json persists across a batch, so an unscoped read
-#              gives Trivial ticket 2 Elevated ticket 1's round count.
+#            - skeptic_rounds must not be inherited from another ticket via
+#              loop-state.json, which persists across a batch, so an unscoped
+#              read gives Trivial ticket 2 Elevated ticket 1's round count.
 #            - detection must skip ONE malformed line, not abort the whole
 #              parse. The ledger is appended locklessly; a torn line is an
 #              expected input, and slurp would disable detection for every
 #              ticket in the file permanently.
 #            - duplicate pr_number must resolve latest-wins (replay carries
 #              the resolved qa_status and higher skeptic_rounds).
+#          Review round 2:
+#            - the Trivial rationale needs a definition site a Trivial ticket
+#              can actually REACH. Phase 6b's skip branch carries the same
+#              string but is unreachable on the Trivial path, so a
+#              Phase-6b-only definition satisfies the prose and still writes
+#              null. It must be set at the Phase 2 declaration. Pinned by
+#              prose invariants, because a runtime fixture that injects
+#              QA_STATUS asserts pass-through, not derivation - which is
+#              precisely how this defect survived a green suite once.
+#            - the three in-context variables that feed the record
+#              (RISK_CLASS, SKEPTIC_ROUNDS, QA_STATUS) must be reset per
+#              ticket. The conductor carries ONE scope across a batch, so
+#              without the reset a Trivial ticket inherits the previous
+#              Elevated ticket's values - and a stale SKEPTIC_ROUNDS also
+#              short-circuits the [ -z "$TRL_ROUNDS" ] gate, disabling the
+#              ticket_id/phase guards in the exact case they exist for.
 #
 # Public API: ./bin/tests/test_ticket_rework_ledger.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -109,6 +129,18 @@ if ! _extract "$RESET_MARKER" "$RESET_BLOCK"; then
   echo "Results: $PASS passed, $FAIL failed"; exit 1
 fi
 _pass "extracted Phase 1 per-ticket reset block from the shipped spec"
+
+# Self-check: this file's own manifest must name every marker it extracts.
+# The manifest tells a maintainer which comments are load-bearing; a manifest
+# that undercounts them invites removing one that is. (This exact staleness
+# was a Major finding in review round 3, when a third marker was added and
+# the header still said "two executable blocks".)
+MARKER_COUNT=3
+if [[ "$(grep -cE '^[A-Z]+_MARKER=' "$0")" -eq "$MARKER_COUNT" ]]; then
+  _pass "marker count matches the manifest's stated $MARKER_COUNT blocks"
+else
+  _fail "this file defines $(grep -cE '^[A-Z]+_MARKER=' "$0") markers but its manifest documents $MARKER_COUNT - update the Purpose field"
+fi
 
 for b in "$WRITE_BLOCK" "$READ_BLOCK" "$RESET_BLOCK"; do
   if bash -n "$b" 2>/dev/null; then
@@ -275,7 +307,10 @@ env GH_REPO=o/r REWORK_DETECTION=true bash -c '
 bare=$(tail -1 .agentic/ticket-ledger.jsonl)
 _eq "reset alone neutralises qa_status carry-over"  "$(echo "$bare" | jq -r '.qa_status|type')"      "null"
 _eq "reset alone neutralises rounds carry-over"     "$(echo "$bare" | jq -r '.skeptic_rounds|type')" "null"
-_eq "reset alone neutralises risk_class carry-over" "$(echo "$bare" | jq -r .risk_class)"            ""
+# risk_class normalizes ""->null like its two siblings, so a cleared value
+# stores an explicit null (which the null-render rule renders "n/a") rather
+# than an empty string, which that rule has nothing sensible to render.
+_eq "reset alone neutralises risk_class carry-over" "$(echo "$bare" | jq -r '.risk_class|type')"    "null"
 
 # ===========================================================================
 echo ""

--- a/bin/tests/test_ticket_rework_ledger.sh
+++ b/bin/tests/test_ticket_rework_ledger.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Purpose: Regression guard for the ticket-rework alert's two executable
+#          blocks in content/commands/ds-implement-ticket.md - the Phase 9
+#          ledger write and the Phase 1 detection read. The blocks are
+#          EXTRACTED FROM THE SHIPPED SPEC and executed, not copied here, so
+#          this test fails if the spec's bash drifts from the behaviour the
+#          spec's own prose promises.
+#
+#          Each fixture below pins a defect found in Skeptic review of the
+#          originating PR, so a future edit that reintroduces one fails here:
+#            - qa_status must carry the skip rationale on BOTH non-QA paths
+#              (Trivial, and Elevated with qa_skip), never a bare null. A
+#              null renders "n/a" in the operator notice, which says QA was
+#              unavailable when the truth is it was deliberately skipped.
+#            - skeptic_rounds must be the SKEPTIC round count, not the QA
+#              loop's. Phase 6b overwrites loop-state.json with
+#              phase:qa, iteration:1 before Phase 9 runs.
+#            - skeptic_rounds must not be inherited from another ticket.
+#              loop-state.json persists across a batch, so an unscoped read
+#              gives Trivial ticket 2 Elevated ticket 1's round count.
+#            - detection must skip ONE malformed line, not abort the whole
+#              parse. The ledger is appended locklessly; a torn line is an
+#              expected input, and slurp would disable detection for every
+#              ticket in the file permanently.
+#            - duplicate pr_number must resolve latest-wins (replay carries
+#              the resolved qa_status and higher skeptic_rounds).
+#
+# Public API: ./bin/tests/test_ticket_rework_ledger.sh
+#             Exits 0 on all pass, 1 on any failure.
+#             Auto-wired into CI by the bin/tests/test_*.sh glob in
+#             .github/workflows/bin-tests.yml - no orphans entry needed.
+#
+# Upstream deps: bash, jq, python3, mktemp. Reads
+#                content/commands/ds-implement-ticket.md from the checkout.
+#
+# Downstream consumers: developer running locally before commit; CI
+#                       (.github/workflows/bin-tests.yml).
+#
+# Failure modes: a missing or renamed extraction marker fails loudly rather
+#                than silently testing nothing - the marker comments are part
+#                of the contract. `gh` is stubbed on PATH, so no network call
+#                is ever made and the real gh is never invoked. All state is
+#                written under a mktemp dir; the repo is never touched.
+#
+# Performance: < 2 s wall time (pure shell + jq, no network).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="$REPO_DIR/content/commands/ds-implement-ticket.md"
+
+PASS=0
+FAIL=0
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+_eq() { # _eq <label> <actual> <expected>
+  if [[ "$2" == "$3" ]]; then _pass "$1 = $2"; else _fail "$1: got '$2' want '$3'"; fi
+}
+
+if [[ ! -f "$SPEC" ]]; then
+  echo "FAIL: $SPEC not found" >&2
+  exit 1
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# --- Extract the two fenced bash blocks from the shipped spec by marker ----
+# The marker comments are the first line of each block in the spec. If either
+# is renamed the extraction fails loudly rather than testing a stale copy.
+WRITE_MARKER='# Phase 9: ticket-rework ledger write'
+READ_MARKER='# Phase 1: ticket-rework detection'
+
+_extract() { # _extract <marker> <outfile>
+  python3 - "$SPEC" "$1" "$2" <<'PY'
+import sys
+spec, marker, out = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(spec).read()
+i = text.find(marker)
+if i < 0:
+    sys.exit("marker not found: " + marker)
+j = text.find("\n```", i)
+if j < 0:
+    sys.exit("unterminated fenced block for marker: " + marker)
+open(out, "w").write(text[i:j] + "\n")
+PY
+}
+
+WRITE_BLOCK="$TMP_ROOT/write.sh"
+READ_BLOCK="$TMP_ROOT/read.sh"
+
+if ! _extract "$WRITE_MARKER" "$WRITE_BLOCK"; then
+  _fail "could not extract the Phase 9 write block from the spec"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+_pass "extracted Phase 9 write block from the shipped spec"
+
+if ! _extract "$READ_MARKER" "$READ_BLOCK"; then
+  _fail "could not extract the Phase 1 detection block from the spec"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+_pass "extracted Phase 1 detection block from the shipped spec"
+
+for b in "$WRITE_BLOCK" "$READ_BLOCK"; do
+  if bash -n "$b" 2>/dev/null; then
+    _pass "extracted block parses: $(basename "$b")"
+  else
+    _fail "extracted block is not valid bash: $(basename "$b")"
+  fi
+done
+
+# --- Sandbox: fake gh on PATH, throwaway repo root -------------------------
+WORK="$TMP_ROOT/work"
+mkdir -p "$WORK/.agentic" "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/gh" <<'GH'
+#!/usr/bin/env bash
+# Stub: emits $FAKE_GH_PR, or fails like `gh pr view` on an unknown branch.
+[ -n "${FAKE_GH_PR:-}" ] || exit 1
+echo "$FAKE_GH_PR"
+GH
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+cd "$WORK" || exit 1
+
+_write() { # _write - run the Phase 9 block with the caller's env
+  env "$@" bash -c "source '$WRITE_BLOCK'"
+}
+_last() { tail -1 .agentic/ticket-ledger.jsonl; }
+_field() { _last | jq -r "$1"; }
+
+# ===========================================================================
+echo ""
+echo "--- Elevated happy path: full record ---"
+: > .agentic/ticket-ledger.jsonl
+printf '{"ticket_id":"DS-87","loop_state":{"phase":"skeptic","iteration":3}}' > .agentic/loop-state.json
+printf '%s\n' \
+  '{"task_id":"DS-87-a","ticket_id":"DS-87"}' \
+  '{"task_id":"DS-87-b","ticket_id":"DS-87"}' \
+  '{"task_id":"DS-99-a","ticket_id":"DS-99"}' > .agentic/tasks.jsonl
+_write REWORK_DETECTION=true TICKET_ID=DS-87 BRANCH_NAME=feature/ds-87 GH_REPO=o/r \
+       RISK_CLASS=Elevated SKEPTIC_ROUNDS=3 QA_STATUS=PASS FAKE_GH_PR=458
+_eq "elevated pr_number"      "$(_field .pr_number)"      "458"
+_eq "elevated skeptic_rounds" "$(_field .skeptic_rounds)" "3"
+_eq "elevated qa_status"      "$(_field .qa_status)"      "PASS"
+_eq "elevated unit_count"     "$(_field .unit_count)"     "2"
+_eq "elevated branch"         "$(_field .branch)"         "feature/ds-87"
+_eq "opened_ts is ISO8601 Z"  "$(_field .opened_ts | grep -cE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$')" "1"
+
+# ===========================================================================
+echo ""
+echo "--- Major 1: qa_status carries the rationale on BOTH non-QA paths ---"
+: > .agentic/ticket-ledger.jsonl
+rm -f .agentic/loop-state.json .agentic/tasks.jsonl
+# Trivial: no Skeptic loop, no QA. Rationale, not null.
+_write REWORK_DETECTION=true TICKET_ID=DS-91 BRANCH_NAME=fix/ds-91 GH_REPO=o/r \
+       RISK_CLASS=Trivial QA_STATUS="skipped:Trivial path" FAKE_GH_PR=462
+_eq "trivial risk_class"     "$(_field .risk_class)"          "Trivial"
+_eq "trivial qa_status"      "$(_field .qa_status)"           "skipped:Trivial path"
+_eq "trivial qa NOT null"    "$(_field '.qa_status|type')"    "string"
+_eq "trivial skeptic null"   "$(_field '.skeptic_rounds|type')" "null"
+_eq "trivial unit_count"     "$(_field .unit_count)"          "1"
+
+# Elevated with qa_skip: Skeptic ran, QA did not. Rationale, not null.
+printf '{"ticket_id":"DS-92","loop_state":{"phase":"skeptic","iteration":2}}' > .agentic/loop-state.json
+_write REWORK_DETECTION=true TICKET_ID=DS-92 BRANCH_NAME=feature/ds-92 GH_REPO=o/r \
+       RISK_CLASS=Elevated SKEPTIC_ROUNDS=2 QA_STATUS="skipped:docs-only" FAKE_GH_PR=463
+_eq "qa_skip qa_status"      "$(_field .qa_status)"           "skipped:docs-only"
+_eq "qa_skip qa NOT null"    "$(_field '.qa_status|type')"    "string"
+_eq "qa_skip rounds kept"    "$(_field .skeptic_rounds)"      "2"
+
+# ===========================================================================
+echo ""
+echo "--- Major 2: skeptic_rounds is the Skeptic count, not the QA count ---"
+# Phase 6b has overwritten loop-state with phase:qa, iteration:1 by Phase 9.
+# The in-context SKEPTIC_ROUNDS captured at Phase 6 clean exit must win.
+: > .agentic/ticket-ledger.jsonl
+printf '{"ticket_id":"DS-93","loop_state":{"phase":"qa","iteration":1}}' > .agentic/loop-state.json
+_write REWORK_DETECTION=true TICKET_ID=DS-93 BRANCH_NAME=feature/ds-93 GH_REPO=o/r \
+       RISK_CLASS=Elevated SKEPTIC_ROUNDS=3 QA_STATUS=PASS FAKE_GH_PR=464
+_eq "3 skeptic rounds not 1 QA iteration" "$(_field .skeptic_rounds)" "3"
+
+# Resume fallback: in-context value lost, disk says phase:qa -> must NOT be used.
+: > .agentic/ticket-ledger.jsonl
+_write REWORK_DETECTION=true TICKET_ID=DS-93 BRANCH_NAME=feature/ds-93 GH_REPO=o/r \
+       RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=464
+_eq "phase:qa disk read rejected" "$(_field '.skeptic_rounds|type')" "null"
+
+# Resume fallback: disk says phase:skeptic for THIS ticket -> may be used.
+: > .agentic/ticket-ledger.jsonl
+printf '{"ticket_id":"DS-93","loop_state":{"phase":"skeptic","iteration":4}}' > .agentic/loop-state.json
+_write REWORK_DETECTION=true TICKET_ID=DS-93 BRANCH_NAME=feature/ds-93 GH_REPO=o/r \
+       RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=464
+_eq "phase:skeptic disk read accepted" "$(_field .skeptic_rounds)" "4"
+
+# ===========================================================================
+echo ""
+echo "--- Major 3: batch - ticket 2 must not inherit ticket 1's rounds ---"
+# Elevated ticket 1 finished and left loop-state.json behind at iteration 3.
+: > .agentic/ticket-ledger.jsonl
+printf '{"ticket_id":"DS-87","loop_state":{"phase":"skeptic","iteration":3}}' > .agentic/loop-state.json
+# Trivial ticket 2 now opens its PR. It never ran a Skeptic loop.
+_write REWORK_DETECTION=true TICKET_ID=DS-91 BRANCH_NAME=fix/ds-91 GH_REPO=o/r \
+       RISK_CLASS=Trivial QA_STATUS="skipped:Trivial path" FAKE_GH_PR=465
+_eq "foreign ticket rounds not inherited" "$(_field '.skeptic_rounds|type')" "null"
+
+# ===========================================================================
+echo ""
+echo "--- Phase 9 skip conditions: no record written ---"
+: > .agentic/ticket-ledger.jsonl
+_write REWORK_DETECTION=false TICKET_ID=DS-94 BRANCH_NAME=b GH_REPO=o/r RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=999
+_eq "toggle off writes nothing"   "$(wc -l < .agentic/ticket-ledger.jsonl | tr -d ' ')" "0"
+_write REWORK_DETECTION=true TICKET_ID= BRANCH_NAME=b GH_REPO=o/r RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=999
+_eq "empty ticket writes nothing" "$(wc -l < .agentic/ticket-ledger.jsonl | tr -d ' ')" "0"
+_write REWORK_DETECTION=true TICKET_ID=DS-94 BRANCH_NAME=b GH_REPO=o/r RISK_CLASS=Elevated QA_STATUS=PASS FAKE_GH_PR=
+_eq "no PR number writes nothing" "$(wc -l < .agentic/ticket-ledger.jsonl | tr -d ' ')" "0"
+
+# ===========================================================================
+echo ""
+echo "--- Phase 1 detection ---"
+_read() { # _read <ticket> <toggle> -> "<attempts>|<is_rework>|<latest_pr>"
+  env REWORK_DETECTION="$2" TICKET_ID="$1" bash -c \
+    "source '$READ_BLOCK'
+     printf '%s|%s|%s' \"\$PRIOR_ATTEMPTS\" \"\$IS_REWORK\" \
+       \"\$(printf '%s' \"\$PRIOR_COMPLETED_JSON\" | jq -r '.[-1].pr_number // \"-\"')\""
+}
+
+: > .agentic/ticket-ledger.jsonl
+printf '%s\n' \
+  '{"ticket_id":"DS-87","pr_number":458,"opened_ts":"2026-07-17T11:54:58Z"}' \
+  '{"ticket_id":"DS-99","pr_number":401,"opened_ts":"2026-07-01T00:00:00Z"}' \
+  '{"ticket_id":"DS-87","pr_number":470,"opened_ts":"2026-07-20T09:00:00Z"}' \
+  >> .agentic/ticket-ledger.jsonl
+_eq "two attempts, latest last" "$(_read DS-87 true)" "2|true|470"
+_eq "other ticket unaffected"   "$(_read DS-99 true)" "1|true|401"
+_eq "unknown ticket is inert"   "$(_read DS-404 true)" "0|false|-"
+_eq "toggle off is inert"       "$(_read DS-87 false)" "0|false|-"
+
+echo ""
+echo "--- Major 4: ONE malformed line must not disable the whole ledger ---"
+cp .agentic/ticket-ledger.jsonl "$TMP_ROOT/ledger.good"
+printf '%s\n' '{"ticket_id":"DS-87","pr_num' >> .agentic/ticket-ledger.jsonl   # torn append
+printf '%s\n' '{"ticket_id":"DS-87","pr_number":480,"opened_ts":"2026-07-22T00:00:00Z"}' \
+  >> .agentic/ticket-ledger.jsonl
+_eq "good lines survive a torn line" "$(_read DS-87 true)" "3|true|480"
+cp "$TMP_ROOT/ledger.good" .agentic/ticket-ledger.jsonl
+
+echo ""
+echo "--- Minor 2: duplicate pr_number resolves latest-wins ---"
+: > .agentic/ticket-ledger.jsonl
+printf '%s\n' \
+  '{"ticket_id":"DS-87","pr_number":458,"opened_ts":"2026-07-17T00:00:00Z","skeptic_rounds":1,"qa_status":null}' \
+  '{"ticket_id":"DS-87","pr_number":458,"opened_ts":"2026-07-18T00:00:00Z","skeptic_rounds":3,"qa_status":"PASS"}' \
+  >> .agentic/ticket-ledger.jsonl
+dup=$(env REWORK_DETECTION=true TICKET_ID=DS-87 bash -c \
+  "source '$READ_BLOCK'
+   printf '%s|%s' \"\$PRIOR_ATTEMPTS\" \
+     \"\$(printf '%s' \"\$PRIOR_COMPLETED_JSON\" | jq -r '.[-1].skeptic_rounds')\"")
+_eq "duplicate collapses, later record wins" "$dup" "1|3"
+
+echo ""
+echo "--- absent ledger ---"
+rm -f .agentic/ticket-ledger.jsonl
+_eq "absent ledger is inert" "$(_read DS-87 true)" "0|false|-"
+
+# ===========================================================================
+# Prose invariants. Some defects in this feature live in the spec's PROSE, not
+# its bash - the conductor is the interpreter, so an instruction that tells it
+# to set a variable to the wrong value is a real defect that no runtime
+# fixture can catch. (Precedent: bin/tests/test_tracker_writeback_ranking_spec.py
+# pins prose invariants for another block in this same file.)
+echo ""
+echo "--- Major 1 (prose): qa_status contract must not contradict itself ---"
+
+_absent() { # _absent <label> <pattern>
+  if grep -qiE "$2" "$SPEC"; then
+    _fail "$1 - spec still contains: /$2/"
+  else
+    _pass "$1"
+  fi
+}
+_present() { # _present <label> <pattern>
+  if grep -qiE "$2" "$SPEC"; then
+    _pass "$1"
+  else
+    _fail "$1 - spec no longer contains: /$2/"
+  fi
+}
+
+# The retracted clause: it named Trivial and qa_skip as null-writing paths,
+# directly contradicting the sentence before it and the merged reference doc
+# (content/references/ticket-rework.md nullability table + Trivial example).
+_absent "no 'empty when legitimately null (Trivial, or Elevated with qa_skip)' clause" \
+        'empty when it is legitimately null'
+_absent "no 'Null on two paths' claim for qa_status" \
+        '\*\*Null on two paths\*\*'
+
+# The contract that replaced it must still be stated.
+_present "both non-QA paths documented as writing the rationale" \
+         'Both non-QA paths .* write the rationale, not null'
+_present "Phase 6b skip branch sets QA_STATUS" \
+         'QA_STATUS="skipped:<rationale>"'
+_present "Phase 6b clean exit sets QA_STATUS" \
+         'QA_STATUS. to the qa-engineer.s result verdict'
+
+echo ""
+echo "--- Major 2 (prose): SKEPTIC_ROUNDS captured before Phase 6b overwrites ---"
+_present "Phase 6 Step 3 clean exit sets SKEPTIC_ROUNDS" \
+         'Set .SKEPTIC_ROUNDS. to this loop.s final'
+_present "the overwrite hazard is stated at the capture site" \
+         'overwriting the Phase 6 state'
+
+echo ""
+echo "--- Major 4 (prose): the anti-slurp rule must survive edits ---"
+_present "spec warns against -s (slurp) for the detection read" \
+         'Do NOT use .-s. \(slurp\)'
+_absent  "detection block no longer uses jq -cs" \
+         'jq -cs --arg t'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -826,6 +826,41 @@ When Phase 0a-pre or the per-ticket Resume check detects an in-flight ticket who
 
 When `normalized_input.additional_operator_context` is non-null, append it verbatim to every entry's downstream architect (Phase 3) and engineer (Phase 5) brief, prefixed with `"Additional operator context (applied to all entries):"`. This routes mixed-input residue into the per-entry brief without dropping operator intent.
 
+### Per-ticket variable reset (binding, runs FIRST on every entry)
+
+**Before the tracker sub-section dispatch below, clear every in-context variable that feeds the Phase 9 ticket-rework ledger write or the rework notice:**
+
+```bash
+# Phase 1: per-ticket variable reset (runs first on EVERY entry, before sub-section dispatch).
+# These three have exactly one definition site each, on one path. A ticket that does not take
+# that path inherits the previous batch ticket's value - see the table below.
+RISK_CLASS=""
+SKEPTIC_ROUNDS=""
+QA_STATUS=""
+```
+
+**Why this is binding rather than housekeeping.** The conductor carries ONE variable scope across an entire batch; Phase 1 iterates per entry but nothing else in this command resets anything. Every one of these three variables has exactly one definition site on one path, so a ticket that does not take that path silently inherits the previous ticket's value. The failure is always an affirmative false statement, never an error:
+
+| Variable | Set only on | Batch failure without this reset |
+|---|---|---|
+| `SKEPTIC_ROUNDS` | Phase 6 clean exit | Trivial ticket 2 inherits Elevated ticket 1's round count - the notice reports adversarial review that never happened. **It also disables the Phase 9 disk-fallback guards**, which are gated on `[ -z "$TRL_ROUNDS" ]` and never execute when a stale value is present. |
+| `QA_STATUS` | Phase 6b (both branches) | Trivial ticket 2 skips Phase 6b entirely and inherits `PASS` - the notice reports that QA passed when no QA ran. |
+| `RISK_CLASS` | Phase 2 declaration | Ticket 2 inherits ticket 1's class, or writes `""` if ticket 1 never set it - an empty slot the null-render rule forbids. |
+
+This is the same hazard the Phase 9 write already hardens `pr_number` against by deriving it live rather than reading `$PR_NUMBER` (see "Ticket-rework ledger write"). `pr_number` can be re-derived from an external source; these three cannot, so they are reset at the per-ticket entry point instead. **Any future in-context variable that feeds the ledger or the notice belongs in this reset block** - the hazard is structural to a single scope spanning a batch, not specific to these three names.
+
+**Full sweep of the Phase 9 write's external reads**, so a future editor can see the analysis rather than redo it. Every variable the write block reads without assigning locally, and why it is or is not exposed:
+
+| Variable | Scope | Exposed to batch carry-over? |
+|---|---|---|
+| `RISK_CLASS`, `SKEPTIC_ROUNDS`, `QA_STATUS` | per-ticket, single definition path | **Yes** - reset above |
+| `TICKET_ID` | per-entry, from Phase 1 iteration | No - re-bound on every entry by construction |
+| `BRANCH_NAME` | per-ticket | No - Phase 4 resolves it "regardless of path", so every ticket re-sets it before Phase 9 |
+| `GH_REPO`, `REWORK_DETECTION` | session constants from Setup | No - batch-scoped is correct for both |
+| `PR_NUMBER` | per-ticket | Not read - the write derives `pr_number` live precisely to avoid it |
+
+Clearing rather than leaving unset is deliberate: it makes the Phase 9 disk fallback for `SKEPTIC_ROUNDS` reachable (its `[ -z "$TRL_ROUNDS" ]` gate now passes on a ticket that never reached Phase 6), so the `ticket_id` and `loop_state.phase` guards actually run in the batch scenario they exist to prevent.
+
 #### If TRACKER is `linear`
 
 1. Call `mcp__linear__get_issue` with the ticket ID and `includeRelations: true`.
@@ -949,13 +984,33 @@ When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening a
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
-Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+Apply the floor to the classification *before* it is declared in the next subsection, which is where `RISK_CLASS` is actually set.
 
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
 
 **Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
+
+### Risk classification declaration (unconditional - runs on every ticket)
+
+**This subsection is NOT gated on `IS_REWORK`, `REWORK_DETECTION`, or anything else. It runs for every ticket on every path**, including when the rework floor above did not fire and when the feature is switched off entirely. It is a sibling of the floor section, not part of it: the floor *adjusts* the classification, this *records* it.
+
+Declare the risk classification and set:
+
+```
+RISK_CLASS="<Trivial | Low | Elevated>"     # post-floor
+```
+
+**When the declared classification is `Trivial`, also set:**
+
+```
+QA_STATUS="skipped:Trivial path"
+```
+
+**This is the only point in the command a Trivial ticket can record that rationale.** Phase 6b's skip branch carries the same string, but Phase 6b is unreachable on the Trivial path - "The Trivial path never enters Phase 6b" - so that branch only ever fires for an Elevated ticket with a non-null `qa_skip`. Setting it there alone would leave every Trivial ticket writing `qa_status: null`, and the notice rendering `QA n/a` for precisely the record `content/references/ticket-rework.md` uses as its canonical worked example.
+
+Both assignments are unconditional in the sense that matters: they do not depend on the rework feature being active. A ticket whose ledger write is later skipped simply never reads them.
 
 ---
 
@@ -1735,7 +1790,9 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS="PASS"` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+
+**`QA_STATUS` on every other terminal QA outcome.** Whenever Phase 6b reaches a terminal verdict for this ticket by any route, set `QA_STATUS` to that verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`. In particular, when the operator accepts INCONCLUSIVE with `qa_unverified=true` on the `qa_blocked` path and the ticket continues to Phase 9, set `QA_STATUS="INCONCLUSIVE"`. A known verdict must never be discarded to null: the ledger's contract reserves null for the case where *neither* a result *nor* a rationale can be resolved, and "the operator looked at this and accepted that QA could not verify it" is a result. Recording it as `n/a` would tell a later rework attempt that QA status was simply unavailable, hiding an accepted-unverified ticket - the exact class of silent downgrade this field exists to surface.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2273,16 +2330,18 @@ Capture the PR number from the URL printed by `gh pr create`.
 Field derivation:
 - `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
 
 **Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
 
-| Variable | Set where | Value |
-|---|---|---|
-| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
-| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
-| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
+| Variable | Reset | Set where | Value |
+|---|---|---|---|
+| `RISK_CLASS` | Phase 1, per-ticket reset | Phase 2 "Risk classification declaration (unconditional)" | `Trivial` \| `Low` \| `Elevated`, post-floor |
+| `SKEPTIC_ROUNDS` | Phase 1, per-ticket reset | Phase 6, Step 3 clean exit | final `loop_state.iteration`; stays empty on the Trivial path, which never reaches Phase 6 |
+| `QA_STATUS` | Phase 1, per-ticket reset | **Three** sites: Phase 2 declaration (`skipped:Trivial path`, the only Trivial-reachable one); Phase 6b skip branch (`skipped:<qa_skip enum>`); Phase 6b terminal outcome (the QA verdict) | see the bullet above |
+
+Every row is cleared at the Phase 1 per-ticket reset and re-set on this ticket's own path. Without that reset each variable's single definition site would leak the previous batch ticket's value into any ticket that does not take that path - see "Per-ticket variable reset" in Phase 1.
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2328,7 +2328,7 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 "Risk classification declaration (unconditional)" subsection** to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`. All three of `risk_class`, `skeptic_rounds`, and `qa_status` normalize an empty value to `null` in the record builder. For `risk_class` this is defence-in-depth rather than a reachable path - the Phase 2 declaration is unconditional, so an empty value would mean the declaration was skipped - but the three fields are read from the same per-ticket-reset in-context variables and are handled identically, so that a bug upstream produces an explicit `null` (which the null-render rule renders `n/a`) rather than an empty string, which that rule has nothing sensible to render.
 - `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
 - `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA reached a terminal verdict; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value (set on Phase 6b's skip branch) or the literal `Trivial path` (set at the **Phase 2 declaration**, because Phase 6b is unreachable on the Trivial path). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
@@ -2392,7 +2392,8 @@ if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
       --arg sr "${TRL_ROUNDS:-}" \
       --arg qs "${QA_STATUS:-}" \
       --argjson uc "$TRL_UNITS" \
-      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br,
+        risk_class:(if $rc == "" then null else $rc end),
         skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
         qa_status:(if $qs == "" then null else $qs end),
         unit_count:$uc}' 2>/dev/null || true)

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -855,22 +855,31 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
 
 1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
-2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number`, keeping the record with the **latest `opened_ts`** within each duplicate group (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count). Latest-wins matters: a duplicate `pr_number` arises from a Phase 9 replay, and the later record is the one carrying the resolved `qa_status` and the higher `skeptic_rounds`. Keeping the earliest would show the operator the staler of the two.
 3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
-4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+4. **Soft-fail, per line.** If the ledger is absent or unreadable, resolve to `PRIOR_ATTEMPTS = 0`. If an individual line is malformed, **skip that line and keep going** - a single partial write must not disable detection for every other ticket in the file. A missing or corrupt ledger must never block the ticket it exists to help with.
 
 ```bash
 # Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
-# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+# Emits the deduped prior-attempt records, most recent last.
 PRIOR_COMPLETED_JSON='[]'
 PRIOR_ATTEMPTS=0
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
-  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
-  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
-  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
-  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
-    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
-    | unique_by(.pr_number)
+  # `-Rn` + `inputs` + `fromjson? // empty` parses PER LINE and drops only the lines that fail.
+  # Do NOT use `-s` (slurp) here: slurp aborts the whole parse on the first malformed line, so
+  # one partial write from a concurrent appender would silently disable detection for every
+  # ticket in the file, permanently and with no operator signal. The ledger is written
+  # locklessly and O_APPEND is not atomic over NFS, so a torn line is a real, expected input.
+  #
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any partial
+  # output. Do NOT use `$(jq ... || echo '[]')`: on an unreadable file some jq builds emit a
+  # result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -Rn --arg t "$TICKET_ID" '
+    [ inputs
+      | fromjson? // empty
+      | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | group_by(.pr_number)
+    | map(max_by(.opened_ts // ""))
     | sort_by(.opened_ts // "")
   ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
   [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
@@ -882,7 +891,9 @@ if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
 
 `PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
 
-(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+`group_by | map(max_by(...))` is used in place of `unique_by(.pr_number)` deliberately: jq's `unique_by` is `group_by | map(.[0])` over a stable sort, so it keeps the *earliest* member of each duplicate group - the opposite of what a replay duplicate calls for.
+
+Regression coverage for this block lives in `bin/tests/test_ticket_rework_ledger.sh`.
 
 **The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
 
@@ -932,13 +943,17 @@ Trivial-classified tickets skip the investigator (not required); the shippable c
 
 ### Ticket-rework escalation: Elevated risk floor
 
-**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream. One consumer sits *upstream* of this point and is therefore not covered: Phase 0b's `qa.md` snapshot, which reads the classification before Phase 1 detection has run. See the known gap at the end of this section.
 
 When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
 
 The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
 
+Set `RISK_CLASS` to the declared, **post-floor** classification (`Trivial` | `Low` | `Elevated`). This is the in-context variable the Phase 9 ticket-rework ledger write records as `risk_class`.
+
 Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+**Known gap - the Phase 0b qa.md snapshot is not retroactive.** Phase 0b's `qa.md` snapshot is Elevated-only and runs *before* Phase 1, so it has already been skipped by the time the floor fires. A would-be-Trivial ticket floored to Elevated here therefore has no `.agentic/qa.md.snapshot-<ticket_id>`, and Phase 11b's `qa_md_diff` comes back empty for it. This is bounded and degrades gracefully - `wrap-ticket` already handles an absent snapshot - so the floor does not attempt to reach backwards and create one. The consequence is a missing qa.md-additions summary on floored tickets, nothing more.
 
 This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
@@ -1497,7 +1512,9 @@ META-DIVERGENCE: meta-Skeptic identified [Critical|Major] '<finding-title>' that
 Tracker append is a single line per `original_task_id`; the file is created if absent (`.agentic/.meta-divergence-surfaced`, gitignored under the `.agentic/` umbrella). Minor-only divergences are NOT surfaced inline. See `content/references/skeptic-protocol.md` Section 14 for the full specification.
 
 **Step 3. Termination check:**
-- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+- If no Critical or Major findings: auto-close all `findings_log` entries with `status: open` or `status: addressed` (set to `closed`). Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `SKEPTIC_ROUNDS` to this loop's final `loop_state.iteration` (in-context variable; see below). **Then run "Learning extraction" below, followed by "Calibration emit + meta-Skeptic sampling".** Exit loop cleanly. Proceed to Phase 6b.
+
+**`SKEPTIC_ROUNDS` must be captured here, at Phase 6 clean exit - not read back later.** Phase 6b initializes its own loop state **overwriting the Phase 6 state** with `phase: qa, iteration: 1`, and Phase 6b fires for every Elevated unit with `qa_skip == null` - the common case. By the time Phase 9 runs, `loop_state.iteration` on disk is the QA iteration count, not the Skeptic round count: a ticket with 3 Skeptic rounds and a first-pass QA reads back as `1`. Capturing at clean exit is the same pattern Phase 6b already uses for `QA_RAN_AND_PASSED`. The Trivial path never reaches Phase 6, so it never sets `SKEPTIC_ROUNDS`, which is exactly why the ledger's `skeptic_rounds` is legitimately null there.
 - If `iteration == max_iterations` AND Critical or Major findings remain: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human (see Escalation section below). Phase 6b does NOT run.
 - If any Critical finding carries `re_raised: true` (same finding re-raised after a claimed fix): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection below. Escalate to human. (This overrides the 2-re-route rule in `skeptic-protocol.md` Section 5 - see that section for the override note. One re-raise after a claimed fix is sufficient within the loop.)
 
@@ -1665,7 +1682,7 @@ After normalization, re-evaluate the trigger conditions (with `qa_skip` now null
 
 - **If trigger conditions hold (QA fires) - UI-visible changes (concurrent path):** when the unit's diff is UI-visible, `qa-engineer` was already spawned IN PARALLEL with the Skeptic during Phase 6 (single message, both background). If QA passed concurrently, Phase 6b is already satisfied - skip to Phase 7. If QA failed concurrently or was deferred, proceed with the QA loop contract below. See `content/references/qa-gate.md` §"QA gate flow (UI-visible - concurrent)" for the full concurrent QA spec.
 - **If trigger conditions hold (QA fires) - non-UI changes (sequential path):** proceed with the QA loop contract below.
-- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7.
+- **If trigger conditions do not hold (QA skipped):** record the skip rationale (`qa_skip` value or "Trivial path") in the conductor's status update and proceed directly to Phase 7. Also set `QA_STATUS="skipped:<rationale>"` using that same rationale (in-context variable consumed by the Phase 9 ticket-rework ledger write). Writing the rationale rather than leaving it empty is what lets the rework notice distinguish "QA was deliberately skipped, here is why" from "QA status unavailable".
 
 For full QA gate rules, see `METHODOLOGY.md §QA Gate`.
 
@@ -1718,7 +1735,7 @@ The following failures were identified and fix attempts were made in earlier ite
 - Overwrite `.agentic/loop-state.json` with the updated LOOP_STATE.
 
 **Step 3. Termination check:**
-- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
+- If PASS (all acceptance criteria met): auto-close all `qa_failures_log` entries. Set `termination_reason: clean`. Overwrite `.agentic/loop-state.json`. Set `QA_RAN_AND_PASSED="true"` (in-context variable used by Phase 9 QA Evidence section) and `QA_STATUS` to the qa-engineer's result verdict - one of `PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE` (in-context variable used by the Phase 9 ticket-rework ledger write). **Parse QA screenshot evidence (see below).** Exit loop cleanly. Proceed to Phase 7.
 - If `iteration == max_iterations` AND still failing: set `termination_reason: cap_reached`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with the `qa_failures_log`. Phase 7 does NOT run.
 - If same failure recurs unchanged after a claimed fix (`re_raised: true`): set `termination_reason: convergence_failure`. Overwrite `.agentic/loop-state.json`. Before escalating, apply the "Batch-mode escalation routing (mark-blocked-and-continue)" subsection in Phase 6. Escalate to human with convergence note.
 
@@ -2254,27 +2271,50 @@ Capture the PR number from the URL printed by `gh pr create`.
 **Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
 
 Field derivation:
-- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
-- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
-- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `risk_class` - `$RISK_CLASS`, **set at the Phase 2 risk-classification declaration point** (see "Ticket-rework escalation: Elevated risk floor") to the conductor's declared classification, post-floor: `Trivial` | `Low` | `Elevated`.
+- `skeptic_rounds` - `$SKEPTIC_ROUNDS`, **captured at Phase 6 clean exit**, before Phase 6b overwrites the loop state. Do **not** read `loop_state.iteration` at this point unguarded: Phase 6b reinitializes that file with `phase: qa, iteration: 1`, so a post-QA read returns the QA iteration count, not the Skeptic round count. **Null on the Trivial path**, which never reaches Phase 6 and therefore never sets the variable. The disk fallback below exists only for a resumed session that lost the in-context variable, and it is doubly guarded - on `ticket_id` *and* on `loop_state.phase == "skeptic"`.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran; otherwise the skip rationale as `"skipped:<rationale>"`, where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Both non-QA paths - Trivial, and Elevated with a non-null `qa_skip` - write the rationale, not null.** That is the whole point of the field: a bare null renders `n/a` in the notice, which tells an operator doing manual verification that QA is *unavailable* when the truth is that QA was *deliberately skipped, for a stated reason*. Null is reserved for the degenerate case where neither a result nor a rationale can be resolved at all.
 - `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+**Variable definition sites.** `RISK_CLASS` and `QA_STATUS` carry the record's semantic content, so unlike `$BRANCH_NAME` / `$GH_REPO` they are stated explicitly rather than assumed:
+
+| Variable | Set where | Value |
+|---|---|---|
+| `RISK_CLASS` | Phase 2, at the risk-classification declaration (post-floor) | `Trivial` \| `Low` \| `Elevated` |
+| `SKEPTIC_ROUNDS` | Phase 6, Step 3 clean exit | final `loop_state.iteration`; unset on the Trivial path |
+| `QA_STATUS` | Phase 6b - clean exit sets the QA result; the skip branch sets `skipped:<rationale>` | see the bullet above |
 
 ```bash
 # Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
 # Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
-# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
-# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
-# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
-# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / SKEPTIC_ROUNDS / QA_STATUS are the shell-variable
+# form of the conductor's in-context state (definition sites in the table above).
+# QA_STATUS holds the QA result when QA ran, and "skipped:<qa_skip enum>" or
+# "skipped:Trivial path" when it did not. It is empty ONLY in the degenerate case where neither
+# a result nor a rationale exists - the two ordinary non-QA paths both carry a rationale.
 if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
   # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
   TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
 
   if [ -n "$TRL_PR_NUMBER" ]; then
-    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
-    TRL_ROUNDS=""
-    if [ -f .agentic/loop-state.json ]; then
-      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    # skeptic_rounds: prefer the value captured at Phase 6 clean exit. Empty on the Trivial
+    # path, which never reaches Phase 6 - that is a correct null, not a missing read.
+    TRL_ROUNDS="${SKEPTIC_ROUNDS:-}"
+
+    # Disk fallback for a resumed session that lost the in-context variable. TWO guards, both
+    # required and for different reasons:
+    #   ticket_id  - loop-state.json persists across tickets in a batch (Phase 12 may leave it
+    #                at status:complete rather than deleting). Without this guard, Trivial
+    #                ticket 2 inherits Elevated ticket 1's round count - telling the operator
+    #                a Trivial attempt got three rounds of review when it got none.
+    #   phase      - Phase 6b overwrites the file with phase:qa, iteration:1. Without this
+    #                guard, an Elevated ticket that passed QA on the first try records 1
+    #                Skeptic round regardless of how many it actually took.
+    if [ -z "$TRL_ROUNDS" ] && [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r --arg t "$TICKET_ID" '
+        select(.ticket_id == $t and .loop_state.phase == "skeptic")
+        | .loop_state.iteration // empty
+      ' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
     fi
     case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
 

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -279,6 +279,7 @@ Before any phase, read the project's `AGENTS.md` and extract the following value
 - `DEBUGGER_ON_FAILURE` — read from `.agentic/config.json` key `debugger_on_failure` (boolean, default `false`). When `true` and the path is Elevated, a Debugger diagnosis step is interposed between a failed quality gate and the next engineer fix pass in Phase 7 - see Phase 7 for the full flow.
 - `AUTO_MERGE_ON_CI_GREEN` — read from `.agentic/config.json` key `auto_merge_on_ci_green` (boolean, default `false`). When `true`, Phase 12 squash-merges the PR after CI passes, the PR is ready, and no reviewer has requested changes. Default `false` leaves the PR open for human review.
 - `PR_WORKFLOW_REVIEWERS` — read from `AGENTS.md` `## PR Workflow` section, `Reviewers:` field (comma-separated GitHub usernames). Default: empty string. Section absence = empty. Used in Phase 10b as fallback reviewer assignment when no CODEOWNERS file is found.
+- `REWORK_DETECTION` — read from `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). When `false`, the ticket-rework alert goes fully dark: the Phase 9 ledger write, the Phase 1 detection read, the REWORK notice, and the escalation (Elevated risk floor, architect/Skeptic callouts, Tier-3 bump) are all disabled. See `content/references/ticket-rework.md`.
 
 **Tracker resolution** — read tracker config using this fallback chain:
 
@@ -847,6 +848,62 @@ No ticket to fetch. **Use `normalized_input.freeform_task` as the ticket content
 
 ---
 
+### Ticket-rework detection (per-entry, runs after the sub-section dispatch above)
+
+**Anchoring (binding).** This step sits at the per-entry level, AFTER the three mutually exclusive tracker sub-sections above have dispatched - so it runs exactly once per entry regardless of which sub-section executed. The `TRACKER is none` sub-section only executes when `entries` is empty and `freeform_task` is set; anchoring detection inside any single sub-section would skip it for the other paths. Do not move it into one.
+
+Detection makes **zero tracker calls and zero network calls** - it is a single local file read, so it behaves identically at `TRACKER=none` as it does with a tracker configured. `TRACKER=none` is in fact the case the ledger matters most for: there is no tracker comment thread to carry prior-attempt signal.
+
+1. If `REWORK_DETECTION` is `false`, or the current `[TICKET_ID]` is null/empty: skip detection entirely. Set `PRIOR_ATTEMPTS = 0`, `IS_REWORK = false`, `PRIOR_COMPLETED = []`. Emit nothing.
+2. Otherwise read `.agentic/ticket-ledger.jsonl` and collect every record whose `ticket_id` is an **exact string match** for the current `[TICKET_ID]`. Dedupe the collected records by `pr_number` (read-side dedupe is what makes the lockless append at Phase 9 safe - a benign duplicate collapses here rather than inflating the count).
+3. Set `PRIOR_COMPLETED` to the deduped record set ordered by `opened_ts` ascending, `PRIOR_ATTEMPTS` to its size, and `IS_REWORK` to `PRIOR_ATTEMPTS >= 1`.
+4. **Soft-fail.** If the ledger is absent, unreadable, or a line is malformed, skip the bad line and continue; a wholly unusable ledger resolves to `PRIOR_ATTEMPTS = 0`. A missing or corrupt ledger must never block the ticket it exists to help with.
+
+```bash
+# Phase 1: ticket-rework detection (soft-fail; zero tracker/network calls - one local file read).
+# Emits the deduped prior-attempt records, most recent last. Malformed lines are skipped, not fatal.
+PRIOR_COMPLETED_JSON='[]'
+PRIOR_ATTEMPTS=0
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ] && [ -f .agentic/ticket-ledger.jsonl ]; then
+  # `X=$(...) || X=default` puts the fallback on jq's own exit status and discards any
+  # partial output. Do NOT use `$(jq ... || echo '[]')` here: on an unreadable file some
+  # jq builds emit a result AND fail, so the fallback would concatenate onto it.
+  PRIOR_COMPLETED_JSON=$(jq -cs --arg t "$TICKET_ID" '
+    [ .[] | select(type == "object" and .ticket_id == $t and (.pr_number != null)) ]
+    | unique_by(.pr_number)
+    | sort_by(.opened_ts // "")
+  ' .agentic/ticket-ledger.jsonl 2>/dev/null) || PRIOR_COMPLETED_JSON='[]'
+  [ -n "$PRIOR_COMPLETED_JSON" ] || PRIOR_COMPLETED_JSON='[]'
+  PRIOR_ATTEMPTS=$(printf '%s' "$PRIOR_COMPLETED_JSON" | jq 'length' 2>/dev/null) || PRIOR_ATTEMPTS=0
+  case "$PRIOR_ATTEMPTS" in ''|*[!0-9]*) PRIOR_ATTEMPTS=0 ;; esac
+fi
+if [ "$PRIOR_ATTEMPTS" -ge 1 ]; then IS_REWORK=true; else IS_REWORK=false; fi
+```
+
+`PRIOR_COMPLETED_JSON` is the shell-variable form of the conductor's in-context `PRIOR_COMPLETED` record set, matching the existing `$BRANCH_NAME` / `$GH_REPO` pattern used elsewhere in this command.
+
+(`jq -cs` slurps the whole file, so a single malformed line aborts the parse and the fallback resolves to `PRIOR_ATTEMPTS = 0` - the conservative direction, and the one that cannot block the ticket. A per-line parse that salvages the good lines and skips only the bad one is equally acceptable and strictly better; either way, detection must never error.)
+
+**The REWORK notice.** When `IS_REWORK` is true, emit this at the conductor's first user-facing turn after Phase 1, before any spawn:
+
+```
+REWORK: ticket <ID> has <N> prior AE attempt(s) that opened a PR - prior work on this ticket may need verification.
+  Last attempt: PR #<n> (<date>), risk <class>, <r> Skeptic round(s), QA <status>, <u> unit(s).
+Risk floored to Elevated; architect and Skeptic briefed on the prior attempt.
+Manual verification of PR #<n> is recommended.
+[phase: rework-detected]
+```
+
+- `<n>`, `<date>`, `<class>`, `<r>`, `<status>`, `<u>` come from the **most recent** record in `PRIOR_COMPLETED` (the highest `opened_ts`); `<date>` renders that record's `opened_ts` as a date.
+- **Null-render rule.** A null field renders `n/a` - never a bare `null`, never an empty slot. `<r>` renders `n/a` when `skeptic_rounds` is null (the prior attempt took the Trivial path and never entered the Skeptic loop). `<status>` is the one exception: it prefers the record's skip rationale (`skipped:<rationale>`) over `n/a`, because "QA never ran, and here is why" is exactly what an operator doing manual verification needs; only a genuinely absent `qa_status` with no rationale renders `n/a`. A Trivial-path prior record therefore reads `risk Trivial, n/a Skeptic round(s), QA skipped:Trivial path`.
+- When `PRIOR_ATTEMPTS > 1`, append `(+<N-1> earlier: PR #<a>, #<b>)` to the `Last attempt:` line, listing the older attempts by PR number only. Only the most recent attempt is described inline.
+
+This notice is **command-scoped**: it fires inside Phase 1, once per ticket, for this specific ticket. It is not one of the stacked session-start first-user-turn notices enumerated in `content/rules/conventions.md` and does not add to that count.
+
+The notice's third line asserts an escalation. That escalation is applied at the risk-classification declaration point, in the Phase 3 architect brief, and in the Phase 6 Skeptic brief - see "Ticket-rework escalation" in each. Full rationale, schema, and limitations: `content/references/ticket-rework.md`.
+
+---
+
 Proceed to Phase 2 regardless of which sub-section executed.
 
 ---
@@ -872,6 +929,18 @@ Focus on understanding enough to make a solid plan - don't over-read.
 **Investigator conditional:** If the task risk is **Low or above AND** the code area touched by this ticket is unfamiliar to the current session (files not yet read, subsystems not yet traced), spawn an `investigator` agent first. Pass its brief to the Architect in Phase 3. Skip this step if Phase 2 reads already covered the relevant area.
 
 Trivial-classified tickets skip the investigator (not required); the shippable change is still performed by a worktree-isolated `engineer` (no Skeptic, no brief) per METHODOLOGY.md §Risk Classification - the conductor does not edit the shippable tree directly.
+
+### Ticket-rework escalation: Elevated risk floor
+
+**Applies at the risk-classification declaration point** - the classification the conductor declares here is what Phase 2b, Phase 3, Phase 5, Phase 6, and Phase 9 all consume, so the floor must be applied before that declaration is made, not retrofitted downstream.
+
+When `IS_REWORK` is true (Phase 1 detection found one or more prior PR-opening attempts on this ticket), the risk classification for this ticket is **floored to Elevated**. It is never Trivial and never Low, regardless of how small the change looks and regardless of any profile-level Low override that would otherwise apply (`relaxed`-profile single-file behavioral edits, the bounded 2-3-file override, UI-only copy, and so on). A ticket that already came back once is, by construction, a ticket where the previous classification was not conservative enough.
+
+The floor raises the classification only. A ticket independently classified Elevated stays Elevated; the floor never lowers anything.
+
+Placing the floor here puts it upstream of the Phase 2b gate, which applies only when risk is Elevated - a floored ticket therefore correctly receives the pre-architect ambiguity scan it would have skipped as Trivial or Low.
+
+This is a **command-scoped** trigger. It does not add an entry to the global Elevated-signal list in `content/sections/04-risk-classification.md`, and nothing outside `/ds-implement-ticket` reads it. When `REWORK_DETECTION` is `false`, `IS_REWORK` is always false and the floor never fires.
 
 ---
 
@@ -986,6 +1055,39 @@ Factor these into the implementation plan. Ensure the plan explicitly addresses 
 ```
 
 Omit this entire section when `COMMENT_THREAD_SUMMARY` is empty (TRACKER=none, empty thread, or comment fetch failed).
+
+**Ticket-rework callout (inject only when `IS_REWORK` is true) — independent top-level block:**
+
+**This block is gated SOLELY on `IS_REWORK`. It is deliberately NOT part of the "Prior ticket context" section above and is NOT subject to that section's omit rule.** The two signals are unrelated: "Prior ticket context" is omitted when `COMMENT_THREAD_SUMMARY` is empty, which is exactly the `TRACKER=none` case - and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists, because there is no comment thread to carry one. Nesting this callout inside that section would drop it in the single case it matters most. Inject it whenever `IS_REWORK` is true, whether or not "Prior ticket context" was injected, and in either order.
+
+Append the following block to the architect spawn brief when `IS_REWORK` is true:
+
+```
+## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK
+
+AE has already carried this ticket to an opened PR [PRIOR_ATTEMPTS] time(s). The most recent attempt:
+
+- PR: #[pr_number] ([opened_ts])
+- Risk class: [risk_class]
+- Skeptic rounds: [skeptic_rounds, or "n/a" when null]
+- QA: [qa_status, or its "skipped:<rationale>" value, or "n/a"]
+- Units: [unit_count]
+[when PRIOR_ATTEMPTS > 1: - Earlier attempts: PR #<a>, #<b>]
+
+Something about the prior attempt was insufficient, OR this ticket was always going to need
+another wave - AE cannot tell which, and does not guess. Treat it as the former.
+
+Your plan MUST:
+1. Identify what the prior attempt missed, got wrong, or left incomplete. Read the prior PR's
+   diff before planning. State your conclusion explicitly, even if it is "the prior attempt
+   looks complete and this appears to be planned continuation" - that is a finding, not a
+   non-answer, and the Skeptic will grade it.
+2. Include at least one `qa_criteria` scenario that exercises the specific regression or gap
+   you identified. A rework plan whose QA criteria do not cover the failure mode that brought
+   the ticket back has not addressed the rework.
+```
+
+Apply the null-render rule when filling this block: a null `skeptic_rounds` renders `n/a`; a null `qa_status` renders its `skipped:<rationale>` value when one exists, otherwise `n/a`. Never emit a bare `null` into a spawn brief.
 
 **Architect plan Skeptic review (mandatory):** After the Architect returns its plan, spawn a Skeptic with the "Document synthesis, architecture, and planning" adversarial brief. Do not proceed to Phase 3b or Phase 4 until the Skeptic grants sign-off. If the Skeptic-approved plan contains a non-empty "Open questions" section, resolve every genuine Open Question before proceeding - see `METHODOLOGY.md` for resolution paths. A plan with only a "Deferred defaults" section (empty or non-empty) and an empty "Open questions" section does not block. For the full adversarial brief menu, see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
@@ -1283,10 +1385,17 @@ Spawn a `skeptic` agent with:
 - The full diff: `git -C $REPO diff origin/$BASE_BRANCH..HEAD`
 - The ticket description as the success criteria
 - The QA section from the ticket as acceptance tests
+- **When `IS_REWORK` is true:** the same `## PRIOR ATTEMPT(S) OPENED A PR - THIS IS REWORK` block injected into the Phase 3 architect brief, verbatim (same fields, same null-render rule), followed by: `Verify that the failure mode which brought this ticket back is actually addressed. Reviewing only whether the new diff is internally sound is insufficient - a diff can be clean on its own terms and still repeat or fail to fix what the prior attempt got wrong. Read the prior PR's diff. Withholding sign-off because the new diff does not demonstrably close the prior gap is a correct outcome.` Gated solely on `IS_REWORK` - this bullet is independent of `COMMENT_THREAD_SUMMARY` and fires at `TRACKER=none`.
 
 For the full adversarial brief menu (security, logic, performance, data integrity, etc.), see `~/DinoStack/.claude/skills/agentic-engineering/references/skeptic-protocol.md`.
 
 **Tier:** Declare a tier if this spawn warrants non-default model selection (see Tier declaration in METHODOLOGY.md). Default is Tier 2 (omit the model param).
+
+**Ticket-rework tier escalation.** When `PRIOR_ATTEMPTS >= 2` — two or more prior attempts, not one — declare `Tier: 3` for this Skeptic spawn and pass an explicit `model: opus` on the Agent tool call. At `PRIOR_ATTEMPTS == 1` the tier is unchanged (Tier 2, role default, omit the model param): one prior attempt gets the callout and the Elevated floor, not an Opus Skeptic. A ticket that has come back twice has had a review-depth problem, not just an implementation problem.
+
+This trigger is **command-scoped and advisory-only — there is no mechanical backstop.** `hooks/enforce-tier.py` backstops Tier-3 by matching the five *global* escalation signals against the spawn brief's text; `PRIOR_ATTEMPTS >= 2` is conductor-computed state that appears in no marker pattern the hook recognises, so the hook will neither detect this trigger nor deny a sub-Opus spawn under it. The conductor's explicit `model: opus` is the only enforcement. Omitting it silently downgrades the review with no error anywhere. This also does not add to the Mandatory Tier-3 escalation category count in `content/references/risk-config-and-tiers.md`.
+
+Known cost: a genuinely multi-wave ticket (big, always needed three passes, never actually regressed) draws an Opus Skeptic from its third wave onward, because `PRIOR_ATTEMPTS` cannot distinguish that from a ticket that came back twice. This is accepted; if it proves expensive the fix is raising this threshold, not adding a discriminator. See `content/references/ticket-rework.md` §Known limitations.
 
 **Findings handling - loop contract:**
 
@@ -2129,6 +2238,75 @@ fi
 For `TRACKER=none`, omit the tracker reference block line and drop the `[TICKET_PREFIX]-NNN:` prefix from `--title`.
 
 Capture the PR number from the URL printed by `gh pr create`.
+
+### Ticket-rework ledger write
+
+**Anchoring (binding).** This write sits HERE - after the Case A / Case B `if`/`else` above has closed, at the PR-number capture point - precisely because it must fire downstream of BOTH `gh pr create` calls. Case B is not a fallback: it is the branch every Trivial ticket takes, since a Trivial ticket never produces QA evidence. Anchoring this write inside Case A would silently drop every Trivial ticket's record. Do not move it into either branch. See `content/references/ticket-rework.md` §The dual-branch anchoring pattern.
+
+**Skip conditions.** Skip the write entirely (no file created, no line appended) when either holds:
+- `REWORK_DETECTION` is `false`.
+- `TICKET_ID` is null or empty (pure-freeform work has nothing to key a ledger record on).
+
+**`pr_number` is derived at the write site, never read from `$PR_NUMBER`.** `$PR_NUMBER` is an in-context variable that is not reset between tickets in a batch; a failed `gh pr create` on ticket 2 would leave ticket 1's number in it and record the wrong PR against ticket 2. Derive it live from the currently-resolved `$BRANCH_NAME` using the same `gh pr view` lookup pattern Phase 11c uses. If the derivation yields nothing, skip the write - a record with no PR number is not a record. `$BRANCH_NAME` is a lookup key only; it is recorded in the `branch` field for forensics and is never an identity key (see `content/references/ticket-rework.md` §`pr_number` as the sole identity key).
+
+**One line, one `write()`.** The record is appended as a single `O_APPEND` write of one complete line. Never compose the line from multiple appends - the offset-atomicity guarantee that makes a lockless append safe is per-`write()`-call, not per-logical-record. There is no write-time lock and no read-before-write; all deduplication happens on read, keyed on `pr_number`.
+
+**Soft-fail throughout.** Any failure in this block (missing `jq`, unwritable `.agentic/`, failed `gh` lookup) is swallowed. It must never block Phase 9 or anything downstream.
+
+Field derivation:
+- `risk_class` - the conductor's in-context risk classification (`Trivial` | `Low` | `Elevated`), the same value declared at Phase 2/3.
+- `skeptic_rounds` - `.agentic/loop-state.json` `loop_state.iteration`. **Null on the Trivial path**, which never enters the Skeptic loop and therefore never writes that field.
+- `qa_status` - the QA result (`PASS`/`FAIL`/`PARTIAL`/`BLOCKED`/`INCONCLUSIVE`) when QA ran, else `"skipped:<rationale>"` where `<rationale>` is the `qa_criteria.qa_skip` enum value or the literal `Trivial path` (the same rationale Phase 6b already records on its skip branch). **Null on two paths**: Trivial, and Elevated with a non-null `qa_skip`.
+- `unit_count` - **derived, not read**; there is no `unit_count` variable in this command. Count of `.agentic/tasks.jsonl` records whose `ticket_id` matches this ticket (the Phase 5 fan-out path). `1` on a single-engineer path, and `1` when `tasks.jsonl` is absent or unreadable.
+
+```bash
+# Phase 9: ticket-rework ledger write (soft-fail; never blocks Phase 9 or anything downstream).
+# Anchored AFTER the Case A / Case B if/else above - fires for both branches, Trivial included.
+# REWORK_DETECTION / TICKET_ID / RISK_CLASS / QA_STATUS are the shell-variable form of the
+# conductor's in-context state, matching the existing $BRANCH_NAME / $GH_REPO pattern.
+# QA_STATUS holds the QA result when QA ran, "skipped:<qa_skip enum>" or "skipped:Trivial path"
+# when it did not, and is empty when it is legitimately null (Trivial, or Elevated with qa_skip).
+if [ "$REWORK_DETECTION" != "false" ] && [ -n "$TICKET_ID" ]; then
+  # pr_number derived live from the ticket currently in flight's own branch - never $PR_NUMBER.
+  TRL_PR_NUMBER=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json number -q .number 2>/dev/null || true)
+
+  if [ -n "$TRL_PR_NUMBER" ]; then
+    # skeptic_rounds: null on the Trivial path (loop-state.json has no iteration to read).
+    TRL_ROUNDS=""
+    if [ -f .agentic/loop-state.json ]; then
+      TRL_ROUNDS=$(jq -r '.loop_state.iteration // empty' .agentic/loop-state.json 2>/dev/null) || TRL_ROUNDS=""
+    fi
+    case "$TRL_ROUNDS" in ''|*[!0-9]*) TRL_ROUNDS="" ;; esac
+
+    # unit_count: derived from tasks.jsonl; 1 when absent, unreadable, or no matching records.
+    TRL_UNITS=$(jq -r --arg t "$TICKET_ID" 'select(.ticket_id == $t) | .task_id' \
+      .agentic/tasks.jsonl 2>/dev/null | grep -c . || true)
+    case "$TRL_UNITS" in ''|0|*[!0-9]*) TRL_UNITS=1 ;; esac
+
+    # Build the whole record first, then append it with ONE write. Do not split this append.
+    TRL_LINE=$(jq -cn \
+      --arg tid "$TICKET_ID" \
+      --argjson pr "$TRL_PR_NUMBER" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg br "$BRANCH_NAME" \
+      --arg rc "$RISK_CLASS" \
+      --arg sr "${TRL_ROUNDS:-}" \
+      --arg qs "${QA_STATUS:-}" \
+      --argjson uc "$TRL_UNITS" \
+      '{ticket_id:$tid, pr_number:$pr, opened_ts:$ts, branch:$br, risk_class:$rc,
+        skeptic_rounds:(if $sr == "" then null else ($sr|tonumber) end),
+        qa_status:(if $qs == "" then null else $qs end),
+        unit_count:$uc}' 2>/dev/null || true)
+
+    if [ -n "$TRL_LINE" ]; then
+      mkdir -p .agentic 2>/dev/null || true
+      printf '%s\n' "$TRL_LINE" >> .agentic/ticket-ledger.jsonl 2>/dev/null || true
+    fi
+  fi
+fi
+```
+
+`.agentic/ticket-ledger.jsonl` is append-only and gitignored under the existing `.agentic/` umbrella (machine-local; no `.gitignore` change needed). It is never truncated or rewritten by this command, and Phase 12 cleanup does not remove it - the history is the point.
 
 **QA Evidence section (append to PR body after `gh pr create` - Case B only).**
 


### PR DESCRIPTION
Wires the ticket-rework alert into `/ds-implement-ticket`. U2 of the 5-unit ticket-rework Plan, depends on U1 (#483, merged).

This is a **merged unit** (the plan's former U2 + U3): the notice and the escalation it asserts ship together. A notice claiming "Risk floored to Elevated; architect and Skeptic briefed" while the floor has not shipped would be a false statement on `main`.

## What changed

Five insertion points, all in `content/commands/ds-implement-ticket.md`.

| # | Where | What |
|---|---|---|
| 1 | Setup variable list | `REWORK_DETECTION` from `.agentic/config.json` `rework_detection` (boolean, default `true`, absent key = `true`). `false` takes the whole feature dark. |
| 2 | Phase 9, after the PR-number capture | Ledger write appending one line to `.agentic/ticket-ledger.jsonl`. |
| 3 | Phase 1, after the tracker sub-section dispatch | Per-entry detection: `PRIOR_COMPLETED[]`, `PRIOR_ATTEMPTS`, `IS_REWORK`. |
| 4 | Phase 1, same section | The operator REWORK notice, with the null-render rule. |
| 5 | Phase 2 / Phase 3 / Phase 6 | The escalation: Elevated floor, architect callout, Skeptic bullet, Tier-3 at 2+. |

Three placement decisions carry most of the correctness weight, and each is documented inline as **binding** so a future editor does not "tidy" it back:

**The Phase 9 write is anchored after the Case A / Case B `if`/`else` closes**, at the line reading *Capture the PR number from the URL printed by `gh pr create`* - downstream of both `gh pr create` calls. Case B is not a fallback; it is the branch every Trivial ticket takes, because a Trivial ticket never produces QA evidence. Anchoring inside Case A would have silently dropped every Trivial record.

**`pr_number` is derived live at the write site** via `gh pr view "$BRANCH_NAME" --json number -q .number`, never read from the in-context `$PR_NUMBER`. `$PR_NUMBER` is not reset between batch tickets, so a failed `gh pr create` on ticket 2 would have recorded ticket 1's PR against ticket 2.

**The architect callout is an independent top-level block gated solely on `IS_REWORK`**, deliberately not nested in the "Prior ticket context" section. That section's omit rule fires when `COMMENT_THREAD_SUMMARY` is empty - which is exactly `TRACKER=none`, and `TRACKER=none` is precisely where the ledger is the only prior-attempt signal that exists.

Also: the record is appended as **one line via one `write()`** (the `O_APPEND` offset-atomicity guarantee is per-`write()`-call, not per-logical-record - splitting the line loses it); there is no write lock because dedupe is read-side on `pr_number`; detection makes **zero tracker and zero network calls**; and `loop-state.json` gains no field and no new creation point.

## Verification

`bin/tests/test_ticket_rework_ledger.sh` - **63 assertions, committed and CI-wired.** It extracts all three bash blocks from the shipped spec by marker comment and executes them rather than copying them, so it fails if the spec's bash drifts from what the spec's prose promises. A renamed marker fails loudly instead of silently testing nothing. `gh` is stubbed on PATH; no network calls, no repo writes. Auto-wired by the `bin/tests/test_*.sh` glob in `bin-tests.yml` - no `orphans` entry needed.

The suite also self-checks its own manifest: it asserts the number of `^[A-Z]+_MARKER=` assignments matches the count its header documents. Round 3 found that header stale - it still said "two blocks" after round 2 added a third - which matters because the same header warns that the marker comments are part of the contract. A maintainer reading "two" could delete the third believing it uncovered. That class of staleness is now mechanically caught rather than left to review.

Coverage is per-path, one fixture group per defect found in review:

```
Elevated happy path                                    6 PASS
R1 Major 1  qa_status rationale on BOTH non-QA paths  11 PASS  (3 runtime + 8 prose)
R1 Major 2  Skeptic count, not QA count                5 PASS  (3 runtime + 2 prose)
R1 Major 3  batch: no foreign round-count (disk)       1 PASS
R1 Major 4  one torn line must not kill the ledger     3 PASS  (1 runtime + 2 prose)
R1 Minor 2  duplicate pr_number resolves latest-wins   1 PASS
R2 Major A  Trivial-REACHABLE definition site          3 PASS  (prose: mechanism, not promise)
R2 Major B  batch carry-over, one shell scope         14 PASS  (9 runtime + 5 prose)
Phase 9 skip conditions                                3 PASS
Phase 1 detection: scoping, inert cases, absent file   5 PASS
extraction + parse guards + manifest self-check       11 PASS
Results: 63 passed, 0 failed
```

The round-2 fixtures close the gap that let Major A through a green 41/0. `_write()` built a fresh env per call, so no fixture could model the real conductor shape - one variable scope spanning a whole batch. The new batch group runs two tickets inside a single `bash -c` with no env reset, sourcing the spec's own reset block between them. It includes an isolation case where ticket 2 sets nothing beyond its identity, so any non-empty field can only have come from ticket 1 - that is the assertion that fails without the reset regardless of whether a later definition site fires.

**Pre-fix attestation, round 1** (suite vs. the spec at `8831b14a`) - **13 failures** across every round-1 Major and Minor 2:

```
FAIL: 3 skeptic rounds not 1 QA iteration: got '1' want '3'
FAIL: phase:qa disk read rejected: got 'number' want 'null'
FAIL: foreign ticket rounds not inherited: got 'number' want 'null'
FAIL: good lines survive a torn line: got '0|false|-' want '3|true|480'
FAIL: duplicate collapses, later record wins: got '1|1' want '1|3'
  (+8 prose invariants)
Results: 28 passed, 13 failed
```

**Pre-fix attestation, round 2** (suite vs. the spec at `99e10327`) - **15 failures**, now including runtime failures for both round-2 Majors:

```
FAIL: batch t2 does NOT inherit rounds: got 'number' want 'null'
FAIL: disk fallback ran and its ticket_id guard rejected the foreign record: got 'number' want 'null'
FAIL: reset alone neutralises qa_status carry-over: got 'string' want 'null'
FAIL: reset alone neutralises rounds carry-over: got 'number' want 'null'
FAIL: reset alone neutralises risk_class carry-over: got 'Elevated' want ''
FAIL: a Trivial-REACHABLE QA_STATUS definition site exists (Phase 2 declaration)
  (+9 more prose invariants)
Results: 47 passed, 15 failed
```

Round 2's attestation runs against `99e10327` with an **empty reset stub injected** - marker present, no assignments. Run without it, extraction aborts the suite immediately, which is itself the cleanest proof that no reset mechanism existed. The stub isolates "these fixtures test the mechanism" from "these fixtures test the marker's presence."

Round-1 Major 1 and round-2 Major A are covered by **prose** invariants as well as runtime ones, and for Major 1 the prose assertions are the only ones that could fail pre-fix: the bash always passed `QA_STATUS` through unchanged, so that defect was never observable at runtime - the contradiction lived in the instruction to the conductor, which is the interpreter here. Round 2 flagged that this pinned the promise and not the mechanism, which is exactly how Major A survived; the added assertions now require a Trivial-*reachable* definition site to exist, not merely a sentence claiming one does. Precedent for pinning prose invariants against this same file: `bin/tests/test_tracker_writeback_ranking_spec.py`.

Two robustness bugs were caught by the pre-review harness and fixed before the first commit: `$(jq ... || echo '[]')` can concatenate its fallback onto partial jq output on an unreadable file (moved to `X=$(...) || X=default`), and the `unit_count` guard's `[ -z ] || [ -lt ]` chain had fragile precedence (now a numeric `case`). Both carry inline comments explaining why.

Adapters rebuilt via `scripts/build-all.sh`; `git status --short` clean across all 11 dirs. `.kimi` and `.omp` symlink `content/`, `.pi` carries a pointer stub, and `.copilot`'s output is `.github/prompts/` - none require a separate diff. `scripts/.methodology-baseline.sha256` untouched: 0 files under `content/sections/`.

## Doc-sync

Predicate triggered (new behavior in a command), but every count and list site it touches is owned by a later unit of the same Plan: the `rework_detection` toggle-catalog entry and the seven `sixteen`->`seventeen` count sites are U3's scope; the drifted slide counts and `docs/index.html` prose are U5's. This unit asserts no count or list of its own, and `content/references/ticket-rework.md` (U1) already documents every mechanism added here.

## North Star alignment

- **Works for everyone (universality).** Detection is a single local file read with zero tracker and zero network calls, so it behaves identically for an operator on Jira, on Linear, or with no tracker at all. `TRACKER=none` is explicitly the case the design optimizes for - it is where the ledger is the only prior-attempt signal available, and the architect callout is structured as an independent top-level block specifically so it is not dropped there. Nothing resolves against one operator's workspace, credentials, or harness. The ledger is machine-local and gitignored; a teammate's absent ledger degrades to "no notice," never to an error.
- **Enforcement floors are never lowered by capability.** The Elevated risk floor raises classification only and overrides profile-level Low overrides; it can never downgrade a ticket. The Tier-3 bump at 2+ attempts is honest about having **no mechanical backstop** - `hooks/enforce-tier.py` matches the five global signals and cannot see command-scoped conductor state, so the PR text states plainly that the explicit `model: opus` is the only enforcement and that omitting it downgrades review silently.
- **Fails safe, never blocks - and fails safe per line.** Every path soft-fails: an absent or unreadable ledger resolves to `PRIOR_ATTEMPTS = 0`; a failed `gh` lookup skips the write; a missing `jq` swallows. Review sharpened this: the read is now per-line (`fromjson? // empty`) rather than slurped, so one torn append from a concurrent lockless writer costs one record instead of disabling detection for every ticket in the file. A feature that exists to help with a ticket must never be the reason that ticket stalls, and it must not die silently on one bad byte. One toggle (`rework_detection: false`) takes the whole thing dark.
- **Honest telemetry beats flattering telemetry.** Most of the review findings reduce to this. A ledger that told an operator a Trivial attempt received three rounds of adversarial review when it received none, or reported `QA PASS` on a ticket that ran no QA, or rendered a deliberate `qa_skip` and an operator-accepted INCONCLUSIVE as an indistinguishable `n/a`, would be worse than showing nothing - it would launder absent review as completed review at exactly the moment the operator is deciding what to verify by hand. Every one of those was a live failure mode in some version of this branch; each now has a fixture that fails without its fix.
- **No always-loaded cost.** Nothing lands in `content/sections/`, so the methodology body assembled by `build-methodology.sh` is byte-identical and the baseline hash is untouched. The cost is paid only by sessions that actually invoke `/ds-implement-ticket`.

## Review rigor

- **Plan / Brief:** `docs/planning/ticket-rework/architect-plan.md` (Skeptic-approved, 3 rounds), `docs/planning/ticket-rework/brief.md`. Unit record: `u2-detection-notice-escalation` in `orchestration.jsonl`.
- **Risk / Tier:** Elevated, Tier 3. Load-bearing unit of the Plan - novel mechanism in the most-invoked command in the methodology, high blast radius.
- **Skeptic strategy:** per-unit. Two rounds complete, sign-off pending.
  - **Round 1: 0 Critical, 5 Major, 4 Minor.** Fix pass 1 in `99e10327`. Majors 1-5, Minors 1/2/4; Minor 3 no action (U3's scope).
  - **Round 2: 0 Critical, 2 Major, 4 Minor.** Fix pass 2 in `e14f3d8a`. Majors A/B, Minors A/B/C; Minor D closed by U3's merge at `ef57f0d6`. Both Majors were new defects in round 1's new text - no re-raise, no convergence failure.
  - **Round 3: 0 Critical, 1 Major, 1 Minor.** Fix pass 3 in `0d8f62e9`. Both functional Majors from round 2 verified resolved by the reviewer re-running both halves of the attestation. Remaining Major was documentation staleness in the test's own manifest; Minor was `risk_class` missing the empty-to-null normalization its two siblings have. Neither was a live defect in the shipped mechanism.
- **The pattern both rounds found, and what finally addressed it:** seven of the nine Majors are one class - *a value that reads plausibly and is wrong, where nothing throws.* `skeptic_rounds` returned the QA loop's iteration. The same read inherited another ticket's count from disk. `qa_status` was specified to write null on precisely the two paths whose rationale is the field's reason for existing. Then round 1's own fix reintroduced the class twice: a contract implemented on only one of its two branches because the other branch was unreachable, and three variables exposed to the batch carry-over hazard *my own diff had named for a fourth*. None of these throw; all of them ship a durable ledger that misinforms the operator notice and both spawn briefs. Round 2's instruction to sweep the class rather than the instances is what produced the per-ticket reset block and the recorded sweep of all eight external reads - the point being that the next variable added to this write is covered by construction rather than by someone remembering.
- **What the round-2 findings say about the round-1 test:** a green 41/0 did not prevent Major A, because the Major-1 fixture asserted pass-through of an injected value rather than that the value could be derived on the path in question. A test that pins a promise instead of a mechanism reports success at exactly the moment it is least warranted. The round-2 fixtures execute the spec's own reset block inside a single shell scope across two tickets, which is the shape the conductor actually has.
- **Anchoring discipline:** every line number in the architect plan was stale (PR #481 and U1 both shifted the file). All five insertion points were located by content grep, not offset, and each of the three load-bearing anchors is documented inline as binding with the failure mode it prevents.
- **Deviation from the plan text, approved in the brief:** the notice's first line ends `- prior work on this ticket may need verification.` per `content/references/ticket-rework.md`, not the plan's `- this ticket is being re-worked.` The reference doc wins where the two disagree.



