### PR TITLE
feat(protocol): surface rework tickets in ds-ticket-triage (U4)

### DIFF
--- a/.claude/commands/ds-ticket-triage.md
+++ b/.claude/commands/ds-ticket-triage.md
@@ -64,7 +64,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -107,7 +109,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -148,7 +150,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -225,19 +227,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -247,7 +251,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -267,11 +275,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -280,10 +294,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -291,6 +307,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -330,9 +348,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -353,6 +377,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -363,7 +392,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -405,7 +434,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -414,7 +443,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.claude/commands/ds-ticket-triage.md
+++ b/.claude/commands/ds-ticket-triage.md
@@ -20,12 +20,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -51,7 +55,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -87,6 +94,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -111,6 +120,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -203,7 +227,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -243,19 +271,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -313,6 +348,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -323,7 +363,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -374,9 +414,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.codex/commands/ds-ticket-triage.md
+++ b/.codex/commands/ds-ticket-triage.md
@@ -62,7 +62,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -105,7 +107,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -146,7 +148,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -223,19 +225,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -245,7 +249,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -265,11 +273,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -278,10 +292,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -289,6 +305,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -328,9 +346,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -351,6 +375,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -361,7 +390,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -403,7 +432,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -412,7 +441,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.codex/commands/ds-ticket-triage.md
+++ b/.codex/commands/ds-ticket-triage.md
@@ -18,12 +18,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -49,7 +53,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -85,6 +92,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -109,6 +118,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -201,7 +225,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -241,19 +269,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -311,6 +346,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -321,7 +361,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -372,9 +412,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.cursor/commands/ds-ticket-triage.md
+++ b/.cursor/commands/ds-ticket-triage.md
@@ -62,7 +62,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -105,7 +107,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -146,7 +148,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -223,19 +225,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -245,7 +249,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -265,11 +273,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -278,10 +292,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -289,6 +305,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -328,9 +346,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -351,6 +375,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -361,7 +390,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -403,7 +432,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -412,7 +441,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.cursor/commands/ds-ticket-triage.md
+++ b/.cursor/commands/ds-ticket-triage.md
@@ -18,12 +18,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -49,7 +53,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -85,6 +92,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -109,6 +118,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -201,7 +225,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -241,19 +269,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -311,6 +346,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -321,7 +361,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -372,9 +412,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.gemini/commands/ds-ticket-triage.toml
+++ b/.gemini/commands/ds-ticket-triage.toml
@@ -24,12 +24,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -55,7 +59,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -91,6 +98,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -115,6 +124,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -207,7 +231,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -247,19 +275,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -317,6 +352,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -327,7 +367,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -378,10 +418,12 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.
 """

--- a/.gemini/commands/ds-ticket-triage.toml
+++ b/.gemini/commands/ds-ticket-triage.toml
@@ -68,7 +68,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -111,7 +113,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -152,7 +154,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -229,19 +231,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -251,7 +255,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -271,11 +279,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -284,10 +298,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -295,6 +311,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -334,9 +352,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -357,6 +381,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -367,7 +396,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -409,7 +438,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -418,7 +447,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.github/prompts/ds-ticket-triage.prompt.md
+++ b/.github/prompts/ds-ticket-triage.prompt.md
@@ -65,7 +65,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -108,7 +110,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -149,7 +151,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -226,19 +228,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -248,7 +252,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -268,11 +276,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -281,10 +295,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -292,6 +308,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -331,9 +349,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -354,6 +378,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -364,7 +393,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -406,7 +435,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -415,7 +444,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.github/prompts/ds-ticket-triage.prompt.md
+++ b/.github/prompts/ds-ticket-triage.prompt.md
@@ -21,12 +21,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -52,7 +56,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -88,6 +95,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -112,6 +121,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -204,7 +228,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -244,19 +272,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -314,6 +349,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -324,7 +364,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -375,9 +415,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -18052,12 +18052,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -18083,7 +18087,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -18119,6 +18126,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -18143,6 +18152,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -18235,7 +18259,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -18275,19 +18303,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -18345,6 +18380,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -18355,7 +18395,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -18406,10 +18446,12 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -18096,7 +18096,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -18139,7 +18141,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -18180,7 +18182,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -18257,19 +18259,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -18279,7 +18283,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -18299,11 +18307,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -18312,10 +18326,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -18323,6 +18339,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -18362,9 +18380,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -18385,6 +18409,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -18395,7 +18424,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -18437,7 +18466,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -18446,7 +18475,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.openclaw/skills/ds-ticket-triage/SKILL.md
+++ b/.openclaw/skills/ds-ticket-triage/SKILL.md
@@ -23,12 +23,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -54,7 +58,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -90,6 +97,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -114,6 +123,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -206,7 +230,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -246,19 +274,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -316,6 +351,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -326,7 +366,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -377,9 +417,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.openclaw/skills/ds-ticket-triage/SKILL.md
+++ b/.openclaw/skills/ds-ticket-triage/SKILL.md
@@ -67,7 +67,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -110,7 +112,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -151,7 +153,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -228,19 +230,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -250,7 +254,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -270,11 +278,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -283,10 +297,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -294,6 +310,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -333,9 +351,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -356,6 +380,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -366,7 +395,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -408,7 +437,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -417,7 +446,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/.opencode/commands/ds-ticket-triage.md
+++ b/.opencode/commands/ds-ticket-triage.md
@@ -22,12 +22,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -53,7 +57,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -89,6 +96,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -113,6 +122,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -205,7 +229,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -245,19 +273,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -315,6 +350,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -325,7 +365,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -376,9 +416,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.

--- a/.opencode/commands/ds-ticket-triage.md
+++ b/.opencode/commands/ds-ticket-triage.md
@@ -66,7 +66,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -109,7 +111,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -150,7 +152,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -227,19 +229,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -249,7 +253,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -269,11 +277,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -282,10 +296,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -293,6 +309,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -332,9 +350,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -355,6 +379,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -365,7 +394,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -407,7 +436,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -416,7 +445,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/bin/tests/test_ticket_rework_triage_badge.sh
+++ b/bin/tests/test_ticket_rework_triage_badge.sh
@@ -103,8 +103,8 @@ _present "badge placement is the Ticket cell of the per-ticket summary table" \
 
 echo ""
 echo "--- The never-parallel lane rule ---"
-_present "rework isolation rule exists" \
-         'Rework isolation \(after in-progress removal, before Rule 2\)'
+_present "rework isolation rule exists, anchored after Rule 2 (Critical fix)" \
+         'Rework isolation \(after Rule 2, before Rule 3\)'
 _present "rework tickets are never designated parallel" \
          'never\*\* .parallel.'
 _present "rework tickets get their own single-ticket chain" \
@@ -113,13 +113,35 @@ _present "rework tickets are not deferred and not excluded from kickoff" \
          'neither deferred nor excluded from kickoff'
 _present "Notes cell annotation names the prior PR" \
          'Elevated floor, may draw Tier-3 Skeptic; verify PR'
-_absent  "rework tickets are not silently folded into Rule 3 parallel grouping" \
-         'rework .{0,40}parallel grouping'
+_present "Rule 2 explicitly consumes DAG-connected rework tickets (Critical fix)" \
+         'including any member separately flagged .entry\.IS_REWORK: true'
+_present "Rule 2 explains why isolation would sever the in-set edge" \
+         'silently severing that edge'
+_present "Rule 3 excludes rework tickets from its own remainder" \
+         'zero internal DAG edges AND .entry\.IS_REWORK: false'
+_present "Notes-cell rule documents the blocked-by + rework combined format" \
+         'blocked by A; rework x2 - Elevated floor'
+_present "Rule 4 message distinguishes rework-induced lanes from dependency chains (Minor 1)" \
+         'dependency chain\(s\) plus'
+_present "Rule 4 message names num_rework_lanes distinctly from num_dep_chains" \
+         'num_rework_lanes.*rework-isolated ticket'
+
+echo ""
+echo "--- In-progress + rework interaction (Minor 2) ---"
+_present "in-progress rework ticket gets a combined badge" \
+         '\[IN PROGRESS\] \[REWORK xN\]'
+_present "spec states this is the only place that signal appears" \
+         'ONLY place an in-progress rework ticket'
+
+echo ""
+echo "--- No-args fallthrough no longer reads as bypassing the new section (Minor 3) ---"
+_present "no-args >=2 branch names Ticket-rework detection before Phase 1+" \
+         'proceed into Ticket-rework detection and Phase 1\+'
 
 echo ""
 echo "--- Phase 4b checklist gains a 6th point ---"
-_present "Phase 4b Skeptic brief checks rework isolation as item (6)" \
-         '\(6\) Rework isolation'
+_present "Phase 4b Skeptic brief checks rework annotation as item (6)" \
+         '\(6\) Rework annotation'
 
 echo ""
 echo "--- Module manifest Upstream deps ---"
@@ -131,6 +153,42 @@ if printf '%s' "$HEADER_FLAT" | grep -qE 'Upstream deps:.*\.agentic/ticket-ledge
   _pass "manifest Upstream deps names the ledger file"
 else
   _fail "manifest Upstream deps names the ledger file - header no longer contains .agentic/ticket-ledger.jsonl in the Upstream deps field"
+fi
+
+echo ""
+echo "--- Module manifest Performance field (Minor 5) ---"
+if printf '%s' "$HEADER_FLAT" | grep -qE 'Performance:.*ticket-ledger\.jsonl'; then
+  _pass "manifest Performance field names the per-entry ledger read cost"
+else
+  _fail "manifest Performance field does not mention the per-entry ticket-ledger.jsonl read cost"
+fi
+
+echo ""
+echo "--- Positional check (Minor 4): heading must sit after BOTH breadcrumbs, before Phase 1 ---"
+# All 19 assertions above are string presence/absence - none of them pin the
+# *position* of the '## Ticket-rework detection' heading. Someone could move
+# the heading back inside the explicit-input branch (leaving all the prose
+# above intact) and every string check would still pass. This is the exact
+# defect class flagged during review: a move that string-matching cannot see.
+LINE_RESOLVE="$(grep -n 'phase=resolve-assigned' "$SPEC" | head -1 | cut -d: -f1)"
+LINE_NORMALIZE="$(grep -n 'phase=normalize' "$SPEC" | head -1 | cut -d: -f1)"
+LINE_HEADING="$(grep -n '^## Ticket-rework detection' "$SPEC" | head -1 | cut -d: -f1)"
+LINE_PHASE1="$(grep -n '^## Phase 1: Metadata fetch' "$SPEC" | head -1 | cut -d: -f1)"
+
+if [[ -z "$LINE_RESOLVE" || -z "$LINE_NORMALIZE" || -z "$LINE_HEADING" || -z "$LINE_PHASE1" ]]; then
+  _fail "positional check: one or more anchor lines missing (resolve=$LINE_RESOLVE normalize=$LINE_NORMALIZE heading=$LINE_HEADING phase1=$LINE_PHASE1)"
+else
+  if (( LINE_HEADING > LINE_RESOLVE && LINE_HEADING > LINE_NORMALIZE )); then
+    _pass "Ticket-rework detection heading (line $LINE_HEADING) sits AFTER both Phase 0 breadcrumbs (resolve=$LINE_RESOLVE, normalize=$LINE_NORMALIZE)"
+  else
+    _fail "Ticket-rework detection heading (line $LINE_HEADING) does NOT sit after both breadcrumbs (resolve=$LINE_RESOLVE, normalize=$LINE_NORMALIZE) - it may have been moved back inside a Phase 0 branch"
+  fi
+
+  if (( LINE_HEADING < LINE_PHASE1 )); then
+    _pass "Ticket-rework detection heading (line $LINE_HEADING) sits BEFORE Phase 1 (line $LINE_PHASE1)"
+  else
+    _fail "Ticket-rework detection heading (line $LINE_HEADING) does NOT sit before Phase 1 (line $LINE_PHASE1)"
+  fi
 fi
 
 echo ""

--- a/bin/tests/test_ticket_rework_triage_badge.sh
+++ b/bin/tests/test_ticket_rework_triage_badge.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Purpose: Prose-invariant regression guard for the ticket-rework badge/lane
+#          rule in content/commands/ds-ticket-triage.md. Unlike
+#          bin/tests/test_ticket_rework_ledger.sh (which extracts and RUNS
+#          executable bash blocks), this file's spec carries no executable
+#          block of its own for the ledger read - Phase 0 and the
+#          ticket-rework detection step both reuse ds-implement-ticket.md's
+#          logic "by reference", explicitly not forking or copying it. There
+#          is therefore nothing here to extract and execute; what CAN drift
+#          silently is the PROSE that anchors the read downstream of both
+#          Phase 0 branches and outside the Phase 1 tracker gate - exactly the
+#          failure mode flagged as most likely during this unit's review
+#          (anchoring to only the "normalize" breadcrumb would silently drop
+#          the badge for every no-args invocation, the default form for a
+#          tracker-connected operator). This suite pins that prose, plus the
+#          never-parallel lane rule and the manifest upstream-dep addition,
+#          the same way test_ticket_rework_ledger.sh's own "Prose invariants"
+#          section pins non-executable contract language in its sibling spec.
+#
+# Public API: ./bin/tests/test_ticket_rework_triage_badge.sh
+#             Exits 0 on all pass, 1 on any failure.
+#             Auto-wired into CI by the bin/tests/test_*.sh glob in
+#             .github/workflows/bin-tests.yml - no orphans entry needed.
+#
+# Upstream deps: bash, grep. Reads content/commands/ds-ticket-triage.md from
+#                the checkout. No jq, no python3, no network - pure text
+#                assertions, since there is no runtime block to execute.
+#
+# Downstream consumers: developer running locally before commit; CI
+#                       (.github/workflows/bin-tests.yml).
+#
+# Failure modes: none beyond a failing assertion - this test makes no writes
+#                and no network calls.
+#
+# Performance: < 1 s wall time (pure grep, no network).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="$REPO_DIR/content/commands/ds-ticket-triage.md"
+
+PASS=0
+FAIL=0
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+if [[ ! -f "$SPEC" ]]; then
+  echo "FAIL: $SPEC not found" >&2
+  exit 1
+fi
+
+_present() { # _present <label> <pattern>
+  if grep -qiE "$2" "$SPEC"; then
+    _pass "$1"
+  else
+    _fail "$1 - spec no longer contains: /$2/"
+  fi
+}
+_absent() { # _absent <label> <pattern>
+  if grep -qiE "$2" "$SPEC"; then
+    _fail "$1 - spec still contains: /$2/"
+  else
+    _pass "$1"
+  fi
+}
+
+echo ""
+echo "--- Dual-branch anchoring: the read must cover BOTH Phase 0 branches ---"
+# The failure mode this unit is most likely to ship: anchoring the read to
+# only the explicit-input branch's breadcrumb would silently skip the badge
+# for every no-args invocation (the default, tracker-connected shape).
+_present "detection section names the no-args breadcrumb (resolve-assigned)" \
+         'phase=resolve-assigned'
+_present "detection section names the explicit-input breadcrumb (normalize)" \
+         'phase=normalize'
+_present "detection section states it runs downstream of BOTH branches" \
+         'downstream of BOTH'
+_present "detection section has its own terminal breadcrumb" \
+         '\[phase: ticket-triage \| phase=rework-detect\]'
+
+echo ""
+echo "--- Outside the Phase 1 tracker gate ---"
+_present "detection is explicitly NOT gated on TRACKER != none" \
+         'NOT gated on .TRACKER != none'
+_present "spec explains why: zero tracker/network calls" \
+         'zero tracker and zero network calls'
+_present "TRACKER=none named as the case detection matters most for" \
+         'TRACKER=none.{0,40}(matters most|no tracker comment thread)'
+
+echo ""
+echo "--- Reuse by reference, not fork ---"
+_present "detection reuses the implement-ticket algorithm by reference" \
+         'reuse .{0,20}/ds-implement-ticket. Phase 1.{0,80}by reference'
+_present "spec explicitly forbids forking the jq algorithm" \
+         'Do not fork or re-derive'
+
+echo ""
+echo "--- The badge ---"
+_present "the [REWORK xN] badge is documented" \
+         '\[REWORK xN\]'
+_present "badge placement is the Ticket cell of the per-ticket summary table" \
+         'Ticket column: append .\[REWORK xN\].'
+
+echo ""
+echo "--- The never-parallel lane rule ---"
+_present "rework isolation rule exists" \
+         'Rework isolation \(after in-progress removal, before Rule 2\)'
+_present "rework tickets are never designated parallel" \
+         'never\*\* .parallel.'
+_present "rework tickets get their own single-ticket chain" \
+         'own single-ticket chain'
+_present "rework tickets are not deferred and not excluded from kickoff" \
+         'neither deferred nor excluded from kickoff'
+_present "Notes cell annotation names the prior PR" \
+         'Elevated floor, may draw Tier-3 Skeptic; verify PR'
+_absent  "rework tickets are not silently folded into Rule 3 parallel grouping" \
+         'rework .{0,40}parallel grouping'
+
+echo ""
+echo "--- Phase 4b checklist gains a 6th point ---"
+_present "Phase 4b Skeptic brief checks rework isolation as item (6)" \
+         '\(6\) Rework isolation'
+
+echo ""
+echo "--- Module manifest Upstream deps ---"
+# The manifest header is a multi-line HTML comment; grep -E has no cross-line
+# match, so flatten the header block (between "<!--" and the FIRST "-->")
+# onto one line before asserting.
+HEADER_FLAT="$(awk '/<!--/{f=1} f{print} /-->/{if(f)exit}' "$SPEC" | tr '\n' ' ')"
+if printf '%s' "$HEADER_FLAT" | grep -qE 'Upstream deps:.*\.agentic/ticket-ledger\.jsonl'; then
+  _pass "manifest Upstream deps names the ledger file"
+else
+  _fail "manifest Upstream deps names the ledger file - header no longer contains .agentic/ticket-ledger.jsonl in the Upstream deps field"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0

--- a/content/commands/ds-ticket-triage.md
+++ b/content/commands/ds-ticket-triage.md
@@ -62,7 +62,9 @@ Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
              one background Skeptic in Phase 4b. Proportional to ticket count.
              >20 tickets: investigator pass skipped (HEURISTIC_ONLY=true) after
-             a proceed prompt.
+             a proceed prompt. Ticket-rework detection adds N entries x one
+             full-file jq parse of the local `.agentic/ticket-ledger.jsonl`
+             (no network, no tracker call) once per triage run.
 -->
 
 # /ds-ticket-triage
@@ -105,7 +107,7 @@ When `/ds-ticket-triage` is invoked with no input, resolve the operator's open a
 - **Linear:** query issues where `assignee: me`, team = the resolved team (from `Team`/`TICKET_PREFIX` in the tracker resolution), and state type not in `(completed, canceled)` using `mcp__linear__list_issues`. Collect entries as `{ticket_id, source: "assigned"}`.
 - **0 results:** print "No open tickets assigned to you." and exit.
 - **1 result:** fall through to the single-ticket degenerate path (print "Single ticket: run /ds-implement-ticket <id> directly." and exit).
-- **>=2 results:** proceed into Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
+- **>=2 results:** proceed into Ticket-rework detection and Phase 1+ exactly as for an explicit list input. Print the resolved ticket IDs (one per line) before proceeding so the operator can confirm the scope.
 
 `[phase: ticket-triage | phase=resolve-assigned]`
 
@@ -146,7 +148,7 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 
 **Terminal-status detection:** tickets whose status maps to a Done/Cancelled/Won't-do state are marked `terminal: true`. They are added to the deferred set in Phase 3 Rule 1 without further analysis.
 
-**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts).
+**In-progress detection:** tickets whose status maps to an active/started/in-progress workflow state are marked `in_progress: true`. They are carried through Phase 2 analysis but removed from lane assignment after Rule 1 (shown badged `[IN PROGRESS]` in the artifact; excluded from kickoff prompts). When `entry.IS_REWORK` is also true (see Ticket-rework detection above), the badge becomes `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table - the only place that ticket's rework signal appears, since in-progress removal happens before Rule 2 and Rework isolation and the ticket never reaches a lane.
 
 > **Story-size preflight** - runs once, immediately after all metadata is collected.
 >
@@ -223,19 +225,21 @@ Defer the following; they are removed from all downstream rules:
 - Tickets with `cycle_warning: true`.
 - Lowest-priority tickets with no dependents when `num_entries > lanes * 4` (documented overflow deferral; use judgment and document reason).
 
-**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
+**In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` (combined as `[IN PROGRESS] [REWORK xN]` when `entry.IS_REWORK` is also true - see the In-progress tickets table below) and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned, and they never reach Rule 2 or Rework isolation below.
 
-**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
 
-Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2 - **including any member separately flagged `entry.IS_REWORK: true`.**
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
+**Why a DAG-connected rework ticket is consumed HERE, not by Rework isolation below.** Rule 2 is the only mechanism in this command that honours an in-set dependency edge at all - Rule 1 defers a ticket only when its blocker is *outside* the set. Isolating a rework ticket before Rule 2 ran would remove it from the DAG-chain pool, silently severing that edge: its blocker (or the ticket it blocks) would then fall through to Rule 3 with zero remaining internal edges and could land in a different, possibly-`parallel` lane - telling the operator to run a blocked ticket concurrently with its own blocker. A chain is not a `parallel` lane, so consuming the rework ticket in its topo-sorted chain here already satisfies the never-parallel mandate without needing to special-case Rule 2 itself. See the Notes-cell rule below for how the dependency edge stays visible in the artifact for this case.
 
-For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
+Each chain = one lane slot consumed in the cap accounting. `num_dep_chains` is the count of chains assigned here (referenced by Rule 4 below).
 
-Each chain = one lane slot consumed in the cap accounting.
+**Rework isolation (after Rule 2, before Rule 3):** every remaining ticket with `entry.IS_REWORK: true` that Rule 2 did **not** already consume above - i.e. it has zero in-set DAG edges, or its only edges point to a ticket that was deferred, in-progress-removed, or otherwise outside the surviving DAG component - is assigned its own single-ticket chain lane here, **never** `parallel`. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. `num_rework_lanes` is the count of lanes assigned here (referenced by Rule 4 below); each is one lane slot consumed in the cap accounting, same as a Rule 2 chain. `num_chains` (the total Rule 4 uses for cap accounting) = `num_dep_chains + num_rework_lanes`.
 
-**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges):**
+**Notes-cell annotation (applies to every `entry.IS_REWORK: true` ticket, regardless of which rule consumed it):** its Notes cell (At-a-glance and Per-ticket summary tables) always carries `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. When Rule 2 consumed the ticket (it is DAG-connected), the Notes cell leads with its in-set blocker/blocked-by relationship first - the same convention Rule 2 already uses for its non-rework chain members (e.g. `blocked by A`) - separated from the rework annotation by `; `, so the dependency edge stays visible in the artifact rather than only implied by lane structure. Example: `blocked by A; rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458`. When Rework isolation consumed the ticket instead (no in-set edge), the Notes cell carries the rework annotation alone.
+
+**Rule 3 - Parallel grouping (sees only the remainder: tickets with zero internal DAG edges AND `entry.IS_REWORK: false`):**
 
 1. Sort candidates by **priority descending, then ticket_id ascending** (total order; deterministic).
 2. For each candidate in that order: place it in the **lowest-index existing lane** that has no conflict with it (conflict = shared conflict group per Phase 2b). If no existing lane is conflict-free AND current lane count < cap: open a new lane. If cap is reached: hold for the overflow step.
@@ -245,7 +249,11 @@ Each chain = one lane slot consumed in the cap accounting.
 
 Cap = `--lanes N` (default 3).
 
-- If `num_chains > cap`: do NOT merge chains (they are hard dependency units). Report in the artifact: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Proceed with `num_chains` lanes for chains.
+- If `num_chains > cap`: do NOT merge chains (they are hard dependency units, and a rework-isolated lane is equally never merged into a parallel batch - see Rework isolation above). Report in the artifact:
+  - When `num_rework_lanes == 0`: "Dependency structure requires `<num_chains>` sequential lanes, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions."
+  - When `num_rework_lanes > 0`: "`<num_dep_chains>` dependency chain(s) plus `<num_rework_lanes>` rework-isolated ticket(s) require `<num_chains>` sequential lane(s) total, exceeding the cap of `<cap>`. Raise --lanes to `<num_chains>` or accept `<num_chains>` concurrent sessions." Distinguishing the two counts matters: without it, an operator with several rework tickets and zero real dependency chains would be told "dependency structure" forces the lane count, when the actual cause is the never-parallel mandate.
+
+  Proceed with `num_chains` lanes for chains either way.
 - If `num_chains + num_parallel_lanes > cap`: run a deterministic merge post-pass over **parallel lanes only**. Repeatedly merge the pair of parallel lanes that introduces the **fewest new intra-lane conflicts**; ties broken by (smallest combined ticket count, then lexicographically smallest member ticket_id). A merged lane runs its tickets sequentially as a comma-list batch. Each merge strictly reduces lane count, so the loop terminates. Stop when total lanes <= cap OR no parallel lanes remain to merge. If still > cap after exhausting merges, emit a cap-warning recommending a higher `--lanes`. **Rule 3 is NOT recomputed after merges.**
 
 `[phase: ticket-triage | phase=distribute]`
@@ -265,11 +273,17 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 
 ## At a glance
 
+<!-- Type column: a lane containing a DAG-connected rework ticket (Rule 2 consumed it) is still
+     "chain", never "parallel" - see Rule 2's rework-handling note and the Notes-cell rule in
+     Phase 3. Lane 4 below illustrates this: G is rework AND blocked by F, so Rule 2 (not
+     Rework isolation) assigned the chain, and G's Notes lead with the in-set blocker. -->
+
 | Lane | Tickets | Type | Notes |
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
 | Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| Lane 4 | F, G | chain | G blocked by F; G rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
@@ -278,10 +292,12 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
      Display-only; no distribution rule consumes it.
      ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
      Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
-     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
-     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
-     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
-     At-a-glance row for that lane. -->
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value - a
+     rework ticket's lane always shows Type "chain": its own single-ticket chain (Rework
+     isolation) when it has no in-set DAG edge, or the DAG-connected chain Rule 2 already
+     assigned it when it does. Its Notes cell always carries the "rework xN - ...; verify PR
+     #<n>" annotation; when Rule 2 consumed it (DAG-connected), the Notes cell leads with the
+     in-set blocker relationship first, separated by "; " (see G below). -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
@@ -289,6 +305,8 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
 | E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
+| F | Med | To Do | 2 | | Lane 4 | |
+| G [REWORK x1] | Med | To Do | 3 | | Lane 4 | blocked by F; rework x1 - Elevated floor, may draw Tier-3 Skeptic; verify PR #500 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -328,9 +346,15 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 ## In-progress tickets
 
+<!-- Ticket column: append "[REWORK xN]" after "[IN PROGRESS]" when entry.IS_REWORK is true - see
+     Ticket-rework detection above. This is the ONLY place an in-progress rework ticket's signal
+     appears: in-progress removal happens before Rule 2 and Rework isolation, so it never gets a
+     lane, a Per-ticket-summary badge, or a Notes-cell annotation elsewhere. -->
+
 | Ticket | Assignee | Notes |
 |--------|----------|-------|
 | Z [IN PROGRESS] | ... | Excluded from kickoff prompts |
+| W [IN PROGRESS] [REWORK x1] | ... | Excluded from kickoff prompts; verify PR #501 once back from in-progress |
 
 ## Kickoff prompts
 
@@ -351,6 +375,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket E
 ```
+
+**Lane 4** (sequential chain, includes a DAG-connected rework ticket - never parallel; verify PR #500 before running):
+```
+/ds-implement-ticket F, G
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -361,7 +390,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework annotation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge and a Notes-cell annotation naming the prior PR? Is it placed in a chain, never `parallel` - either its own single-ticket rework-isolated chain, or the DAG-connected chain Rule 2 already assigned it, with the in-set blocker relationship preserved first in that case?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -403,7 +432,7 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | No args, no tracker | Print "No tracker configured - an explicit ticket list or URL is required when no tracker is connected." and exit. |
 | No args, 0 assigned | Print "No open tickets assigned to you." and exit. |
 | No args, 1 assigned | Print "Single ticket: run /ds-implement-ticket <id> directly." and exit. |
-| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Phase 1+ as for an explicit list. |
+| No args, >=2 assigned | Print resolved ticket IDs, then proceed into Ticket-rework detection and Phase 1+ as for an explicit list. |
 | Single ticket | Print "run /ds-implement-ticket <id> directly." and exit before Phase 1. |
 | All tickets independent (no DAG edges) | Rule 2 is a no-op; all tickets go to Rule 3 parallel grouping. |
 | Circular dependency | Break at lowest-confidence link; defer both with `cycle_warning`. Do not abort. |
@@ -412,7 +441,9 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
-| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true`, no in-set DAG edge | Badged `[REWORK xN]`. Given its own single-ticket chain lane by Rework isolation (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| Ticket with `IS_REWORK: true` AND an in-set DAG edge (blocks or is blocked by another surviving ticket) | Badged `[REWORK xN]`. Consumed by Rule 2, not Rework isolation - stays in its topo-sorted chain (Type `chain`, never `parallel`) so the dependency edge is preserved. Notes cell leads with the in-set blocker relationship, then the rework annotation (e.g. `blocked by F; rework x1 - ...`). |
+| Ticket with `IS_REWORK: true` AND `in_progress: true` | In-progress removal runs before Rule 2 and Rework isolation, so the ticket never reaches a lane. Badged `[IN PROGRESS] [REWORK xN]` in the In-progress tickets table only - the sole place this signal appears. Excluded from kickoff prompts, same as any in-progress ticket. |
 | `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline

--- a/content/commands/ds-ticket-triage.md
+++ b/content/commands/ds-ticket-triage.md
@@ -18,12 +18,16 @@ Public API: /ds-ticket-triage                         -- triage operator's open 
             are identical between the two commands.
 
 Upstream deps: content/commands/ds-implement-ticket.md Phase 0 (input normalizer,
-               invoked by reference - no copy); METHODOLOGY.md (activation
+               invoked by reference - no copy) and Phase 1 Ticket-rework
+               detection (per-entry ledger read, invoked by reference - no
+               fork of the jq algorithm); METHODOLOGY.md (activation
                preflight); AGENTS.md ## Tracker / ## Linear sections (TRACKER
                resolution chain, same as implement-ticket Setup); Jira MCP
                (mcp__mcp-atlassian__jira_get_issue / jira_search); Linear MCP
                (mcp__linear__get_issue); content/references/trigger-catalog.md
-               (yolo-guard, §d).
+               (yolo-guard, §d); .agentic/ticket-ledger.jsonl (local,
+               gitignored, tracker-independent read - see content/references/
+               ticket-rework.md for schema and algorithm).
 
 Downstream consumers: operator-invoked only (standalone) OR /ds-implement-ticket
                       Phase 0a (integration path - algorithm reused by reference,
@@ -49,7 +53,10 @@ Failure modes: soft-fail per ticket throughout; fetch failures treated as
                heuristic-only notice; no-args + no-tracker exits immediately
                (explicit list required). 0 assigned tickets exits immediately.
                Phase 4b Skeptic skipped when artifact contains zero lanes and
-               zero chains (all deferred / in-progress).
+               zero chains (all deferred / in-progress). Ticket-rework ledger
+               read soft-fails per line (absent/unreadable ledger or a single
+               malformed line never blocks triage of the remaining set - see
+               Ticket-rework detection below).
 
 Performance: one tracker API call per ticket in Phase 1 (conductor-direct);
              one background investigator in Phase 2b when !HEURISTIC_ONLY;
@@ -85,6 +92,8 @@ Run the activation preflight (see `METHODOLOGY.md`). If inactive, no-op and exit
 
 Resolve `TRACKER`, `TICKET_PREFIX`, and `JIRA_BASE_URL` using the SAME resolution chain as `/ds-implement-ticket` Setup (AGENTS.md `## Tracker` / `## Linear` sections). Cache results in-context for the session; do not re-resolve mid-command.
 
+Resolve `REWORK_DETECTION` the SAME way as `/ds-implement-ticket` Setup: read `.agentic/config.json` key `rework_detection` (boolean, default `true`; absent key resolves to `true`). This governs the per-entry ledger read below - see `content/references/ticket-rework.md`.
+
 ## Phase 0: Input normalization
 
 **No-args default (invoked with no `<input>` argument).**
@@ -109,6 +118,21 @@ Reuse `/ds-implement-ticket` Phase 0 by reference - invoke the same normalizatio
 **Large-list gate:** if `len(entries) > 20`, prompt: "Ticket count exceeds 20 - investigator pass will be skipped (HEURISTIC_ONLY=true). Conflict analysis will be Level 1 only (component/label overlap). Continue? [y/N]". On `y`: set `HEURISTIC_ONLY=true` and proceed. On `n`: exit.
 
 `[phase: ticket-triage | phase=normalize]`
+
+## Ticket-rework detection (per-entry, runs after entries[] resolves via EITHER Phase 0 branch)
+
+**Anchoring (binding).** Phase 0 above has two mutually exclusive branches - the no-args default (terminal breadcrumb `phase=resolve-assigned`) and explicit input (terminal breadcrumb `phase=normalize`) - each ending in its own breadcrumb. This detection step sits downstream of BOTH: it runs once `entries[]` has been resolved, regardless of which branch produced the list, and before Phase 1 begins. Anchoring to the `normalize` breadcrumb alone would silently skip the badge for every no-args invocation, which is the documented default form for a tracker-connected operator - see the dual-branch anchoring pattern in `content/references/ticket-rework.md`.
+
+**Outside the Phase 1 tracker gate, deliberately.** This step does NOT sit inside Phase 1 and is NOT gated on `TRACKER != none`. Detection makes zero tracker and zero network calls - it is a single local file read, so it works identically whether a tracker is configured or not. Phase 1's no-tracker skip ("if `TRACKER == none`, skip Phase 1 metadata fetch") would, if this read were nested inside Phase 1, hide the badge at exactly the state most consumer repos are in. `TRACKER=none` is in fact the case this ledger matters most for - there is no tracker comment thread to carry prior-attempt signal.
+
+For each entry in the resolved `entries[]`, reuse `/ds-implement-ticket` Phase 1's "Ticket-rework detection" sub-section by reference - same file (`.agentic/ticket-ledger.jsonl`), same exact-`ticket_id`-match + dedupe-by-`pr_number`-latest-wins jq algorithm, same soft-fail-per-line discipline (one malformed line is skipped, not fatal to the whole read; an absent or unreadable ledger resolves to zero prior attempts rather than erroring). Do not fork or re-derive that algorithm here.
+
+1. If `REWORK_DETECTION` is `false` (see Preflight), or a given entry's `ticket_id` is null/empty (a freeform/local entry with no ticket reference), skip detection for that entry: `entry.PRIOR_ATTEMPTS = 0`, `entry.IS_REWORK = false`. No badge, no lane-rule effect.
+2. Otherwise set `entry.PRIOR_ATTEMPTS`, `entry.IS_REWORK`, and `entry.LATEST_PR` (the `pr_number` of the most recent deduped prior record) exactly as the implement-ticket detection produces `PRIOR_ATTEMPTS` / `IS_REWORK` / the last element of `PRIOR_COMPLETED`.
+
+`entry.IS_REWORK` feeds the `[REWORK xN]` badge (Phase 4a) and the never-parallel lane rule (Phase 3) below.
+
+`[phase: ticket-triage | phase=rework-detect]`
 
 ## Phase 1: Metadata fetch
 
@@ -201,7 +225,11 @@ Defer the following; they are removed from all downstream rules:
 
 **In-progress removal (after Rule 1):** tickets with `in_progress: true` are removed from lane assignment. They appear in the artifact badged `[IN PROGRESS]` and are excluded from kickoff prompts. They are NOT deferred and NOT lane-assigned.
 
-**Rule 2 - Sequential chains (consume DAG-connected components with edges):**
+**Rework isolation (after in-progress removal, before Rule 2):** every remaining ticket with `entry.IS_REWORK: true` (see Ticket-rework detection above) is consumed here, unconditionally, and assigned its own single-ticket chain lane - **never** `parallel`, regardless of Phase 2a's DAG or Phase 2b's conflict-group findings for it. A rework ticket carries a forced Elevated risk floor and may draw a Tier-3 Skeptic (`content/references/ticket-rework.md` §Escalation table); folding it into a same-lane parallel batch with other tickets would misrepresent its cost as parallel-safe filler. It is neither deferred nor excluded from kickoff - it runs, just never batched with anything else. Its Notes cell (At-a-glance and Per-ticket summary tables) records `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`, where `N = entry.PRIOR_ATTEMPTS` and `<n> = entry.LATEST_PR`. Each isolated rework ticket = one lane slot consumed in the Rule 4 cap accounting, same as a Rule 2 chain.
+
+Accepted trade-off: a rework ticket that also has a DAG edge to another remaining ticket (it blocks, or is blocked by, a non-rework ticket) loses Rule 2's chain-ordering guarantee for that edge, because rework isolation removes it from the DAG-chain pool before Rule 2 runs. This is deliberate given the never-parallel mandate above; if it proves to lose real dependency information in practice, the fix is to special-case DAG-connected rework tickets, not to weaken the isolation rule for the common (no-DAG-edge) case.
+
+**Rule 2 - Sequential chains (consume DAG-connected components with edges, from the remainder after rework isolation):**
 
 For every connected component of the DAG that has at least one internal edge, topo-sort its members (blockers first) and assign the chain as a single lane (run as an ordered comma-list `/ds-implement-ticket A, B, C` batch). Non-linear components (multiple paths) are still serialized in topological order. All members of a chained component are consumed by Rule 2.
 
@@ -241,19 +269,26 @@ Conflict analysis: Level 1 only (component/label overlap; >20 tickets, investiga
 |------|---------|------|-------|
 | Lane 1 | A, B | chain | B blocked by A |
 | Lane 2 | C, D | parallel | independent |
+| Lane 3 | E | chain | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ...   | ...  | ...  | ... |
 
 ## Per-ticket summary
 
 <!-- Est column: shows the captured estimate (story points / time estimate) or "-" when absent.
      Display-only; no distribution rule consumes it.
-     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty. -->
+     ⚠ column: populated with "⚠ large" when context_risk: high (≥5 pts); otherwise empty.
+     Ticket column: append "[REWORK xN]" when entry.IS_REWORK is true, N = entry.PRIOR_ATTEMPTS
+     (see Ticket-rework detection above). Never combined with a `parallel` Lane/Type value -
+     a rework ticket's own single-ticket chain lane always shows Type "chain" (Rework isolation
+     rule). Its Notes cell carries the same "rework xN - ...; verify PR #<n>" annotation as the
+     At-a-glance row for that lane. -->
 
 | Ticket | Priority | Status | Est | ⚠ | Lane | Notes |
 |--------|----------|--------|-----|---|------|-------|
 | A | High | To Do | 3 | | Lane 1 | |
 | B | Med | To Do | 2 | | Lane 1 | blocked by A |
 | C | High | To Do | 8 | ⚠ large | Lane 2 | |
+| E [REWORK x2] | High | To Do | 3 | | Lane 3 | rework x2 - Elevated floor, may draw Tier-3 Skeptic; verify PR #458 |
 | ... | | | | | | |
 
 ## Dependency notes
@@ -311,6 +346,11 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 ```
 /ds-implement-ticket C, D
 ```
+
+**Lane 3** (rework - single-ticket chain, never parallel; verify PR #458 before running):
+```
+/ds-implement-ticket E
+```
 ```
 
 `[phase: ticket-triage | phase=draft]`
@@ -321,7 +361,7 @@ running /ds-implement-ticket. Running both risks a merge conflict or duplicated 
 
 Otherwise: spawn a fresh background Skeptic on the artifact with this adversarial brief:
 
-> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented?"
+> "Review this triage artifact. Check: (1) Dependency ordering - are blockers placed before the tickets they block within each chain? (2) Parallel safety - are tickets in the same lane genuinely non-conflicting per the Phase 2b analysis? (3) Deferral justification - is each deferred ticket's reason accurate and not overcautious? (4) Kickoff prompt completeness - does every non-deferred, non-in-progress ticket appear in exactly one lane's kickoff prompt? (5) Cap reconciliation - if Rule 4 fired, was the merge post-pass applied correctly and documented? (6) Rework isolation - was every ticket with `IS_REWORK: true` given the `[REWORK xN]` badge, placed in its own single-ticket chain lane (never `parallel`), and is its Notes cell annotated with the prior PR number?"
 
 Max 3 fix passes, then escalate to the operator with open findings listed.
 
@@ -372,9 +412,11 @@ After Phase 4b sign-off (or after the skip condition triggers), print to chat:
 | Terminal-status ticket (Done/Cancelled) | Deferred via Rule 1 with reason "terminal". Not included in lane assignment or kickoff prompts. |
 | In-progress ticket | Carried through analysis; removed from lane assignment after Rule 1. Shown badged `[IN PROGRESS]`. Excluded from kickoff prompts. |
 | No tracker configured (with explicit input) | Skip Phase 1; run Phase 2a with zero link data; run Phase 2b Level 1 with zero component/label data; print notice. |
+| Ticket with `IS_REWORK: true` (one or more prior AE PR-opening attempts recorded in the ledger) | Badged `[REWORK xN]`. Isolated into its own single-ticket chain lane (never `parallel`). NOT deferred, NOT excluded from kickoff. Notes cell names the prior PR. Runs identically at `TRACKER=none` - detection is tracker-independent. |
+| `rework_detection` disabled, or ledger absent/unreadable | Detection soft-fails to `PRIOR_ATTEMPTS = 0` for every entry; no badge, no lane-rule effect. Triage proceeds unaffected. |
 
 ## Soft-fail discipline
 
-Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure.
+Every tracker and MCP call soft-fails: log and continue. A fetch failure on one ticket never aborts the triage of the remaining set. Fetch-failed tickets are treated as independent with no known metadata. The command never errors out on external API failure. The ticket-rework ledger read (a local file, not a tracker/MCP call) follows the same discipline: an absent or unreadable ledger, or a single malformed line within it, resolves to zero prior attempts for the affected entry(ies) rather than erroring - see Ticket-rework detection above.
 
 Emit one breadcrumb per phase as shown in each section above. The terminal breadcrumb is `[phase: ticket-triage | phase=complete]`.


### PR DESCRIPTION
## Summary

Fourth of five units in the ticket-rework Plan. Reads the `.agentic/ticket-ledger.jsonl` schema and detection algorithm that U2 (#485, merged) shipped in `/ds-implement-ticket`, and surfaces it inside `/ds-ticket-triage`:

- **Ledger read** - inserted between Phase 0 and Phase 1, anchored downstream of BOTH Phase 0 branches (no-args default `phase=resolve-assigned` and explicit-input `phase=normalize`), and outside Phase 1's `TRACKER == none` skip. This is the dual-branch anchoring pattern documented in `content/references/ticket-rework.md`; anchoring to only the `normalize` breadcrumb would have silently dropped the badge on every no-args invocation (the default form for a tracker-connected operator).
- **Badge** - `[REWORK xN]` on the Ticket cell of the Per-ticket summary table.
- **Lane rule** - a rework ticket is never designated `parallel`. A new "Rework isolation" step (after in-progress removal, before Rule 2) gives it its own single-ticket chain lane, with a Notes annotation `rework xN - Elevated floor, may draw Tier-3 Skeptic; verify PR #<n>`. Not deferred, not excluded from kickoff.
- **Phase 4b checklist** - added item (6): rework isolation verified.
- **Module manifest** - `Upstream deps` now names `.agentic/ticket-ledger.jsonl`.
- Regenerated adapter output via `scripts/build-all.sh` (9 files: `.claude`, `.codex`, `.cursor`, `.gemini`, `.github`(copilot)/`.hermes`, `.openclaw`, `.opencode`, plus `content/commands/`). `.kimi`/`.omp`/`.pi` are symlinked or gitignored generated output and correctly show no diff.
- New regression test `bin/tests/test_ticket_rework_triage_badge.sh` - a prose-invariant guard (this spec reuses the implement-ticket ledger algorithm by reference, so there's no executable block of its own to extract/run). Confirmed failing (16/19) against the pre-change spec before the fix landed.

## North Star alignment

Extends "works for everyone" (universality): the badge and lane rule are tracker-independent (zero network/tracker calls, work identically at `TRACKER=none`) and degrade gracefully via the existing `rework_detection` config toggle, matching the same operator-context-at-runtime pattern U2 established in `/ds-implement-ticket`. No operator identity, workspace, or tracker assumption is baked in.

## Review rigor

- Read `content/references/ticket-rework.md` (canonical spec) and `content/commands/ds-implement-ticket.md`'s merged Phase 1 detection (U2, #485) before writing - reused its algorithm by reference rather than forking a second copy.
- Verified the new prose-invariant test fails against the pre-change spec (`git stash` + run: 16/19 assertions fail) and passes post-change (19/19).
- Ran `scripts/build-all.sh` and confirmed `git status --short` clean across all 11 adapter dirs (only expected files changed); diffed each modified adapter file against `content/commands/ds-ticket-triage.md` to confirm no unrelated content was reverted.
- `bin/tests/test_ticket_rework_ledger.sh` (U2's existing suite, 63 assertions) re-run and unaffected.

## Test plan

- [x] `bash bin/tests/test_ticket_rework_triage_badge.sh` - 19/19 pass
- [x] `bash bin/tests/test_ticket_rework_ledger.sh` - 63/63 pass (unaffected sibling suite)
- [x] `bash scripts/build-all.sh` - all 11 adapters build; `git status --short` clean except intended files
- [ ] CI: all 14 required checks green

Depends on U2 (#485), already merged to `main`.