### PR TITLE
fix(ci): gate absolutized skill symlinks; exclude generated slide bundles from CodeQL (DS-104, DS-111)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+# CodeQL analysis config for DinoStack.
+#
+# paths-ignore: docs/slides/*.html only - these are marp-cli/marp-core
+# minified bundle output (byte-identical to `bash scripts/build-slides.sh`,
+# zero hand edits), regenerated on every content/ change per AGENTS.md. The
+# repo cannot fix findings in this generated third-party code (e.g. the
+# js/unvalidated-dynamic-method-call alerts from marp-core's `this[t]`
+# minification pattern, all dated 2026-06-18 - five weeks before any PR that
+# merely regenerated the file). Flagging it as "new" on every regeneration
+# trains reviewers to wave through a red security check on an unrelated
+# PR, which is the opposite of what CodeQL is for.
+#
+# The docs/slides/*.md sources are hand-authored and stay scanned - this
+# excludes only the generated .html bundles, not the slides directory as a
+# whole. DS-111.
+paths-ignore:
+  - 'docs/slides/*.html'

--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -32,3 +32,5 @@ jobs:
           fi
       - name: Verify Codex hook commands resolve (DS-57 regression guard)
         run: bash bin/tests/test_codex_hooks_resolve.sh
+      - name: Verify agentic-engineering skill symlinks are relative (DS-104 regression guard)
+        run: bash scripts/check-symlinks-relative.sh "${{ github.sha }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/bin/tests/test_check_symlinks_relative.sh
+++ b/bin/tests/test_check_symlinks_relative.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Purpose: Regression guard for DS-104. scripts/check-symlinks-relative.sh is
+#          the CI gate that fails when any of the four
+#          .claude/skills/agentic-engineering/{agents,commands,references,rules}
+#          symlinks is absolutized in the committed tree. A gate that has
+#          only ever been observed passing has not been verified - this test
+#          exercises both directions: it must FAIL against a constructed
+#          commit with an absolutized symlink, and PASS against one with all
+#          four relative.
+#
+# Public API: ./bin/tests/test_check_symlinks_relative.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, git, mktemp. Builds a throwaway git repo under a temp
+#                directory - never touches the real checkout's HEAD or refs.
+#
+# Downstream consumers: developer running locally before commit; CI
+#                        (bin-sh-tests.yml auto-discovers bin/tests/test_*.sh).
+#
+# Failure modes: gate script missing -> immediate FAIL. Gate does not exit 1
+#                on an absolutized fixture, or does not exit 0 on a relative
+#                fixture -> FAIL with the observed exit code.
+#
+# Performance: < 1 s wall time (pure git plumbing, no network).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GATE_SCRIPT="$REPO_DIR/scripts/check-symlinks-relative.sh"
+
+if [[ ! -f "$GATE_SCRIPT" ]]; then
+  echo "FAIL: $GATE_SCRIPT not found" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+_cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap _cleanup EXIT
+
+FIXTURE_REPO="$TMP_ROOT/fixture-repo"
+mkdir -p "$FIXTURE_REPO"
+(
+  cd "$FIXTURE_REPO"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "DS-104 fixture"
+) || { _fail "could not init fixture repo"; exit 1; }
+
+SKILL_DIR="$FIXTURE_REPO/.claude/skills/agentic-engineering"
+mkdir -p "$SKILL_DIR" "$FIXTURE_REPO/content"
+
+build_commit() {
+  # $1 = commit message; remaining pairs of (name, target) build one
+  # symlink each under $SKILL_DIR.
+  local msg="$1"
+  shift
+  (
+    cd "$FIXTURE_REPO"
+    while [[ $# -gt 0 ]]; do
+      local name="$1" target="$2"
+      shift 2
+      rm -f ".claude/skills/agentic-engineering/$name"
+      ln -s "$target" ".claude/skills/agentic-engineering/$name"
+    done
+    git add -A .claude
+    git commit -q -m "$msg"
+  )
+}
+
+# --- Fixture 1: all four relative (must PASS) ---
+build_commit "all relative" \
+  agents "../../../content/agents" \
+  commands "../../../content/commands" \
+  references "../../../content/references" \
+  rules "../../../content/rules"
+
+GOOD_SHA="$(cd "$FIXTURE_REPO" && git rev-parse HEAD)"
+
+if (cd "$FIXTURE_REPO" && bash "$GATE_SCRIPT" "$GOOD_SHA") >/dev/null 2>&1; then
+  _pass "gate exits 0 against an all-relative commit"
+else
+  rc=$?
+  _fail "gate exited $rc against an all-relative commit (expected 0)"
+fi
+
+# --- Fixture 2: one absolutized (must FAIL) ---
+build_commit "rules absolutized" \
+  rules "$FIXTURE_REPO/content/rules"
+
+BAD_SHA="$(cd "$FIXTURE_REPO" && git rev-parse HEAD)"
+
+if (cd "$FIXTURE_REPO" && bash "$GATE_SCRIPT" "$BAD_SHA") >/dev/null 2>&1; then
+  _fail "gate exited 0 against a commit with an absolutized symlink (expected non-zero)"
+else
+  rc=$?
+  if [[ $rc -eq 1 ]]; then
+    _pass "gate exits 1 against a commit with an absolutized symlink"
+  else
+    _fail "gate exited $rc against an absolutized commit (expected 1)"
+  fi
+fi
+
+# --- Sanity: gate also passes against the real repo's current HEAD ---
+if (cd "$REPO_DIR" && bash "$GATE_SCRIPT" HEAD) >/dev/null 2>&1; then
+  _pass "gate exits 0 against this repo's current HEAD"
+else
+  rc=$?
+  _fail "gate exited $rc against this repo's current HEAD (expected 0) - a real symlink may be absolutized"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_check_symlinks_relative.sh
+++ b/bin/tests/test_check_symlinks_relative.sh
@@ -70,7 +70,7 @@ build_commit() {
   local msg="$1"
   shift
   (
-    cd "$FIXTURE_REPO"
+    cd "$FIXTURE_REPO" || exit 1
     while [[ $# -gt 0 ]]; do
       local name="$1" target="$2"
       shift 2

--- a/scripts/check-symlinks-relative.sh
+++ b/scripts/check-symlinks-relative.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Purpose: Verify the four .claude/skills/agentic-engineering/{agents,commands,
+#          references,rules} symlinks are relative in the COMMITTED tree, not
+#          the working tree. Isolation-worktree side effects have intermittently
+#          rewritten these to absolute paths, which resolve fine on the machine
+#          that broke them but silently break the skill for every other clone.
+#          Root cause is unconfirmed (DS-104) - this script is detection only.
+#
+# Public API: bash scripts/check-symlinks-relative.sh [ref]
+#             ref defaults to HEAD. Exits 0 when all four symlinks are
+#             relative (leading char != "/"), 1 when any is absolute or
+#             missing, 2 on usage/environment error.
+#
+# Upstream deps: git ls-tree, git cat-file. No working-tree filesystem access -
+#                operates purely on the git object database for the given ref.
+#
+# Downstream consumers: .github/workflows/adapter-sync.yml
+#
+# Failure modes: any of the four paths absent from the tree, not a symlink
+#                (mode != 120000), or resolving to an absolute path -> exit 1
+#                with the offending path(s) listed.
+#
+# Performance: O(1) - four fixed git object lookups.
+
+set -euo pipefail
+
+REF="${1:-HEAD}"
+SKILL_DIR=".claude/skills/agentic-engineering"
+LINKS="agents commands references rules"
+
+fail=0
+
+for name in $LINKS; do
+  path="$SKILL_DIR/$name"
+  entry="$(git ls-tree "$REF" -- "$path" 2>/dev/null || true)"
+
+  if [ -z "$entry" ]; then
+    echo "check-symlinks-relative.sh: $path is missing from $REF" >&2
+    fail=1
+    continue
+  fi
+
+  mode="$(echo "$entry" | awk '{print $1}')"
+  sha="$(echo "$entry" | awk '{print $3}')"
+
+  if [ "$mode" != "120000" ]; then
+    echo "check-symlinks-relative.sh: $path is not a symlink in $REF (mode $mode)" >&2
+    fail=1
+    continue
+  fi
+
+  target="$(git cat-file -p "$sha")"
+
+  case "$target" in
+    /*)
+      echo "check-symlinks-relative.sh: $path is ABSOLUTIZED in $REF -> $target" >&2
+      fail=1
+      ;;
+    *)
+      echo "check-symlinks-relative.sh: $path -> $target (relative, OK)"
+      ;;
+  esac
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "One or more agentic-engineering skill symlinks are absolutized in $REF." >&2
+  echo "Restore them to relative form (e.g. ../../../content/<name>) before merging." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Two CI-hygiene fixes that share `.github/`.

## DS-104 — a gate for absolutized skill symlinks

`.claude/skills/agentic-engineering/{agents,commands,references,rules}` must each be `../../../content/<name>`. Isolation-worktree work intermittently rewrites them to **absolute** paths — observed 3 times in a single session, variously after `git stash push -u`/`pop`, after `scripts/build-all.sh`, and after `git add -A`. Root cause is genuinely unknown and deliberately **out of scope**; this is detection.

**Why nothing catches it today:** an absolutized symlink still resolves fine on the machine that broke it, and `check-adapter-sync` compares regenerated *content*. So a landed absolutization breaks the skill silently for **every other user** while looking correct locally.

`scripts/check-symlinks-relative.sh` inspects the **committed tree** (`git ls-tree` / `git cat-file`), not the working tree — a working-tree read would miss a committed absolutization and vice-versa. Wired into `adapter-sync.yml`, which already owns `.claude` sync checks.

**The gate is bidirectional and the test proves it on every run**, rather than being a one-time manual demonstration. Review verified by mutation: breaking the gate's match arm makes the test report `gate exited 0 against a commit with an absolutized symlink (expected non-zero)` and fail. It also probed the ways such a gate fools you — a regular file replacing the symlink, and all four entries deleted, both correctly exit 1 rather than passing vacuously.

## DS-111 — exclude generated slide bundles from CodeQL

10 open `js/unvalidated-dynamic-method-call` high-severity alerts, all in `docs/slides/*.html`, all dated **2026-06-18**. The construct is `this[t]` in marp-cli v4.4.0 minified output, and the shipped `.html` is byte-identical to `scripts/build-slides.sh` — the repo cannot fix findings in generated third-party code.

CodeQL reports them as "new alert in code changed by this pull request" purely because regeneration touched the file, and `AGENTS.md` mandates slide regeneration on every `content/` change. That trains reviewers to wave through a red security check on an unrelated PR, which is the opposite of what CodeQL is for.

Scoped to `docs/slides/*.html` only — the `.md` sources there are hand-authored and **stay scanned**. Review confirmed CodeQL's `*` does not cross `/`, `docs/slides` has no subdirectories, and `docs/index.html` / `docs/changelog.html` / `docs/_archive/*.html` are untouched by the glob. The `config-file` input is live on the action version in use (verified against `init/action.yml`), and an unresolvable path fails `init` loudly — so this is not a silently-ignored config.

The 10 existing alerts are left undismissed: code scanning closes alerts whose location stops appearing in analysis. They will close on the next push-to-main run, not on this PR's.

## North Star alignment

**Verifiable outcomes autonomously.** DS-104 converts a failure that was previously invisible-until-someone-else-broke into a mechanical gate that fails loudly in CI, with a regression test that re-proves both directions on every run.

**Guard the operator's attention.** DS-111 removes a recurring false-red security check. A security signal that fires on every unrelated PR is worse than none, because it teaches people to ignore it — and the next alert may be real.

**Works for everyone.** DS-104's whole point is that the defect is invisible on the machine that causes it and breaks the skill for every other user. Checking the committed tree is what makes the gate about what actually ships.

No enforcement floor is lowered: no hand-authored path is excluded from scanning, and the new gate only adds coverage.

## Review

0 Critical, 0 Major. Four Minors accepted and worth naming: the gate accepts any non-`/` target, so a wrong-depth or repo-escaping relative link passes — but those break *loudly* on every clone rather than silently, so they are a different failure class. The four names are a fixed list, so a newly added 5th symlink under that directory is unchecked. And `MEMORY.md`'s "no CI gate catches it" note becomes false once this merges — a conductor-owned file, corrected in this PR's wake.
