### PR TITLE
fix(hooks): suffix atomic-write tmp names per-pid to stop cross-session collisions (DS-109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,9 @@ content/**/.agentic/
 .pi/git/
 .pi/npm/
 __pycache__/
+
+# Orphaned pid-suffixed atomic_write staging files (DS-109). A SIGKILL between
+# write and rename can leave one of these behind at any tracked path this
+# repo's own tooling writes atomically (e.g. bin/agentic-config writing
+# AGENTS.md) - unpredictable exact name, but the <pid> suffix shape is fixed.
+*.tmp.[0-9]*

--- a/bin/_lib.py
+++ b/bin/_lib.py
@@ -6,8 +6,10 @@ NOT a public CLI - do not invoke directly.
 Purpose: Provide two cross-process primitives reused by multiple CLIs:
   1. acquire_exclusive_lock - fcntl.LOCK_EX context manager with sleep-retry
      until timeout; used for multi-process coordination (e.g. flush lock).
-  2. atomic_write - write content to <path>.tmp then rename; cleans up .tmp on
-     failure; optional chmod mode.
+  2. atomic_write - write content to a pid-suffixed <path>.tmp.<pid> sibling
+     then rename; cleans up OUR OWN pid-suffixed .tmp on failure; optional
+     chmod mode. Atomic for a single writer only - the pid suffix exists to
+     stop two concurrent writers from colliding on one staging path.
 
 Public API:
   acquire_exclusive_lock(lock_path, timeout=30.0)
@@ -116,12 +118,16 @@ def atomic_write(path: Path, content: str, mode: int | None = 0o600) -> None:
     """Write content to path atomically via a .tmp sibling.
 
     Steps:
-      1. Write content to <path>.tmp (text, utf-8).
-      2. If mode is not None, chmod <path>.tmp to mode.
-      3. Rename <path>.tmp -> path.
+      1. Write content to <path>.tmp.<pid> (text, utf-8).
+      2. If mode is not None, chmod <path>.tmp.<pid> to mode.
+      3. Rename <path>.tmp.<pid> -> path.
 
     On any failure, unlinks OUR OWN pid-suffixed <path>.tmp.<pid> (missing_ok)
     and re-raises. The destination file is never partially overwritten.
+    Atomic for a single writer only: the pid suffix guarantees two concurrent
+    callers never share one staging path, but it does not add cross-process
+    locking around the final rename - a last-write-wins race on the
+    destination itself is still possible if two writers target the same path.
 
     The tmp filename is suffixed with the current pid so two concurrent
     callers (e.g. two agentic-identity invocations) never share one staging

--- a/bin/_lib.py
+++ b/bin/_lib.py
@@ -18,10 +18,11 @@ Public API:
     Caller is responsible for ensuring lock_path and its parent exist before entry.
 
   atomic_write(path, content, mode=0o600)
-    Writes str content to path.with_suffix('<ext>.tmp') then renames into place.
-    When mode is not None, applies os.chmod to the tmp file before rename.
-    On any exception, unlinks the tmp file (missing_ok) and re-raises.
-    path must be a pathlib.Path.
+    Writes str content to a pid-suffixed <path>.tmp.<pid> sibling then renames
+    into place. When mode is not None, applies os.chmod to the tmp file before
+    rename. On any exception, unlinks OUR OWN pid-suffixed tmp file
+    (missing_ok) and re-raises - never a shared/fixed name another concurrent
+    caller could own. path must be a pathlib.Path.
 
 Upstream deps: Python 3 stdlib only (contextlib, fcntl, os, time, pathlib).
 
@@ -33,11 +34,15 @@ Failure modes:
     with no lock held; the underlying fd is always closed before raising.
     OS errors opening the lock file propagate to the caller unchanged (the file
     must exist before calling; existence is the caller's responsibility).
-  atomic_write: on any write/chmod/rename failure, removes the .tmp file
-    (missing_ok semantics) and re-raises the original exception. The destination
-    file is never partially written. The .tmp suffix is appended to the full
-    filename (e.g. identity.yml -> identity.yml.tmp) to stay in the same
-    directory and on the same filesystem as the destination.
+  atomic_write: on any write/chmod/rename failure, removes OUR OWN pid-suffixed
+    .tmp.<pid> file (missing_ok semantics) and re-raises the original exception.
+    The destination file is never partially written. The .tmp.<pid> suffix is
+    appended to the full filename (e.g. identity.yml -> identity.yml.tmp.12345)
+    to stay in the same directory and on the same filesystem as the
+    destination, AND to guarantee two concurrent callers never share one
+    staging path (single-writer atomicity only - see rename semantics; the
+    pid suffix prevents cross-process tmp collision/cleanup, not a
+    last-write-wins race on the final destination itself).
 
 Performance: Standard. acquire_exclusive_lock sleeps 0.1s per retry (~300 retries
   over 30s); atomic_write is a single write + fsync-less rename (same filesystem).
@@ -115,12 +120,18 @@ def atomic_write(path: Path, content: str, mode: int | None = 0o600) -> None:
       2. If mode is not None, chmod <path>.tmp to mode.
       3. Rename <path>.tmp -> path.
 
-    On any failure, unlinks <path>.tmp (missing_ok) and re-raises. The
-    destination file is never partially overwritten.
+    On any failure, unlinks OUR OWN pid-suffixed <path>.tmp.<pid> (missing_ok)
+    and re-raises. The destination file is never partially overwritten.
+
+    The tmp filename is suffixed with the current pid so two concurrent
+    callers (e.g. two agentic-identity invocations) never share one staging
+    path - a fixed tmp name would let one process's crash-cleanup unlink
+    another process's still-in-flight write, or let two writers collide on
+    the same tmp file.
 
     path.parent must already exist (no mkdir here - callers handle that).
     """
-    tmp = path.parent / (path.name + ".tmp")
+    tmp = path.parent / (path.name + f".tmp.{os.getpid()}")
     try:
         tmp.write_text(content, encoding="utf-8")
         if mode is not None:

--- a/bin/agentic-identity
+++ b/bin/agentic-identity
@@ -182,7 +182,9 @@ def _write_identity(lines: list[str], target_path: Path | None = None) -> int:
 
     When target_path is None, writes to global IDENTITY_PATH (default, unchanged
     for all existing callers). When provided, writes to that path (mkdir -p parent).
-    Uses atomic_write from _lib (write to .tmp, chmod 0o600, rename; .tmp cleaned on failure).
+    Uses atomic_write from _lib (write to a pid-suffixed .tmp.<pid>, chmod 0o600,
+    rename; our own pid-suffixed .tmp cleaned on failure). Atomic for a single
+    writer only.
     """
     dest = target_path if target_path is not None else IDENTITY_PATH
     content = "\n".join(lines) + "\n"

--- a/bin/tests/test__lib.py
+++ b/bin/tests/test__lib.py
@@ -6,8 +6,11 @@ Test groups:
   1. test_atomic_write_creates_file - basic write + rename.
   2. test_atomic_write_mode_bits    - chmod 0o600 applied to destination.
   3. test_atomic_write_mode_none    - mode=None skips chmod (preserves existing perms).
-  4. test_atomic_write_no_tmp_on_success - .tmp removed after successful write.
-  5. test_atomic_write_cleans_tmp_on_failure - .tmp unlinked when rename impossible.
+  4. test_atomic_write_no_tmp_on_success - .tmp.<pid> removed after successful write.
+  5. test_atomic_write_cleans_tmp_on_failure - .tmp.<pid> unlinked when rename impossible.
+  5a. test_atomic_write_uses_pid_suffixed_tmp_name - DS-109: never stages at the old fixed name.
+  5b. test_atomic_write_failure_does_not_delete_peer_tmp - DS-109: a peer's in-flight
+      tmp (legacy fixed name OR a different pid's suffixed name) survives our failure.
   6. test_acquire_lock_acquires_and_releases - context manager acquires, code runs, releases.
   7. test_acquire_lock_blocks_second - second acquirer times out while first holds lock.
   8. test_acquire_lock_releases_after_with - after 'with' block, second acquirer succeeds.
@@ -80,17 +83,57 @@ class TestAtomicWrite(unittest.TestCase):
         # checking the content round-trips correctly (the main behavioral check).
 
     def test_atomic_write_no_tmp_on_success(self):
-        tmp = self.dest.parent / (self.dest.name + ".tmp")
+        tmp = self.dest.parent / (self.dest.name + f".tmp.{os.getpid()}")
         atomic_write(self.dest, "data\n")
-        self.assertFalse(tmp.exists(), ".tmp file should be removed after successful write")
+        self.assertFalse(tmp.exists(), ".tmp.<pid> file should be removed after successful write")
 
     def test_atomic_write_cleans_tmp_on_failure(self):
-        # Make dest a directory so rename fails; .tmp should be cleaned up.
+        # Make dest a directory so rename fails; .tmp.<pid> should be cleaned up.
         self.dest.mkdir()
-        tmp = self.dest.parent / (self.dest.name + ".tmp")
+        tmp = self.dest.parent / (self.dest.name + f".tmp.{os.getpid()}")
         with self.assertRaises(Exception):
             atomic_write(self.dest, "data\n")
-        self.assertFalse(tmp.exists(), ".tmp file should be removed on failure")
+        self.assertFalse(tmp.exists(), ".tmp.<pid> file should be removed on failure")
+
+    def test_atomic_write_uses_pid_suffixed_tmp_name(self):
+        # DS-109: the staging file must be suffixed with our own pid, not a
+        # fixed name every writer would share.
+        legacy_fixed_tmp = self.dest.parent / (self.dest.name + ".tmp")
+        atomic_write(self.dest, "data\n")
+        self.assertFalse(
+            legacy_fixed_tmp.exists(),
+            "no staging file should ever land at the old fixed <dest>.tmp name",
+        )
+
+    def test_atomic_write_failure_does_not_delete_peer_tmp(self):
+        # DS-109 regression: a concurrent writer's in-flight staging file -
+        # at the legacy fixed name, or at a different pid's suffixed name -
+        # must never be deleted by an unrelated failure in THIS call. Before
+        # the fix, atomic_write unconditionally unlinked a single shared
+        # `<dest>.tmp` name on any exception, which would delete a peer
+        # process's still-in-flight write.
+        self.dest.mkdir()  # forces the rename in this call to fail
+
+        legacy_fixed_peer_tmp = self.dest.parent / (self.dest.name + ".tmp")
+        # Guaranteed to differ from our own pid by construction.
+        foreign_pid = f"{os.getpid()}9"
+        peer_tmp = self.dest.parent / (self.dest.name + f".tmp.{foreign_pid}")
+        legacy_fixed_peer_tmp.write_text("PEER_INFLIGHT_DATA_LEGACY_NAME", encoding="utf-8")
+        peer_tmp.write_text("PEER_INFLIGHT_DATA_PID_SUFFIXED", encoding="utf-8")
+
+        with self.assertRaises(Exception):
+            atomic_write(self.dest, "data\n")
+
+        self.assertEqual(
+            legacy_fixed_peer_tmp.read_text(encoding="utf-8"),
+            "PEER_INFLIGHT_DATA_LEGACY_NAME",
+            "a peer's legacy fixed-name .tmp file must survive our unrelated failure, untouched",
+        )
+        self.assertEqual(
+            peer_tmp.read_text(encoding="utf-8"),
+            "PEER_INFLIGHT_DATA_PID_SUFFIXED",
+            "a peer's pid-suffixed .tmp.<otherpid> file must survive our unrelated failure, untouched",
+        )
 
     def test_atomic_write_overwrites_existing(self):
         self.dest.write_text("old content\n", encoding="utf-8")

--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -242,7 +242,10 @@ def _write_counter(cwd: str, count: int, last_user_msg_count: int) -> bool:
         agentic_dir = os.path.join(cwd, ".agentic")
         os.makedirs(agentic_dir, exist_ok=True)
         path = _counter_path(cwd)
-        tmp = path + ".tmp"
+        # Per-process tmp suffix: two concurrent hook invocations must never
+        # share a staging path (a fixed name would let one process's write
+        # clobber or race the other's os.replace).
+        tmp = path + ".tmp." + str(os.getpid())
         with open(tmp, "w") as f:
             json.dump({"count": count, "last_user_msg_count": last_user_msg_count}, f)
         os.replace(tmp, path)

--- a/hooks/lib/state-mark.js
+++ b/hooks/lib/state-mark.js
@@ -80,10 +80,19 @@
  *                independently. Each candidate file is processed inside its
  *                OWN try/catch so a failure (parse error, fs error) on one
  *                file never skips the other (fail-open PER PATH, not just
- *                per call). Every write is atomic (tmp + rename) with a
- *                catch-block fs.unlinkSync(tmp) cleanup so a crash mid-write
- *                or an early parse-error catch never leaves an orphan .tmp
- *                file. markInterrupted deliberately never writes loop-state's
+ *                per call). Every write is atomic-for-a-single-writer (pid-
+ *                suffixed tmp + rename, `<file>.tmp.<pid>`) with a catch-block
+ *                fs.unlinkSync(tmp) cleanup scoped to ONLY the pid-suffixed
+ *                name this call itself created, so a crash mid-write or an
+ *                early parse-error catch never leaves an orphan .tmp file AND
+ *                never deletes a concurrent process's in-flight staging file.
+ *                "Atomic" here is true single-writer (rename is atomic on the
+ *                same filesystem); with two concurrent sessions writing the
+ *                same candidate file, the two renames still race for last-
+ *                write-wins on the destination, but neither process can ever
+ *                observe or clobber the other's tmp - only the fixed-name
+ *                variant (pre-fix) had that defect. markInterrupted
+ *                deliberately never writes loop-state's
  *                `last_updated` - Contract A's resume-staleness gate reads
  *                only `last_updated` with no `status` exemption, so writing
  *                it on the terminal mark would make a freshly-interrupted
@@ -263,13 +272,17 @@ function _refreshCandidateLiveness(cwd, sessionId, candidate, onOutcome) {
     if (state.status !== 'active') return;
 
     state[candidate.tsField] = new Date().toISOString();
-    tmpPath = filePath + '.tmp';
+    tmpPath = filePath + '.tmp.' + process.pid;
     fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
     fs.renameSync(tmpPath, filePath);
     if (onOutcome) onOutcome(candidate.healthTarget, true, null);
   } catch (err) {
     if (onOutcome) onOutcome(candidate.healthTarget, false, err && err.message);
-    try { fs.unlinkSync(filePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
+    // Only unlink OUR OWN pid-suffixed tmp - never a shared/fixed name another
+    // concurrent process could own (see module manifest Failure modes).
+    if (tmpPath) {
+      try { fs.unlinkSync(tmpPath); } catch (_e) { /* tmp absent or never created */ }
+    }
   }
 }
 
@@ -325,13 +338,17 @@ function _markCandidateInterrupted(cwd, sessionId, candidate, onOutcome) {
     }
     // else: tsField is deliberately NOT written here - see module manifest.
 
-    tmpPath = filePath + '.tmp';
+    tmpPath = filePath + '.tmp.' + process.pid;
     fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
     fs.renameSync(tmpPath, filePath);
     if (onOutcome) onOutcome(candidate.healthTarget, true, null);
   } catch (err) {
     if (onOutcome) onOutcome(candidate.healthTarget, false, err && err.message);
-    try { fs.unlinkSync(filePath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
+    // Only unlink OUR OWN pid-suffixed tmp - never a shared/fixed name another
+    // concurrent process could own (see module manifest Failure modes).
+    if (tmpPath) {
+      try { fs.unlinkSync(tmpPath); } catch (_e) { /* tmp absent or never created */ }
+    }
   }
 }
 

--- a/hooks/lib/wrap-marker.js
+++ b/hooks/lib/wrap-marker.js
@@ -285,15 +285,27 @@ function wrapDir(cwd) {
   return path.join(agenticDir(cwd), 'wrap');
 }
 
-/** Atomic write (tmp + rename). Fail-open: returns true on success, false otherwise. */
+/**
+ * Atomic write (pid-suffixed tmp + rename). Fail-open: returns true on success,
+ * false otherwise. The tmp name is suffixed with this process's own pid so two
+ * concurrent writers targeting the same targetPath never share one staging
+ * path - single-writer atomicity only (see hooks/lib/state-mark.js for the
+ * precedent this mirrors).
+ */
 function atomicWriteJson(targetPath, obj) {
+  let tmpPath;
   try {
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    const tmpPath = targetPath + '.tmp';
+    tmpPath = targetPath + '.tmp.' + process.pid;
     fs.writeFileSync(tmpPath, JSON.stringify(obj, null, 2), 'utf8');
     fs.renameSync(tmpPath, targetPath);
     return true;
   } catch (_) {
+    // Only unlink OUR OWN pid-suffixed tmp - never a shared/fixed name another
+    // concurrent process could own.
+    if (tmpPath) {
+      try { fs.unlinkSync(tmpPath); } catch (_e) { /* tmp absent or never created */ }
+    }
     return false;
   }
 }

--- a/hooks/post-tool-use-capture-nudge.js
+++ b/hooks/post-tool-use-capture-nudge.js
@@ -162,7 +162,9 @@ function readSkillNudgeSurfaced(cwd) {
 
 /**
  * Atomically append a dedup entry for (session_id, candidate_id) to the
- * in-session tracker. Uses read-existing + tmp-write + rename for atomicity.
+ * in-session tracker. Uses read-existing + tmp-write + rename for atomicity
+ * (single-writer atomicity - the tmp name is pid-suffixed per DS-109 so two
+ * concurrent hook invocations never share a staging path).
  * Silent failure: a missed write at worst re-nudges on the next spawn.
  *
  * @param {string} cwd - Project root.
@@ -183,7 +185,10 @@ function recordSkillNudgeSurfaced(cwd, sessionId, candidateId) {
   const body = (existing && !existing.endsWith('\n')) ? existing + '\n' : existing;
   const next = body + entry + '\n';
 
-  const tmpPath = trackerPath + '.tmp';
+  // Per-process tmp suffix: two concurrent hook invocations must never share
+  // a staging path (a fixed name would let one process's write clobber or
+  // race the other's rename).
+  const tmpPath = trackerPath + '.tmp.' + process.pid;
   fs.writeFileSync(tmpPath, next, 'utf8');
   fs.renameSync(tmpPath, trackerPath);
 }
@@ -224,7 +229,9 @@ function alreadySurfaced(cwd, sessionId, lastEventTs) {
 /**
  * Append a dedup entry for this (session_id, lastEventTs) tuple. Atomic via
  * read-existing + tmp-write + rename so a concurrent reader never sees a partial
- * file. Silent failure - a missed write at worst re-nudges next spawn.
+ * file (single-writer atomicity - the tmp name is pid-suffixed per DS-109 so
+ * two concurrent hook invocations never share a staging path). Silent failure
+ * - a missed write at worst re-nudges next spawn.
  *
  * @param {string} cwd - Project root.
  * @param {string} sessionId
@@ -244,7 +251,10 @@ function recordSurfaced(cwd, sessionId, lastEventTs) {
   const body = (existing && !existing.endsWith('\n')) ? existing + '\n' : existing;
   const next = body + entry + '\n';
 
-  const tmpPath = trackerPath + '.tmp';
+  // Per-process tmp suffix: two concurrent hook invocations must never share
+  // a staging path (a fixed name would let one process's write clobber or
+  // race the other's rename).
+  const tmpPath = trackerPath + '.tmp.' + process.pid;
   fs.writeFileSync(tmpPath, next, 'utf8');
   fs.renameSync(tmpPath, trackerPath);
 }

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -1151,16 +1151,18 @@ function appendCaptureGapNoticeToContextMd(cwd, residualOnly, sessionId) {
     // Note: the inner catch uses _cursorErr to avoid shadowing the outer _ at the
     // outer catch below. recordHealth for the cursor write goes in this catch, not
     // in the _e cleanup catch (which handles tmp cleanup only).
+    const tmpCursor = cursorPath + '.tmp.' + process.pid;
     try {
       const nowIso = new Date().toISOString();
-      const tmpCursor = cursorPath + '.tmp';
       fs.writeFileSync(tmpCursor, nowIso, 'utf8');
       fs.renameSync(tmpCursor, cursorPath);
       recordHealth('appendCaptureGapNoticeToContextMd-cursor', true, null);
     } catch (_cursorErr) {
       recordHealth('appendCaptureGapNoticeToContextMd-cursor', false, _cursorErr && _cursorErr.message);
       /* silent - cursor update failure is non-fatal */
-      try { fs.unlinkSync(cursorPath + '.tmp'); } catch (_e) { /* tmp absent or never created */ }
+      // Only unlink OUR OWN pid-suffixed tmp - never a shared/fixed name
+      // another concurrent session could own.
+      try { fs.unlinkSync(tmpCursor); } catch (_e) { /* tmp absent or never created */ }
     }
   } catch (_) {
     recordHealth('appendCaptureGapNoticeToContextMd-context', false, _ && _.message);
@@ -1536,5 +1538,5 @@ run().catch(() => { try { process.exit(0); } catch (_) {} });
 // executing run(). stop-context.js has no production module.exports; this shim
 // is only reached when the test replaces `run();` before requiring.
 if (typeof module !== 'undefined') {
-  module.exports = { recordHealth, flushHealth, healthOutcomes };
+  module.exports = { recordHealth, flushHealth, healthOutcomes, appendCaptureGapNoticeToContextMd };
 }

--- a/hooks/tests/test-enforce-no-abdication.py
+++ b/hooks/tests/test-enforce-no-abdication.py
@@ -23,6 +23,8 @@ Test coverage:
   - Counter increments and CAP halts blocking
   - Counter resets on new user turn (via user_msg_count advance)
   - Corrupt counter file -> treated as 0
+  - DS-109: counter tmp is pid-suffixed; a peer's in-flight tmp (legacy fixed
+    name or a different pid's suffixed name) survives our write untouched
   - Malformed stdin -> ALLOW (fail-open)
   - Smoke: abdicating payload -> exactly one valid JSON block object
   - Smoke: clean payload -> empty stdout
@@ -711,6 +713,78 @@ def test_corrupt_counter_file(tmp_dir: str) -> int:
     return failed
 
 
+def test_write_counter_pid_suffixed_tmp(tmp_dir: str) -> int:
+    """DS-109 regression: _write_counter's staging file must be pid-suffixed.
+
+    Pre-fix, _write_counter always wrote to the SAME fixed `<counter>.tmp`
+    name regardless of which process called it. Confirmed by execution
+    against the pre-fix hook: pre-planting a peer's in-flight content at that
+    exact path and then running the hook silently truncates and consumes it
+    (open(tmp, "w") overwrites it, then os.replace renames it away) - the
+    peer's staging data is destroyed with no error, no trace. Post-fix, the
+    tmp name is `<counter>.tmp.<our-own-pid>`, so this process can never
+    write through, or rename away, a name any other process owns.
+
+    This test asserts the observable contract from the outside: after a
+    normal successful hook invocation that writes the counter, a peer's
+    pre-planted in-flight tmp files - both the legacy fixed `.tmp` name and a
+    different pid's `.tmp.<otherpid>` name - survive the run untouched,
+    byte-for-byte.
+    """
+    print("\n  [DS-109: counter tmp naming + peer-tmp survival]")
+    failed = 0
+    pid_dir = os.path.join(tmp_dir, "pid_tmp_cwd")
+    os.makedirs(pid_dir, exist_ok=True)
+    make_config_file(pid_dir, enabled=True)
+    agentic_dir = os.path.join(pid_dir, ".agentic")
+    os.makedirs(agentic_dir, exist_ok=True)
+    counter_path = os.path.join(agentic_dir, ".abdication-guard-fire-count")
+
+    # Pre-plant two "peer" staging files: the legacy fixed name (what every
+    # writer shared pre-fix) and a pid-suffixed name for a pid that is
+    # provably not this test process's own.
+    legacy_fixed_peer_tmp = counter_path + ".tmp"
+    foreign_pid = f"{os.getpid()}9"
+    peer_tmp = counter_path + f".tmp.{foreign_pid}"
+    with open(legacy_fixed_peer_tmp, "w") as f:
+        f.write("PEER_INFLIGHT_DATA_LEGACY_NAME")
+    with open(peer_tmp, "w") as f:
+        f.write("PEER_INFLIGHT_DATA_PID_SUFFIXED")
+
+    payload = make_payload(pid_dir, last_assistant_message=ABDICATING_MSG)
+    rc, stdout, _ = run_hook(payload)
+    ok_block = is_block(rc, stdout)
+    print(f"    [{'PASS' if ok_block else 'FAIL'}] hook still blocks/writes the counter normally")
+    if not ok_block:
+        failed += 1
+
+    with open(legacy_fixed_peer_tmp) as f:
+        legacy_survived = f.read() == "PEER_INFLIGHT_DATA_LEGACY_NAME"
+    print(f"    [{'PASS' if legacy_survived else 'FAIL'}] peer's legacy fixed-name .tmp survives untouched")
+    if not legacy_survived:
+        failed += 1
+
+    with open(peer_tmp) as f:
+        pid_survived = f.read() == "PEER_INFLIGHT_DATA_PID_SUFFIXED"
+    print(f"    [{'PASS' if pid_survived else 'FAIL'}] peer's pid-suffixed .tmp.<otherpid> survives untouched")
+    if not pid_survived:
+        failed += 1
+
+    # Our own real write should have landed cleanly with no leftover tmp of
+    # ANY shape (own-pid-suffixed or otherwise) once the subprocess exits.
+    leftover = [
+        f for f in os.listdir(agentic_dir)
+        if f.startswith(".abdication-guard-fire-count.tmp")
+        and f not in (os.path.basename(legacy_fixed_peer_tmp), os.path.basename(peer_tmp))
+    ]
+    ok_no_leftover = leftover == []
+    print(f"    [{'PASS' if ok_no_leftover else 'FAIL'}] no orphaned own-tmp remains (found: {leftover or 'none'})")
+    if not ok_no_leftover:
+        failed += 1
+
+    return failed
+
+
 def test_transcript_fallback(tmp_dir: str) -> int:
     """Test transcript_path fallback when last_assistant_message is absent."""
     print("\n  [Transcript fallback tests]")
@@ -847,6 +921,7 @@ def main() -> None:
         total_failed += test_counter_reset_on_new_user_turn(tmp_dir)
         total_failed += test_corrupt_counter_file(tmp_dir)
         total_failed += test_unwritable_counter_allows_stop(tmp_dir)
+        total_failed += test_write_counter_pid_suffixed_tmp(tmp_dir)
 
         # Transcript fallback.
         total_failed += test_transcript_fallback(tmp_dir)

--- a/hooks/tests/test-post-tool-use-capture-nudge.js
+++ b/hooks/tests/test-post-tool-use-capture-nudge.js
@@ -196,6 +196,42 @@ console.log('\nTest 1: fires-when-worthy-event');
 }
 
 // ---------------------------------------------------------------------------
+// Test 1b (DS-109): recordSurfaced's staging file is pid-suffixed, and never
+// clobbers a peer's in-flight tmp at the same base name.
+// ---------------------------------------------------------------------------
+console.log('\nTest 1b (DS-109): recordSurfaced tmp is pid-suffixed; peer tmp survives a real write');
+{
+  const cwd = makeTempProject();
+  const sessionId = 'ptu-session-001b';
+  fs.writeFileSync(
+    path.join(cwd, '.agentic', 'events.jsonl'),
+    makeEvent(sessionId, 'spawn_complete', 'debugger') + '\n', 'utf8'
+  );
+
+  const trackerPath = path.join(cwd, '.agentic', '.capture-gap-surfaced');
+  // Pre-plant a peer's in-flight staging file at the EXACT fixed name every
+  // writer shared pre-DS-109. If recordSurfaced still writes through this
+  // shared name, the real hook invocation below will truncate/consume it.
+  const legacyFixedNamePeerTmp = trackerPath + '.tmp';
+  fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_DATA_LEGACY_NAME');
+
+  const { status } = runHook(taskPayload(cwd, sessionId), cwd);
+  assert(status === 0, 'hook exits 0');
+  assert(fs.existsSync(trackerPath), 'dedup tracker was actually written (recordSurfaced ran for real)');
+  assert(
+    fs.existsSync(legacyFixedNamePeerTmp)
+      && fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_LEGACY_NAME',
+    'DS-109: a peer\'s legacy fixed-name .tmp file survives a real recordSurfaced write, untouched'
+  );
+  // No leftover own-pid tmp (subprocess pid, not ours - just assert no
+  // stray tmp.<digits> files besides the pre-planted legacy one).
+  const strayTmp = fs.readdirSync(path.join(cwd, '.agentic'))
+    .filter((f) => f.startsWith('.capture-gap-surfaced.tmp') && f !== path.basename(legacyFixedNamePeerTmp));
+  assert(strayTmp.length === 0, `no orphaned own-pid tmp remains (found: ${strayTmp.join(', ') || 'none'})`);
+  cleanup(cwd);
+}
+
+// ---------------------------------------------------------------------------
 // Test 2: dedup-suppresses-repeat
 // ---------------------------------------------------------------------------
 console.log('\nTest 2: dedup-suppresses-repeat');

--- a/hooks/tests/test-state-mark.js
+++ b/hooks/tests/test-state-mark.js
@@ -20,7 +20,12 @@
  *       loop-state would make it immortal and unrecoverable).
  *   (e) markInterrupted PROCEEDS on that same absent-session_id file
  *       (opposite polarity, deliberately asymmetric - see module manifest).
- *   (f) no orphan .tmp file on success or on corrupt-JSON input.
+ *   (f) no orphan .tmp.<pid> file on success or on corrupt-JSON input, AND
+ *       the catch-path cleanup unlinks ONLY our own pid-suffixed tmp - a
+ *       foreign/stale tmp (no pid suffix, or a different pid) at the same
+ *       base name survives untouched (DS-109 regression: a fixed tmp name's
+ *       catch-path cleanup used to delete ANY file at that fixed path,
+ *       including a concurrent peer's still-in-flight staging file).
  *   (g) health label on the real code path: corrupt-JSON hits
  *       onOutcome('writeLoopState', false, ...) - literal target string.
  *
@@ -183,17 +188,23 @@ console.log('\n[e] markInterrupted PROCEEDS on absent/null/empty session_id (del
 }
 
 // ---------------------------------------------------------------------------
-// (f) no orphan .tmp on success or corrupt-JSON input
+// (f) no orphan .tmp.<pid> on success or corrupt-JSON input, and catch-path
+//     cleanup is scoped to our own pid-suffixed tmp only (DS-109)
 // ---------------------------------------------------------------------------
-console.log('\n[f] no orphan .tmp files on success or corrupt-JSON input');
+console.log('\n[f] no orphan tmp files on success or corrupt-JSON input; cleanup is own-name-only');
 {
+  // A tmp file left behind by this module is always named
+  // `<file>.tmp.<pid>` - match that shape, not a bare `.tmp` suffix, so this
+  // filter still catches a real leak after the DS-109 rename.
+  const isOwnStyleTmp = (f) => /\.tmp\.\d+$/.test(f);
+
   // Success path (refreshLiveness).
   {
     const { tmpDir, agenticDir } = makeTmp('ae-state-mark-f1-');
     writeLoopState(agenticDir, { status: 'active', session_id: 'sess-a' });
     stateMark.refreshLiveness(tmpDir, 'sess-a');
-    const tmpFiles = fs.readdirSync(agenticDir).filter((f) => f.endsWith('.tmp'));
-    assert(tmpFiles.length === 0, `(refreshLiveness success) no .tmp remains (found: ${tmpFiles.join(', ') || 'none'})`);
+    const tmpFiles = fs.readdirSync(agenticDir).filter(isOwnStyleTmp);
+    assert(tmpFiles.length === 0, `(refreshLiveness success) no .tmp.<pid> remains (found: ${tmpFiles.join(', ') || 'none'})`);
     cleanup(tmpDir);
   }
 
@@ -202,26 +213,74 @@ console.log('\n[f] no orphan .tmp files on success or corrupt-JSON input');
     const { tmpDir, agenticDir } = makeTmp('ae-state-mark-f2-');
     writeLoopState(agenticDir, { status: 'active', session_id: 'sess-a' });
     stateMark.markInterrupted(tmpDir, 'sess-a');
-    const tmpFiles = fs.readdirSync(agenticDir).filter((f) => f.endsWith('.tmp'));
-    assert(tmpFiles.length === 0, `(markInterrupted success) no .tmp remains (found: ${tmpFiles.join(', ') || 'none'})`);
+    const tmpFiles = fs.readdirSync(agenticDir).filter(isOwnStyleTmp);
+    assert(tmpFiles.length === 0, `(markInterrupted success) no .tmp.<pid> remains (found: ${tmpFiles.join(', ') || 'none'})`);
     cleanup(tmpDir);
   }
 
-  // Corrupt-JSON path: pre-plant a stale .tmp, feed corrupt loop-state.json,
-  // confirm the catch-block cleanup removes it (mirrors #262's regression
-  // pattern in test-stop-context-session-log.js sub-test 5).
+  // Own-tmp cleanup on a THIS-CALL failure: tmpPath is only ever assigned
+  // after JSON.parse succeeds (i.e. once this call has actually created its
+  // own tmp.<pid> file), so to exercise "we created a tmp and then failed"
+  // the failure has to happen at/after the rename step, not at parse time.
+  // Monkeypatch fs.renameSync to throw once, after the real writeFileSync
+  // has landed our own tmp.<pid> file on disk, then confirm the catch block
+  // removes exactly that file (own-name-only cleanup, still working for the
+  // case it's meant to cover: a crash between our write and our rename).
   {
     const { tmpDir, agenticDir } = makeTmp('ae-state-mark-f3-');
+    writeLoopState(agenticDir, { status: 'active', session_id: 'sess-a' });
+    const loopStatePath = path.join(agenticDir, 'loop-state.json');
+    const expectedOwnTmp = loopStatePath + '.tmp.' + process.pid;
+
+    const realRenameSync = fs.renameSync;
+    let observedOwnTmpExistedMidWrite = false;
+    fs.renameSync = function patchedRenameSync(src, dest) {
+      if (src === expectedOwnTmp) {
+        observedOwnTmpExistedMidWrite = fs.existsSync(expectedOwnTmp);
+        throw new Error('simulated crash between write and rename');
+      }
+      return realRenameSync.apply(fs, arguments);
+    };
+    try {
+      stateMark.refreshLiveness(tmpDir, 'sess-a');
+    } finally {
+      fs.renameSync = realRenameSync;
+    }
+
+    assert(observedOwnTmpExistedMidWrite,
+      '(simulated crash) our own tmp.<pid> did exist on disk at the moment rename failed');
+    assert(!fs.existsSync(expectedOwnTmp),
+      '(simulated crash) our own tmp.<pid> is cleaned up by the catch block after a failed rename');
+    cleanup(tmpDir);
+  }
+
+  // DS-109 regression: corrupt-JSON path must NEVER delete a PEER's
+  // in-flight staging file. Pre-plant two foreign tmp files - one in the
+  // legacy fixed-name shape (`.tmp`, pre-fix) and one pid-suffixed with a
+  // pid that is provably not ours - then trigger our own catch-path via
+  // corrupt JSON. Both must survive: the catch block only ever unlinks the
+  // exact tmpPath variable IT assigned in the try block, and here that
+  // variable is never assigned at all (JSON.parse throws before tmpPath is
+  // set), so nothing at any other name is ever touched.
+  {
+    const { tmpDir, agenticDir } = makeTmp('ae-state-mark-f4-');
     const loopStatePath = path.join(agenticDir, 'loop-state.json');
     fs.writeFileSync(loopStatePath, '{ bad json !!');
-    const staleTmp = loopStatePath + '.tmp';
-    fs.writeFileSync(staleTmp, 'stale content from a previous crashed session');
+
+    const legacyFixedNamePeerTmp = loopStatePath + '.tmp';
+    // Guaranteed not to equal our own pid: append a digit to our own pid so
+    // it differs by construction, no matter what our actual pid is.
+    const foreignPid = String(process.pid) + '9';
+    const peerTmp = loopStatePath + '.tmp.' + foreignPid;
+    fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_DATA_LEGACY_NAME');
+    fs.writeFileSync(peerTmp, 'PEER_INFLIGHT_DATA_PID_SUFFIXED');
 
     stateMark.refreshLiveness(tmpDir, 'sess-a');
 
-    const tmpFiles = fs.readdirSync(agenticDir).filter((f) => f.endsWith('.tmp'));
-    assert(tmpFiles.length === 0,
-      `(corrupt-JSON) stale .tmp cleaned up by catch block (found: ${tmpFiles.join(', ') || 'none'})`);
+    assert(fs.existsSync(legacyFixedNamePeerTmp) && fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_LEGACY_NAME',
+      'DS-109: a peer\'s legacy fixed-name .tmp file survives our unrelated catch-path cleanup, untouched');
+    assert(fs.existsSync(peerTmp) && fs.readFileSync(peerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_PID_SUFFIXED',
+      'DS-109: a peer\'s pid-suffixed .tmp.<otherpid> file survives our unrelated catch-path cleanup, untouched');
     cleanup(tmpDir);
   }
 }

--- a/hooks/tests/test-stop-context-capture-gap-cursor.js
+++ b/hooks/tests/test-stop-context-capture-gap-cursor.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: stop-context.js appendCaptureGapNoticeToContextMd's pagination
+ * cursor write (.agentic/.capture-gap-last-sweep), via the shim-load pattern
+ * used by test-stop-context-health.js.
+ *
+ * DS-109: the cursor's staging file used to be a single fixed
+ * `<cursorPath>.tmp` name shared by every writer, with an unconditional
+ * catch-path `fs.unlinkSync(cursorPath + '.tmp')` cleanup that could delete
+ * a concurrent peer's still-in-flight staging file. Post-fix, the tmp name
+ * is pid-suffixed (`<cursorPath>.tmp.<pid>`) and the catch-path cleanup is
+ * scoped to only the exact tmp path this call created.
+ *
+ * Test cases:
+ *   (a) normal write succeeds: cursor file is written, no own-style tmp
+ *       remains afterward.
+ *   (b) a peer's in-flight staging file - at the legacy fixed name, or at a
+ *       different pid's suffixed name - survives our own successful write
+ *       untouched.
+ *   (c) a peer's in-flight staging file survives our own FAILED write
+ *       (simulated by monkeypatching fs.renameSync to throw once, after our
+ *       own tmp.<pid> has actually landed on disk) - proves the catch-path
+ *       cleanup is scoped to our own name only, not the shared/legacy name.
+ *
+ * Run with: node hooks/tests/test-stop-context-capture-gap-cursor.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Shim-load stop-context.js (same technique as test-stop-context-health.js)
+// ---------------------------------------------------------------------------
+
+const hookPath = path.resolve(__dirname, '..', 'stop-context.js');
+const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+const { reanchorHookRequires } = require('./lib/hook-shim.js');
+
+let shimmedSource;
+try {
+  shimmedSource = reanchorHookRequires(
+    hookSource.replace(/^run\(\).*;\s*$/m, '// test shim: run() suppressed'),
+    path.resolve(__dirname, '..', 'lib')
+  );
+} catch (shimErr) {
+  console.error('  FATAL: ' + shimErr.message);
+  process.exit(1);
+}
+
+const tmpShimPath = path.join(os.tmpdir(), `stop-ctx-cgc-shim-${Date.now()}.js`);
+fs.writeFileSync(tmpShimPath, shimmedSource, 'utf8');
+let helpers;
+try {
+  helpers = require(tmpShimPath);
+} finally {
+  try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
+}
+
+const { appendCaptureGapNoticeToContextMd } = helpers;
+if (typeof appendCaptureGapNoticeToContextMd !== 'function') {
+  console.error('  FATAL: appendCaptureGapNoticeToContextMd not exported by the shim - update the module.exports shim.');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeTmpProject() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-stop-cgc-'));
+  fs.mkdirSync(path.join(tmpDir, '.agentic'), { recursive: true });
+  return tmpDir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+const isOwnStyleTmp = (f) => /\.capture-gap-last-sweep\.tmp\.\d+$/.test(f);
+
+// ---------------------------------------------------------------------------
+// (a) normal write succeeds, no own-style tmp left behind
+// ---------------------------------------------------------------------------
+console.log('\n[a] normal write succeeds; no orphan tmp.<pid> remains');
+{
+  const tmpDir = makeTmpProject();
+  const agenticDir = path.join(tmpDir, '.agentic');
+  const cursorPath = path.join(agenticDir, '.capture-gap-last-sweep');
+
+  appendCaptureGapNoticeToContextMd(tmpDir, false, 'sess-a');
+
+  assert(fs.existsSync(cursorPath), 'cursor file written');
+  const leftover = fs.readdirSync(agenticDir).filter(isOwnStyleTmp);
+  assert(leftover.length === 0, `no orphan tmp.<pid> remains (found: ${leftover.join(', ') || 'none'})`);
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// (b) DS-109: a peer's in-flight staging file survives our own SUCCESSFUL
+//     write, whether at the legacy fixed name or a different pid's name.
+// ---------------------------------------------------------------------------
+console.log('\n[b] DS-109: peer in-flight tmp survives our own successful write');
+{
+  const tmpDir = makeTmpProject();
+  const agenticDir = path.join(tmpDir, '.agentic');
+  const cursorPath = path.join(agenticDir, '.capture-gap-last-sweep');
+
+  const legacyFixedNamePeerTmp = cursorPath + '.tmp';
+  const foreignPid = String(process.pid) + '9'; // guaranteed not our own pid
+  const peerTmp = cursorPath + '.tmp.' + foreignPid;
+  fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_DATA_LEGACY_NAME');
+  fs.writeFileSync(peerTmp, 'PEER_INFLIGHT_DATA_PID_SUFFIXED');
+
+  appendCaptureGapNoticeToContextMd(tmpDir, false, 'sess-a');
+
+  assert(fs.existsSync(cursorPath), 'cursor file still written correctly despite peer tmp files present');
+  assert(
+    fs.existsSync(legacyFixedNamePeerTmp) && fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_LEGACY_NAME',
+    'peer\'s legacy fixed-name .tmp file survives untouched'
+  );
+  assert(
+    fs.existsSync(peerTmp) && fs.readFileSync(peerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_PID_SUFFIXED',
+    'peer\'s pid-suffixed .tmp.<otherpid> file survives untouched'
+  );
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// (c) DS-109: a peer's in-flight staging file survives our own FAILED write
+//     (forced rename failure), and our own tmp.<pid> is cleaned up by the
+//     catch block - proving cleanup is scoped to our own name only.
+// ---------------------------------------------------------------------------
+console.log('\n[c] DS-109: peer in-flight tmp survives our own failed write; own tmp still cleaned up');
+{
+  const tmpDir = makeTmpProject();
+  const agenticDir = path.join(tmpDir, '.agentic');
+  const cursorPath = path.join(agenticDir, '.capture-gap-last-sweep');
+  const expectedOwnTmp = cursorPath + '.tmp.' + process.pid;
+
+  const legacyFixedNamePeerTmp = cursorPath + '.tmp';
+  fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_DATA_LEGACY_NAME');
+
+  const realRenameSync = fs.renameSync;
+  let observedOwnTmpExistedMidWrite = false;
+  fs.renameSync = function patchedRenameSync(src, dest) {
+    if (src === expectedOwnTmp) {
+      observedOwnTmpExistedMidWrite = fs.existsSync(expectedOwnTmp);
+      throw new Error('simulated crash between write and rename');
+    }
+    return realRenameSync.apply(fs, arguments);
+  };
+  try {
+    appendCaptureGapNoticeToContextMd(tmpDir, false, 'sess-a');
+  } finally {
+    fs.renameSync = realRenameSync;
+  }
+
+  assert(observedOwnTmpExistedMidWrite, 'our own tmp.<pid> did exist on disk at the moment rename failed');
+  assert(!fs.existsSync(expectedOwnTmp), 'our own tmp.<pid> is cleaned up by the catch block after a failed rename');
+  assert(
+    fs.existsSync(legacyFixedNamePeerTmp) && fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_LEGACY_NAME',
+    'DS-109: peer\'s legacy fixed-name .tmp file survives our unrelated failed-write cleanup, untouched'
+  );
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed.`);
+if (failed > 0) {
+  process.exit(1);
+}
+process.exit(0);

--- a/hooks/tests/test-stop-context-session-log.js
+++ b/hooks/tests/test-stop-context-session-log.js
@@ -247,19 +247,24 @@ console.log('\n[4] Write failure: session-log dir is an existing file (unwriteab
 }
 
 // ---------------------------------------------------------------------------
-// Sub-test 5: No orphan .tmp files after a normal hook run (#262 regression)
+// Sub-test 5: No orphan .tmp files after a normal hook run (#262 regression),
+// and (DS-109) the catch-path cleanup is scoped to our own pid-suffixed tmp
+// only - a peer's in-flight staging file at the same base name must survive.
 // ---------------------------------------------------------------------------
-console.log('\n[5] No orphan .tmp files: loop-state atomic write leaves no .tmp on success or failure');
+console.log('\n[5] No orphan tmp files: loop-state atomic write leaves no tmp.<pid> on success or failure; peer tmp survives');
 {
-  // Two scenarios in one sub-test:
-  // (a) normal success path: active loop-state -> atomic write -> rename -> no .tmp
-  // (b) failure path: loop-state.json is corrupt JSON -> catch fires early, no
-  //     .tmp ever written -> catch cleanup is a no-op (unlink of absent file must
-  //     not throw).
-  //
-  // Both scenarios assert that no .tmp files remain after the hook exits, which
-  // is the invariant #262 introduces. If the catch cleanup is removed, a .tmp
-  // planted before scenario (b) would survive and the test would catch it.
+  // A tmp file this write path can leave behind is always named
+  // `<file>.tmp.<pid>` post-DS-109 - match that shape, not a bare `.tmp`
+  // suffix.
+  const isOwnStyleTmp = (f) => /\.tmp\.\d+$/.test(f);
+
+  // Three scenarios in one sub-test:
+  // (a) normal success path: active loop-state -> atomic write -> rename -> no tmp
+  // (b) failure path, own tmp: loop-state.json is corrupt JSON -> catch fires
+  //     early, no tmp ever written by US -> catch cleanup is a no-op.
+  // (c) DS-109 regression: a PEER's in-flight staging file - at the legacy
+  //     fixed name, or at a different pid's suffixed name - must survive our
+  //     unrelated catch-path cleanup untouched.
   //
   // Both invocations pass --cadence=turn (this hook's install.sh-wired
   // default) so the atomic write path exercised here is refreshLiveness, not
@@ -278,31 +283,49 @@ console.log('\n[5] No orphan .tmp files: loop-state atomic write leaves no .tmp 
     JSON.stringify({ status: 'active', session_id: 'test-session-uuid' }),
   );
   try { runHook(projectDir, fakeHome, 'test-session-uuid', 'turn'); } catch (_) {}
-  const tmpFilesA = fs.readdirSync(agenticDir).filter((f) => f.endsWith('.tmp'));
+  const tmpFilesA = fs.readdirSync(agenticDir).filter(isOwnStyleTmp);
   assert(tmpFilesA.length === 0,
-    `(a) no .tmp in .agentic/ after successful atomic write (found: ${tmpFilesA.join(', ') || 'none'})`);
+    `(a) no tmp.<pid> in .agentic/ after successful atomic write (found: ${tmpFilesA.join(', ') || 'none'})`);
   cleanup(tmpDir);
 
-  // --- (b) failure path: pre-plant a .tmp, feed corrupt loop-state -> catch
-  //         fires, catch cleanup must remove the pre-planted .tmp ---
-  // This simulates a stale .tmp left by a previous crashed session being cleaned
-  // up when the next session's catch block runs. We pre-plant the .tmp at exactly
-  // the path the hook would use, feed corrupt JSON (parse fails -> outer catch),
-  // then assert the .tmp is gone.
+  // --- (b) failure path, no tmp ever created by us: corrupt loop-state ->
+  //     JSON.parse throws before tmpPath is assigned -> catch cleanup is a
+  //     no-op (nothing of ours to remove).
   const { tmpDir: tmpDir2, fakeHome: fakeHome2, projectDir: proj2,
     agenticDir: ag2, identityDir: id2 } = makeTmp('ae-stop-t5b-');
   fs.writeFileSync(path.join(id2, 'identity.yml'), STUB_IDENTITY, { mode: 0o600 });
   // Corrupt loop-state.json -> JSON.parse throws -> catch block fires.
   const loopStatePath2 = path.join(ag2, 'loop-state.json');
   fs.writeFileSync(loopStatePath2, '{ bad json !!');
-  // Pre-plant a stale .tmp at the exact path writeLoopState would use.
-  const staleTmp = loopStatePath2 + '.tmp';
-  fs.writeFileSync(staleTmp, 'stale content from a previous crashed session');
   try { runHook(proj2, fakeHome2, 'test-session-uuid', 'turn'); } catch (_) {}
-  const tmpFilesB = fs.readdirSync(ag2).filter((f) => f.endsWith('.tmp'));
+  const tmpFilesB = fs.readdirSync(ag2).filter(isOwnStyleTmp);
   assert(tmpFilesB.length === 0,
-    `(b) stale .tmp cleaned up by catch block (found: ${tmpFilesB.join(', ') || 'none'})`);
+    `(b) no own-style tmp.<pid> remains after a no-write failure (found: ${tmpFilesB.join(', ') || 'none'})`);
   cleanup(tmpDir2);
+
+  // --- (c) DS-109: a peer's in-flight staging file must survive our
+  //     unrelated catch-path failure, whether it uses the legacy fixed name
+  //     or a different pid's suffixed name.
+  const { tmpDir: tmpDir3, fakeHome: fakeHome3, projectDir: proj3,
+    agenticDir: ag3, identityDir: id3 } = makeTmp('ae-stop-t5c-');
+  fs.writeFileSync(path.join(id3, 'identity.yml'), STUB_IDENTITY, { mode: 0o600 });
+  const loopStatePath3 = path.join(ag3, 'loop-state.json');
+  fs.writeFileSync(loopStatePath3, '{ bad json !!');
+  const legacyFixedNamePeerTmp = loopStatePath3 + '.tmp';
+  const foreignPid = String(process.pid) + '9'; // guaranteed not our own pid
+  const peerTmp = loopStatePath3 + '.tmp.' + foreignPid;
+  fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_DATA_LEGACY_NAME');
+  fs.writeFileSync(peerTmp, 'PEER_INFLIGHT_DATA_PID_SUFFIXED');
+  try { runHook(proj3, fakeHome3, 'test-session-uuid', 'turn'); } catch (_) {}
+  assert(
+    fs.existsSync(legacyFixedNamePeerTmp) && fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_LEGACY_NAME',
+    'DS-109: a peer\'s legacy fixed-name .tmp file survives our unrelated catch-path cleanup, untouched'
+  );
+  assert(
+    fs.existsSync(peerTmp) && fs.readFileSync(peerTmp, 'utf8') === 'PEER_INFLIGHT_DATA_PID_SUFFIXED',
+    'DS-109: a peer\'s pid-suffixed .tmp.<otherpid> file survives our unrelated catch-path cleanup, untouched'
+  );
+  cleanup(tmpDir3);
 }
 
 // ---------------------------------------------------------------------------

--- a/hooks/tests/test-wrap-marker-atomic-write.js
+++ b/hooks/tests/test-wrap-marker-atomic-write.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Unit tests: hooks/lib/wrap-marker.js - atomicWriteJson pid-suffixed staging
+ * (DS-109 follow-up fix; the site the original 7-site audit missed).
+ *
+ * Covers:
+ *   (1) writeMarker's staging file is suffixed with the writing process's own
+ *       pid, not the fixed <target>.tmp name.
+ *   (2) On a failure between write and rename, the catch path unlinks ONLY
+ *       our own pid-suffixed tmp file - a peer's legacy fixed-name `.tmp`
+ *       in-flight file, and a peer's pid-suffixed file under a different
+ *       pid, both survive untouched.
+ *
+ * This file exercises the lib directly (require) - no child process, no
+ * `claude` CLI, no network.
+ *
+ * Run with: node hooks/tests/test-wrap-marker-atomic-write.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../lib/wrap-marker.js');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+function makeProject(prefix) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  const projectDir = path.join(base, 'project');
+  const agenticDir = path.join(projectDir, '.agentic');
+  fs.mkdirSync(agenticDir, { recursive: true });
+  return { base, projectDir, agenticDir };
+}
+
+function cleanup(base) {
+  try { fs.rmSync(base, { recursive: true, force: true }); } catch (_) {}
+}
+
+const SID = '77777777-7777-4777-7777-000000000001';
+
+function baseMarker(sessionId) {
+  return {
+    schema_version: 3,
+    session_id: sessionId,
+    staged_at: new Date().toISOString(),
+    status: 'pending',
+    claimed_by: null,
+    claimed_kind: null,
+    claimed_at: null,
+    attempts: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (1) tmp filename is pid-suffixed, not the fixed legacy `.tmp` name.
+// ---------------------------------------------------------------------------
+console.log('\n[1] writeMarker stages at a pid-suffixed tmp name');
+{
+  const { base, projectDir, agenticDir } = makeProject('ae-wm-atomic-1-');
+  delete process.env.AGENTIC_WRAP_DAEMON;
+
+  const markerPath = lib.markerPath(projectDir, SID);
+  const expectedOwnTmp = markerPath + '.tmp.' + process.pid;
+  const legacyFixedTmp = markerPath + '.tmp';
+
+  let observedTmpPathDuringWrite = null;
+  const realWriteFileSync = fs.writeFileSync;
+  fs.writeFileSync = function patchedWriteFileSync(target, ...rest) {
+    if (typeof target === 'string' && target.indexOf(markerPath + '.tmp') === 0) {
+      observedTmpPathDuringWrite = target;
+    }
+    return realWriteFileSync.apply(fs, [target, ...rest]);
+  };
+  try {
+    assert(lib.writeMarker(projectDir, baseMarker(SID)) === true,
+      '[1] writeMarker returns true on success');
+  } finally {
+    fs.writeFileSync = realWriteFileSync;
+  }
+
+  assert(observedTmpPathDuringWrite === expectedOwnTmp,
+    `[1] staging path was pid-suffixed (observed: ${observedTmpPathDuringWrite})`);
+  assert(observedTmpPathDuringWrite !== legacyFixedTmp,
+    '[1] staging path is NOT the fixed legacy <target>.tmp name');
+  assert(!fs.existsSync(expectedOwnTmp),
+    '[1] tmp file is gone after a successful rename');
+  assert(fs.existsSync(markerPath),
+    '[1] final marker file exists at the real path');
+
+  cleanup(base);
+}
+
+// ---------------------------------------------------------------------------
+// (2) DS-109 regression: a failure between write and rename cleans up ONLY
+//     our own pid-suffixed tmp - a peer's fixed-name and pid-suffixed
+//     in-flight files both survive.
+// ---------------------------------------------------------------------------
+console.log('\n[2] catch-path cleanup never touches a peer\'s in-flight tmp file');
+{
+  const { base, projectDir, agenticDir } = makeProject('ae-wm-atomic-2-');
+  delete process.env.AGENTIC_WRAP_DAEMON;
+
+  const markerPath = lib.markerPath(projectDir, SID);
+  const expectedOwnTmp = markerPath + '.tmp.' + process.pid;
+  const legacyFixedNamePeerTmp = markerPath + '.tmp';
+  const foreignPid = String(process.pid) + '9'; // guaranteed != our own pid
+  const peerPidTmp = markerPath + '.tmp.' + foreignPid;
+
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+  fs.writeFileSync(legacyFixedNamePeerTmp, 'PEER_INFLIGHT_LEGACY_NAME');
+  fs.writeFileSync(peerPidTmp, 'PEER_INFLIGHT_PID_SUFFIXED');
+
+  const realRenameSync = fs.renameSync;
+  let observedOwnTmpExistedMidWrite = false;
+  fs.renameSync = function patchedRenameSync(src, dest) {
+    if (src === expectedOwnTmp) {
+      observedOwnTmpExistedMidWrite = fs.existsSync(expectedOwnTmp);
+      throw new Error('simulated crash between write and rename');
+    }
+    return realRenameSync.apply(fs, arguments);
+  };
+  let result;
+  try {
+    result = lib.writeMarker(projectDir, baseMarker(SID));
+  } finally {
+    fs.renameSync = realRenameSync;
+  }
+
+  assert(result === false, '[2] writeMarker returns false on a mid-write failure');
+  assert(observedOwnTmpExistedMidWrite,
+    '[2] our own tmp.<pid> did exist on disk at the moment rename failed');
+  assert(!fs.existsSync(expectedOwnTmp),
+    '[2] our own tmp.<pid> is cleaned up by the catch block after a failed rename');
+  assert(fs.existsSync(legacyFixedNamePeerTmp) &&
+    fs.readFileSync(legacyFixedNamePeerTmp, 'utf8') === 'PEER_INFLIGHT_LEGACY_NAME',
+    'DS-109: a peer\'s legacy fixed-name .tmp file survives our unrelated catch-path cleanup, untouched');
+  assert(fs.existsSync(peerPidTmp) &&
+    fs.readFileSync(peerPidTmp, 'utf8') === 'PEER_INFLIGHT_PID_SUFFIXED',
+    'DS-109: a peer\'s pid-suffixed .tmp.<otherpid> file survives our unrelated catch-path cleanup, untouched');
+
+  cleanup(base);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed.`);
+if (failed > 0) {
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
Seven sites claimed "atomic tmp+rename" while writing to a **fixed** `<path>.tmp`. Under two concurrent sessions that is two writers on one staging path — and several also had an unconditional catch-path unlink of that shared name, so one process's cleanup deleted another's in-flight tmp.

## The defect, measured

Four concurrent processes, 40 `atomic_write` calls each, same destination:

```
PRE-FIX:   28 / 31 / 31 / 32   of 40      8-12 writes per process silently swallowed
POST-FIX:  40 / 40 / 40 / 40              zero loss, zero leftover tmps
```

Peers were renaming the shared staging file out from under each other. Not argued — reproduced.

## The fix

Every tmp is now pid-suffixed (`<path>.tmp.<pid>`), and every catch path unlinks a **captured variable**, never a reconstructed or globbed name: `hooks/lib/state-mark.js` (x2), `hooks/stop-context.js` (capture-gap cursor), `hooks/post-tool-use-capture-nudge.js` (x2), `hooks/enforce-no-abdication.py`, `bin/_lib.py`, plus `hooks/lib/wrap-marker.js`'s `atomicWriteJson` — an **8th site the original audit missed**, found in review.

**Deliberately untouched, each verified as a non-defect:** `stop-context.js`'s pending-marker tmp (its base is `${sessionUuid}.json`, already collision-free) and `wrap-marker.js:1052`/`:1057` (fixed names, but reached only after `fs.mkdirSync(lockDir)` succeeds — i.e. under an exclusive lock). The `wrap-marker.js` diff is exactly one hunk, so the sweep provably did not overreach into them.

Docs corrected to match: `bin/_lib.py`'s Purpose block and `atomic_write` docstring described the fixed name **four lines from** the corrected pid-suffixed text and the actual implementation — self-contradictory in one docstring, and propagated to `bin/agentic-identity`. Both now describe `<path>.tmp.<pid>` and carry the **single-writer qualifier**: this is atomic for one writer, and that distinction is the entire point of the ticket.

`.gitignore` gains `*.tmp.[0-9]*` — suffixed names are unpredictable, so nothing could target an orphan left by a SIGKILL mid-write.

## Verification

Every regression test was **executed against pre-fix code** (`git show 68dec2e5:<path>`) and confirmed failing before being confirmed passing — independently re-derived by review for 6 of 6 test groups, and again for the new `atomicWriteJson` test (5 of 10 assertions fail pre-fix, all 10 pass after).

All 13 `test-wrap-*.js` suites pass, 41/42 hooks suites, `pytest bin/tests` 493/493, under both `/bin/bash` 3.2.57 and `/bin/zsh` 5.9. All four `bin/_lib.py` consumers (`agentic-identity`, `agentic-migrate`, `agentic-config`, `agentic-feedback`) verified — the original brief undercounted these as two.

## North Star alignment

**Works for everyone.** The defect only manifests with concurrent sessions, which is exactly the configuration this repo has been making safe all week. A single-writer developer would never see it; everyone running two sessions was silently losing writes.

**Enforcement floors are not lowered.** No guard is removed. The two already-safe sites are left alone rather than swept, and review confirmed cleanup is scoped to each process's own name with no glob unlink anywhere in `hooks/`, `bin/`, or `scripts/`.

## Known limitations

- **pid-only, not pid+uuid.** `hooks/lib/context-rollup.js` uses pid+uuid. The residual gap needs two processes in different PID namespaces sharing a bind-mounted path *and* colliding on both pid and target — unreachable by any shipped path, and `state-mark.js` has had the identical exposure since it shipped. Closing it here without closing it there would create the inconsistency this fix avoids; deferred as a repo-wide consistency call.
- `.gitignore`'s `*.tmp.[0-9]*` is slightly wider than the pid shape its comment describes. Nothing tracked matches today.
- `wrap-marker.js`'s manifest omits the pending-marker staging file from its Upstream-deps list — pre-existing, not made stale by this diff.

## Review

Two rounds. Round 1 withheld on documentation that contradicted its own code; round 2 granted at 0 Critical / 0 Major. The reviewer also corrected the brief twice: three of the seven sites had no unlink at all (their defect was a same-name **write clobber**, and their tests correctly test that), and `bin/_lib.py` has four consumers rather than two.
