### PR TITLE
docs(memory): preserve concurrent-session G2 wrap-queueing entry

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,6 +32,8 @@ This is the always-loaded tier (imported via `@MEMORY.md`) - keep it under ~120 
 
 - **2026-06-27: A deterministic hook cannot reliably detect an LLM-semantic event.** `events.jsonl` sat empty in ad-hoc sessions because signals like `conductor_direct`/`tool_failure_workaround` depended on the LLM self-reporting inline, which it reliably didn't. Fix pattern: derive that signal at a natural LLM-reflection point (e.g. `/wrap`'s own reflection), not hook instrumentation.
 
+- **2026-07-27: The deferred G2 concurrent-wrap-queueing design's stated premise (`context.md` races) is stale post-#499** - `context.md` is now a lock-free derived rollup (session-keyed shards + compare-and-retry) with no remaining hazard. If G2 is resumed, re-scope it to the three files that actually still contend: `.agentic/_wrap.md`, root `MEMORY.md`, and `decisions.md`. See `.agentic/learnings.md` KNW-20260727-002 for full detail.
+
 ## Methodology Enforcement
 
 - **2026-07-01: The Elevated-signal table and the "when in doubt, classify Elevated" tie-break are duplicated across more files than a grep suggests** (`02-delegation.md`, `subagent-protocol.md`, `skeptic-protocol.md`, plus restatements in `orchestration-planner.md`/`agentic-status.md`). Match copies by semantics, not by grepping one phrase.


### PR DESCRIPTION
A parallel session added this entry to `MEMORY.md` but left it uncommitted while PR #502 was in flight. Pulling #502 required a clean tree, and `git log --all -S "deferred G2 concurrent-wrap-queueing"` returned nothing - the working tree was its only copy.

Purely additive: +2 lines, no deletions.

## Content

Records that the deferred G2 concurrent-wrap-queueing design's stated premise (`context.md` races) is stale post-#499 - `context.md` is now a lock-free derived rollup - and names the three files that still contend (`.agentic/_wrap.md`, root `MEMORY.md`, `decisions.md`). Cross-references `.agentic/learnings.md` KNW-20260727-002.

## Why this PR exists

This is the exact hazard the entry merged in #502 warns about: "Never end a session holding uncommitted `MEMORY.md`/`AGENTS.md` edits - the working tree may be the content's only copy." Committing rather than assuming the originating session would.

## North Star alignment

Universality: unaffected. Knowledge-layer content only; no shared DinoStack behavior, operator identity, or harness assumption introduced.