### PR TITLE
test(hooks-snapshot): restore stability coverage and harden the nested-exclusion regression assertion

### DIFF
--- a/bin/tests/test_hooks_snapshot.sh
+++ b/bin/tests/test_hooks_snapshot.sh
@@ -129,12 +129,17 @@ fi
 # on EVERY call (scripts/lib/hooks-snapshot.sh), by design - a fresh
 # re-sync a second later is expected to change that field. Asserting raw
 # byte-equality on this file is a race against the wall-clock second
-# boundary (measured ~7% flake rate in CI). The field that genuinely must
-# stay stable across an idempotent re-sync is `source_hash`, which is
-# checked separately below. Do not remove this exclusion to "fix" a
-# perceived coverage gap - it would reintroduce the flake.
+# boundary (measured ~7% flake rate in CI). The fields that genuinely must
+# stay stable across an idempotent re-sync - `source_hash`, `source_repo_dir`,
+# and the JSON key set - are checked separately below via targeted field
+# comparisons that skip `snapshotted_at` on purpose. Do not remove this
+# exclusion to "fix" a perceived coverage gap - it would reintroduce the flake;
+# extend the targeted comparisons below instead.
 _snapshot_files() {
-  find "$1" -type f -not -name '.snapshot-meta.json' | sort
+  # Exclude .snapshot-meta.json only at the snapshot root, not at any depth -
+  # a same-named file inside a copied hooks/ subtree must still be compared.
+  local dir="$1"
+  find "$dir" -type f -not -path "$dir/.snapshot-meta.json" | sort
 }
 
 _snapshot_content() {
@@ -145,12 +150,36 @@ _snapshot_content() {
   done < <(_snapshot_files "$dir")
 }
 
-SOURCE_HASH_BEFORE="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['source_hash'])" "$SNAP_DIR/.snapshot-meta.json")"
+# Read a single top-level field from a .snapshot-meta.json file. A missing
+# file, malformed JSON, or a missing key all surface as a python traceback on
+# stderr (intentionally not suppressed - a prior version of this file swallowed
+# stderr on its comparator and produced a 100% vacuous pass on macOS; see
+# PR #506) and an empty string on stdout. Callers must not conflate "empty"
+# with "changed" - see the accurate-message requirement below.
+_meta_field() {
+  local meta_file="$1" field="$2"
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])" \
+    "$meta_file" "$field"
+}
+
+# Read the sorted set of top-level keys from a .snapshot-meta.json file, one
+# per line. Same error-surfacing contract as _meta_field above.
+_meta_keys() {
+  local meta_file="$1"
+  python3 -c "import json,sys; [print(k) for k in sorted(json.load(open(sys.argv[1])).keys())]" \
+    "$meta_file"
+}
+
+SOURCE_HASH_BEFORE="$(_meta_field "$SNAP_DIR/.snapshot-meta.json" source_hash)"
+REPO_DIR_BEFORE="$(_meta_field "$SNAP_DIR/.snapshot-meta.json" source_repo_dir)"
+KEYS_BEFORE="$(_meta_keys "$SNAP_DIR/.snapshot-meta.json")"
 CONTENT_BEFORE="$(_snapshot_content "$SNAP_DIR")"
 
 HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
 
-SOURCE_HASH_AFTER="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['source_hash'])" "$SNAP_DIR/.snapshot-meta.json")"
+SOURCE_HASH_AFTER="$(_meta_field "$SNAP_DIR/.snapshot-meta.json" source_hash)"
+REPO_DIR_AFTER="$(_meta_field "$SNAP_DIR/.snapshot-meta.json" source_repo_dir)"
+KEYS_AFTER="$(_meta_keys "$SNAP_DIR/.snapshot-meta.json")"
 CONTENT_AFTER="$(_snapshot_content "$SNAP_DIR")"
 
 if [[ "$CONTENT_BEFORE" == "$CONTENT_AFTER" ]]; then
@@ -159,10 +188,41 @@ else
   _fail "re-sync with unchanged source produced a different tree"
 fi
 
-if [[ -n "$SOURCE_HASH_BEFORE" && "$SOURCE_HASH_BEFORE" == "$SOURCE_HASH_AFTER" ]]; then
+# Each stability check below distinguishes "both sides empty" (not a real
+# comparison - missing/malformed file or key, reported as such) from
+# "changed" (a real regression, reported with the differing values). A
+# message that says "changed" when both sides were simply empty misdescribes
+# the failure and misleads whoever debugs it next (Finding 2, PR #506
+# follow-up).
+if [[ -z "$SOURCE_HASH_BEFORE" && -z "$SOURCE_HASH_AFTER" ]]; then
+  _fail ".snapshot-meta.json source_hash: both sides empty (missing/malformed .snapshot-meta.json or missing 'source_hash' key - not a stability comparison)"
+elif [[ "$SOURCE_HASH_BEFORE" == "$SOURCE_HASH_AFTER" ]]; then
   _pass ".snapshot-meta.json source_hash is stable across an idempotent re-sync"
 else
   _fail ".snapshot-meta.json source_hash changed across an idempotent re-sync ('$SOURCE_HASH_BEFORE' vs '$SOURCE_HASH_AFTER')"
+fi
+
+# source_repo_dir stability: catches a corrupted/rewired source path across
+# an idempotent re-sync (e.g. a bug that repoints the snapshot at a different
+# repo_dir). Both syncs above pass the identical $REPO_C argument, so this is
+# a stability assertion, not an absolute-value validation of source_repo_dir
+# itself - see the reviewer's Minor rationale in PR #506 follow-up.
+if [[ -z "$REPO_DIR_BEFORE" && -z "$REPO_DIR_AFTER" ]]; then
+  _fail ".snapshot-meta.json source_repo_dir: both sides empty (missing/malformed .snapshot-meta.json or missing 'source_repo_dir' key - not a stability comparison)"
+elif [[ "$REPO_DIR_BEFORE" == "$REPO_DIR_AFTER" ]]; then
+  _pass ".snapshot-meta.json source_repo_dir is stable and non-empty across an idempotent re-sync"
+else
+  _fail ".snapshot-meta.json source_repo_dir changed across an idempotent re-sync ('$REPO_DIR_BEFORE' vs '$REPO_DIR_AFTER')"
+fi
+
+# Key-set stability: catches schema drift (a junk key silently added, or a
+# key going missing) that a source_hash-only comparison can't see.
+if [[ -z "$KEYS_BEFORE" && -z "$KEYS_AFTER" ]]; then
+  _fail ".snapshot-meta.json key set: both sides empty (missing/malformed .snapshot-meta.json) - not a stability comparison"
+elif [[ "$KEYS_BEFORE" == "$KEYS_AFTER" ]]; then
+  _pass ".snapshot-meta.json key set is stable across an idempotent re-sync"
+else
+  _fail ".snapshot-meta.json key set changed across an idempotent re-sync (before: [$(echo "$KEYS_BEFORE" | tr '\n' ' ')], after: [$(echo "$KEYS_AFTER" | tr '\n' ' ')])"
 fi
 
 # Delete propagation: remove extra.sh from source, resync, must vanish from snapshot.
@@ -174,6 +234,28 @@ if [[ ! -f "$SNAP_DIR/hooks/extra.sh" ]]; then
 else
   _fail "deleted source file hooks/extra.sh still present in the snapshot after re-sync"
 fi
+
+# Finding 3 regression: a file literally named .snapshot-meta.json nested
+# inside a copied hooks/ subtree (NOT at the snapshot root) must still be
+# compared - the root-scoped exclusion in _snapshot_files must not match it
+# at any depth.
+mkdir -p "$REPO_C/hooks/nested"
+echo '{"decoy":"v1"}' > "$REPO_C/hooks/nested/.snapshot-meta.json"
+HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
+NESTED_BEFORE="$(_snapshot_content "$SNAP_DIR")"
+
+echo '{"decoy":"v2"}' > "$REPO_C/hooks/nested/.snapshot-meta.json"
+HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
+NESTED_AFTER="$(_snapshot_content "$SNAP_DIR")"
+
+if [[ "$NESTED_BEFORE" != "$NESTED_AFTER" ]]; then
+  _pass "a nested hooks/.../.snapshot-meta.json (not at the snapshot root) is still compared, not silently excluded at depth"
+else
+  _fail "a nested hooks/.../.snapshot-meta.json was silently excluded from comparison at the wrong depth"
+fi
+
+rm -rf "$REPO_C/hooks/nested"
+HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
 
 # =============================================================
 # 3. Bounded-delete guard

--- a/bin/tests/test_hooks_snapshot.sh
+++ b/bin/tests/test_hooks_snapshot.sh
@@ -238,20 +238,34 @@ fi
 # Finding 3 regression: a file literally named .snapshot-meta.json nested
 # inside a copied hooks/ subtree (NOT at the snapshot root) must still be
 # compared - the root-scoped exclusion in _snapshot_files must not match it
-# at any depth.
+# at any depth. Two distinct properties are asserted separately, each with
+# its own message, so a failure names exactly which property broke:
+#   (a) the nested path is actually present in the compared file set at all
+#       (a direct membership check - not an inference from before/after
+#       inequality, which can pass for the wrong reason if an unrelated file
+#       changes elsewhere in the tree at the same time); and
+#   (b) a content change to that nested file is detected across a re-sync
+#       (the property this test exists to catch in the first place).
 mkdir -p "$REPO_C/hooks/nested"
 echo '{"decoy":"v1"}' > "$REPO_C/hooks/nested/.snapshot-meta.json"
 HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
 NESTED_BEFORE="$(_snapshot_content "$SNAP_DIR")"
+NESTED_FILES_BEFORE="$(_snapshot_files "$SNAP_DIR")"
 
 echo '{"decoy":"v2"}' > "$REPO_C/hooks/nested/.snapshot-meta.json"
 HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
 NESTED_AFTER="$(_snapshot_content "$SNAP_DIR")"
 
-if [[ "$NESTED_BEFORE" != "$NESTED_AFTER" ]]; then
-  _pass "a nested hooks/.../.snapshot-meta.json (not at the snapshot root) is still compared, not silently excluded at depth"
+if echo "$NESTED_FILES_BEFORE" | grep -q '/hooks/nested/\.snapshot-meta\.json'; then
+  _pass "a nested hooks/.../.snapshot-meta.json is present in the compared file set (not excluded at depth)"
 else
-  _fail "a nested hooks/.../.snapshot-meta.json was silently excluded from comparison at the wrong depth"
+  _fail "a nested hooks/.../.snapshot-meta.json is absent from the compared file set - the root-scoped exclusion in _snapshot_files matched it at the wrong depth"
+fi
+
+if [[ "$NESTED_BEFORE" != "$NESTED_AFTER" ]]; then
+  _pass "a content change to the nested hooks/.../.snapshot-meta.json is detected across a re-sync"
+else
+  _fail "a content change to the nested hooks/.../.snapshot-meta.json was not detected across a re-sync"
 fi
 
 rm -rf "$REPO_C/hooks/nested"

--- a/bin/tests/test_hooks_snapshot.sh
+++ b/bin/tests/test_hooks_snapshot.sh
@@ -256,8 +256,10 @@ echo '{"decoy":"v2"}' > "$REPO_C/hooks/nested/.snapshot-meta.json"
 HOME="$FAKE_HOME" bash -c "source '$LIB'; sync_hooks_snapshot '$REPO_C' >/dev/null"
 NESTED_AFTER="$(_snapshot_content "$SNAP_DIR")"
 
-if echo "$NESTED_FILES_BEFORE" | grep -q '/hooks/nested/\.snapshot-meta\.json'; then
+if echo "$NESTED_FILES_BEFORE" | grep -q '/hooks/nested/\.snapshot-meta\.json$'; then
   _pass "a nested hooks/.../.snapshot-meta.json is present in the compared file set (not excluded at depth)"
+elif [[ -z "$NESTED_FILES_BEFORE" ]]; then
+  _fail "the compared file set is empty or unreadable (snapshot dir missing or inaccessible) - not a membership comparison"
 else
   _fail "a nested hooks/.../.snapshot-meta.json is absent from the compared file set - the root-scoped exclusion in _snapshot_files matched it at the wrong depth"
 fi


### PR DESCRIPTION
Resolves the four Minors documented when #506 landed, plus two follow-on Minors raised during review of this branch.

## What #506 left behind

#506 fixed a 12% CI flake and a 100% vacuous pass on macOS in `test_hooks_snapshot.sh`'s idempotency assertion. It shipped with four known Minors, all fixed here.

**1. Coverage loss.** Excluding `.snapshot-meta.json` wholesale from the byte comparison meant `source_repo_dir` changes and schema-shape changes (junk or missing keys) were no longer compared across the re-sync; only `source_hash` was. Now three stability assertions run: `source_hash`, `source_repo_dir`, and JSON key-set equality. `snapshotted_at` remains deliberately excluded and commented as such - it is second-resolution and re-stamped on every sync by design, which is what caused the original flake.

**2. Misleading diagnostic.** The both-empty case printed `source_hash changed ('' vs '')` when nothing had changed. Each stability check is now a 3-way branch - both-empty, equal, differing - with an accurate message per branch.

**3. Over-broad exclusion.** `-not -name '.snapshot-meta.json'` matched that basename at any depth, so a same-named file inside a copied `hooks/` subtree was silently dropped from comparison. Now scoped to the snapshot root via `-not -path`.

**4. Duplicated reader.** The `python3 -c` JSON reader is extracted to `_meta_field` / `_meta_keys`, now used at six call sites. Extraction became clearly correct once fix 1 raised the read count from two to three.

## Two follow-on Minors, also fixed

**5. The new nested-file regression assertion could pass for the wrong reason.** It asserted content-set inequality rather than directly asserting the nested path is in the compared set. Reviewer-executed proof: revert fix 3 *and* add one unrelated file between the two nested syncs, and it reports PASS with exit 0 - the regression it exists to catch, silently defanged. Split into two distinct assertions: direct membership, and content-change detection, each with its own message.

**6. The membership pattern was unanchored and its failure message over-claimed.** A `.bak` decoy satisfied the grep while the real file was absent (`21 passed`, exit 0). Anchored with `$`. Separately, an empty or unreadable file set printed the depth-exclusion reason, which is false in that case; an explicit empty/unreadable branch now reports the real cause.

## Evidence

Every case executed against the shipped script as CI invokes it, never against a reimplementation.

**Fail-closed verification** - the three stability assertions on every degradation path: `python3` absent from PATH, malformed JSON, file deleted, field absent, file unreadable. All produce a `_fail` and exit 1. No reachable `empty == empty -> PASS` shape.

**Teeth checks, all caught, all exit 1:** extra file on second sync; `source_hash` perturbed; `source_hash` emptied one side; emptied both sides; malformed JSON; meta deleted; `source_repo_dir` changed to `/evil/other/repo`; junk key added. The last two were previously missed.

**Regression assertion proven load-bearing:** reverting fix 3 makes it fail; the defeat scenario in Minor 5 now fails with the correct message; the `.bak` decoy now fails.

**Flake stays fixed:** 45 jittered iterations with sub-second sleeps straddling wall-clock second boundaries, 45/45 pass. Forced >1s gap between the two syncs passes with both `snapshotted_at` values printed as evidence the race was genuinely armed.

**Other:** root `.snapshot-meta.json` positively confirmed still excluded by instrumenting the real run; bash and zsh byte-identical; failures reach the process exit code under direct invocation (an earlier pass had a pipeline `tail` masking it); `scripts/lib/hooks-snapshot.sh` untouched.

## Deliberately deferred

Two Minors are left as-is with reasons. Extracting the three near-identical 3-way stability blocks into a helper would break the file's uniform inline-assertion convention, which all 21 assertions follow. The `$dir` trailing-slash brittleness in `_snapshot_files` is unreachable through the sole caller, which builds the path without a trailing slash.

## North Star alignment

- **Produce verifiable outcomes autonomously.** Three stability properties that were silently unasserted after #506 are now gated, and a regression assertion that could pass with the regression present is now direct. Every claim above was established by watching a mutation fail, not by reading code.
- **Works for everyone (universality).** No operator identity, path, or tooling assumption is introduced. bash and zsh verified byte-identical, and the empty/unreadable branch means a contributor whose environment lacks `python3` gets an accurate failure rather than a silent pass.
- **Enforcement floors are not relaxed by capability gains.** Net coverage increases; nothing was traded away. The one exclusion retained (`snapshotted_at`) is the field whose change is by design, and it is commented so it is not "fixed" back into a race.
- No pillar regressed; no write to `docs/overview/vision.md` or `requirements.md`.

## Review

Two rounds. Round 1 granted sign-off with 4 Minors; the conductor elected to fix one of them before merge rather than defer, because "works today but any future edit in this block disables it invisibly" is the exact failure mode this file has already suffered undetected. Round 2 verified the hardening, confirmed the membership assertion cannot pass vacuously in any reachable configuration, and raised the two Minors fixed in the final commit.
