### PR TITLE
fix(protocol): assess Global-context n/a rationales on the merits, not by string match (DS-98)

### DIFF
--- a/.codex/agents/skeptic.toml
+++ b/.codex/agents/skeptic.toml
@@ -25,7 +25,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -37,7 +37,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/.copilot/references/skeptic-protocol.md
+++ b/.copilot/references/skeptic-protocol.md
@@ -261,6 +261,8 @@ Every Skeptic spawn prompt MUST include the following block in this order, after
 6. Diff under review: <git diff command OR file paths>
 ```
 
+On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6 lists the paths the plan proposes to modify, since no diff exists yet.
+
 ### Enumerated `n/a` rationale set
 
 A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
@@ -271,6 +273,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - non-shared-utility surface (importer count below 5 threshold)` (per-consumer table only)
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
+- `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.copilot/references/skeptic-protocol.md
+++ b/.copilot/references/skeptic-protocol.md
@@ -265,7 +265,7 @@ On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6
 
 ### Enumerated `n/a` rationale set
 
-A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
+A bare `n/a` is invalid - every `n/a` value MUST carry a specific reason in the shape `n/a - <reason>`. The strings below are the canonical, preferred wording for their recurring situations and MUST be used verbatim when one applies. This list is not exhaustive: a situation none of them covers may supply its own `n/a - <reason>` string, provided the reason is specific and truthful for the unit under review (see Step 0 check 2 below for how this is assessed).
 
 - `n/a - Trivial direct edit`
 - `n/a - permission-blocked carve-out`
@@ -275,8 +275,10 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
-- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
+- `n/a - architect skipped (judgment-based skip for a well-understood, self-contained change, or mechanical skip per the simple/targeted-unit metric)` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit and `content/references/agent-team.md` for both skip paths)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
+
+**Why this is open rather than closed:** the set above was previously treated as exhaustive. Four legitimate situations were discovered in two days, each while fixing the one before it (Skeptic-on-plan; single Elevated unit; mechanical architect skip; judgment-based architect skip). Completeness by enumeration does not hold for an evolving methodology with this many valid spawn shapes - a closed vocabulary guarantees a fifth instance. Do not re-close this list by reverting to string-membership checking; assess rationales on the merits instead (Step 0 check 2).
 
 ### Review-environment freshness precondition
 
@@ -291,9 +293,9 @@ A Skeptic comparing a PR against a base branch MUST work from a live, synchroniz
 Before reading any artifact or producing any findings, the Skeptic verifies the Global-context input set is complete and well-formed:
 
 1. All 6 fields are present.
-2. Any `n/a` value is one of the enumerated strings above.
+2. Every `n/a` value carries a specific reason after the `n/a - ` prefix. The Skeptic BLOCKS when a value is a bare `n/a`, has an empty or vacuous rationale (e.g. `n/a - not applicable`), or states a rationale that is factually false for the unit under review (e.g. citing "Trivial direct edit" on an Elevated unit, or citing a skip path that did not occur). A truthful, specific rationale that is NOT one of the enumerated strings above is valid and must NOT be BLOCKED on that basis alone - the enumerated set is canonical preferred wording for recurring situations, not an exhaustive whitelist.
 
-When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. a diff that adds, removes, or rewords one of the enumerated strings above), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.copilot/references/skeptic-protocol.md
+++ b/.copilot/references/skeptic-protocol.md
@@ -274,6 +274,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
+- `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.copilot/references/skeptic-protocol.md
+++ b/.copilot/references/skeptic-protocol.md
@@ -275,6 +275,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
+- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition
@@ -291,6 +292,8 @@ Before reading any artifact or producing any findings, the Skeptic verifies the 
 
 1. All 6 fields are present.
 2. Any `n/a` value is one of the enumerated strings above.
+
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.cursor/references/skeptic-protocol.md
+++ b/.cursor/references/skeptic-protocol.md
@@ -261,6 +261,8 @@ Every Skeptic spawn prompt MUST include the following block in this order, after
 6. Diff under review: <git diff command OR file paths>
 ```
 
+On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6 lists the paths the plan proposes to modify, since no diff exists yet.
+
 ### Enumerated `n/a` rationale set
 
 A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
@@ -271,6 +273,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - non-shared-utility surface (importer count below 5 threshold)` (per-consumer table only)
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
+- `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.cursor/references/skeptic-protocol.md
+++ b/.cursor/references/skeptic-protocol.md
@@ -265,7 +265,7 @@ On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6
 
 ### Enumerated `n/a` rationale set
 
-A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
+A bare `n/a` is invalid - every `n/a` value MUST carry a specific reason in the shape `n/a - <reason>`. The strings below are the canonical, preferred wording for their recurring situations and MUST be used verbatim when one applies. This list is not exhaustive: a situation none of them covers may supply its own `n/a - <reason>` string, provided the reason is specific and truthful for the unit under review (see Step 0 check 2 below for how this is assessed).
 
 - `n/a - Trivial direct edit`
 - `n/a - permission-blocked carve-out`
@@ -275,8 +275,10 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
-- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
+- `n/a - architect skipped (judgment-based skip for a well-understood, self-contained change, or mechanical skip per the simple/targeted-unit metric)` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit and `content/references/agent-team.md` for both skip paths)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
+
+**Why this is open rather than closed:** the set above was previously treated as exhaustive. Four legitimate situations were discovered in two days, each while fixing the one before it (Skeptic-on-plan; single Elevated unit; mechanical architect skip; judgment-based architect skip). Completeness by enumeration does not hold for an evolving methodology with this many valid spawn shapes - a closed vocabulary guarantees a fifth instance. Do not re-close this list by reverting to string-membership checking; assess rationales on the merits instead (Step 0 check 2).
 
 ### Review-environment freshness precondition
 
@@ -291,9 +293,9 @@ A Skeptic comparing a PR against a base branch MUST work from a live, synchroniz
 Before reading any artifact or producing any findings, the Skeptic verifies the Global-context input set is complete and well-formed:
 
 1. All 6 fields are present.
-2. Any `n/a` value is one of the enumerated strings above.
+2. Every `n/a` value carries a specific reason after the `n/a - ` prefix. The Skeptic BLOCKS when a value is a bare `n/a`, has an empty or vacuous rationale (e.g. `n/a - not applicable`), or states a rationale that is factually false for the unit under review (e.g. citing "Trivial direct edit" on an Elevated unit, or citing a skip path that did not occur). A truthful, specific rationale that is NOT one of the enumerated strings above is valid and must NOT be BLOCKED on that basis alone - the enumerated set is canonical preferred wording for recurring situations, not an exhaustive whitelist.
 
-When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. a diff that adds, removes, or rewords one of the enumerated strings above), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.cursor/references/skeptic-protocol.md
+++ b/.cursor/references/skeptic-protocol.md
@@ -274,6 +274,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
+- `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.cursor/references/skeptic-protocol.md
+++ b/.cursor/references/skeptic-protocol.md
@@ -275,6 +275,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
+- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition
@@ -291,6 +292,8 @@ Before reading any artifact or producing any findings, the Skeptic verifies the 
 
 1. All 6 fields are present.
 2. Any `n/a` value is one of the enumerated strings above.
+
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -26,7 +26,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -38,7 +38,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -261,6 +261,8 @@ Every Skeptic spawn prompt MUST include the following block in this order, after
 6. Diff under review: <git diff command OR file paths>
 ```
 
+On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6 lists the paths the plan proposes to modify, since no diff exists yet.
+
 ### Enumerated `n/a` rationale set
 
 A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
@@ -271,6 +273,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - non-shared-utility surface (importer count below 5 threshold)` (per-consumer table only)
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
+- `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -265,7 +265,7 @@ On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6
 
 ### Enumerated `n/a` rationale set
 
-A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
+A bare `n/a` is invalid - every `n/a` value MUST carry a specific reason in the shape `n/a - <reason>`. The strings below are the canonical, preferred wording for their recurring situations and MUST be used verbatim when one applies. This list is not exhaustive: a situation none of them covers may supply its own `n/a - <reason>` string, provided the reason is specific and truthful for the unit under review (see Step 0 check 2 below for how this is assessed).
 
 - `n/a - Trivial direct edit`
 - `n/a - permission-blocked carve-out`
@@ -275,8 +275,10 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
-- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
+- `n/a - architect skipped (judgment-based skip for a well-understood, self-contained change, or mechanical skip per the simple/targeted-unit metric)` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit and `content/references/agent-team.md` for both skip paths)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
+
+**Why this is open rather than closed:** the set above was previously treated as exhaustive. Four legitimate situations were discovered in two days, each while fixing the one before it (Skeptic-on-plan; single Elevated unit; mechanical architect skip; judgment-based architect skip). Completeness by enumeration does not hold for an evolving methodology with this many valid spawn shapes - a closed vocabulary guarantees a fifth instance. Do not re-close this list by reverting to string-membership checking; assess rationales on the merits instead (Step 0 check 2).
 
 ### Review-environment freshness precondition
 
@@ -291,9 +293,9 @@ A Skeptic comparing a PR against a base branch MUST work from a live, synchroniz
 Before reading any artifact or producing any findings, the Skeptic verifies the Global-context input set is complete and well-formed:
 
 1. All 6 fields are present.
-2. Any `n/a` value is one of the enumerated strings above.
+2. Every `n/a` value carries a specific reason after the `n/a - ` prefix. The Skeptic BLOCKS when a value is a bare `n/a`, has an empty or vacuous rationale (e.g. `n/a - not applicable`), or states a rationale that is factually false for the unit under review (e.g. citing "Trivial direct edit" on an Elevated unit, or citing a skip path that did not occur). A truthful, specific rationale that is NOT one of the enumerated strings above is valid and must NOT be BLOCKED on that basis alone - the enumerated set is canonical preferred wording for recurring situations, not an exhaustive whitelist.
 
-When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. a diff that adds, removes, or rewords one of the enumerated strings above), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -274,6 +274,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
+- `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -275,6 +275,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
+- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition
@@ -291,6 +292,8 @@ Before reading any artifact or producing any findings, the Skeptic verifies the 
 
 1. All 6 fields are present.
 2. Any `n/a` value is one of the enumerated strings above.
+
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.github/agents/skeptic.md
+++ b/.github/agents/skeptic.md
@@ -22,7 +22,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -34,7 +34,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4354,6 +4354,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
+- `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4355,6 +4355,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
+- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition
@@ -4371,6 +4372,8 @@ Before reading any artifact or producing any findings, the Skeptic verifies the 
 
 1. All 6 fields are present.
 2. Any `n/a` value is one of the enumerated strings above.
+
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4345,7 +4345,7 @@ On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6
 
 ### Enumerated `n/a` rationale set
 
-A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
+A bare `n/a` is invalid - every `n/a` value MUST carry a specific reason in the shape `n/a - <reason>`. The strings below are the canonical, preferred wording for their recurring situations and MUST be used verbatim when one applies. This list is not exhaustive: a situation none of them covers may supply its own `n/a - <reason>` string, provided the reason is specific and truthful for the unit under review (see Step 0 check 2 below for how this is assessed).
 
 - `n/a - Trivial direct edit`
 - `n/a - permission-blocked carve-out`
@@ -4355,8 +4355,10 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
-- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
+- `n/a - architect skipped (judgment-based skip for a well-understood, self-contained change, or mechanical skip per the simple/targeted-unit metric)` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit and `content/references/agent-team.md` for both skip paths)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
+
+**Why this is open rather than closed:** the set above was previously treated as exhaustive. Four legitimate situations were discovered in two days, each while fixing the one before it (Skeptic-on-plan; single Elevated unit; mechanical architect skip; judgment-based architect skip). Completeness by enumeration does not hold for an evolving methodology with this many valid spawn shapes - a closed vocabulary guarantees a fifth instance. Do not re-close this list by reverting to string-membership checking; assess rationales on the merits instead (Step 0 check 2).
 
 ### Review-environment freshness precondition
 
@@ -4371,9 +4373,9 @@ A Skeptic comparing a PR against a base branch MUST work from a live, synchroniz
 Before reading any artifact or producing any findings, the Skeptic verifies the Global-context input set is complete and well-formed:
 
 1. All 6 fields are present.
-2. Any `n/a` value is one of the enumerated strings above.
+2. Every `n/a` value carries a specific reason after the `n/a - ` prefix. The Skeptic BLOCKS when a value is a bare `n/a`, has an empty or vacuous rationale (e.g. `n/a - not applicable`), or states a rationale that is factually false for the unit under review (e.g. citing "Trivial direct edit" on an Elevated unit, or citing a skip path that did not occur). A truthful, specific rationale that is NOT one of the enumerated strings above is valid and must NOT be BLOCKED on that basis alone - the enumerated set is canonical preferred wording for recurring situations, not an exhaustive whitelist.
 
-When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. a diff that adds, removes, or rewords one of the enumerated strings above), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -10193,7 +10193,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -10205,7 +10205,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4341,6 +4341,8 @@ Every Skeptic spawn prompt MUST include the following block in this order, after
 6. Diff under review: <git diff command OR file paths>
 ```
 
+On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6 lists the paths the plan proposes to modify, since no diff exists yet.
+
 ### Enumerated `n/a` rationale set
 
 A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
@@ -4351,6 +4353,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - non-shared-utility surface (importer count below 5 threshold)` (per-consumer table only)
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
+- `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/.openclaw/skills/agent-skeptic/SKILL.md
+++ b/.openclaw/skills/agent-skeptic/SKILL.md
@@ -22,7 +22,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -34,7 +34,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/.opencode/agents/skeptic.md
+++ b/.opencode/agents/skeptic.md
@@ -27,7 +27,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -39,7 +39,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -27,7 +27,7 @@ Your spawn prompt will contain four things:
 1. **Adversarial brief** - the specific attack surface or failure scenario to probe. This is your primary lens.
 2. **Worker output** - either pasted inline or as file paths. If file paths are given, read those files before evaluating.
 3. **Resolved issues preflight** - findings from prior rounds that have already been addressed. Round 1 will say "No prior rounds." Rounds 2+ will list each resolved finding and its resolution.
-4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and enumerated `n/a` values.
+4. **Global-context input set** - a `## Global-context inputs` block containing: (1) architect plan path, (2) Brief/Plan artifact path, (3) qa_criteria block verbatim, (4) per-consumer impact table verbatim, (5) related files list, (6) diff under review. Read the architect plan file in full before evaluating - it is the spec the Worker implemented against. See `content/references/skeptic-protocol.md` Section 4.5 for the canonical block format and `n/a` rationale rules.
 
 ## Classification definitions
 
@@ -39,7 +39,7 @@ Your spawn prompt will contain four things:
 
 **Step 0 (BLOCKED on incomplete inputs).** Before reading any artifact, verify the Global-context input set is present and well-formed:
 - All 6 fields of the `## Global-context inputs` block are present.
-- Any `n/a` value is one of the enumerated strings in `content/references/skeptic-protocol.md` Section 4.5.
+- Every `n/a` value carries a specific reason after `n/a - `. BLOCK on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review. A truthful, specific rationale outside the canonical list in `content/references/skeptic-protocol.md` Section 4.5 is valid and must not be BLOCKED on that basis alone.
 
 If either check fails, return immediately with:
 ```

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -261,6 +261,8 @@ Every Skeptic spawn prompt MUST include the following block in this order, after
 6. Diff under review: <git diff command OR file paths>
 ```
 
+On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6 lists the paths the plan proposes to modify, since no diff exists yet.
+
 ### Enumerated `n/a` rationale set
 
 A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
@@ -271,6 +273,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - non-shared-utility surface (importer count below 5 threshold)` (per-consumer table only)
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
+- `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -265,7 +265,7 @@ On a pre-implementation review (e.g. Skeptic-on-plan, Skeptic-on-Brief), field 6
 
 ### Enumerated `n/a` rationale set
 
-A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any other string triggers Skeptic Step 0 BLOCKED.
+A bare `n/a` is invalid - every `n/a` value MUST carry a specific reason in the shape `n/a - <reason>`. The strings below are the canonical, preferred wording for their recurring situations and MUST be used verbatim when one applies. This list is not exhaustive: a situation none of them covers may supply its own `n/a - <reason>` string, provided the reason is specific and truthful for the unit under review (see Step 0 check 2 below for how this is assessed).
 
 - `n/a - Trivial direct edit`
 - `n/a - permission-blocked carve-out`
@@ -275,8 +275,10 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
-- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
+- `n/a - architect skipped (judgment-based skip for a well-understood, self-contained change, or mechanical skip per the simple/targeted-unit metric)` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit and `content/references/agent-team.md` for both skip paths)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
+
+**Why this is open rather than closed:** the set above was previously treated as exhaustive. Four legitimate situations were discovered in two days, each while fixing the one before it (Skeptic-on-plan; single Elevated unit; mechanical architect skip; judgment-based architect skip). Completeness by enumeration does not hold for an evolving methodology with this many valid spawn shapes - a closed vocabulary guarantees a fifth instance. Do not re-close this list by reverting to string-membership checking; assess rationales on the merits instead (Step 0 check 2).
 
 ### Review-environment freshness precondition
 
@@ -291,9 +293,9 @@ A Skeptic comparing a PR against a base branch MUST work from a live, synchroniz
 Before reading any artifact or producing any findings, the Skeptic verifies the Global-context input set is complete and well-formed:
 
 1. All 6 fields are present.
-2. Any `n/a` value is one of the enumerated strings above.
+2. Every `n/a` value carries a specific reason after the `n/a - ` prefix. The Skeptic BLOCKS when a value is a bare `n/a`, has an empty or vacuous rationale (e.g. `n/a - not applicable`), or states a rationale that is factually false for the unit under review (e.g. citing "Trivial direct edit" on an Elevated unit, or citing a skip path that did not occur). A truthful, specific rationale that is NOT one of the enumerated strings above is valid and must NOT be BLOCKED on that basis alone - the enumerated set is canonical preferred wording for recurring situations, not an exhaustive whitelist.
 
-When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. a diff that adds, removes, or rewords one of the enumerated strings above), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -274,6 +274,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - architect plan deferred to Plan-tier second pass` (Brief field only)
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
+- `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -275,6 +275,7 @@ A bare `n/a` is invalid. Only the following strings are valid `n/a` values. Any 
 - `n/a - Skeptic-on-Brief (Brief is the artifact under review)` (Brief field only)
 - `n/a - Skeptic-on-plan (Brief authoring gated on this sign-off)` (Brief field only)
 - `n/a - single Elevated unit (no Brief required by the promotion gate)` (Brief field only)
+- `n/a - architect skipped per the simple/targeted-unit metric` (architect plan field only; see `content/sections/04-risk-classification.md` §Simple/targeted unit)
 - `n/a - assembled Plan review (per-unit plans listed inline)` (architect plan field only, on Plan-tier second-pass)
 
 ### Review-environment freshness precondition
@@ -291,6 +292,8 @@ Before reading any artifact or producing any findings, the Skeptic verifies the 
 
 1. All 6 fields are present.
 2. Any `n/a` value is one of the enumerated strings above.
+
+When the diff under review itself amends the enumerated `n/a` rationale set (i.e. this file), the Skeptic validates every field against the branch's own copy of this section, not the copy installed in its own environment - otherwise a PR that adds a value is spuriously BLOCKED against the pre-change enum it is itself updating.
 
 If either check fails, the Skeptic returns immediately with:
 


### PR DESCRIPTION
## Summary

Stops `skeptic-protocol.md` §4.5 requiring an exhaustive enumeration of every legitimate reason a Global-context field can be `n/a`. Step 0's check 2 moves from string-membership to a merits assessment: a bare `n/a` still fails, the enumerated values remain the preferred wording, but a situation none of them covers may state its own specific rationale — judged on truthfulness rather than string match.

## Why the mechanism changed rather than the vocabulary

The ticket opened as "add one missing value." Four legitimate uncovered situations were found in two days, each discovered while fixing the previous, each by a different reviewer:

| # | Field | Situation | Found |
|---|---|---|---|
| 1 | 2 | Skeptic-on-plan at Brief tier — no Brief exists yet | during DS-97; blocked a real spawn |
| 2 | 2 | Single Elevated unit — promotion gate requires no Brief | preparing this ticket's own review |
| 3 | 1 | Architect skipped via the simple/targeted-unit metric | round 1 |
| 4 | 1 | Architect skipped via the judgment-based path | round 2 |

Instances 3 and 4 were each demonstrated by a review spawn brief for *this ticket* asserting a rationale that was false for this unit, because no true one existed. That is the tell: **a closed vocabulary for an open set of situations.** Adding a fifth value closes instance 4 and guarantees instance 5.

All four historical false values remain catchable under the new rule — the two worked examples in check 2 name them directly ("citing `Trivial direct edit` on an Elevated unit, or citing a skip path that did not occur"). Enforcement moves from mechanical to judgment, which is a real weakening; it is named and argued in the artifact rather than glossed.

## What changed

- **`§4.5` enumerated set** — declared canonical-and-preferred rather than exhaustive; a bare `n/a` remains invalid and every value must carry a specific reason in `n/a - <reason>` shape.
- **Step 0 check 2** — BLOCKs on a bare `n/a`, a vacuous rationale, or one factually false for the unit under review; a truthful specific rationale outside the set must **not** be BLOCKed on that basis alone. Check 1 (all 6 fields present) is byte-identical.
- **Four new canonical values** for the situations above, plus a broadened architect-skip value covering both skip paths in `content/references/agent-team.md`.
- **A rationale note** recording why the set is open, so a future maintainer does not helpfully re-close it.
- **A branch-copy rule** — when a diff amends the enumerated set, the Skeptic validates against the branch's copy, not its installed one. Without it, the PR that adds a value is spuriously BLOCKed against the enum it is updating. This PR is that case, and the rule was exercised in its own reviews.
- **Field 6 clarification** — on a pre-implementation review, field 6 lists the paths the plan proposes to modify. No `n/a` value added for field 6.
- **`content/agents/skeptic.md`** — the closed-world rule was restated on the path that actually executes, so the mechanism change was ineffective until propagated. See below.

## The finding worth reading

Round 3 caught that `content/agents/skeptic.md:42` still asserted `Any n/a value is one of the enumerated strings` — the instruction injected into every Skeptic. So §4.5 was open while the enforcement path was closed. Evidence it was live: `.hermes/SKILL.md`, a file this PR already modified, contradicted **itself** — the new open-set rule at one line, the old membership rule at another. Seven files carried the stale line; `git grep` now returns zero.

This is the same defect class as the rest of the ticket, one level out: a rule restated in more places than a single-phrase grep reveals. The fix was found only by searching for the rule's *meaning* rather than its wording.

## Verification

- `check-methodology-drift.sh` exits 0; `scripts/.methodology-baseline.sha256` byte-unchanged (no `content/sections/**` touched — a changed baseline here would be a defect)
- Second `build-all.sh` leaves all 11 adapter dirs clean; `check-symlinks-relative.sh` exits 0
- `pytest bin/tests/` — 499 passed
- `git grep "is one of the enumerated strings"` → 0 hits repo-wide; both `.hermes/SKILL.md` embeds agree
- `31` reference docs / `25` command files re-derived, unchanged; no doc or slide asserts the enum set or its size
- 5 commits, all DCO-signed

**A guard shipped hours earlier caught a real violation here.** The first draft used the word "discretionary" twice, which failed `bin/tests/test_learnings_agent_capture_model_spec.py` — the DS-97 regression guard reserving that token to two sanctioned sites. Reworded to "judgment-based" with fidelity to `agent-team.md`'s actual language preserved. A mechanical guard catching unrelated work within hours is the best evidence available that guards beat round-by-round manual verification.

## North Star alignment

- **Guard operator attention (pillar 1)** — removes a recurring spurious-BLOCK class that burned `.agentic/.spawn-block-counter-<slug>` increments and escalated to the operator after three strikes, for spawns that were correctly formed.
- **Verifiable outcomes, autonomously (pillar 2)** — a conductor can now supply a truthful rationale for a novel spawn shape instead of choosing between a false value and a spurious block. Four of the four known instances were conductors writing something false because nothing true was available.
- **Low friction (pillar 3)** — net reduction. No new required field, no new gate; one closed check becomes an open one with a quality bar.
- **Works for everyone (pillar 4)** — unaffected. No operator identity, tracker, workspace, or harness assumption enters the change.

Trade-off stated plainly: mechanical string-matching was more verifiable than judgment. It was also wrong four times in two days. The rule now asks the reviewer to assess truthfulness — which is what the enum was approximating all along.

## Follow-ups filed

- **DS-113** — four recorded Minors: no mechanical guard against re-closing the list (copy DS-97's pattern); the branch-copy parenthetical overshot from too-broad to too-narrow and misses a PR changing only Step 0's checks; the architect-skip value is a disjunction that blunts check 2's own falsity test and should split in two; Step 0 gives no disposition for falsity discovered *after* the artifacts are read.
- **DS-112** — `content/commands/ds-skeptic.md` omits the Global-context block entirely, so that command cannot succeed as documented. Pre-existing, separate file.
