### PR TITLE
fix(commands): real picker descriptions for all 25 ds-* commands + merge-blocking gate

### DIFF
--- a/.claude/commands.frontmatter/ds-brief.yaml
+++ b/.claude/commands.frontmatter/ds-brief.yaml
@@ -1,0 +1,1 @@
+description: "Interactive planning dialogue that produces a Brief artifact before architects and engineers are spawned. /ds-brief --from <path> extracts a Brief from an existing PRD."

--- a/.claude/commands.frontmatter/ds-cleanup-worktrees.yaml
+++ b/.claude/commands.frontmatter/ds-cleanup-worktrees.yaml
@@ -1,0 +1,1 @@
+description: "Remove stale subagent and feature worktrees."

--- a/.claude/commands.frontmatter/ds-config.yaml
+++ b/.claude/commands.frontmatter/ds-config.yaml
@@ -1,0 +1,1 @@
+description: "View and change methodology settings (profile, mode, .agentic/config.json toggles) with guided prompts."

--- a/.claude/commands.frontmatter/ds-configure-team.yaml
+++ b/.claude/commands.frontmatter/ds-configure-team.yaml
@@ -1,0 +1,1 @@
+description: "Configure and verify a cross-harness agent team (.agentic/team.yml): discovers installed harnesses and assigns a model per role."

--- a/.claude/commands.frontmatter/ds-cost.yaml
+++ b/.claude/commands.frontmatter/ds-cost.yaml
@@ -1,0 +1,1 @@
+description: "Token and wall-time rollups per agent/session/task from .agentic/events.jsonl."

--- a/.claude/commands.frontmatter/ds-disable.yaml
+++ b/.claude/commands.frontmatter/ds-disable.yaml
@@ -1,0 +1,1 @@
+description: "Opt this project out (writes an opt-out marker to AGENTS.md). --global also sets global mode=opt-out."

--- a/.claude/commands.frontmatter/ds-feedback-triage.yaml
+++ b/.claude/commands.frontmatter/ds-feedback-triage.yaml
@@ -1,0 +1,1 @@
+description: "Triage captured session friction (~/.agentic/feedback.jsonl) into tracker tickets."

--- a/.claude/commands.frontmatter/ds-help.yaml
+++ b/.claude/commands.frontmatter/ds-help.yaml
@@ -1,0 +1,1 @@
+description: "This list."

--- a/.claude/commands.frontmatter/ds-identity.yaml
+++ b/.claude/commands.frontmatter/ds-identity.yaml
@@ -1,0 +1,1 @@
+description: "Manage the developer identity used for session telemetry attribution (manual, auto-derived, or provisional-to-confirmed)."

--- a/.claude/commands.frontmatter/ds-implement-ticket.yaml
+++ b/.claude/commands.frontmatter/ds-implement-ticket.yaml
@@ -1,0 +1,1 @@
+description: "Drive a ticket from spec to a merged PR through the full risk-classified workflow (architect, skeptic, engineer, QA gate)."

--- a/.claude/commands.frontmatter/ds-init-project.yaml
+++ b/.claude/commands.frontmatter/ds-init-project.yaml
@@ -1,0 +1,1 @@
+description: "Scaffold a project: AGENTS.md hierarchy, CLI config, gitignore, .agentic/ seeds. Asks up front how you want work done."

--- a/.claude/commands.frontmatter/ds-memory-update.yaml
+++ b/.claude/commands.frontmatter/ds-memory-update.yaml
@@ -1,0 +1,1 @@
+description: "Capture a stable project fact or decision into MEMORY.md."

--- a/.claude/commands.frontmatter/ds-migrate-project.yaml
+++ b/.claude/commands.frontmatter/ds-migrate-project.yaml
@@ -1,0 +1,1 @@
+description: "Apply scaffolding migrations to bring a project up to the current manifest version."

--- a/.claude/commands.frontmatter/ds-prune-harness.yaml
+++ b/.claude/commands.frontmatter/ds-prune-harness.yaml
@@ -1,0 +1,1 @@
+description: "Propose deletions of rules that are not earning their keep."

--- a/.claude/commands.frontmatter/ds-pull-and-install.yaml
+++ b/.claude/commands.frontmatter/ds-pull-and-install.yaml
@@ -1,0 +1,1 @@
+description: "Pull and reinstall agentic-engineering from upstream, or fresh-install if not yet set up."

--- a/.claude/commands.frontmatter/ds-representation-audit.yaml
+++ b/.claude/commands.frontmatter/ds-representation-audit.yaml
@@ -1,0 +1,1 @@
+description: "Propose prose rewrites where the methodology is unclear or bloated."

--- a/.claude/commands.frontmatter/ds-skeptic.yaml
+++ b/.claude/commands.frontmatter/ds-skeptic.yaml
@@ -1,0 +1,1 @@
+description: "Run the adversarial review loop on a diff or artifact (findings classified Critical/Major/Minor)."

--- a/.claude/commands.frontmatter/ds-skill-candidates.yaml
+++ b/.claude/commands.frontmatter/ds-skill-candidates.yaml
@@ -1,0 +1,1 @@
+description: "Read-only view of the skill-candidate backlog: recurring workflow friction grouped by domain, count, and suggested artifact type."

--- a/.claude/commands.frontmatter/ds-status.yaml
+++ b/.claude/commands.frontmatter/ds-status.yaml
@@ -1,0 +1,1 @@
+description: "Shows the resolved mode/profile, WHERE each value comes from, what behavior it produces, and how to change it."

--- a/.claude/commands.frontmatter/ds-test-suite-comprehension.yaml
+++ b/.claude/commands.frontmatter/ds-test-suite-comprehension.yaml
@@ -1,0 +1,1 @@
+description: "Produce a test-gap map for a codebase."

--- a/.claude/commands.frontmatter/ds-ticket-status-sync.yaml
+++ b/.claude/commands.frontmatter/ds-ticket-status-sync.yaml
@@ -1,0 +1,1 @@
+description: "Reconcile a tracker column with the real PR/branch state."

--- a/.claude/commands.frontmatter/ds-ticket-triage.yaml
+++ b/.claude/commands.frontmatter/ds-ticket-triage.yaml
@@ -1,0 +1,1 @@
+description: "Triage a set of tickets: analyse dependencies, distribute across parallel lanes, emit paste-ready /ds-implement-ticket kickoff prompts. Plan-only; no code edits, no tracker writes."

--- a/.claude/commands.frontmatter/ds-update-agentic-engineering.yaml
+++ b/.claude/commands.frontmatter/ds-update-agentic-engineering.yaml
@@ -1,0 +1,1 @@
+description: "Edit, sync, build, and commit changes to the methodology itself."

--- a/.claude/commands.frontmatter/ds-wrap-deferred.yaml
+++ b/.claude/commands.frontmatter/ds-wrap-deferred.yaml
@@ -1,0 +1,1 @@
+description: "Non-interactive single-pass session enrichment invoked by the deferred-wrap daemon; not for direct use."

--- a/.claude/commands.frontmatter/ds-wrap.yaml
+++ b/.claude/commands.frontmatter/ds-wrap.yaml
@@ -1,1 +1,2 @@
 model: sonnet
+description: "Summarize the current session into .agentic/context.md."

--- a/.claude/commands.frontmatter/ds-wrap.yaml
+++ b/.claude/commands.frontmatter/ds-wrap.yaml
@@ -1,2 +1,2 @@
 model: sonnet
-description: "Summarize the current session into .agentic/context.md."
+description: "Summarize the current session into .agentic/_wrap.md."

--- a/.claude/commands/ds-brief.md
+++ b/.claude/commands/ds-brief.md
@@ -1,3 +1,7 @@
+---
+description: "Interactive planning dialogue that produces a Brief artifact before architects and engineers are spawned. /ds-brief --from <path> extracts a Brief from an existing PRD."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-brief

--- a/.claude/commands/ds-cleanup-worktrees.md
+++ b/.claude/commands/ds-cleanup-worktrees.md
@@ -1,3 +1,7 @@
+---
+description: "Remove stale subagent and feature worktrees."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-cleanup-worktrees

--- a/.claude/commands/ds-config.md
+++ b/.claude/commands/ds-config.md
@@ -1,3 +1,7 @@
+---
+description: "View and change methodology settings (profile, mode, .agentic/config.json toggles) with guided prompts."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-config

--- a/.claude/commands/ds-configure-team.md
+++ b/.claude/commands/ds-configure-team.md
@@ -1,3 +1,7 @@
+---
+description: "Configure and verify a cross-harness agent team (.agentic/team.yml): discovers installed harnesses and assigns a model per role."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-configure-team - Cross-Harness Team Setup

--- a/.claude/commands/ds-cost.md
+++ b/.claude/commands/ds-cost.md
@@ -1,3 +1,7 @@
+---
+description: "Token and wall-time rollups per agent/session/task from .agentic/events.jsonl."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-cost

--- a/.claude/commands/ds-disable.md
+++ b/.claude/commands/ds-disable.md
@@ -1,3 +1,7 @@
+---
+description: "Opt this project out (writes an opt-out marker to AGENTS.md). --global also sets global mode=opt-out."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-disable

--- a/.claude/commands/ds-feedback-triage.md
+++ b/.claude/commands/ds-feedback-triage.md
@@ -1,3 +1,7 @@
+---
+description: "Triage captured session friction (~/.agentic/feedback.jsonl) into tracker tickets."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-feedback-triage

--- a/.claude/commands/ds-help.md
+++ b/.claude/commands/ds-help.md
@@ -1,3 +1,7 @@
+---
+description: "This list."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-help

--- a/.claude/commands/ds-identity.md
+++ b/.claude/commands/ds-identity.md
@@ -1,3 +1,7 @@
+---
+description: "Manage the developer identity used for session telemetry attribution (manual, auto-derived, or provisional-to-confirmed)."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-identity

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -1,3 +1,7 @@
+---
+description: "Drive a ticket from spec to a merged PR through the full risk-classified workflow (architect, skeptic, engineer, QA gate)."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # Implement Ticket

--- a/.claude/commands/ds-init-project.md
+++ b/.claude/commands/ds-init-project.md
@@ -1,3 +1,7 @@
+---
+description: "Scaffold a project: AGENTS.md hierarchy, CLI config, gitignore, .agentic/ seeds. Asks up front how you want work done."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-init-project

--- a/.claude/commands/ds-memory-update.md
+++ b/.claude/commands/ds-memory-update.md
@@ -1,3 +1,7 @@
+---
+description: "Capture a stable project fact or decision into MEMORY.md."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-memory-update - Memory Protocol: Capture a Decision

--- a/.claude/commands/ds-migrate-project.md
+++ b/.claude/commands/ds-migrate-project.md
@@ -1,3 +1,7 @@
+---
+description: "Apply scaffolding migrations to bring a project up to the current manifest version."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-migrate-project

--- a/.claude/commands/ds-prune-harness.md
+++ b/.claude/commands/ds-prune-harness.md
@@ -1,3 +1,7 @@
+---
+description: "Propose deletions of rules that are not earning their keep."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-prune-harness

--- a/.claude/commands/ds-pull-and-install.md
+++ b/.claude/commands/ds-pull-and-install.md
@@ -1,3 +1,7 @@
+---
+description: "Pull and reinstall agentic-engineering from upstream, or fresh-install if not yet set up."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-pull-and-install

--- a/.claude/commands/ds-representation-audit.md
+++ b/.claude/commands/ds-representation-audit.md
@@ -1,3 +1,7 @@
+---
+description: "Propose prose rewrites where the methodology is unclear or bloated."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-representation-audit

--- a/.claude/commands/ds-skeptic.md
+++ b/.claude/commands/ds-skeptic.md
@@ -1,3 +1,7 @@
+---
+description: "Run the adversarial review loop on a diff or artifact (findings classified Critical/Major/Minor)."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-skeptic - The Skeptic Protocol Invocation

--- a/.claude/commands/ds-skill-candidates.md
+++ b/.claude/commands/ds-skill-candidates.md
@@ -1,3 +1,7 @@
+---
+description: "Read-only view of the skill-candidate backlog: recurring workflow friction grouped by domain, count, and suggested artifact type."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-skill-candidates

--- a/.claude/commands/ds-status.md
+++ b/.claude/commands/ds-status.md
@@ -1,3 +1,7 @@
+---
+description: "Shows the resolved mode/profile, WHERE each value comes from, what behavior it produces, and how to change it."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-status

--- a/.claude/commands/ds-test-suite-comprehension.md
+++ b/.claude/commands/ds-test-suite-comprehension.md
@@ -1,3 +1,7 @@
+---
+description: "Produce a test-gap map for a codebase."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-test-suite-comprehension

--- a/.claude/commands/ds-ticket-status-sync.md
+++ b/.claude/commands/ds-ticket-status-sync.md
@@ -1,3 +1,7 @@
+---
+description: "Reconcile a tracker column with the real PR/branch state."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-ticket-status-sync

--- a/.claude/commands/ds-ticket-triage.md
+++ b/.claude/commands/ds-ticket-triage.md
@@ -1,3 +1,7 @@
+---
+description: "Triage a set of tickets: analyse dependencies, distribute across parallel lanes, emit paste-ready /ds-implement-ticket kickoff prompts. Plan-only; no code edits, no tracker writes."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 <!--

--- a/.claude/commands/ds-update-agentic-engineering.md
+++ b/.claude/commands/ds-update-agentic-engineering.md
@@ -1,3 +1,7 @@
+---
+description: "Edit, sync, build, and commit changes to the methodology itself."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-update-agentic-engineering

--- a/.claude/commands/ds-wrap-deferred.md
+++ b/.claude/commands/ds-wrap-deferred.md
@@ -1,3 +1,7 @@
+---
+description: "Non-interactive single-pass session enrichment invoked by the deferred-wrap daemon; not for direct use."
+---
+
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.
 
 # /ds-wrap-deferred - Non-Interactive Single-Pass Session Enrichment

--- a/.claude/commands/ds-wrap.md
+++ b/.claude/commands/ds-wrap.md
@@ -1,6 +1,6 @@
 ---
 model: sonnet
-description: "Summarize the current session into .agentic/context.md."
+description: "Summarize the current session into .agentic/_wrap.md."
 ---
 
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.

--- a/.claude/commands/ds-wrap.md
+++ b/.claude/commands/ds-wrap.md
@@ -1,5 +1,6 @@
 ---
 model: sonnet
+description: "Summarize the current session into .agentic/context.md."
 ---
 
 > **Prerequisite:** If the /agentic-engineering skill has not been loaded in this session, invoke it first before proceeding.

--- a/bin/agentic-help
+++ b/bin/agentic-help
@@ -50,7 +50,7 @@ Plan & build
 Maintain & curate
   /ds-memory-update               Capture a stable project fact or decision into MEMORY.md.
   /ds-pull-and-install            Pull and reinstall agentic-engineering from upstream, or fresh-install if not yet set up.
-  /ds-wrap                        Summarize the current session into .agentic/context.md.
+  /ds-wrap                        Summarize the current session into .agentic/_wrap.md.
   /ds-migrate-project             Apply scaffolding migrations to bring a project up to the current manifest version.
   /ds-cleanup-worktrees           Remove stale subagent and feature worktrees.
   /ds-ticket-status-sync          Reconcile a tracker column with the real PR/branch state.

--- a/bin/agentic-help
+++ b/bin/agentic-help
@@ -38,6 +38,7 @@ Inspect & configure
   /ds-help                This list.
   /ds-disable             Opt this project out (writes an opt-out marker to AGENTS.md). --global also sets global mode=opt-out.
   /ds-cost                Token and wall-time rollups per agent/session/task from .agentic/events.jsonl.
+  /ds-identity            Manage the developer identity used for session telemetry attribution (manual, auto-derived, or provisional-to-confirmed).
 
 Plan & build
   /ds-brief                       Interactive planning dialogue that produces a Brief artifact before architects and engineers are spawned. /ds-brief --from <path> extracts a Brief from an existing PRD.
@@ -54,6 +55,9 @@ Maintain & curate
   /ds-cleanup-worktrees           Remove stale subagent and feature worktrees.
   /ds-ticket-status-sync          Reconcile a tracker column with the real PR/branch state.
   /ds-feedback-triage             Triage captured session friction (~/.agentic/feedback.jsonl) into tracker tickets.
+  /ds-configure-team              Configure and verify a cross-harness agent team (.agentic/team.yml): discovers installed harnesses and assigns a model per role.
+  /ds-skill-candidates            Read-only view of the skill-candidate backlog: recurring workflow friction grouped by domain, count, and suggested artifact type.
+  /ds-wrap-deferred               Non-interactive single-pass session enrichment invoked by the deferred-wrap daemon; not for direct use.
 
 Audit & improve the methodology
   /ds-prune-harness               Propose deletions of rules that are not earning their keep.

--- a/bin/tests/test_command_picker_descriptions.py
+++ b/bin/tests/test_command_picker_descriptions.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Purpose: Guard against malformed `.claude/commands.frontmatter/<name>.yaml`
+         sidecars silently regenerating a broken or truncated Claude Code
+         command-picker `description:` into `.claude/commands/<name>.md`.
+         `check-adapter-sync` compares regenerated output byte-for-byte, so
+         a malformed sidecar that regenerates DETERMINISTICALLY goes green
+         there - it never sees the semantic content, only that the build was
+         reproduced. This test is the only gate that actually parses the
+         generated frontmatter and checks its meaning.
+
+Public API: pytest test functions. Run with
+              python3 -m pytest bin/tests/test_command_picker_descriptions.py -q
+            (.github/workflows/bin-tests.yml's `python-bin-tests` job runs
+            `python3 -m pytest bin/tests/ -q`, auto-discovering; no additional
+            CI wiring is required.)
+
+Upstream deps: `.claude/commands/*.md` (must be freshly built by
+               `bash .claude/build.sh` before this runs - CI's adapter-sync
+               job builds before the drift check, and bin-tests runs on the
+               same checked-out tree), `bin/agentic-help` (imported as the
+               canonical description source), stdlib + pyyaml.
+
+Downstream consumers: none (CI gate only).
+
+Failure modes this test exists to catch, none of which raise anywhere else
+in the build pipeline:
+  - B1: an unquoted `description:` value containing `: ` - a bare `cat` never
+    errors, but `yaml.safe_load` raises ScannerError. Caught by
+    test_frontmatter_parses_without_error.
+  - B2: an unquoted `#` mid-value - parses "successfully" but SILENTLY
+    TRUNCATES everything after the `#` (YAML end-of-line comment). No error
+    anywhere in the build. Caught by test_description_matches_agentic_help,
+    since a truncated string no longer equals the canonical `bin/agentic-help`
+    line.
+  - B3: a sidecar missing its trailing newline - the closing `---` fence
+    glues onto the description value and no valid frontmatter block exists
+    at byte 0. Caught by test_frontmatter_block_at_byte_zero.
+
+Performance: parses 25 small files; well under a second.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_COMMANDS_DST = _REPO_ROOT / ".claude" / "commands"
+_CONTENT_COMMANDS = _REPO_ROOT / "content" / "commands"
+_AGENTIC_HELP = _REPO_ROOT / "bin" / "agentic-help"
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?\n)---\n", re.DOTALL)
+
+
+def _load_agentic_help_descriptions() -> dict[str, str]:
+    """Import bin/agentic-help and parse its per-command one-liners.
+
+    Returns {command-name-without-leading-slash: description text}.
+    """
+    loader = importlib.machinery.SourceFileLoader("agentic_help", str(_AGENTIC_HELP))
+    spec = importlib.util.spec_from_loader("agentic_help", loader)
+    if spec is None:
+        raise RuntimeError(f"Cannot build spec for agentic-help from {_AGENTIC_HELP}")
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)  # type: ignore[union-attr]
+    text: str = mod.HELP_TEXT
+    found: dict[str, str] = {}
+    for line in text.splitlines():
+        m = re.match(r"^\s*(/ds-[a-z-]+)\s{2,}(.*)$", line)
+        if m:
+            found[m.group(1)[1:]] = m.group(2).strip()
+    return found
+
+
+def _all_command_names() -> list[str]:
+    return sorted(p.stem for p in _CONTENT_COMMANDS.glob("ds-*.md"))
+
+
+def _generated_body(name: str) -> str:
+    dst = _COMMANDS_DST / f"{name}.md"
+    assert dst.is_file(), (
+        f"{dst} does not exist - run `bash .claude/build.sh` before this test"
+    )
+    return dst.read_text()
+
+
+def test_all_25_commands_present():
+    """Sanity check on the fixture set itself, not the gate's own subject."""
+    names = _all_command_names()
+    assert len(names) == 25, f"Expected 25 commands, found {len(names)}: {names}"
+
+
+def test_frontmatter_block_at_byte_zero():
+    """Catches B3 (missing trailing newline -> glued closing fence).
+
+    A sidecar without a trailing newline produces `..."text"---` on one
+    line, which does not match a `---\\n...\\n---\\n` frontmatter block at
+    byte 0 at all.
+    """
+    for name in _all_command_names():
+        body = _generated_body(name)
+        m = _FRONTMATTER_RE.match(body)
+        assert m is not None, (
+            f"{name}.md: no well-formed frontmatter block at byte 0 - "
+            f"check for a missing trailing newline in the sidecar. "
+            f"First 120 chars: {body[:120]!r}"
+        )
+
+
+def test_frontmatter_parses_without_error():
+    """Catches B1 (unquoted `: ` in the description value).
+
+    An unquoted colon-space inside a YAML scalar breaks the parser
+    (ScannerError) rather than silently misparsing.
+    """
+    for name in _all_command_names():
+        body = _generated_body(name)
+        m = _FRONTMATTER_RE.match(body)
+        assert m is not None, f"{name}.md: frontmatter block missing (see test_frontmatter_block_at_byte_zero)"
+        raw_yaml = m.group(1)
+        try:
+            yaml.safe_load(raw_yaml)
+        except yaml.YAMLError as exc:
+            raise AssertionError(
+                f"{name}.md: frontmatter failed to parse as YAML - "
+                f"likely an unquoted ': ' in the description. Error: {exc}"
+            ) from exc
+
+
+def test_description_key_present_and_nonempty():
+    for name in _all_command_names():
+        body = _generated_body(name)
+        m = _FRONTMATTER_RE.match(body)
+        assert m is not None
+        parsed = yaml.safe_load(m.group(1)) or {}
+        desc = parsed.get("description")
+        assert desc, f"{name}.md: frontmatter has no non-empty 'description' key"
+
+
+def test_description_matches_agentic_help():
+    """Catches B2 (unquoted `#` -> silent truncation) and future drift.
+
+    `bin/agentic-help` is the canonical description source (plan Step 1).
+    A truncated description simply stops equaling the canonical line -
+    this is the assertion that makes B2 detectable at all, since a bare
+    `cat`-based build (`.claude/build.sh`) never errors on it.
+    """
+    canonical = _load_agentic_help_descriptions()
+    for name in _all_command_names():
+        assert name in canonical, (
+            f"{name}: no corresponding line in bin/agentic-help HELP_TEXT - "
+            f"every command must have a canonical description there (plan Step 1)"
+        )
+        body = _generated_body(name)
+        m = _FRONTMATTER_RE.match(body)
+        assert m is not None
+        parsed = yaml.safe_load(m.group(1)) or {}
+        desc = parsed.get("description")
+        assert desc == canonical[name], (
+            f"{name}.md: generated description does not match bin/agentic-help "
+            f"canonical text.\nGenerated: {desc!r}\nCanonical: {canonical[name]!r}"
+        )
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
All 25 `ds-*` slash commands showed the same boilerplate line in Claude Code's command picker. Each generated command file lacked a `description:` frontmatter key, so the picker fell back to the first body line - which is the identical Activation-preflight blockquote on 15 of the 25.

## Change

- 24 new `.claude/commands.frontmatter/<name>.yaml` sidecars + `description:` added to the existing `ds-wrap.yaml` (which keeps `model: sonnet`).
- `bin/agentic-help` is the canonical source. It already carried 21 of the 25 one-liners; the 4 missing ones (`ds-identity`, `ds-configure-team`, `ds-skill-candidates`, `ds-wrap-deferred`) were added there, and every sidecar description matches its `agentic-help` line byte-for-byte.
- New merge-blocking gate: `bin/tests/test_command_picker_descriptions.py`.
- 25 regenerated `.claude/commands/*.md`.

No changes to `.claude/build.sh` - the sidecar path already emits arbitrary YAML into the frontmatter fence.

## Why a gate was required

`.claude/build.sh` cats sidecars raw and is blind to YAML. Three failure modes were reproduced empirically:

| Input | Result |
|---|---|
| Unquoted `: ` | `ScannerError` - loud |
| Unquoted `#` | **Parses clean, silently truncates.** Wrong text ships |
| No trailing newline | Closing fence glues on; no valid frontmatter block |

`check-adapter-sync` cannot catch any of these - malformed input regenerates deterministically and goes green. The `#` case is caught by exactly one assertion: parsed description equality against `bin/agentic-help`. All three failure modes plus a vacuity probe (glob repointed to a non-matching pattern) were verified to fail the gate, then restored.

## Alternative rejected on evidence

Moving the PREREQ blockquote below the H1 in `build.sh` would be one line and no authored prose, but measured across all 25 files: 19 H1s merely restate the command name (`/ds-brief: /ds-brief`), only 5 carry a real subtitle, and `ds-ticket-triage.md` has no leading H1 (HTML comment manifest to ~line 77), so the transform splices the blockquote inside a comment.

## Verification

- `bash scripts/build-all.sh` - 11 adapters
- Drift pathspec extracted programmatically from `adapter-sync.yml:29` after a fresh build - exit 0, committed output reproduces exactly
- `pytest bin/tests/` - 662 passed; new gate 5 passed
- All 100 repo symlinks relative, zero absolutized
- DCO signed off, author verified with lowercase `%ae`

## North Star alignment

- **Guard operator attention** - the picker now shows real routing text per command instead of 25 copies of the same sentence, so command selection stops costing a read-and-guess.
- **Verifiable outcomes autonomously** - a previously undetectable silent-truncation failure is now caught by a required status check, and the gate was proven capable of failing rather than assumed.
- **Works for everyone** - no operator identity, workspace, or local setup is baked in; descriptions derive from an in-repo canonical source.

No pillar regression.
