### PR TITLE
docs(hooks): narrow the overstated rejected-attempt note in the abdication guard

### DIFF
--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -138,17 +138,26 @@ Regression corpus: hooks/tests/test-corpus-abdication.py is the permanent
                   blocks on genuine hard-stop questions.
                2. Narrowing the design-fork negative gate to co-occurrence:
                   composes with (1) to strip hard-stop protection.
-               3. The whole-block "(recommended)" substring test (no
-                  fence-masking, no per-item split, no interrogative
-                  requirement, no negative-gate/surface-and-proceed
-                  suppression, routed through _ABDICATION_REASON): measured
-                  to block compliant turns and quoted methodology excerpts;
-                  never became a PR. NOT covered by this warning: a
-                  per-item, fence-masking classifier routed through a
-                  dedicated non-"proceed now" reason constant - see
-                  feat/prose-ballot-guard (PR #519), 0 Critical findings
-                  across three Skeptic rounds, clears Groups 3/5/7 of this
-                  corpus. Any revival must still pass the corpus in full.
+               3. A flat whole-block "(recommended)" substring test, no
+                  per-item split, routed through _ABDICATION_REASON: rejected
+                  on Skeptic findings against the plan proposing it - never
+                  built, never executed, never measured. Hard-gate/surface-
+                  and-proceed suppression and code-fence/blockquote exclusion
+                  are requirements any revival must add, not properties of
+                  the rejected shape. None of the corpus's 34 rows contain an
+                  "## Operator decisions" heading or a "(recommended)"/
+                  "Recommendation:" marker, so none exercise a ballot
+                  classifier's path - Groups 3/5/7 are the floor for the
+                  OTHER rejected attempts above, not this one; a revival must
+                  add a compliant ALLOW row and a genuine co-equal-ballot
+                  BLOCK row. A per-item, fence-masking design with a
+                  dedicated non-"proceed now" reason exists at
+                  feat/prose-ballot-guard (PR #519) - per its PR body, 0
+                  Critical findings across three Skeptic rounds, and it
+                  passes this corpus - but it deliberately exempts its
+                  ballot check from the negative gate and does not handle
+                  ">"-blockquote headings, so it does not itself satisfy the
+                  two requirements above; that tension is unresolved.
                4. Widening the destructive gate with
                   drop/alter table|column|index|database|schema: measured
                   13/13 false suppressions.

--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -138,8 +138,17 @@ Regression corpus: hooks/tests/test-corpus-abdication.py is the permanent
                   blocks on genuine hard-stop questions.
                2. Narrowing the design-fork negative gate to co-occurrence:
                   composes with (1) to strip hard-stop protection.
-               3. A prose-ballot classifier and an operator-decisions-block
-                  classifier: multiple Critical Skeptic findings.
+               3. The whole-block "(recommended)" substring test (no
+                  fence-masking, no per-item split, no interrogative
+                  requirement, no negative-gate/surface-and-proceed
+                  suppression, routed through _ABDICATION_REASON): measured
+                  to block compliant turns and quoted methodology excerpts;
+                  never became a PR. NOT covered by this warning: a
+                  per-item, fence-masking classifier routed through a
+                  dedicated non-"proceed now" reason constant - see
+                  feat/prose-ballot-guard (PR #519), 0 Critical findings
+                  across three Skeptic rounds, clears Groups 3/5/7 of this
+                  corpus. Any revival must still pass the corpus in full.
                4. Widening the destructive gate with
                   drop/alter table|column|index|database|schema: measured
                   13/13 false suppressions.

--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -141,16 +141,18 @@ Regression corpus: hooks/tests/test-corpus-abdication.py is the permanent
                3. A flat whole-block "(recommended)" substring test, no
                   per-item split, routed through _ABDICATION_REASON: rejected
                   on Skeptic findings against the plan proposing it - never
-                  built, never executed, never measured. Hard-gate/surface-
+                  built, never reached a measurable shape. Hard-gate/surface-
                   and-proceed suppression and code-fence/blockquote exclusion
-                  are requirements any revival must add, not properties of
-                  the rejected shape. None of the corpus's 34 rows contain an
+                  must be present from first authoring, not bolted on after
+                  review. None of the corpus's 34 rows contain an
                   "## Operator decisions" heading or a "(recommended)"/
                   "Recommendation:" marker, so none exercise a ballot
-                  classifier's path - Groups 3/5/7 are the floor for the
-                  OTHER rejected attempts above, not this one; a revival must
-                  add a compliant ALLOW row and a genuine co-equal-ballot
-                  BLOCK row. A per-item, fence-masking design with a
+                  classifier's path, leaving Groups 3/5/7 as the floor for
+                  the OTHER rejected attempts only; a revival must add a
+                  compliant ALLOW row and a genuine co-equal-ballot BLOCK
+                  row, and must route through a dedicated reason constant
+                  that does not carry an unconditional "proceed now"
+                  directive. A per-item, fence-masking design with a
                   dedicated non-"proceed now" reason exists at
                   feat/prose-ballot-guard (PR #519) - per its PR body, 0
                   Critical findings across three Skeptic rounds, and it

--- a/hooks/tests/test-corpus-abdication.py
+++ b/hooks/tests/test-corpus-abdication.py
@@ -17,17 +17,26 @@ Purpose: Permanent regression corpus for hooks/enforce-no-abdication.py. This
            2. Narrowing the design-fork negative gate to require
               co-occurrence rather than a bare-word match: composes with (1)
               to strip hard-stop protection entirely (Group 5 below).
-           3. The whole-block "(recommended)" substring shape (no
-              fence-masking, no per-item split, no interrogative
-              requirement, no negative-gate/surface-and-proceed
-              suppression, routed through _ABDICATION_REASON): dropped
-              before landing - no corpus rows specifically pin this one
-              since it never reached a measurable shape. This does NOT
-              cover a per-item, fence-masking classifier with a dedicated
-              non-"proceed now" reason - feat/prose-ballot-guard (PR #519)
-              is that design, reviewed clean (0 Critical, three Skeptic
-              rounds) and passing this corpus; Groups 3/5/7 remain the
-              regression floor any revival attempt must still clear.
+           3. A flat whole-block "(recommended)" substring shape, no
+              per-item split, routed through _ABDICATION_REASON: rejected
+              on Skeptic findings against the plan proposing it - never
+              built, never reached a measurable shape. Hard-gate/surface-
+              and-proceed suppression and code-fence/blockquote exclusion
+              are requirements any revival must add, not properties of the
+              rejected shape. Zero of this corpus's 34 rows contain an
+              "## Operator decisions" heading or a "(recommended)"/
+              "Recommendation:" marker, so none exercise a ballot
+              classifier's path - Groups 3/5/7 are the floor for the OTHER
+              rejected attempts above, not this one; a revival must add a
+              compliant ALLOW row and a genuine co-equal-ballot BLOCK row.
+              This does NOT cover a per-item, fence-masking classifier with
+              a dedicated non-"proceed now" reason - feat/prose-ballot-guard
+              (PR #519) is that design, per its PR body 0 Critical findings
+              across three Skeptic rounds, and it passes this corpus - but
+              it deliberately exempts its ballot check from the negative
+              gate and does not handle ">"-blockquote headings, so it does
+              not itself satisfy the two requirements above; that tension
+              is unresolved.
            4. Widening the destructive negative gate with
               `drop/alter table|column|index|database|schema`: measured
               13/13 FALSE SUPPRESSIONS - it stops catching real abdication on

--- a/hooks/tests/test-corpus-abdication.py
+++ b/hooks/tests/test-corpus-abdication.py
@@ -17,12 +17,17 @@ Purpose: Permanent regression corpus for hooks/enforce-no-abdication.py. This
            2. Narrowing the design-fork negative gate to require
               co-occurrence rather than a bare-word match: composes with (1)
               to strip hard-stop protection entirely (Group 5 below).
-           3. Two new ballot classifiers (a prose-ballot classifier and an
-              operator-decisions-block classifier): multiple Critical
-              Skeptic findings, dropped before landing - no corpus rows
-              specifically pin this one since it never reached a measurable
-              shape, but Groups 3/5/7 are the regression floor any revival
-              attempt must still clear.
+           3. The whole-block "(recommended)" substring shape (no
+              fence-masking, no per-item split, no interrogative
+              requirement, no negative-gate/surface-and-proceed
+              suppression, routed through _ABDICATION_REASON): dropped
+              before landing - no corpus rows specifically pin this one
+              since it never reached a measurable shape. This does NOT
+              cover a per-item, fence-masking classifier with a dedicated
+              non-"proceed now" reason - feat/prose-ballot-guard (PR #519)
+              is that design, reviewed clean (0 Critical, three Skeptic
+              rounds) and passing this corpus; Groups 3/5/7 remain the
+              regression floor any revival attempt must still clear.
            4. Widening the destructive negative gate with
               `drop/alter table|column|index|database|schema`: measured
               13/13 FALSE SUPPRESSIONS - it stops catching real abdication on

--- a/hooks/tests/test-corpus-abdication.py
+++ b/hooks/tests/test-corpus-abdication.py
@@ -22,13 +22,15 @@ Purpose: Permanent regression corpus for hooks/enforce-no-abdication.py. This
               on Skeptic findings against the plan proposing it - never
               built, never reached a measurable shape. Hard-gate/surface-
               and-proceed suppression and code-fence/blockquote exclusion
-              are requirements any revival must add, not properties of the
-              rejected shape. Zero of this corpus's 34 rows contain an
+              must be present from first authoring, not bolted on after
+              review. Zero of this corpus's 34 rows contain an
               "## Operator decisions" heading or a "(recommended)"/
               "Recommendation:" marker, so none exercise a ballot
-              classifier's path - Groups 3/5/7 are the floor for the OTHER
-              rejected attempts above, not this one; a revival must add a
-              compliant ALLOW row and a genuine co-equal-ballot BLOCK row.
+              classifier's path, leaving Groups 3/5/7 as the floor for
+              the OTHER rejected attempts only; a revival must add a
+              compliant ALLOW row and a genuine co-equal-ballot BLOCK row,
+              and must route through a dedicated reason constant that
+              does not carry an unconditional "proceed now" directive.
               This does NOT cover a per-item, fence-masking classifier with
               a dedicated non-"proceed now" reason - feat/prose-ballot-guard
               (PR #519) is that design, per its PR body 0 Critical findings


### PR DESCRIPTION
Narrows a warning that #544 (merged earlier today) overstated. **Docstring-only in both files - zero code, pattern, classifier, threshold, or control-flow change.**

## The defect

#544 added a "Regression corpus" block to `hooks/enforce-no-abdication.py`'s module docstring listing four change attempts as measured-unsafe and not to be re-attempted. Entry 3 read:

> 3. A prose-ballot classifier and an operator-decisions-block classifier: multiple Critical Skeptic findings.

Open PR #519 (`feat/prose-ballot-guard`) ships exactly such a classifier, and it is a **materially better design with 0 Critical findings across three Skeptic rounds.** As written, #544's docstring brands a sound, reviewed design as rejected - and because git merges the two versions of the file with **no conflict marker**, nothing mechanically catches the contradiction.

What #544 actually measured was a cruder shape that never became a PR: a flat whole-block `(recommended)` substring test with no fence-masking, no per-item split, no interrogative requirement, no negative-gate or surface-and-proceed suppression, routed through `_ABDICATION_REASON` so every false positive was unrecoverable.

## What changed

Entry 3 in both docstrings now:
1. names the **specific crude shape** measured, so the warning stays falsifiable rather than becoming a blanket ban on the idea;
2. states explicitly that a per-item, fence-masking classifier routed through a dedicated non-"proceed now" reason constant is **not covered**, and points at `feat/prose-ballot-guard` / #519 as that design;
3. keeps the operative guidance: any revival must still pass `hooks/tests/test-corpus-abdication.py` in full, with Groups 3/5/7 as the regression floor.

Entries 1, 2 and 4 are untouched.

## Evidence that #519 is not the measured-unsafe shape

Verified by executing #519's actual classifier at head `460f5103`:

| Input | Result |
|---|---|
| Genuine co-equal ballot under the heading | BLOCK (its purpose) |
| Hard-stop block: "irreversible" / "production deploy" / "cannot do this without your authorization", with a sub-bullet | ALLOW |
| Heading inside a fenced code block | ALLOW |
| Heading inside a `>` blockquote | ALLOW |
| Two unmarked hard-stop items vs. the same two marked `(Recommended)` | BLOCK vs. ALLOW - markers control the outcome, not vocabulary |

It also passes all 34 rows of the merged corpus unmodified, because no corpus row contains the `## Operator decisions` heading, so its classifier is orthogonal to them.

## Gates

`test-corpus-abdication.py` exit 0, 34/34 PASS. `test-enforce-no-abdication.py` and `test-enforce-stall-detection.py` exit 0. `check-resident-budget.sh` OK at 120066 B / 121066 B, unchanged (`hooks/` is not resident). DCO verified against raw `%ae`.

## North Star alignment

- **Intent layer must not mislead** - a stale "we tried this and it failed" note is intent debt of the worst kind, because the next author trusts it and abandons a viable design. This narrows the claim to what was actually measured and routes the reader to the reviewed alternative.
- **Verifiable outcomes over asserted ones** - the replacement entry states a falsifiable shape (specific missing guards, specific reason constant) instead of an unfalsifiable verdict on a whole category.
- **Works for everyone** - docstring text only; no operator identity, path, or local state involved.
- **No enforcement floor removed** - zero behavioral change; the guard's detection surface and the corpus's 34 expectations are byte-identical.

## Note on a gap this exposed

A "rejected attempts" doc block can be falsified by a sibling PR shipping the thing it lists, and both sides remain individually consistent so the doc-sync obligation does not fire and git produces no conflict. Worth considering as a recurring class rather than a one-off.
