### PR TITLE
test(phase8): executable shell harness for the Phase 8 commit-and-telemetry block

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2253,6 +2253,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2309,6 +2309,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2247,6 +2247,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2253,6 +2253,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2250,6 +2250,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -16,7 +16,15 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install pytest pyyaml
+      - name: install zsh (required for the bash/zsh parity matrix in test_phase8_telemetry_shell.py)
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - run: python3 -m pytest bin/tests/ -q
+      - name: floor collected test_phase8_telemetry_shell.py count at 18
+        # 9 test functions x 2 shells (bash, zsh) = 18 collected IDs. Adding or
+        # removing a test function in bin/tests/test_phase8_telemetry_shell.py
+        # obliges updating the floor below in the same PR.
+        run: |
+          python3 -m pytest bin/tests/test_phase8_telemetry_shell.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 18) { print "expected >= 18 collected tests (9 functions x 2 shells), got " $1; exit 1 } }'
   # Python hook tests live here (shared python toolchain with bin-tests); JS/sh
   # hook tests live in hooks-tests.yml.
   hooks-python-tests:

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -15144,6 +15144,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2252,6 +2252,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2251,6 +2251,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 

--- a/bin/tests/lib/git_fixture.py
+++ b/bin/tests/lib/git_fixture.py
@@ -1,0 +1,327 @@
+"""
+Purpose: Builds hermetic, disposable git repo fixtures that reproduce the six
+         shapes of consumer/project state the Phase 8 commit-and-telemetry
+         shell block (content/commands/ds-implement-ticket.md:2249-2346) can
+         run against: the DinoStack repo itself, an /ds-init-project-scaffolded
+         consumer repo, a fan-out engineer worktree, a fan-out primary
+         checkout, an unconfirmed-identity operator, and a confirmed identity
+         with no git user.* config. Built for
+         bin/tests/test_phase8_telemetry_shell.py.
+
+Public API: Fixture (dataclass: repo_dir, worktree_dir, branch_name,
+            developer, env)
+            build_dinostack_shape(tmp_path) -> Fixture
+            build_consumer_shape(tmp_path) -> Fixture
+            build_worktree_shape(tmp_path) -> Fixture
+            build_fanout_shape(tmp_path) -> Fixture
+            build_no_identity_shape(tmp_path) -> Fixture
+            build_identity_no_gitconfig_shape(tmp_path) -> Fixture
+
+Upstream deps: stdlib only (subprocess, dataclasses, pathlib). Shells out to
+               the system `git` binary. Does not touch the developer's real
+               $HOME, ~/.gitconfig, or /etc/gitconfig - every fixture pins
+               GIT_CONFIG_NOSYSTEM=1 and a fixture-local GIT_CONFIG_GLOBAL so
+               no ambient git identity, init.defaultBranch, or gpgsign setting
+               can leak in.
+
+Downstream consumers: bin/tests/test_phase8_telemetry_shell.py
+
+Failure modes: builders raise via subprocess.CalledProcessError (check=True
+               everywhere) if any setup git command fails - a broken fixture
+               must not silently produce a misleading test result. No network
+               access; every repo is git-init'd locally, never cloned.
+
+Performance: standard; each builder does a handful of local git commands
+             (~10-50ms) against a pytest tmp_path.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DUMMY_NAME = "AE Test Fixture"
+DUMMY_EMAIL = "ae-fixture@example.invalid"
+
+# The `.gitignore` block a fresh /ds-init-project-scaffolded consumer repo
+# carries (content/commands/ds-init-project.md Step 9): a targeted denylist,
+# NOT an umbrella. `.agentic/session-log/` is not ignored by anything in this
+# block - it is tracked by default. Trimmed to the entries load-bearing for
+# this harness; the full block also lists loop-state/tasks/events/etc, which
+# are irrelevant here.
+CONSUMER_GITIGNORE = """\
+# Agentic engineering runtime artifacts (must not be committed).
+.agentic/loop-state.json
+.agentic/loop-state-*.json
+.agentic/hud/
+.agentic/tasks.jsonl
+.agentic/events.jsonl
+.agentic/context.md
+.agentic/context.d/
+.agentic/_wrap.md
+.agentic/_foreign.md
+.agentic/memory/
+.agentic/memory.md
+.agentic/wrap/
+.agentic/preferences.json
+.agentic/compression-state.json
+.agentic/tracker.yml
+.agentic/tracker-states.json
+!.agentic/session-log/
+!.agentic/learnings.md
+!.agentic/qa.md
+!.agentic/deploy.md
+!.agentic/tracking.md
+!.agentic/qa-regressions.md
+!.agentic/config.json
+"""
+
+# DinoStack's own `.gitignore` (root .gitignore:28-30): a root-anchored
+# umbrella that ignores the ENTIRE .agentic/ directory except team.yml -
+# `.agentic/session-log/**` is ignored by this, unlike the consumer shape.
+DINOSTACK_GITIGNORE = """\
+/.agentic/*
+!/.agentic/team.yml
+"""
+
+
+@dataclass
+class Fixture:
+    repo_dir: Path
+    worktree_dir: Optional[Path]
+    branch_name: str
+    developer: str
+    env: dict[str, str]
+
+
+def _run(args: list[str], cwd: Path, env: dict[str, str]) -> None:
+    subprocess.run(args, cwd=str(cwd), env=env, check=True, capture_output=True, text=True)
+
+
+def _base_env(tmp_path: Path, user_name: Optional[str], user_email: Optional[str]) -> dict[str, str]:
+    """Every fixture's env: hermetic from the operator's real git identity and
+    locale, so behavior does not depend on the machine running the tests."""
+    global_gitconfig = tmp_path / ".empty-gitconfig"
+    if user_name is not None and user_email is not None:
+        global_gitconfig.write_text(
+            f"[user]\n\tname = {user_name}\n\temail = {user_email}\n", encoding="utf-8"
+        )
+    else:
+        global_gitconfig.write_text("", encoding="utf-8")
+
+    env = dict(os.environ)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = str(global_gitconfig)
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+    # Drop any AUTHOR/COMMITTER identity inherited from the calling process
+    # (e.g. this test suite's own CI commit env) unless a fixture opts back
+    # in (build_identity_no_gitconfig_shape).
+    for key in (
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+        "EMAIL",
+    ):
+        env.pop(key, None)
+    return env
+
+
+def _init_repo(path: Path, branch_name: str, env: dict[str, str]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-q", "-b", branch_name], cwd=path, env=env)
+    (path / "README.md").write_text("fixture repo\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=path, env=env)
+    commit_env = dict(env)
+    commit_env["GIT_AUTHOR_NAME"] = DUMMY_NAME
+    commit_env["GIT_AUTHOR_EMAIL"] = DUMMY_EMAIL
+    commit_env["GIT_COMMITTER_NAME"] = DUMMY_NAME
+    commit_env["GIT_COMMITTER_EMAIL"] = DUMMY_EMAIL
+    _run(["git", "commit", "-q", "-m", "initial commit"], cwd=path, env=commit_env)
+
+
+def _write_gitignore(path: Path, content: str, env: dict[str, str]) -> None:
+    (path / ".gitignore").write_text(content, encoding="utf-8")
+    _run(["git", "add", ".gitignore"], cwd=path, env=env)
+    commit_env = dict(env)
+    commit_env["GIT_AUTHOR_NAME"] = DUMMY_NAME
+    commit_env["GIT_AUTHOR_EMAIL"] = DUMMY_EMAIL
+    commit_env["GIT_COMMITTER_NAME"] = DUMMY_NAME
+    commit_env["GIT_COMMITTER_EMAIL"] = DUMMY_EMAIL
+    _run(["git", "commit", "-q", "-m", "add .gitignore"], cwd=path, env=commit_env)
+
+
+def _seed_session_log(repo_dir: Path, developer: str) -> Path:
+    log_dir = repo_dir / ".agentic" / "session-log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{developer}.jsonl"
+    log_path.write_text(
+        '{"ts":"2026-08-03T00:00:00Z","event":"session_total","tool_calls":1}\n',
+        encoding="utf-8",
+    )
+    return log_path
+
+
+def _stub_agentic_identity(
+    bin_dir: Path, env: dict[str, str], developer: Optional[str], provisional: bool = False
+) -> None:
+    """Install a PATH-shadowing fake `agentic-identity` executable so the
+    block's `agentic-identity show` calls resolve deterministically without
+    depending on this machine's real ~/.agentic/identity.yml."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "agentic-identity"
+    if developer is None:
+        body = (
+            "#!/bin/sh\n"
+            'echo "No identity set. Run: agentic-identity init <handle>"\n'
+            "exit 0\n"
+        )
+    elif provisional:
+        body = (
+            "#!/bin/sh\n"
+            f'echo "developer_id:  {developer}"\n'
+            'echo "provisional:   true"\n'
+            "exit 0\n"
+        )
+    else:
+        body = "#!/bin/sh\n" f'echo "developer_id:  {developer}"\n' "exit 0\n"
+    stub.write_text(body, encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+
+def build_dinostack_shape(tmp_path: Path) -> Fixture:
+    """(i) DinoStack itself: `/.agentic/*` umbrella ignores session-log, so
+    both the feature-commit `git add` and the telemetry `git add` hit the
+    ignored-paths error and no-op. $REPO is on $BRANCH_NAME directly."""
+    branch_name = "feature/harness-fixture-i"
+    developer = "dev-dinostack"
+    repo_dir = tmp_path / "repo"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, branch_name, env)
+    _write_gitignore(repo_dir, DINOSTACK_GITIGNORE, env)
+    _seed_session_log(repo_dir, developer)
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = ""
+    return Fixture(repo_dir, None, branch_name, developer, env)
+
+
+def build_consumer_shape(tmp_path: Path) -> Fixture:
+    """(ii) A /ds-init-project-scaffolded consumer repo: session-log is
+    tracked (targeted denylist, no umbrella). $REPO stays on a non-target
+    default branch; PR_CHECKOUT resolves via WORKTREE_PATH, mirroring the
+    common single-engineer path. Correct positive path."""
+    branch_name = "feature/harness-fixture-ii"
+    developer = "dev-consumer"
+    repo_dir = tmp_path / "repo"
+    worktree_dir = tmp_path / "worktree"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, "main", env)
+    _write_gitignore(repo_dir, CONSUMER_GITIGNORE, env)
+    _seed_session_log(repo_dir, developer)
+    _run(["git", "worktree", "add", "-q", str(worktree_dir), "-b", branch_name], cwd=repo_dir, env=env)
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = str(worktree_dir)
+    return Fixture(repo_dir, worktree_dir, branch_name, developer, env)
+
+
+def build_worktree_shape(tmp_path: Path) -> Fixture:
+    """(iii) Dedicated base fixture for the D1/D2 mutation tests. Same shape
+    as (ii) (WORKTREE_PATH resolution, PR_CHECKOUT != REPO), except the
+    destination session-log file inside worktree_dir MUST be absent before
+    the block runs - the D2 mutant relies on `[ -f <dest> ]` being false
+    pre-mkdir/cp so its inserted guard actually no-ops the block instead of
+    passing through."""
+    branch_name = "feature/harness-fixture-iii"
+    developer = "dev-worktree"
+    repo_dir = tmp_path / "repo"
+    worktree_dir = tmp_path / "worktree"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, "main", env)
+    _write_gitignore(repo_dir, CONSUMER_GITIGNORE, env)
+    _seed_session_log(repo_dir, developer)
+    _run(["git", "worktree", "add", "-q", str(worktree_dir), "-b", branch_name], cwd=repo_dir, env=env)
+    dest = worktree_dir / ".agentic" / "session-log" / f"{developer}.jsonl"
+    assert not dest.exists(), (
+        f"fixture invariant violated: {dest} must not exist before the "
+        f"block runs (required for the D2 mutant to be a valid no-op test)"
+    )
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = str(worktree_dir)
+    return Fixture(repo_dir, worktree_dir, branch_name, developer, env)
+
+
+def build_fanout_shape(tmp_path: Path) -> Fixture:
+    """(iv) Fan-out primary checkout: $REPO is already checked out on
+    $BRANCH_NAME (per the block's own comment: "Fan-out path: $REPO is on
+    $FEATURE_BRANCH after the line-977 checkout"), so PR_CHECKOUT resolves
+    to $REPO directly with no WORKTREE_PATH involved. Correct positive path."""
+    branch_name = "feature/harness-fixture-iv"
+    developer = "dev-fanout"
+    repo_dir = tmp_path / "repo"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, branch_name, env)
+    _write_gitignore(repo_dir, CONSUMER_GITIGNORE, env)
+    _seed_session_log(repo_dir, developer)
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = ""
+    return Fixture(repo_dir, None, branch_name, developer, env)
+
+
+def build_no_identity_shape(tmp_path: Path) -> Fixture:
+    """(v) Identity unconfirmed/absent: `agentic-identity show` resolves no
+    `developer_id:` line, so $DEVELOPER is empty and the
+    `[ "$COMMIT_TELEMETRY" = "true" ] && [ -n "$DEVELOPER" ]` guard at :2283
+    short-circuits - the telemetry block is never entered."""
+    branch_name = "feature/harness-fixture-v"
+    repo_dir = tmp_path / "repo"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, branch_name, env)
+    _write_gitignore(repo_dir, CONSUMER_GITIGNORE, env)
+    # No session-log seeded - DEVELOPER never resolves, so SESSION_LOG_SRC is
+    # never referenced (nothing to seed against).
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer=None)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = ""
+    return Fixture(repo_dir, None, branch_name, "", env)
+
+
+def build_identity_no_gitconfig_shape(tmp_path: Path) -> Fixture:
+    """(vi) D3 base fixture: confirmed developer identity, but NO
+    `git config user.name`/`user.email` anywhere (no global, no repo-local).
+    `git commit` still succeeds because GIT_AUTHOR_*/GIT_COMMITTER_*/EMAIL
+    are set directly in the process env - but `SO_NAME`/`SO_EMAIL` (built
+    exclusively from `git config user.name`/`user.email`, :2261-2262) resolve
+    empty, so the telemetry trailer lands as the malformed
+    `Signed-off-by:  <>` (D3, live on main today)."""
+    branch_name = "feature/harness-fixture-vi"
+    developer = "dev-no-gitconfig"
+    repo_dir = tmp_path / "repo"
+    # user_name/user_email=None -> empty global gitconfig (no [user] section).
+    env = _base_env(tmp_path, None, None)
+    env["GIT_AUTHOR_NAME"] = DUMMY_NAME
+    env["GIT_AUTHOR_EMAIL"] = DUMMY_EMAIL
+    env["GIT_COMMITTER_NAME"] = DUMMY_NAME
+    env["GIT_COMMITTER_EMAIL"] = DUMMY_EMAIL
+    env["EMAIL"] = DUMMY_EMAIL
+    _init_repo(repo_dir, branch_name, env)
+    _write_gitignore(repo_dir, CONSUMER_GITIGNORE, env)
+    _seed_session_log(repo_dir, developer)
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    env["REPO"] = str(repo_dir)
+    env["BRANCH_NAME"] = branch_name
+    env["WORKTREE_PATH"] = ""
+    return Fixture(repo_dir, None, branch_name, developer, env)

--- a/bin/tests/lib/git_fixture.py
+++ b/bin/tests/lib/git_fixture.py
@@ -1,12 +1,12 @@
 """
 Purpose: Builds hermetic, disposable git repo fixtures that reproduce the six
          shapes of consumer/project state the Phase 8 commit-and-telemetry
-         shell block (content/commands/ds-implement-ticket.md:2249-2346) can
+         shell block (content/commands/ds-implement-ticket.md:2249-2347) can
          run against: the DinoStack repo itself, an /ds-init-project-scaffolded
-         consumer repo, a fan-out engineer worktree, a fan-out primary
-         checkout, an unconfirmed-identity operator, and a confirmed identity
-         with no git user.* config. Built for
-         bin/tests/test_phase8_telemetry_shell.py.
+         consumer repo, a single-engineer worktree (WORKTREE_PATH-resolved PR
+         checkout), a fan-out primary checkout, an unconfirmed-identity
+         operator, and a confirmed identity with no git user.* config. Built
+         for bin/tests/test_phase8_telemetry_shell.py.
 
 Public API: Fixture (dataclass: repo_dir, worktree_dir, branch_name,
             developer, env)
@@ -20,9 +20,11 @@ Public API: Fixture (dataclass: repo_dir, worktree_dir, branch_name,
 Upstream deps: stdlib only (subprocess, dataclasses, pathlib). Shells out to
                the system `git` binary. Does not touch the developer's real
                $HOME, ~/.gitconfig, or /etc/gitconfig - every fixture pins
-               GIT_CONFIG_NOSYSTEM=1 and a fixture-local GIT_CONFIG_GLOBAL so
-               no ambient git identity, init.defaultBranch, or gpgsign setting
-               can leak in.
+               HOME to a fixture-local temp dir, GIT_CONFIG_NOSYSTEM=1, and a
+               fixture-local GIT_CONFIG_GLOBAL so no ambient git identity,
+               init.defaultBranch, gpgsign setting, or ~/.nvm/nvm.sh (which
+               would otherwise prepend to PATH ahead of the agentic-identity
+               stub dir) can leak in.
 
 Downstream consumers: bin/tests/test_phase8_telemetry_shell.py
 
@@ -112,7 +114,11 @@ def _base_env(tmp_path: Path, user_name: Optional[str], user_email: Optional[str
     else:
         global_gitconfig.write_text("", encoding="utf-8")
 
+    fixture_home = tmp_path / ".fixture-home"
+    fixture_home.mkdir(parents=True, exist_ok=True)
+
     env = dict(os.environ)
+    env["HOME"] = str(fixture_home)
     env["GIT_CONFIG_NOSYSTEM"] = "1"
     env["GIT_CONFIG_GLOBAL"] = str(global_gitconfig)
     env["LC_ALL"] = "C"
@@ -283,7 +289,7 @@ def build_fanout_shape(tmp_path: Path) -> Fixture:
 def build_no_identity_shape(tmp_path: Path) -> Fixture:
     """(v) Identity unconfirmed/absent: `agentic-identity show` resolves no
     `developer_id:` line, so $DEVELOPER is empty and the
-    `[ "$COMMIT_TELEMETRY" = "true" ] && [ -n "$DEVELOPER" ]` guard at :2283
+    `[ "$COMMIT_TELEMETRY" = "true" ] && [ -n "$DEVELOPER" ]` guard at :2284
     short-circuits - the telemetry block is never entered."""
     branch_name = "feature/harness-fixture-v"
     repo_dir = tmp_path / "repo"
@@ -304,7 +310,7 @@ def build_identity_no_gitconfig_shape(tmp_path: Path) -> Fixture:
     `git config user.name`/`user.email` anywhere (no global, no repo-local).
     `git commit` still succeeds because GIT_AUTHOR_*/GIT_COMMITTER_*/EMAIL
     are set directly in the process env - but `SO_NAME`/`SO_EMAIL` (built
-    exclusively from `git config user.name`/`user.email`, :2261-2262) resolve
+    exclusively from `git config user.name`/`user.email`, :2262-2263) resolve
     empty, so the telemetry trailer lands as the malformed
     `Signed-off-by:  <>` (D3, live on main today)."""
     branch_name = "feature/harness-fixture-vi"

--- a/bin/tests/lib/md_shell_extract.py
+++ b/bin/tests/lib/md_shell_extract.py
@@ -31,6 +31,20 @@ Failure modes: every extraction/render/transform step is fail-closed - 0 or
 
 Performance: standard; extraction/render/transform are pure string ops over
              a <5KB block. syntax_check() forks a subprocess per call.
+
+Known scope limitation: PLACEHOLDER_WHITELIST["[specific files]"] renders to
+             `.agentic/session-log/${DEVELOPER}.jsonl`, but that `git add`
+             line executes before `$DEVELOPER` is assigned a few lines later
+             in the rendered block. The feature-commit `git add` is therefore
+             a guaranteed `fatal: pathspec '.agentic/session-log/.jsonl' did
+             not match` under every fixture this harness builds, and no test
+             in bin/tests/test_phase8_telemetry_shell.py produces or asserts
+             a feature commit - only the telemetry-commit path (which
+             resolves $DEVELOPER first) is exercised. Extending coverage to
+             the feature commit requires a placeholder value that does not
+             depend on a later-assigned variable; this whitelist value was
+             deliberately left unchanged rather than papered over, to avoid
+             masking the render()-order defect it documents.
 """
 from __future__ import annotations
 

--- a/bin/tests/lib/md_shell_extract.py
+++ b/bin/tests/lib/md_shell_extract.py
@@ -1,0 +1,236 @@
+"""
+Purpose: Extracts and mutates fenced ```bash blocks out of a markdown command
+         file (specifically content/commands/ds-implement-ticket.md) so their
+         shell can be executed against real git fixtures in a pytest suite,
+         instead of only ever being read as prose. Built for
+         bin/tests/test_phase8_telemetry_shell.py, which exercises the Phase 8
+         commit-and-telemetry block.
+
+Public API: extract_marked_block(md_path, marker) -> str
+            render(block_text) -> str
+            apply_transform(block_text, anchor, transform_fn) -> str
+            with_completion_marker(rendered_script) -> str
+            syntax_check(rendered_script, shell) -> subprocess.CompletedProcess
+            line_containing(text, substr) -> str
+            PLACEHOLDER_WHITELIST: dict[str, str]
+            COMPLETION_MARKER: str
+            HarnessExtractionError, HarnessTransformError
+
+Upstream deps: stdlib only (re, subprocess, tempfile, os).
+
+Downstream consumers: bin/tests/test_phase8_telemetry_shell.py
+
+Failure modes: every extraction/render/transform step is fail-closed - 0 or
+               >1 matches raises rather than silently picking one. This
+               mirrors the defect class the harness exists to catch (an
+               anchor that stops being unique after a prose edit must break
+               the test suite loudly, not degrade into extracting the wrong
+               block). No side effects other than syntax_check(), which
+               shells out to `<shell> -n` against a temp file it creates and
+               deletes; safe to call repeatedly.
+
+Performance: standard; extraction/render/transform are pure string ops over
+             a <5KB block. syntax_check() forks a subprocess per call.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+from typing import Callable
+
+
+class HarnessExtractionError(Exception):
+    """Raised when a fenced ```bash block cannot be uniquely located, or a
+    placeholder in PLACEHOLDER_WHITELIST does not appear exactly once."""
+
+
+class HarnessTransformError(Exception):
+    """Raised when an anchor substring used for a mutation (or a
+    line_containing() lookup) does not match exactly once inside the
+    extracted block."""
+
+
+# Placeholders that appear in the Phase 8 commit-and-telemetry block as
+# human-facing template text (e.g. `git -C $REPO add [specific files]`) that
+# must be substituted with a concrete value before the block is executable.
+#
+# Deliberately NOT a generic bracket regex: the block also has 8+ legitimate
+# `[ ... ]` shell test expressions (e.g. `[ -n "$PR_CHECKOUT" ]`), so a naive
+# `\[[^]]*\]` pattern is permanently red, and `\[[A-Z_]+\]` is blind to the
+# lowercase, space-containing "[specific files]" placeholder.
+PLACEHOLDER_WHITELIST: dict[str, str] = {
+    "[specific files]": ".agentic/session-log/${DEVELOPER}.jsonl",
+    "[BRANCH_NAME]": "$BRANCH_NAME",
+    "[TICKET_PREFIX]": "DS-000",
+}
+
+# Appended as the final line of a rendered script to prove the block ran to
+# completion rather than crashing partway through.
+#
+# PRECONDITION: marker-absence in stdout proves non-completion ONLY if the
+# block contains no `exit` of its own (an early `exit 0` would still leave
+# the marker unprinted while the block "succeeded"). Verified 0 occurrences
+# of `exit` in the current Phase 8 block (grep -cw exit == 0); re-verify this
+# precondition if this helper is ever reused against a different block.
+COMPLETION_MARKER = "HARNESS_BLOCK_COMPLETED"
+
+_BASH_FENCE_RE = re.compile(r"```bash\n(.*?)```", re.DOTALL)
+
+
+def _marker_line(marker: str) -> str:
+    return f"# @harness:{marker}"
+
+
+def extract_marked_block(md_path: str, marker: str) -> str:
+    """Return the body (marker line stripped) of the single fenced ```bash
+    block in md_path whose first non-blank inner line is exactly
+    `# @harness:<marker>`. Raises HarnessExtractionError on 0 or >1 matches.
+    """
+    with open(md_path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+
+    target = _marker_line(marker)
+    matches: list[str] = []
+    for block in _BASH_FENCE_RE.findall(text):
+        lines = block.split("\n")
+        first_non_blank_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() != "":
+                first_non_blank_idx = i
+                break
+        if first_non_blank_idx is None:
+            continue
+        if lines[first_non_blank_idx].strip() == target:
+            remainder = "\n".join(lines[first_non_blank_idx + 1 :])
+            matches.append(remainder.lstrip("\n"))
+
+    if len(matches) == 0:
+        raise HarnessExtractionError(
+            f"marker '{target}' not found in any ```bash block in {md_path} "
+            f"(expected exactly 1 match, got 0). Remedy: update the anchor in "
+            f"bin/tests/lib/md_shell_extract.py to match the new prose; this "
+            f"harness tests Phase 8's telemetry-commit shell, see "
+            f"bin/tests/test_phase8_telemetry_shell.py."
+        )
+    if len(matches) > 1:
+        raise HarnessExtractionError(
+            f"marker '{target}' matched {len(matches)} ```bash blocks in "
+            f"{md_path} (expected exactly 1). Remedy: update the anchor in "
+            f"bin/tests/lib/md_shell_extract.py to match the new prose; this "
+            f"harness tests Phase 8's telemetry-commit shell, see "
+            f"bin/tests/test_phase8_telemetry_shell.py."
+        )
+    return matches[0]
+
+
+def render(block_text: str) -> str:
+    """Substitute every PLACEHOLDER_WHITELIST key for its value.
+
+    Fails closed in both directions:
+      (a) PRE-RENDER: every key must appear exactly once in block_text, or
+          this raises - catches "prose renamed the placeholder so render()
+          would otherwise silently substitute nothing".
+      (b) POST-RENDER: no key may survive substitution.
+    """
+    for key in PLACEHOLDER_WHITELIST:
+        count = block_text.count(key)
+        if count != 1:
+            raise HarnessExtractionError(
+                f"placeholder '{key}' occurs {count} times in the extracted "
+                f"block (expected exactly 1). Remedy: update "
+                f"PLACEHOLDER_WHITELIST in bin/tests/lib/md_shell_extract.py "
+                f"to match content/commands/ds-implement-ticket.md; this "
+                f"harness tests Phase 8's telemetry-commit shell, see "
+                f"bin/tests/test_phase8_telemetry_shell.py."
+            )
+
+    rendered = block_text
+    for key, value in PLACEHOLDER_WHITELIST.items():
+        rendered = rendered.replace(key, value)
+
+    for key in PLACEHOLDER_WHITELIST:
+        if key in rendered:
+            raise HarnessExtractionError(
+                f"placeholder '{key}' still present after render() "
+                f"substitution - substitution did not take effect."
+            )
+    return rendered
+
+
+def line_containing(text: str, substr: str) -> str:
+    """Return the single full line (no trailing newline) in text that
+    contains substr exactly once across the whole text. Raises
+    HarnessTransformError on 0 or >1 matching lines, or if substr itself
+    occurs more than once total (ambiguous anchor)."""
+    total = text.count(substr)
+    if total != 1:
+        raise HarnessTransformError(
+            f"anchor '{substr}' occurs {total} times in the block (expected "
+            f"exactly 1). Remedy: update the anchor in "
+            f"bin/tests/test_phase8_telemetry_shell.py to match "
+            f"content/commands/ds-implement-ticket.md; this harness tests "
+            f"Phase 8's telemetry-commit shell."
+        )
+    for line in text.split("\n"):
+        if substr in line:
+            return line
+    raise HarnessTransformError(
+        f"anchor '{substr}' found via count() but not via line scan - "
+        f"internal inconsistency in line_containing()."
+    )
+
+
+def apply_transform(
+    block_text: str, anchor: str, transform_fn: Callable[[str], str]
+) -> str:
+    """Validate anchor occurs exactly once in block_text, then apply
+    transform_fn(block_text) -> mutated_text. Raises HarnessTransformError on
+    0 or >1 anchor occurrences, or if transform_fn returns the input
+    unchanged (a no-op transform is a harness bug, not a valid mutant)."""
+    count = block_text.count(anchor)
+    if count != 1:
+        raise HarnessTransformError(
+            f"anchor '{anchor}' occurs {count} times in the block (expected "
+            f"exactly 1). Remedy: update the anchor in "
+            f"bin/tests/test_phase8_telemetry_shell.py to match "
+            f"content/commands/ds-implement-ticket.md; this harness tests "
+            f"Phase 8's telemetry-commit shell, see "
+            f"bin/tests/test_phase8_telemetry_shell.py."
+        )
+    mutated = transform_fn(block_text)
+    if mutated == block_text:
+        raise HarnessTransformError(
+            f"transform_fn anchored on '{anchor}' produced no change - "
+            f"the mutant is identical to the original block."
+        )
+    return mutated
+
+
+def with_completion_marker(rendered_script: str) -> str:
+    """Append `echo "HARNESS_BLOCK_COMPLETED"` as the final line.
+
+    PRECONDITION (see COMPLETION_MARKER docstring above): marker-absence
+    proves non-completion only if the block contains no `exit` of its own.
+    """
+    script = rendered_script
+    if not script.endswith("\n"):
+        script += "\n"
+    return script + f'echo "{COMPLETION_MARKER}"\n'
+
+
+def syntax_check(rendered_script: str, shell: str) -> subprocess.CompletedProcess:
+    """Run `<shell> -n` against rendered_script via a temp file. Returns the
+    CompletedProcess (caller inspects .returncode / .stderr)."""
+    fd, path = tempfile.mkstemp(prefix="phase8-syntax-", suffix=".sh")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(rendered_script)
+        return subprocess.run(
+            [shell, "-n", path],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.remove(path)

--- a/bin/tests/test_loop_state_site_coverage.sh
+++ b/bin/tests/test_loop_state_site_coverage.sh
@@ -302,6 +302,7 @@ content/sections/09-events-log.md
 docs/agentic-engineering-comparison.html
 scripts/codex-skills.py
 bin/tests/test_agentic_migrate.py
+bin/tests/lib/git_fixture.py
 EOF
 
 diff "$TMP/actual" "$TMP/accounted" > "$TMP/gatec" 2>&1 || true

--- a/bin/tests/test_phase8_telemetry_shell.py
+++ b/bin/tests/test_phase8_telemetry_shell.py
@@ -1,0 +1,340 @@
+"""
+Purpose: Executes the Phase 8 commit-and-telemetry shell block
+         (content/commands/ds-implement-ticket.md:2249-2346, marked
+         `@harness:phase8-commit-and-telemetry`) against real temp-git
+         fixtures under both bash and zsh, so the class of defect that two
+         review rounds each missed fails mechanically instead of surviving a
+         third: D1 (a hoisted SESSION_LOG_SRC assignment silently drops the
+         telemetry commit), D2 (an existence guard placed before the mkdir/cp
+         that creates the file no-ops the whole block), and D3 (a missing
+         DCO-identity guard on the telemetry commit emits a malformed
+         `Signed-off-by:  <>` trailer - live and unfixed on main today).
+
+Public API: none (pytest test module; 9 functions x {bash, zsh} = 18 tests).
+
+Upstream deps: bin/tests/lib/md_shell_extract.py, bin/tests/lib/git_fixture.py,
+               content/commands/ds-implement-ticket.md (file under test).
+
+Downstream consumers: .github/workflows/bin-tests.yml (python-bin-tests job),
+               which additionally floors the collected-test count at >= 18 -
+               see the comment on that step for why.
+
+Failure modes: n/a (test module). Tests #7 and #8 are themselves a self-check
+               of the harness: if a mutant fails to be caught, the harness
+               regressed to not detecting the defect class it exists for.
+               Test #9 is a deliberate characterization test that PASSES
+               against current unfixed main - see its docstring.
+
+Performance: standard; each parametrized test does a handful of local git
+             operations plus one subprocess shell invocation. Whole suite
+             runs in low single-digit seconds.
+"""
+from __future__ import annotations
+
+import functools
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lib.git_fixture as git_fixture  # noqa: E402
+import lib.md_shell_extract as mse  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MD_PATH = REPO_ROOT / "content" / "commands" / "ds-implement-ticket.md"
+MARKER = "phase8-commit-and-telemetry"
+
+SHELLS = ["bash", "zsh"]
+
+SESSION_LOG_SRC_ANCHOR = 'SESSION_LOG_SRC="$REPO/.agentic/session-log/${DEVELOPER}.jsonl"'
+CP_LINE_ANCHOR = (
+    'cp "$SESSION_LOG_SRC" "$PR_CHECKOUT/.agentic/session-log/${DEVELOPER}.jsonl" '
+    "2>/dev/null || true"
+)
+MKDIR_LINE_ANCHOR = 'mkdir -p "$PR_CHECKOUT/.agentic/session-log/"'
+
+
+def _shell_or_skip(shell: str) -> str:
+    """Skip locally when a shell is missing; hard-fail in CI so the zsh half
+    of the matrix can never be silently dropped (see MEMORY.md's
+    'green often means the check did not run' lesson)."""
+    if shutil.which(shell) is None:
+        if os.environ.get("CI"):
+            pytest.fail(f"{shell} not found in CI - the python-bin-tests job must install it")
+        pytest.skip(f"{shell} not found on this machine")
+    return shell
+
+
+@functools.lru_cache(maxsize=1)
+def _raw_block() -> str:
+    return mse.extract_marked_block(str(MD_PATH), MARKER)
+
+
+def _pr_checkout(fixture: git_fixture.Fixture) -> Path:
+    return fixture.worktree_dir if fixture.worktree_dir is not None else fixture.repo_dir
+
+
+def _make_d1_mutant(block_text: str) -> str:
+    """D1: hoist SESSION_LOG_SRC's assignment to immediately AFTER the `cp`
+    line that reads it, so `cp ""` runs against an as-yet-unset variable."""
+    src_line = mse.line_containing(block_text, SESSION_LOG_SRC_ANCHOR)
+    cp_line = mse.line_containing(block_text, CP_LINE_ANCHOR)
+
+    def transform(text: str) -> str:
+        without_src = text.replace(src_line + "\n", "", 1)
+        return without_src.replace(cp_line, cp_line + "\n" + src_line, 1)
+
+    return mse.apply_transform(block_text, SESSION_LOG_SRC_ANCHOR, transform)
+
+
+def _make_d2_mutant(block_text: str) -> str:
+    """D2: wrap the mkdir+cp pair in a guard checking for the very file they
+    create, so on a fixture where the destination is absent, the guard is
+    always false and the pair never runs."""
+    mkdir_line = mse.line_containing(block_text, MKDIR_LINE_ANCHOR)
+    cp_line = mse.line_containing(block_text, CP_LINE_ANCHOR)
+    indent = mkdir_line[: len(mkdir_line) - len(mkdir_line.lstrip())]
+    pair = mkdir_line + "\n" + cp_line
+
+    def transform(text: str) -> str:
+        guarded = (
+            f'{indent}if [ -f "$PR_CHECKOUT/.agentic/session-log/${{DEVELOPER}}.jsonl" ]; then\n'
+            f"{mkdir_line}\n{cp_line}\n"
+            f"{indent}fi"
+        )
+        return text.replace(pair, guarded, 1)
+
+    return mse.apply_transform(block_text, MKDIR_LINE_ANCHOR, transform)
+
+
+def _execute(
+    rendered_block: str, fixture: git_fixture.Fixture, shell: str
+) -> subprocess.CompletedProcess:
+    script = mse.with_completion_marker(rendered_block)
+    return subprocess.run(
+        [shell, "-c", script],
+        cwd=str(fixture.repo_dir),
+        env=fixture.env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _commit_subjects(path: Path, branch: str, env: dict) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(path), "log", branch, "--format=%s"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.splitlines()
+
+
+def _telemetry_commit_body(path: Path, branch: str, env: dict) -> str | None:
+    """Full commit message body of the first `chore(telemetry):` commit on
+    `branch`, or None if no such commit exists."""
+    subjects = _commit_subjects(path, branch, env)
+    for i, subject in enumerate(subjects):
+        if subject.startswith("chore(telemetry):"):
+            result = subprocess.run(
+                ["git", "-C", str(path), "log", branch, "-1", f"--skip={i}", "--format=%B"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 1. Static harness self-check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_extraction_is_non_vacuous(shell):
+    shell = _shell_or_skip(shell)
+    block = _raw_block()
+    lines = block.splitlines()
+    assert len(lines) > 40, f"expected >40 lines, got {len(lines)}"
+    for anchor in ("SESSION_LOG_SRC", "Signed-off-by", "PR_CHECKOUT"):
+        assert anchor in block, f"expected literal anchor {anchor!r} in extracted block"
+
+    rendered = mse.render(block)
+    for key in mse.PLACEHOLDER_WHITELIST:
+        assert key not in rendered, f"placeholder {key!r} survived render()"
+
+    d1 = mse.render(_make_d1_mutant(block))
+    d1_check = mse.syntax_check(d1, shell)
+    assert d1_check.returncode == 0, f"D1 mutant failed to parse under {shell}: {d1_check.stderr}"
+
+    d2 = mse.render(_make_d2_mutant(block))
+    d2_check = mse.syntax_check(d2, shell)
+    assert d2_check.returncode == 0, f"D2 mutant failed to parse under {shell}: {d2_check.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# 2-4. Correct-block positive paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_correct_block_commits_telemetry_on_consumer_shape(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_consumer_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    check = mse.syntax_check(rendered, shell)
+    assert check.returncode == 0, check.stderr
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is not None, "expected a chore(telemetry): commit"
+    assert f"Signed-off-by: {git_fixture.DUMMY_NAME} <{git_fixture.DUMMY_EMAIL}>" in body
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_correct_block_commits_telemetry_on_worktree_shape(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_worktree_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    check = mse.syntax_check(rendered, shell)
+    assert check.returncode == 0, check.stderr
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is not None, "expected a chore(telemetry): commit"
+    assert f"Signed-off-by: {git_fixture.DUMMY_NAME} <{git_fixture.DUMMY_EMAIL}>" in body
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_correct_block_commits_telemetry_on_fanout_shape(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_fanout_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    check = mse.syntax_check(rendered, shell)
+    assert check.returncode == 0, check.stderr
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is not None, "expected a chore(telemetry): commit"
+    assert f"Signed-off-by: {git_fixture.DUMMY_NAME} <{git_fixture.DUMMY_EMAIL}>" in body
+
+
+# ---------------------------------------------------------------------------
+# 5-6. Correct-block negative paths (genuine, non-crash no-ops).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_correct_block_noops_on_dinostack_shape(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_dinostack_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, (
+        f"block did not run to completion (a genuine no-op is required, not "
+        f"a crash): {result.stderr}"
+    )
+    assert "The following paths are ignored by one of your .gitignore files" in result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is None, "expected no chore(telemetry): commit on the dinostack shape"
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_correct_block_skips_telemetry_when_identity_unconfirmed(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_no_identity_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is None, "expected no chore(telemetry): commit when identity is unconfirmed"
+
+
+# ---------------------------------------------------------------------------
+# 7-8. Mutation tests: D1 and D2 must be caught by this harness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_defect1_hoisted_cp_silently_drops_telemetry_commit(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_worktree_shape(tmp_path)
+    mutant = mse.render(_make_d1_mutant(_raw_block()))
+    check = mse.syntax_check(mutant, shell)
+    assert check.returncode == 0, f"D1 mutant must parse (same-scope reorder): {check.stderr}"
+    result = _execute(mutant, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is None, (
+        "D1 (hoisted SESSION_LOG_SRC assignment) should silently drop the "
+        "telemetry commit - if this fails, the harness is not catching the "
+        "defect class it exists to catch"
+    )
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_defect2_guard_before_cp_noops_on_single_engineer_path(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_worktree_shape(tmp_path)
+    mutant_raw = _make_d2_mutant(_raw_block())
+    mutant = mse.render(mutant_raw)
+    check = mse.syntax_check(mutant, shell)
+    assert check.returncode == 0, (
+        f"D2 mutant must parse under {shell} - there is no accepted "
+        f"'unparseable' branch for this mutation: {check.stderr}"
+    )
+    result = _execute(mutant, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is None, (
+        "D2 (existence guard inserted before the mkdir/cp that creates the "
+        "file) should no-op the whole block on a fixture where the "
+        "destination is absent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. D3 characterization test - documents a LIVE, unfixed defect on main.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_defect3_missing_dco_guard_emits_malformed_trailer(tmp_path, shell):
+    """CHARACTERIZATION TEST - passes against current main because it
+    documents a live, unfixed defect. Do NOT mark this xfail(strict=True):
+    a prior revision did, and it was inverted (the assertions below hold
+    today, so the test passes, and strict xfail turns a pass into
+    XPASS(strict) -> suite red on merge).
+
+    Defect location: content/commands/ds-implement-ticket.md:2274-2325 - the
+    telemetry-commit block builds TELEM_MSG (:2316) from $SO_NAME/$SO_EMAIL
+    with NO guard analogous to the one at :2264 that protects the FEATURE
+    commit. When git config user.name/user.email are unset (but the commit
+    itself still succeeds via GIT_AUTHOR_*/GIT_COMMITTER_* env vars, as a CI
+    runner or a fresh clone with no `git config --global user.*` might have),
+    the telemetry commit lands with the literal malformed trailer
+    `Signed-off-by:  <>` (two spaces, empty angle brackets).
+
+    The follow-up ticket that adds the :2283-2325 guard MUST invert this
+    test (assert the malformed trailer no longer occurs) in the SAME PR
+    that fixes the defect.
+    """
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_identity_no_gitconfig_shape(tmp_path)
+    rendered = mse.render(_raw_block())
+    result = _execute(rendered, fixture, shell)
+    assert mse.COMPLETION_MARKER in result.stdout, result.stderr
+    body = _telemetry_commit_body(_pr_checkout(fixture), fixture.branch_name, fixture.env)
+    assert body is not None, "expected a chore(telemetry): commit even with no git user.* config"
+    assert "Signed-off-by:  <>" in body, (
+        f"expected the LIVE malformed trailer 'Signed-off-by:  <>' (D3, "
+        f"unfixed on main) in the telemetry commit body, got: {body!r}"
+    )

--- a/bin/tests/test_phase8_telemetry_shell.py
+++ b/bin/tests/test_phase8_telemetry_shell.py
@@ -1,6 +1,6 @@
 """
 Purpose: Executes the Phase 8 commit-and-telemetry shell block
-         (content/commands/ds-implement-ticket.md:2249-2346, marked
+         (content/commands/ds-implement-ticket.md:2249-2347, marked
          `@harness:phase8-commit-and-telemetry`) against real temp-git
          fixtures under both bash and zsh, so the class of defect that two
          review rounds each missed fails mechanically instead of surviving a
@@ -28,6 +28,15 @@ Failure modes: n/a (test module). Tests #7 and #8 are themselves a self-check
 Performance: standard; each parametrized test does a handful of local git
              operations plus one subprocess shell invocation. Whole suite
              runs in low single-digit seconds.
+
+Known scope limitation: the feature-commit `git add [specific files]` line
+             (rendered to `.agentic/session-log/${DEVELOPER}.jsonl` via
+             md_shell_extract.PLACEHOLDER_WHITELIST) runs before $DEVELOPER
+             is assigned later in the block, so it is a guaranteed pathspec
+             mismatch under every fixture here and no test exercises the
+             feature-commit path - only the telemetry-commit path (which
+             resolves $DEVELOPER first) is covered. See
+             bin/tests/lib/md_shell_extract.py's manifest for detail.
 """
 from __future__ import annotations
 
@@ -265,8 +274,32 @@ def test_correct_block_skips_telemetry_when_identity_unconfirmed(tmp_path, shell
 
 @pytest.mark.parametrize("shell", SHELLS)
 def test_defect1_hoisted_cp_silently_drops_telemetry_commit(tmp_path, shell):
+    """Both-directions check (M3): the unmutated block MUST produce a
+    telemetry commit on this exact fixture shape before we assert the mutant
+    suppresses it - otherwise a broken fixture (e.g. a wrong session-log
+    filename that makes a commit impossible under any block) would make this
+    test pass vacuously regardless of whether the mutant is actually caught."""
     shell = _shell_or_skip(shell)
-    fixture = git_fixture.build_worktree_shape(tmp_path)
+
+    unmutated_dir = tmp_path / "unmutated"
+    unmutated_dir.mkdir()
+    unmutated_fixture = git_fixture.build_worktree_shape(unmutated_dir)
+    unmutated_rendered = mse.render(_raw_block())
+    unmutated_result = _execute(unmutated_rendered, unmutated_fixture, shell)
+    assert mse.COMPLETION_MARKER in unmutated_result.stdout, unmutated_result.stderr
+    unmutated_body = _telemetry_commit_body(
+        _pr_checkout(unmutated_fixture), unmutated_fixture.branch_name, unmutated_fixture.env
+    )
+    assert unmutated_body is not None, (
+        "harness self-check failed: the UNMUTATED block produced no "
+        "telemetry commit on this fixture shape - the fixture (not the "
+        "defect) is broken, so a mutant assertion of body is None below "
+        "would be vacuous"
+    )
+
+    mutant_dir = tmp_path / "mutant"
+    mutant_dir.mkdir()
+    fixture = git_fixture.build_worktree_shape(mutant_dir)
     mutant = mse.render(_make_d1_mutant(_raw_block()))
     check = mse.syntax_check(mutant, shell)
     assert check.returncode == 0, f"D1 mutant must parse (same-scope reorder): {check.stderr}"
@@ -282,8 +315,30 @@ def test_defect1_hoisted_cp_silently_drops_telemetry_commit(tmp_path, shell):
 
 @pytest.mark.parametrize("shell", SHELLS)
 def test_defect2_guard_before_cp_noops_on_single_engineer_path(tmp_path, shell):
+    """Both-directions check (M3): see test_defect1's docstring - the
+    unmutated block must be shown to produce a telemetry commit on this
+    fixture shape before the mutant's suppression of it is meaningful."""
     shell = _shell_or_skip(shell)
-    fixture = git_fixture.build_worktree_shape(tmp_path)
+
+    unmutated_dir = tmp_path / "unmutated"
+    unmutated_dir.mkdir()
+    unmutated_fixture = git_fixture.build_worktree_shape(unmutated_dir)
+    unmutated_rendered = mse.render(_raw_block())
+    unmutated_result = _execute(unmutated_rendered, unmutated_fixture, shell)
+    assert mse.COMPLETION_MARKER in unmutated_result.stdout, unmutated_result.stderr
+    unmutated_body = _telemetry_commit_body(
+        _pr_checkout(unmutated_fixture), unmutated_fixture.branch_name, unmutated_fixture.env
+    )
+    assert unmutated_body is not None, (
+        "harness self-check failed: the UNMUTATED block produced no "
+        "telemetry commit on this fixture shape - the fixture (not the "
+        "defect) is broken, so a mutant assertion of body is None below "
+        "would be vacuous"
+    )
+
+    mutant_dir = tmp_path / "mutant"
+    mutant_dir.mkdir()
+    fixture = git_fixture.build_worktree_shape(mutant_dir)
     mutant_raw = _make_d2_mutant(_raw_block())
     mutant = mse.render(mutant_raw)
     check = mse.syntax_check(mutant, shell)
@@ -314,18 +369,20 @@ def test_defect3_missing_dco_guard_emits_malformed_trailer(tmp_path, shell):
     today, so the test passes, and strict xfail turns a pass into
     XPASS(strict) -> suite red on merge).
 
-    Defect location: content/commands/ds-implement-ticket.md:2274-2325 - the
-    telemetry-commit block builds TELEM_MSG (:2316) from $SO_NAME/$SO_EMAIL
-    with NO guard analogous to the one at :2264 that protects the FEATURE
+    Defect location: content/commands/ds-implement-ticket.md:2284-2325 - the
+    telemetry-commit block builds TELEM_MSG (:2317) from $SO_NAME/$SO_EMAIL
+    with NO guard analogous to the one at :2265 that protects the FEATURE
     commit. When git config user.name/user.email are unset (but the commit
     itself still succeeds via GIT_AUTHOR_*/GIT_COMMITTER_* env vars, as a CI
     runner or a fresh clone with no `git config --global user.*` might have),
     the telemetry commit lands with the literal malformed trailer
     `Signed-off-by:  <>` (two spaces, empty angle brackets).
 
-    The follow-up ticket that adds the :2283-2325 guard MUST invert this
-    test (assert the malformed trailer no longer occurs) in the SAME PR
-    that fixes the defect.
+    The follow-up ticket that adds a :2284-2325 guard analogous to :2265
+    MUST invert this test (assert the malformed trailer no longer occurs)
+    in the SAME PR that fixes the defect. Follow-up ticket: DS-<TBD> - no
+    ticket has been filed yet; the conductor will replace this placeholder
+    with the real ticket ID when one is filed.
     """
     shell = _shell_or_skip(shell)
     fixture = git_fixture.build_identity_no_gitconfig_shape(tmp_path)

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2247,6 +2247,7 @@ For each debug-fix cycle (cycle count tracked in-context; escalate to human afte
 Stage specific files - never `git add -A` or `git add .`:
 
 ```bash
+# @harness:phase8-commit-and-telemetry
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20
 git -C $REPO add [specific files]
 


### PR DESCRIPTION
Executes the Phase 8 commit-and-telemetry shell in CI. Nothing in this repo has ever executed the shell embedded in methodology command prose; three Critical defects in a proposed Phase 8 change were missed across two review rounds because no test could catch them.

## What it does

Extracts a marker-tagged fenced block from `content/commands/ds-implement-ticket.md:2249-2347`, renders placeholders through an explicit whitelist, executes it under **both bash and zsh** against real temp-git fixtures, and asserts on resulting git state (never exit code alone - all three target defects exit 0 while silently doing nothing).

9 test functions x 2 shells = 18 tests, wired into the existing `python-bin-tests` job plus a collected-count floor step.

## The three defects it catches

| | Defect | Test |
|---|---|---|
| D1 | `cp "$SESSION_LOG_SRC"` hoisted above the assignment - `cp ""` fails, silenced by `2>/dev/null \|\| true`, telemetry commit silently vanishes | `test_defect1_*` |
| D2 | An existence check placed ahead of the `mkdir`+`cp` that creates the file - whole block no-ops | `test_defect2_*` |
| D3 | Telemetry commit built with no `SO_NAME`/`SO_EMAIL` guard - emits literal `Signed-off-by:  <>` | `test_defect3_*` |

**D3 is live on `main` today.** The guard at `:2265` covers only the feature commit; `TELEM_MSG` at `:2317` is unguarded. `test_defect3_*` is a **characterization test with no `xfail`** - it PASSES by asserting the defect exists. When the follow-up ticket adds the guard, that test goes red by design, which is the forcing function to invert it in the same PR. Docstring carries a `DS-<TBD>` placeholder pending the ticket.

## Anti-vacuity - verified by mutation, not inspection

The reviewer broke the implementation and confirmed the suite reddens:

- `extract_marked_block` returns `""` -> **18 failed**
- Mutation transform neutered to a no-op -> **4 failed** (`mutated != original` fired)
- Fixture seeded so no commit is possible -> positive-path tests AND both defect tests fail
- Hostile ambient env (`EMAIL`, `GIT_AUTHOR_*`, `LANG=fr_FR.UTF-8`) -> **18 passed, identical** (hermetic)
- `CI=1` with zsh absent -> **fails, never skips**; locally without CI -> 9 skipped
- Collection-error case -> awk floor exits 1; the `grep -c` exit-1-in-a-pipe hazard does not swallow it

## Known scope limitation (disclosed, not worked around)

`[specific files]` renders to a path referencing `${DEVELOPER}` at `:2252`, four lines before that variable is assigned at `:2256`. The feature-commit `git add` is therefore a guaranteed pathspec mismatch under every fixture - **only the telemetry-commit path is exercised.** Documented in both the `md_shell_extract.py` manifest and the test module docstring.

## Design notes

- **Marker comment over fence-ordinal indexing** - ordinals drift silently when any earlier block is added; `extract_marked_block` raises on 0 or >1 matches.
- **Explicit placeholder whitelist over a bracket regex** - the block has 8+ legitimate `[ ... ]` shell tests; a generic pattern is either permanently red or blind to the lowercase, space-containing `[specific files]`.
- **Not migrated to `scripts/lib/*.sh`** - that is the right long-term direction but carries a counted 78-block, 9-file blast radius and changes the runtime shape of the feature. Out of scope.

## Follow-up ticket (to file)

1. The live D3 defect at `content/commands/ds-implement-ticket.md:2284-2325` (unguarded `TELEM_MSG` at `:2317`); landing it requires inverting `test_defect3_*`.
2. Two stale "line-977 checkout" citations at `:2287`/`:2350`, already wrong on `main` and unrelated to this change.

## Gates

`pytest bin/tests/ -q` 725 passed - hooks JS suite 40 files + 3 wrap-lock, 0 failures - `build-all.sh` + adapter-drift clean against the verbatim CI pathspec - `check-symlinks-relative.sh` OK - `check-resident-budget.sh` OK (148 B headroom, no `content/` prose added) - doc-sync predicate checked, not triggered - deliberate-failure self-check produced FAILED on both parametrizations, then reverted.

## North Star alignment

**Produce verifiable outcomes autonomously.** Converts never-executed prose shell into a real merge gate at ~9s CI cost. Three defect classes that previously required a human reading a diff now fail mechanically.

**Works for everyone (universality).** No operator identity, workspace, or local setup is baked in: fixtures pin `HOME`, `GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_GLOBAL`, `LC_ALL`/`LANG`, and stub `agentic-identity` via a PATH shadow. Verified unchanged under a hostile ambient environment.

No pillar regression. No operator-facing ceremony added. No writes to `docs/overview/`.
