### PR TITLE
test(ds-90): executable reachability and drain models for /ds-wrap routing

### DIFF
--- a/bin/tests/drain_model.py
+++ b/bin/tests/drain_model.py
@@ -25,7 +25,10 @@ Public API:
                               by retained())
   drain(staged, fresh, dispositions, *, cap=CAP, reserve=RESERVE,
         order_mode=None, reject_disposition=None, reserve_rule=None)
-                           -> DrainResult
+                           -> DrainResult (dispositions values, when given,
+                              MUST be drawn from PRESENTED_OUTCOMES - an
+                              UNPRESENTED-category value is rejected
+                              fail-closed, not honoured)
   presented(result)        -> arrival-ordered list of DRAINED entries
                               (presented to the adjudicator this run)
   retained(result)         -> arrival-ordered list of RETAINED entries (not
@@ -47,10 +50,14 @@ Downstream consumers: test_drain_invariants.py (D1-D5 property tests, tier 1
                       which implements the drain step this file specifies.
 
 Failure modes: `drain()` raises `ValueError` on a missing or duplicate `sid`
-               across the combined staged+fresh set, or on an entry whose
-               disposition requires quote verification but whose `quote`
-               field is missing/empty - FAIL-CLOSED ATOMICITY (D4): on
-               either error, drain() raises BEFORE computing any partial
+               across the combined staged+fresh set, on an entry whose
+               disposition is not a member of PRESENTED_OUTCOMES (an
+               adjudicator cannot emit an UNPRESENTED-category verdict -
+               those two labels are drain()'s own, applied only to entries
+               it did not present), or on an entry whose disposition
+               requires quote verification but whose `quote` field is
+               missing/empty - FAIL-CLOSED ATOMICITY (D4): on any of these
+               errors, drain() raises BEFORE computing any partial
                DrainResult; it never returns a half-formed result. Otherwise
                pure - no I/O, no filesystem, no network, no wall-clock.
 
@@ -226,6 +233,15 @@ def _validate(combined: List[Dict[str, Any]], dispositions: Dict[str, Any]) -> N
     for e in combined:
         sid = e["sid"]
         disp = dispositions.get(sid)
+        #: An adjudicator can only emit a PRESENTED-category verdict. The two
+        #: UNPRESENTED categories are drain()'s OWN labels for entries it did
+        #: not present; a caller supplying one is a malformed adjudication
+        #: table, rejected fail-closed (D4) rather than honoured.
+        if disp is not None and disp not in PRESENTED_OUTCOMES:
+            raise ValueError(
+                f"entry {sid!r} carries an UNPRESENTED-category disposition "
+                f"({disp}); dispositions must come from PRESENTED_OUTCOMES"
+            )
         #: A disposition claiming duplication against an existing structured
         #: learning must be backed by a verbatim, non-empty quote - an
         #: unverifiable "trust me" duplicate claim is exactly the failure
@@ -322,13 +338,8 @@ def drain(
     for e in ordered:
         sid = e["sid"]
         if sid in presented_sids:
-            #: Honored verbatim, including a caller-supplied UNPRESENTED-
-            #: category value (an odd but harmless input - `presented_sids`
-            #: membership, not the recorded Outcome, is what `presented()`/
-            #: `retained()` key off; this keeps the exhaustive tier-1 sweep
-            #: in test_drain_invariants.py - which iterates the FULL 9-member
-            #: Outcome universe per entry, not just the 7 presentable ones -
-            #: well-defined rather than raising on 2/9 of its own domain).
+            #: Validated above to be a PRESENTED-category outcome, so the
+            #: DRAINED <=> PRESENTED correspondence holds by construction.
             outcomes[sid] = dispositions.get(sid, Outcome.REJECTED_ON_THE_MERITS)
         elif sid in plain_sids:
             # Would have fit under plain FIFO-cap ordering, but the reserve

--- a/bin/tests/drain_model.py
+++ b/bin/tests/drain_model.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Purpose: Executable reference implementation of the DS-90 staging-drain
+         algorithm - the single normative definition of which staged/fresh
+         learning entries get PRESENTED to the adjudicator on a given
+         `/ds-wrap` run, given a bounded per-run cap and a reserve carve-out
+         that protects fresh entries from starvation behind an
+         ever-growing staged backlog. It models ONLY the algorithm: whether
+         Part B step 0 (the drain step) is REACHED AT ALL on a given run is
+         `reach_model.py`'s contract, not this file's. A reader must not
+         conclude from a green drain suite that the drain runs - only that
+         IF it runs, these five properties (D1-D5) hold.
+
+Public API:
+  Outcome                 -> enum, exactly 9 members (1 appended, 2
+                             superseded-in-place, 3 skipped-duplicate, 4
+                             skipped-already-a-structured-learning, 5
+                             consolidated, 6 deferred-to-memory-pending, 7
+                             rejected-on-the-merits, 8 dropped-by-cap, 9
+                             never-adjudicated)
+  PRESENTED_OUTCOMES       -> frozenset, outcomes 1-7 (this run's judged set)
+  UNPRESENTED_OUTCOMES     -> frozenset, outcomes 8-9 (still in the backlog)
+  DrainResult              -> dataclass: .order, .outcomes, .presented_sids,
+                              .reject_disposition (echoed input, consulted
+                              by retained())
+  drain(staged, fresh, dispositions, *, cap=CAP, reserve=RESERVE,
+        order_mode=None, reject_disposition=None, reserve_rule=None)
+                           -> DrainResult
+  presented(result)        -> arrival-ordered list of DRAINED entries
+                              (presented to the adjudicator this run)
+  retained(result)         -> arrival-ordered list of RETAINED entries (not
+                              presented this run, PLUS - under the
+                              REJECT_DISPOSITION="retained" mutation - any
+                              REJECTED_ON_THE_MERITS entry, which is the
+                              defect this mutation models: a rejected entry
+                              that never actually leaves the pool)
+  CAP, RESERVE             -> the normative per-run cap (3) and fresh
+                              reserve (1)
+  Mutation switches (test-only), THREE: REJECT_DISPOSITION, ORDER_MODE,
+  RESERVE_RULE.
+
+Upstream deps: none (stdlib only: dataclasses, enum).
+
+Downstream consumers: test_drain_invariants.py (D1-D5 property tests, tier 1
+                      exhaustive + tier 2 seeded-random multi-run
+                      simulation); PR 2's edit to content/commands/ds-wrap.md,
+                      which implements the drain step this file specifies.
+
+Failure modes: `drain()` raises `ValueError` on a missing or duplicate `sid`
+               across the combined staged+fresh set, or on an entry whose
+               disposition requires quote verification but whose `quote`
+               field is missing/empty - FAIL-CLOSED ATOMICITY (D4): on
+               either error, drain() raises BEFORE computing any partial
+               DrainResult; it never returns a half-formed result. Otherwise
+               pure - no I/O, no filesystem, no network, no wall-clock.
+
+Performance: O(n log n) per call (one sort under ORDER_MODE="date"; O(n)
+             under the default "arrival" mode, already ordered by input
+             position).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional, Set
+
+
+CAP = 3
+RESERVE = 1
+
+
+class Outcome(Enum):
+    """Exactly NINE members. See PRESENTED_OUTCOMES / UNPRESENTED_OUTCOMES
+    for the two-way split this enum partitions into."""
+
+    #: The staged/fresh entry was written to a durable store (memory.md or
+    #: an AGENTS.md file) as a brand-new entry.
+    APPENDED = auto()
+
+    #: The entry replaced an existing durable entry in place (same topic,
+    #: updated or corrected) - fold_model.py's I5/provenance analogue for
+    #: the staging layer.
+    SUPERSEDED_IN_PLACE = auto()
+
+    #: Skipped because it duplicates the entry's own destination file, or
+    #: duplicates another entry already presented earlier THIS SAME run.
+    SKIPPED_DUPLICATE_OF_DESTINATION_OR_ALREADY_PRESENTED = auto()
+
+    #: Skipped because the same fact is already captured as a structured
+    #: `.agentic/learnings.md` entry (ds-wrap.md:296, "check whether a
+    #: proposed memory entry is already captured here as a structured
+    #: learning before proposing it").
+    SKIPPED_ALREADY_A_STRUCTURED_LEARNING = auto()
+
+    #: Merged with one or more other presented entries into a single
+    #: durable entry (the staging-layer analogue of a semantic merge).
+    CONSOLIDATED = auto()
+
+    #: Routed to `.agentic/memory-pending.md` / `.agentic/agents-md-pending
+    #: .md` rather than the live file (ds-wrap.md:473, :485 - the open-PR
+    #: deferral pass: the entry's substance depends on an unmerged PR).
+    DEFERRED_TO_MEMORY_PENDING = auto()
+
+    #: Reviewed and explicitly declined on the merits (not a duplicate, not
+    #: deferred - the adjudicator judged it not worth keeping).
+    REJECTED_ON_THE_MERITS = auto()
+
+    #: NOT presented this run because the per-run CAP (3) was reached before
+    #: this entry's turn - an UNPRESENTED outcome, still in the backlog.
+    DROPPED_BY_CAP = auto()
+
+    #: NOT presented this run and NOT specifically bumped by the cap either
+    #: (it simply has not reached the front of the arrival queue yet) - an
+    #: UNPRESENTED outcome, still in the backlog. The default state of any
+    #: entry drain() has never had a reason to look at.
+    NEVER_ADJUDICATED = auto()
+
+
+#: This run's judged set - every entry the adjudicator actually looked at.
+PRESENTED_OUTCOMES = frozenset(
+    {
+        Outcome.APPENDED,
+        Outcome.SUPERSEDED_IN_PLACE,
+        Outcome.SKIPPED_DUPLICATE_OF_DESTINATION_OR_ALREADY_PRESENTED,
+        Outcome.SKIPPED_ALREADY_A_STRUCTURED_LEARNING,
+        Outcome.CONSOLIDATED,
+        Outcome.DEFERRED_TO_MEMORY_PENDING,
+        Outcome.REJECTED_ON_THE_MERITS,
+    }
+)
+
+#: Still in the backlog - DRAINED never touched these this run.
+UNPRESENTED_OUTCOMES = frozenset({Outcome.DROPPED_BY_CAP, Outcome.NEVER_ADJUDICATED})
+
+assert PRESENTED_OUTCOMES | UNPRESENTED_OUTCOMES == set(Outcome)
+assert PRESENTED_OUTCOMES & UNPRESENTED_OUTCOMES == set()
+
+
+# --------------------------------------------------------------------------
+# Mutation switches - DEFAULTS ARE THE NORMATIVE BEHAVIOUR.
+# --------------------------------------------------------------------------
+
+#: "removed" (default): a REJECTED_ON_THE_MERITS entry is terminal - once
+#: presented and rejected, it never re-enters the pool. "retained" (non-
+#: default): rejected entries are never actually removed from the backlog -
+#: they keep re-occupying a presented slot on every future run without ever
+#: resolving. Reddens D2 (residency bound - it never truly resolves) and D5
+#: (no reserved-slot capture - it keeps recapturing a slot that should have
+#: gone to the next entry in arrival order).
+REJECT_DISPOSITION = "removed"
+
+#: "arrival" (default): entries are ordered by arrival index (staged
+#: entries - the existing backlog - before fresh entries, each in their own
+#: list order). "date" (non-default): orders by a `date` field instead,
+#: which is NOT guaranteed to be arrival-monotonic (an entry can be staged
+#: today for content dated yesterday) and reddens D2.
+ORDER_MODE = "arrival"
+
+#: "staged-and-fresh-split" (default): at least RESERVE of the CAP slots on
+#: any run are reserved for fresh entries when fresh entries exist,
+#: preventing an ever-growing staged backlog from consuming the entire cap
+#: indefinitely. "none" (non-default): no reservation - the first CAP
+#: entries in arrival order are presented, full stop; a staged backlog >=
+#: CAP starves fresh entries forever. Reddens D2.
+RESERVE_RULE = "staged-and-fresh-split"
+
+
+# --------------------------------------------------------------------------
+# Result type
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class DrainResult:
+    """`order` is the full combined staged+fresh set in arrival order (the
+    ordering `retained()` and `presented()` preserve). `outcomes` maps sid
+    -> Outcome for EVERY entry in `order` (never partial - see D4)."""
+
+    order: List[Dict[str, Any]] = field(default_factory=list)
+    outcomes: Dict[str, Outcome] = field(default_factory=dict)
+    presented_sids: Set[str] = field(default_factory=set)
+    reject_disposition: str = REJECT_DISPOSITION
+
+
+def presented(result: DrainResult) -> List[Dict[str, Any]]:
+    """Arrival-ordered entries DRAINED this run (presented to the
+    adjudicator), regardless of what they were subsequently judged."""
+    return [e for e in result.order if e["sid"] in result.presented_sids]
+
+
+def retained(result: DrainResult) -> List[Dict[str, Any]]:
+    """Arrival-ordered entries RETAINED - not presented this run, PLUS (only
+    under the REJECT_DISPOSITION="retained" mutation) any entry whose
+    outcome is REJECTED_ON_THE_MERITS: the mutation's defect is precisely
+    that such an entry, though nominally judged, never actually leaves the
+    backlog a caller feeds into the next run."""
+    out = []
+    for e in result.order:
+        sid = e["sid"]
+        if sid not in result.presented_sids:
+            out.append(e)
+        elif (
+            result.reject_disposition == "retained"
+            and result.outcomes.get(sid) == Outcome.REJECTED_ON_THE_MERITS
+        ):
+            out.append(e)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Validation (D4: fail-closed atomicity - raise BEFORE computing anything)
+# --------------------------------------------------------------------------
+
+
+def _validate(combined: List[Dict[str, Any]], dispositions: Dict[str, Any]) -> None:
+    seen: Set[str] = set()
+    for e in combined:
+        sid = e.get("sid")
+        if not sid:
+            raise ValueError(f"entry missing required 'sid': {e!r}")
+        if sid in seen:
+            raise ValueError(f"duplicate sid: {sid!r}")
+        seen.add(sid)
+
+    for e in combined:
+        sid = e["sid"]
+        disp = dispositions.get(sid)
+        #: A disposition claiming duplication against an existing structured
+        #: learning must be backed by a verbatim, non-empty quote - an
+        #: unverifiable "trust me" duplicate claim is exactly the failure
+        #: mode fail-closed atomicity exists to reject before it can corrupt
+        #: a run.
+        if disp in (
+            Outcome.SKIPPED_DUPLICATE_OF_DESTINATION_OR_ALREADY_PRESENTED,
+            Outcome.SKIPPED_ALREADY_A_STRUCTURED_LEARNING,
+        ):
+            quote = e.get("quote")
+            if not quote or not isinstance(quote, str) or not quote.strip():
+                raise ValueError(
+                    f"entry {sid!r} claims a duplicate disposition "
+                    f"({disp}) with no verifiable quote"
+                )
+
+
+# --------------------------------------------------------------------------
+# Ordering
+# --------------------------------------------------------------------------
+
+
+def _order(combined: List[Dict[str, Any]], order_mode: str) -> List[Dict[str, Any]]:
+    if order_mode == "arrival":
+        return list(combined)  # already in arrival order by construction
+    if order_mode == "date":
+        return sorted(combined, key=lambda e: (e.get("date", ""), e["sid"]))
+    raise ValueError("unknown ORDER_MODE: %r" % (order_mode,))
+
+
+# --------------------------------------------------------------------------
+# The drain
+# --------------------------------------------------------------------------
+
+
+def drain(
+    staged: List[Dict[str, Any]],
+    fresh: List[Dict[str, Any]],
+    dispositions: Dict[str, Any],
+    *,
+    cap: int = CAP,
+    reserve: int = RESERVE,
+    order_mode: Optional[str] = None,
+    reject_disposition: Optional[str] = None,
+    reserve_rule: Optional[str] = None,
+) -> DrainResult:
+    """Drain `staged` (the carried-over backlog, oldest first) plus `fresh`
+    (this run's new entries) against a per-run `cap`, reserving `reserve`
+    slots for fresh entries. See module docstring for the full contract."""
+    order_mode = ORDER_MODE if order_mode is None else order_mode
+    reject_disposition = (
+        REJECT_DISPOSITION if reject_disposition is None else reject_disposition
+    )
+    reserve_rule = RESERVE_RULE if reserve_rule is None else reserve_rule
+
+    combined = list(staged) + list(fresh)
+    _validate(combined, dispositions)  # D4: raise before computing anything
+
+    ordered = _order(combined, order_mode)
+
+    #: The plain FIFO-cap window, ignoring reserve - used only to label the
+    #: two UNPRESENTED outcomes (DROPPED_BY_CAP vs NEVER_ADJUDICATED).
+    plain_sids = {e["sid"] for e in ordered[:cap]}
+
+    if reserve_rule == "none":
+        chosen = ordered[:cap]
+    else:
+        #: `reserve` is a FLOOR guarantee for fresh entries, not a ceiling:
+        #: staged gets first crack at (cap - reserve) slots; fresh then
+        #: gets whatever remains (which can exceed `reserve` when staged's
+        #: own backlog is smaller than cap - reserve); any slots still
+        #: unused (fresh had fewer entries than the remainder) roll back to
+        #: staged.
+        staged_sids = {e["sid"] for e in staged}
+        staged_ordered = [e for e in ordered if e["sid"] in staged_sids]
+        fresh_ordered = [e for e in ordered if e["sid"] not in staged_sids]
+        n_staged_base = max(cap - reserve, 0)
+        chosen_staged = staged_ordered[:n_staged_base]
+        remaining_after_staged = cap - len(chosen_staged)
+        chosen_fresh = fresh_ordered[:remaining_after_staged]
+        remaining_after_fresh = cap - len(chosen_staged) - len(chosen_fresh)
+        if remaining_after_fresh > 0:
+            already = {e["sid"] for e in chosen_staged}
+            extra = [e for e in staged_ordered if e["sid"] not in already]
+            chosen_staged = chosen_staged + extra[:remaining_after_fresh]
+        chosen_sids = {e["sid"] for e in chosen_staged} | {
+            e["sid"] for e in chosen_fresh
+        }
+        chosen = [e for e in ordered if e["sid"] in chosen_sids]
+
+    presented_sids = {e["sid"] for e in chosen}
+
+    outcomes: Dict[str, Outcome] = {}
+    for e in ordered:
+        sid = e["sid"]
+        if sid in presented_sids:
+            #: Honored verbatim, including a caller-supplied UNPRESENTED-
+            #: category value (an odd but harmless input - `presented_sids`
+            #: membership, not the recorded Outcome, is what `presented()`/
+            #: `retained()` key off; this keeps the exhaustive tier-1 sweep
+            #: in test_drain_invariants.py - which iterates the FULL 9-member
+            #: Outcome universe per entry, not just the 7 presentable ones -
+            #: well-defined rather than raising on 2/9 of its own domain).
+            outcomes[sid] = dispositions.get(sid, Outcome.REJECTED_ON_THE_MERITS)
+        elif sid in plain_sids:
+            # Would have fit under plain FIFO-cap ordering, but the reserve
+            # carve-out gave its slot to a fresh entry instead.
+            outcomes[sid] = Outcome.DROPPED_BY_CAP
+        else:
+            outcomes[sid] = Outcome.NEVER_ADJUDICATED
+
+    return DrainResult(
+        order=ordered,
+        outcomes=outcomes,
+        presented_sids=presented_sids,
+        reject_disposition=reject_disposition,
+    )

--- a/bin/tests/reach_model.py
+++ b/bin/tests/reach_model.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+Purpose: (a) Executable reference implementation of `/ds-wrap`'s route x
+         entry-path x reachability contract - the SINGLE NORMATIVE DEFINITION
+         of which route a `SessionState` resolves to, and whether Part B's
+         staging-drain step and Part E's compression step are REACHED from
+         that route. (b) `content/commands/ds-wrap.md` does NOT yet conform
+         to this model: the defaults below encode the DS-90 TARGET routing
+         (staging always drains, an over-gate target always compresses,
+         regardless of which route a session takes); `AS_SHIPPED_PRE_DS90`
+         reproduces TODAY's routing, under which R1 and R2 are RED - i.e. a
+         merged executable record that today's ds-wrap.md has two dead paths
+         (a session that is otherwise zero-substance or light-path can still
+         silently strand staged learnings or an over-gate compression
+         target). PR 2 edits ds-wrap.md to make it conform; this file is the
+         spec PR 2 implements against, not a description of current behavior.
+         (c) Two-layer structure: `ROUTE_PREDICATES` is a 4-entry PARTITION
+         over `SessionState` (every state resolves to exactly one route via
+         `route()`); `zs_fast_admissible` is a SEPARATE entry-path predicate
+         - Step 0-pre's fast zero-substance short-circuit - that is NOT a
+         member of `ROUTE_PREDICATES` and is NOT consulted by `route()`. It
+         is consulted only by `executes_part_b_step0` / `executes_part_e`,
+         which check it BEFORE ever calling `route()`.
+
+         MANDATED BOUNDARY STATEMENT: This model covers only the routing
+         decision derivable from a `SessionState`, plus the two-entry
+         structure of the zero-substance procedure. It deliberately does NOT
+         model the four lock-held mid-run escalations at ds-wrap.md:433,
+         :435, :441, and :649 (Skeptic re-route/format-reinvocation limits
+         that escalate to the user), nor :94's open-ended user-abort class
+         ("any user-abort path (e.g. drift requiring input, Skeptic scope
+         bail)"), nor the background-Worker abort at :63 ("Pre-flight check
+         - no active Workers"). :651 is NOT an abort: it skips compression
+         for one target ("skip compression for that target this session")
+         and the run continues to normal completion at :91 ("successful
+         completion at Step 6"). Do not add :651 to the excluded-abort list.
+         Only :433 and :435 are excluded by R1/R2's "reaches Step 4"
+         qualifier (Skeptic escalations occur INSIDE the draft-worker loop
+         that itself is downstream of routing). :441 and :649 are lock-held
+         escalations occurring AFTER the modelled mechanisms (Part B step 0,
+         Part E) have already run, so R1 and R2 hold on those runs. A reader
+         must not conclude from a green R1/R2 that Part B step 0 executed on
+         a run that aborted at Step 3 (the pre-Part-B-and-E format/sign-off
+         validation, ds-wrap.md:431-435).
+
+Public API:
+  SessionState(L, f, a, g, v, s, e) -> frozen dataclass, the seven booleans
+                                        a routing decision is derived from
+  all_states()                       -> all 128 SessionState values, in
+                                         deterministic dataclass-field order
+  Route                              -> enum, exactly 6 members
+  ROUTE_PREDICATES                   -> the 4-entry route partition (dict);
+                                         R_ABORT_WORKERS and R_ZS_FAST are
+                                         DELIBERATELY ABSENT - see their
+                                         Route docstrings
+  route(state, **switches)           -> Route, or raises RouteResolutionError
+                                         if != 1 predicate holds
+  zs_fast_admissible(state, **switches) -> bool, the :166-172 entry path.
+                                         NOT in ROUTE_PREDICATES, NOT called
+                                         by route().
+  executes_part_b_step0(state, **switches) -> bool
+  executes_part_e(state, **switches)       -> bool
+  RouteResolutionError               -> raised by route() when the 4-entry
+                                         partition does not resolve to
+                                         exactly one holder (R3 defect class)
+  Mutation switches (test-only), NINE: ZS_FAST_CRITERIA, ZS_CRITERIA,
+  LIGHT_TRIGGER, PART_B_GUARD, PART_E_GUARDS, AS_SHIPPED_PRE_DS90,
+  R3_PREDICATE_OVERLAP, R3_PREDICATE_GAP, ABORT_SEMANTICS.
+
+Upstream deps: none (stdlib only: dataclasses, enum, itertools, typing).
+
+Downstream consumers: test_reach_invariants.py (R1-R5 property tests over
+                      the full 128-state space); PR 2's edit to
+                      content/commands/ds-wrap.md, which must implement the
+                      staging-aware / gate-aware defaults this file encodes.
+
+Failure modes: `route()` raises `RouteResolutionError` when the active
+               `ROUTE_PREDICATES` (as mutated by R3_PREDICATE_OVERLAP /
+               R3_PREDICATE_GAP) do not partition - zero or 2+ holders for a
+               given state. `executes_part_b_step0` / `executes_part_e` never
+               raise; every mutation switch degrades them to `False` on some
+               states rather than raising. Pure - no I/O, no filesystem, no
+               network, no wall-clock, no input mutation. `SessionState` is
+               frozen (hashable, immutable).
+
+Performance: O(1) per call; `all_states()` is O(128).
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, fields
+from enum import Enum, auto
+from typing import Dict, Iterator, Tuple
+
+
+# --------------------------------------------------------------------------
+# Session state
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionState:
+    """The seven booleans a `/ds-wrap` routing decision is derivable from.
+
+    L: lock acquired (ds-wrap.md:65-96, "Pre-flight lock acquisition").
+    f: fresh memory entries drafted this session (Output 2 non-"None").
+    a: AGENTS.md updates drafted this session (Output 3 non-"None").
+    g: a specialist agent (perf-analyst / release-orchestrator /
+       dependency-auditor) ran with session-scoped issues to capture.
+    v: file activity worth preserving in _wrap.md (uncommitted tracked
+       changes, new stashes, files touched beyond reads, meaningful next
+       steps) - the Step 0.5 "no file activity worth preserving" clause,
+       negated.
+    s: staging (the DS-90 staged-learnings/memory area) is non-empty.
+    e: at least one Part E compression target is over its size gate
+       (ds-wrap.md:614-618, the existing per-target Gate).
+    """
+
+    L: bool
+    f: bool
+    a: bool
+    g: bool
+    v: bool
+    s: bool
+    e: bool
+
+
+def all_states() -> Iterator[SessionState]:
+    """All 128 (2^7) SessionState values, in deterministic order: itertools
+    .product over the dataclass's own field order (L, f, a, g, v, s, e), each
+    axis False-before-True. Exhaustive - no sampling, no seed."""
+    field_names = [fld.name for fld in fields(SessionState)]
+    for combo in itertools.product((False, True), repeat=len(field_names)):
+        yield SessionState(**dict(zip(field_names, combo)))
+
+
+# --------------------------------------------------------------------------
+# Route enum and the 4-entry partition
+# --------------------------------------------------------------------------
+
+
+class Route(Enum):
+    """Exactly SIX members. Only four are routing-partition destinations
+    (see ROUTE_PREDICATES); R_ABORT_WORKERS and R_ZS_FAST are named here for
+    completeness but are deliberately excluded from the partition."""
+
+    #: ds-wrap.md:63, "Pre-flight check - no active Workers". Its trigger is
+    #: a PROCESS-TABLE LIVENESS PROBE ("check whether any background Workers
+    #: or subagents are currently running"), not a SessionState field - there
+    #: is no boolean here that can stand in for "is a background Worker
+    #: alive right now". Deliberately absent from ROUTE_PREDICATES; adding a
+    #: fabricated field for it would model a fact this SessionState cannot
+    #: observe.
+    R_ABORT_WORKERS = auto()
+
+    #: ds-wrap.md:65-96, "Pre-flight lock acquisition" (the busy/timeout/
+    #: fatal exit-code branches at :68-79). Corresponds to `not state.L`.
+    R_ABORT_LOCK = auto()
+
+    #: The Step 0-pre fast zero-substance short-circuit's DESTINATION, not
+    #: the entry-path predicate itself (that is `zs_fast_admissible`).
+    #: Deliberately absent from ROUTE_PREDICATES - see `zs_fast_admissible`'s
+    #: docstring for why it is an entry path, not a route.
+    R_ZS_FAST = auto()
+
+    #: ds-wrap.md:248-264, the Step 0.5 "Zero-substance path".
+    R_ZS = auto()
+
+    #: ds-wrap.md:265-281, the Step 0.5 "Light path".
+    R_LIGHT = auto()
+
+    #: ds-wrap.md:285, the Step 0.5 "Standard path".
+    R_STD = auto()
+
+
+class RouteResolutionError(Exception):
+    """Raised by route() when the active ROUTE_PREDICATES do not partition
+    SessionState - i.e. zero or 2+ predicates hold for a given state. See
+    R3_PREDICATE_OVERLAP / R3_PREDICATE_GAP for the two ways this is forced."""
+
+
+#: The 4-entry route partition. EXACTLY these four keys - R_ABORT_WORKERS and
+#: R_ZS_FAST are DELIBERATELY ABSENT (see their Route docstrings above).
+#: Adding either one reproduces a defect that took two review rounds to
+#: find: R_ABORT_WORKERS because its trigger (:63) is a process-table
+#: liveness probe with no SessionState field to key off; R_ZS_FAST because
+#: :173 ("On ANY uncertainty, fall through to the full Step 0") is conductor
+#: judgement over context this model cannot observe, AND :175 ("go straight
+#: to the Zero-substance procedure under Step 0.5") sends a successful
+#: short-circuit into R_ZS's OWN procedure rather than a distinct
+#: destination - so it is an ENTRY PATH into R_ZS, never a route in its own
+#: right.
+#:
+#: CRITICAL: `s` and `e` must NEVER appear in any of these four lambdas.
+#: They are the invariant SUBJECTS (what R1/R2 assert about), not routing
+#: inputs - the four predicates below read only L, f, a, g, v. Folding `s`/
+#: `e` into a lambda here (e.g. "and not s.s" on P_ZS) breaks the partition:
+#: on state (L, ~f, ~a, ~g, ~v, s=True, e=True) zero predicates would hold,
+#: route() would raise, and R3 would go RED at DEFAULTS - the exact defect a
+#: prior review round caught. The five fix-site switches
+#: (ZS_FAST_CRITERIA / ZS_CRITERIA / LIGHT_TRIGGER / PART_B_GUARD /
+#: PART_E_GUARDS) model whether `s`/`e` disqualify Part B step 0 / Part E
+#: EXECUTION, strictly downstream of routing - never inside the partition.
+ROUTE_PREDICATES: Dict[Route, "callable"] = {
+    Route.R_ABORT_LOCK: lambda s: not s.L,
+    Route.R_ZS:         lambda s: s.L and not s.f and not s.a and not s.g and not s.v,
+    Route.R_LIGHT:      lambda s: s.L and not s.f and not s.a and not s.g and     s.v,
+    Route.R_STD:        lambda s: s.L and (s.f or s.a or s.g),
+}
+
+
+# --------------------------------------------------------------------------
+# Mutation switches - DEFAULTS ARE THE NORMATIVE (DS-90 TARGET) BEHAVIOUR.
+#
+# These exist so test_reach_invariants.py can reintroduce a specific fix-site
+# defect and demonstrate that R1 or R2 goes RED. PR 2 (the ds-wrap.md edit)
+# must never leave any of these five sites at its non-default value.
+# --------------------------------------------------------------------------
+
+#: Applied inside `zs_fast_admissible`. "staging-and-gate-aware" (default):
+#: the :166-172 fast short-circuit also requires staging empty (~s) and no
+#: over-gate target (~e) before it is admissible - i.e. it never bypasses a
+#: pending drain or compression. "session-only": ignores s/e entirely
+#: (today's :166-172 criteria, which have no staging/gate concept at all).
+ZS_FAST_CRITERIA = "staging-and-gate-aware"
+
+#: Applied inside the R_ZS route's downstream disqualifier logic (NOT by
+#: adding s/e terms to the P_ZS lambda in ROUTE_PREDICATES - see the CRITICAL
+#: note above). "staging-and-gate-aware" (default): on route R_ZS, Part B
+#: step 0 / Part E still execute when s / e hold respectively.
+#: "session-only": on route R_ZS, Part B step 0 / Part E never execute
+#: regardless of s/e - reproduces the defect a review round (round 6)
+#: caught, where routing to the zero-substance procedure silently dropped a
+#: pending drain or compression.
+ZS_CRITERIA = "staging-and-gate-aware"
+
+#: Applied inside the R_LIGHT route's downstream disqualifier logic, the
+#: R_LIGHT analogue of ZS_CRITERIA. "staging-aware" (default): on route
+#: R_LIGHT, Part B step 0 / Part E still execute when s / e hold.
+#: "fresh-only": on route R_LIGHT they never execute - reproduces a review
+#: round (round 5) finding that the light path's "Skip Part B ... Skip
+#: Part E entirely" (ds-wrap.md:274, :276) silently discarded staging.
+LIGHT_TRIGGER = "staging-aware"
+
+#: The dominant top-level Part-B gate. "staging-aware" (default): governed
+#: by route + ZS_CRITERIA/LIGHT_TRIGGER (see _executes_b_on_route).
+#: "fresh-only" (non-default): reproduces TODAY's actual Part B gate exactly
+#: - "Skip Part B entirely if the memory entries input above is 'None'"
+#: (ds-wrap.md:471) checks ONLY whether fresh memory-entry content (f) was
+#: drafted; it has no concept of `route` or `s` at all, because DS-90's
+#: drain step does not exist yet in the shipped doc (round 3 finding).
+PART_B_GUARD = "staging-aware"
+
+#: The dominant top-level Part-E gate, the PART_B_GUARD analogue for
+#: compression. "gate-aware" (default): governed by route + ZS_CRITERIA/
+#: LIGHT_TRIGGER, honoring `e`. "inflow-only" (non-default): reproduces
+#: TODAY's actual Part E gate exactly - "Skip Part E entirely if Parts B and
+#: C both reported no changes" (ds-wrap.md:591) checks only whether upstream
+#: Parts produced content (f or a); it ignores a target's own size-gate
+#: state (e) entirely, so a target that crossed its gate from PRIOR session
+#: drift, with no f/a change this session, is silently never compressed
+#: (round 3 finding, the same review round as PART_B_GUARD).
+PART_E_GUARDS = "gate-aware"
+
+#: Convenience switch: True flips all five fix-site switches above to their
+#: non-default value simultaneously, reproducing today's shipped ds-wrap.md
+#: routing in full (no staging/gate-awareness anywhere).
+AS_SHIPPED_PRE_DS90 = False
+
+#: R3 mutation. False (default): ROUTE_PREDICATES as declared. True: drops
+#: `not s.a` from the R_LIGHT predicate, so on state L∧~f∧a∧~g∧v BOTH
+#: P_LIGHT and P_STD hold -> route() sees 2 holders and raises.
+R3_PREDICATE_OVERLAP = False
+
+#: R3 mutation. False (default): ROUTE_PREDICATES as declared. True: narrows
+#: the R_STD predicate to `L and (s.f or s.g)` (drops the `s.a` disjunct), so
+#: on state L∧~f∧a∧~g∧~v ZERO predicates hold -> route() sees 0 holders and
+#: raises.
+R3_PREDICATE_GAP = False
+
+#: R4 mutation. "pre-lock-inert" (default): a pre-lock abort (route
+#: R_ABORT_LOCK, `not state.L`) never executes Part B step 0 or Part E -
+#: neither mechanism can run before the lock that guards their shared
+#: writes is held. "pre-lock-executes" (non-default): forces both to execute
+#: anyway on R_ABORT_LOCK, reproducing an unsafe pre-lock write.
+ABORT_SEMANTICS = "pre-lock-inert"
+
+#: The five fix-site switch names AS_SHIPPED_PRE_DS90 flips together.
+_AS_SHIPPED_FLIPS: Tuple[str, ...] = (
+    "ZS_FAST_CRITERIA",
+    "ZS_CRITERIA",
+    "LIGHT_TRIGGER",
+    "PART_B_GUARD",
+    "PART_E_GUARDS",
+)
+
+_NON_DEFAULT = {
+    "ZS_FAST_CRITERIA": "session-only",
+    "ZS_CRITERIA": "session-only",
+    "LIGHT_TRIGGER": "fresh-only",
+    "PART_B_GUARD": "fresh-only",
+    "PART_E_GUARDS": "inflow-only",
+}
+
+
+def _resolve_switches(switches: dict) -> dict:
+    """Merge caller-supplied switches with AS_SHIPPED_PRE_DS90's bulk flip.
+    Caller-supplied values for an individual fix-site switch still win over
+    the bulk flip (explicit beats bulk), matching ordinary kwarg precedence."""
+    resolved = dict(switches)
+    if resolved.get("AS_SHIPPED_PRE_DS90", AS_SHIPPED_PRE_DS90):
+        for name in _AS_SHIPPED_FLIPS:
+            resolved.setdefault(name, _NON_DEFAULT[name])
+    return resolved
+
+
+# --------------------------------------------------------------------------
+# route() and the entry path
+# --------------------------------------------------------------------------
+
+
+def _route_predicates(**switches) -> Dict[Route, "callable"]:
+    overlap = switches.get("R3_PREDICATE_OVERLAP", R3_PREDICATE_OVERLAP)
+    gap = switches.get("R3_PREDICATE_GAP", R3_PREDICATE_GAP)
+    preds = dict(ROUTE_PREDICATES)
+    if overlap:
+        preds[Route.R_LIGHT] = (
+            lambda s: s.L and not s.f and not s.g and s.v
+        )  # R3 mutation: drops `not s.a`
+    if gap:
+        preds[Route.R_STD] = (
+            lambda s: s.L and (s.f or s.g)
+        )  # R3 mutation: drops the `s.a` disjunct
+    return preds
+
+
+def route(state: SessionState, **switches) -> Route:
+    """Resolve `state` to exactly one Route by counting holders over the
+    active (possibly R3-mutated) 4-entry partition. Raises
+    RouteResolutionError if != 1 predicate holds."""
+    switches = _resolve_switches(switches)
+    preds = _route_predicates(**switches)
+    holders = [r for r, p in preds.items() if p(state)]
+    if len(holders) != 1:
+        raise RouteResolutionError(
+            f"{len(holders)} predicates hold for {state}: {holders}"
+        )
+    return holders[0]
+
+
+def zs_fast_admissible(state: SessionState, **switches) -> bool:
+    """The Step 0-pre :166-172 entry path (":173 on ANY uncertainty, fall
+    through"; on success, ":175 go straight to the Zero-substance procedure
+    under Step 0.5" - R_ZS's own procedure, not a distinct destination).
+    NOT a member of ROUTE_PREDICATES. NOT called by route()."""
+    switches = _resolve_switches(switches)
+    criteria = switches.get("ZS_FAST_CRITERIA", ZS_FAST_CRITERIA)
+    base = not state.f and not state.a and not state.g and not state.v
+    if criteria == "session-only":
+        return base
+    # staging-and-gate-aware (default)
+    return base and not state.s and not state.e
+
+
+# --------------------------------------------------------------------------
+# Downstream reachability: Part B step 0 (staging drain) and Part E
+# (compression)
+# --------------------------------------------------------------------------
+
+
+def _executes_b_on_route(route_: Route, state: SessionState, **switches) -> bool:
+    """Part B step 0's downstream disqualifier, consulted only after the
+    zs_fast_admissible entry-path check has already passed. See PART_B_GUARD
+    / ZS_CRITERIA / LIGHT_TRIGGER for what each branch reproduces."""
+    part_b_guard = switches.get("PART_B_GUARD", PART_B_GUARD)
+    if part_b_guard == "fresh-only":
+        return state.f
+    if route_ == Route.R_STD:
+        return True
+    if route_ == Route.R_ZS:
+        zs_criteria = switches.get("ZS_CRITERIA", ZS_CRITERIA)
+        if zs_criteria == "session-only":
+            return False
+        return state.s
+    if route_ == Route.R_LIGHT:
+        light_trigger = switches.get("LIGHT_TRIGGER", LIGHT_TRIGGER)
+        if light_trigger == "fresh-only":
+            return False
+        return state.s
+    return False
+
+
+def _executes_e_on_route(route_: Route, state: SessionState, **switches) -> bool:
+    """Part E's downstream disqualifier - the _executes_b_on_route analogue,
+    keyed on `e` (over-gate) instead of `s` (staging)."""
+    part_e_guards = switches.get("PART_E_GUARDS", PART_E_GUARDS)
+    if part_e_guards == "inflow-only":
+        return state.f or state.a
+    if route_ == Route.R_STD:
+        return True
+    if route_ == Route.R_ZS:
+        zs_criteria = switches.get("ZS_CRITERIA", ZS_CRITERIA)
+        if zs_criteria == "session-only":
+            return False
+        return state.e
+    if route_ == Route.R_LIGHT:
+        light_trigger = switches.get("LIGHT_TRIGGER", LIGHT_TRIGGER)
+        if light_trigger == "fresh-only":
+            return False
+        return state.e
+    return False
+
+
+def executes_part_b_step0(state: SessionState, **switches) -> bool:
+    """Conservative over BOTH entry paths (fast short-circuit and normal
+    Step 0.5 routing). R4 (ABORT_SEMANTICS): a pre-lock abort never executes
+    this, by construction - `not state.L` returns False before either entry
+    path is even consulted, under both ABORT_SEMANTICS values except the
+    explicit non-default override below."""
+    switches = _resolve_switches(switches)
+    if not state.L:
+        abort_semantics = switches.get("ABORT_SEMANTICS", ABORT_SEMANTICS)
+        return abort_semantics == "pre-lock-executes"
+    if zs_fast_admissible(state, **switches):
+        return False   # :175 -> :257 skips Part B
+    return _executes_b_on_route(route(state, **switches), state, **switches)
+
+
+def executes_part_e(state: SessionState, **switches) -> bool:
+    """Mirrors executes_part_b_step0, keyed on Part E / `e` instead of Part
+    B step 0 / `s`."""
+    switches = _resolve_switches(switches)
+    if not state.L:
+        abort_semantics = switches.get("ABORT_SEMANTICS", ABORT_SEMANTICS)
+        return abort_semantics == "pre-lock-executes"
+    if zs_fast_admissible(state, **switches):
+        return False
+    return _executes_e_on_route(route(state, **switches), state, **switches)

--- a/bin/tests/reach_model.py
+++ b/bin/tests/reach_model.py
@@ -46,8 +46,10 @@ Purpose: (a) Executable reference implementation of `/ds-wrap`'s route x
 Public API:
   SessionState(L, f, a, g, v, s, e) -> frozen dataclass, the seven booleans
                                         a routing decision is derived from
-  all_states()                       -> all 128 SessionState values, in
-                                         deterministic dataclass-field order
+  all_states()                       -> list of all 128 SessionState values,
+                                         in deterministic dataclass-field
+                                         order (a list, not a generator - may
+                                         be iterated more than once)
   Route                              -> enum, exactly 6 members
   ROUTE_PREDICATES                   -> the 4-entry route partition (dict);
                                          R_ABORT_WORKERS and R_ZS_FAST are
@@ -91,7 +93,7 @@ from __future__ import annotations
 import itertools
 from dataclasses import dataclass, fields
 from enum import Enum, auto
-from typing import Dict, Iterator, Tuple
+from typing import Dict, List, Tuple
 
 
 # --------------------------------------------------------------------------
@@ -126,13 +128,16 @@ class SessionState:
     e: bool
 
 
-def all_states() -> Iterator[SessionState]:
+def all_states() -> List[SessionState]:
     """All 128 (2^7) SessionState values, in deterministic order: itertools
     .product over the dataclass's own field order (L, f, a, g, v, s, e), each
-    axis False-before-True. Exhaustive - no sampling, no seed."""
+    axis False-before-True. Exhaustive - no sampling, no seed. Returns a
+    list (not a generator) - callers may iterate it more than once."""
     field_names = [fld.name for fld in fields(SessionState)]
-    for combo in itertools.product((False, True), repeat=len(field_names)):
-        yield SessionState(**dict(zip(field_names, combo)))
+    return [
+        SessionState(**dict(zip(field_names, combo)))
+        for combo in itertools.product((False, True), repeat=len(field_names))
+    ]
 
 
 # --------------------------------------------------------------------------

--- a/bin/tests/test_drain_invariants.py
+++ b/bin/tests/test_drain_invariants.py
@@ -70,8 +70,13 @@ def _mk_entries(prefix, n, start=0):
 
 
 def _all_dispositions(sids, values):
-    """itertools.product over `values` (the full 9-member Outcome universe),
-    one choice per sid, in sid order - the literal tier-1 enumeration."""
+    """itertools.product over `values` (a caller-supplied set of Outcome
+    values - not a fixed universe), one choice per sid, in sid order - the
+    literal tier-1 enumeration. Tier 1 calls this with the 7 PRESENTABLE
+    outcomes: the 2 UNPRESENTED labels are drain()'s own output for entries
+    it did not present, not adjudicator inputs, so they have no place in
+    this enumeration. See TestD1TierOne's docstring for the closed-form
+    derivation of the resulting assignment count."""
     for combo in itertools.product(values, repeat=len(sids)):
         yield dict(zip(sids, combo))
 

--- a/bin/tests/test_drain_invariants.py
+++ b/bin/tests/test_drain_invariants.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
 Purpose: Property tests for `drain_model.py`'s staging-drain invariants
-         D1-D5, asserted over an exhaustive tier-1 sweep (every size <= 3
-         entries, every one of the 9 Outcome values per entry) plus a
-         seeded-random tier-2 sweep (sizes up to 8, multi-run simulation).
+         D1-D5, asserted over an exhaustive tier-1 sweep (every size
+         <= CAP + 2 entries, every one of the 7 PRESENTABLE Outcome values
+         per entry - the two UNPRESENTED labels are drain()'s own and
+         rejected fail-closed as input) plus a seeded-random tier-2 sweep
+         (sizes up to 8, multi-run simulation).
 
 Public API: unittest TestCases. Run with
               python3 -m pytest bin/tests/test_drain_invariants.py -q
@@ -21,8 +23,8 @@ Downstream consumers: PR 2's edit to content/commands/ds-wrap.md, which this
 Failure modes: DETERMINISTIC. Tier 2 is seeded from SEED below; no unseeded
                RNG, no wall-clock, no filesystem, no network.
 
-Performance: 3178 tier-1 assignments + 14200 tier-2 schedules; well under a
-             few seconds.
+Performance: 114381 tier-1 assignments + 14200 tier-2 schedules; a few
+             seconds.
 """
 
 from __future__ import annotations
@@ -48,7 +50,16 @@ COVERAGE = {
     "zero_fresh_schedules": 0,
     "cap_deferred_reentries": 0,
     "single_entry_mode_entered": 0,
+    "d1_correspondence_checks": 0,
+    "tier2_d1_results_checked": 0,
 }
+
+#: The presentable outcomes a random adjudicator draws from (never one of
+#: the two UNPRESENTED categories - a real adjudicator never self-assigns
+#: "dropped by cap"). Defined here (not in the tier-2 section below) because
+#: tier 1 now needs it too - drain() rejects an UNPRESENTED-category
+#: disposition fail-closed, so tier 1's own sweep must draw from this set.
+_PRESENTABLE = sorted(dmod.PRESENTED_OUTCOMES, key=lambda o: o.name)
 
 
 def _mk_entries(prefix, n, start=0):
@@ -83,32 +94,47 @@ def _check_d1(tc, result):
     if result.reject_disposition != "retained":
         tc.assertEqual(len(pres_sids) + len(ret_sids), len(order_sids),
                         "D1: not disjoint under default reject_disposition")
+    # D1 SEMANTIC HALF - the partition AXIS, not just the split. The two
+    # assertions above derive both operands from `presented_sids` and are
+    # true by construction; this one is the falsifiable half.
+    for sid in order_sids:
+        tc.assertEqual(
+            result.outcomes[sid] in dmod.PRESENTED_OUTCOMES,
+            sid in result.presented_sids,
+            f"D1: {sid} outcome {result.outcomes[sid]} disagrees with "
+            f"presented-ness ({sid in result.presented_sids})",
+        )
+        COVERAGE["d1_correspondence_checks"] += 1
 
 
 class TestD1TierOne(unittest.TestCase):
     """Tier 1: exhaustive over every (n_staged, n_fresh) pair summing to
-    <= 3, and every one of the 9^n disposition assignments for that size.
-    For n <= 3 the #presented <= CAP(3) filter is NON-BINDING (drain()
-    never truncates a group this small), so the assignment count collapses
-    to 9^n exactly.
+    <= CAP + 2, and every assignment of the 7 PRESENTABLE outcomes.
 
-    COVERAGE["tier1_assignments"] must equal 3178, derived as follows.
-    For n entries, assignments with #presented <= 3 = sum_{k=0}^{min(n,3)}
-    C(n,k) * 7^k * 2^(n-k) (choose which k of n entries are "presented"-
-    outcome-tagged, 7 presentable outcomes each, 2 unpresented outcomes for
-    the rest). For n <= 3 the binomial filter never excludes anything,
-    collapsing the sum to 9^n. Summing over the 10 size pairs (n+1 pairs at
-    each total n, for n = 0..3, i.e. (n_staged, n_fresh) with n_staged +
-    n_fresh == n):
+    Base is 7, not 9: outcomes 8-9 are drain()'s OWN labels for entries it
+    did not present. No adjudicator can emit them, so drain() now rejects
+    them fail-closed and they have no place in the input enumeration.
 
-        sum_{n=0}^{3} (n+1) * 9^n = 1*1 + 2*9 + 3*81 + 4*729
-                                   = 1 + 18 + 243 + 2916 = 3178
+    The size domain is CAP + 2, not CAP: with CAP = 3, no entry is ever
+    retained at n <= 3, so the RETAINED half of the partition is never
+    constructed and the correspondence assertion CANNOT FAIL there
+    (measured: 0 violations at n <= 3 under the break-7 mutant, 36015 at
+    n <= CAP + 2). n = CAP + 1 is the first size where the cap binds;
+    n = CAP + 2 is the first size where both UNPRESENTED labels co-occur
+    in a single result.
+
+        tier1_size_pairs  = sum_{n=0}^{CAP+2} (n+1)
+                          = 1+2+3+4+5+6 = 21
+        tier1_assignments = sum_{n=0}^{CAP+2} (n+1) * 7^n
+                          = 1*1 + 2*7 + 3*49 + 4*343 + 5*2401 + 6*16807
+                          = 1 + 14 + 147 + 1372 + 12005 + 100842
+                          = 114381
     """
 
     def test_d1_partition_total_and_disjoint(self):
-        values = list(dmod.Outcome)
-        self.assertEqual(len(values), 9)
-        for total in range(4):  # 0, 1, 2, 3
+        values = _PRESENTABLE
+        self.assertEqual(len(values), 7)
+        for total in range(dmod.CAP + 3):   # n <= CAP + 2; NOT a literal 5
             for n_staged in range(total + 1):
                 n_fresh = total - n_staged
                 COVERAGE["tier1_size_pairs"] += 1
@@ -119,8 +145,8 @@ class TestD1TierOne(unittest.TestCase):
                     COVERAGE["tier1_assignments"] += 1
                     result = dmod.drain(staged, fresh, disp)
                     _check_d1(self, result)
-        self.assertEqual(COVERAGE["tier1_size_pairs"], 10)
-        self.assertEqual(COVERAGE["tier1_assignments"], 3178)
+        self.assertEqual(COVERAGE["tier1_size_pairs"], 21)
+        self.assertEqual(COVERAGE["tier1_assignments"], 114381)
 
     def test_d1_outcome_enum_is_exhaustively_bucketed(self):
         self.assertEqual(
@@ -138,10 +164,11 @@ class TestD1TierOne(unittest.TestCase):
 # Tier 2 - seeded random, multi-run simulation
 # ==========================================================================
 
-#: The presentable outcomes a random adjudicator draws from (never one of
-#: the two UNPRESENTED categories - a real adjudicator never self-assigns
-#: "dropped by cap").
-_PRESENTABLE = sorted(dmod.PRESENTED_OUTCOMES, key=lambda o: o.name)
+#: TestCase instance used to run D1's correspondence assertion against every
+#: tier-2 result (see _run_schedule below) - tier 2 must not be a D1 blind
+#: spot just because it iterates DrainResult objects rather than unittest
+#: test methods.
+_TC = unittest.TestCase()
 
 
 def _run_schedule(rng, n_staged, n_fresh, n_runs=6, fresh_every_run=True,
@@ -179,6 +206,8 @@ def _run_schedule(rng, n_staged, n_fresh, n_runs=6, fresh_every_run=True,
         if n_fresh == 0:
             COVERAGE["zero_fresh_schedules"] += 1
         result = dmod.drain(staged, fresh, disp, **switches)
+        _check_d1(_TC, result)
+        COVERAGE["tier2_d1_results_checked"] += 1
         for e in dmod.presented(result):
             presented_at_run.setdefault(e["sid"], run_idx)
         results.append(result)
@@ -403,6 +432,18 @@ class TestMutationReserveRuleNoneIsRed(unittest.TestCase):
         self.assertIn("f0", default_result.presented_sids)
 
 
+class TestUnpresentableDispositionAborts(unittest.TestCase):
+    def test_unpresentable_disposition_aborts(self):
+        """Outcomes 8-9 are drain()'s own labels, never adjudicator input."""
+        for bad in (dmod.Outcome.DROPPED_BY_CAP, dmod.Outcome.NEVER_ADJUDICATED):
+            with self.assertRaises(ValueError):
+                dmod.drain([{"sid": "a", "quote": "q"}], [], {"a": bad})
+        # A presentable outcome does not raise.
+        r = dmod.drain([{"sid": "a", "quote": "q"}], [],
+                       {"a": dmod.Outcome.APPENDED})
+        self.assertIn("a", r.presented_sids)
+
+
 class TestNoSkipGuardSwitchExists(unittest.TestCase):
     def test_no_skip_guard_switch_exists(self):
         """drain_model must NOT expose a SKIP_GUARD attribute - route-level
@@ -417,21 +458,36 @@ class TestZReport(unittest.TestCase):
             "\ndrain coverage: tier1_size_pairs=%(tier1_size_pairs)d "
             "tier1_assignments=%(tier1_assignments)d "
             "tier2_size_pairs=%(tier2_size_pairs)d "
-            "tier2_schedules=%(tier2_schedules)d\n"
+            "tier2_schedules=%(tier2_schedules)d "
+            "tier2_d1_results_checked=%(tier2_d1_results_checked)d\n"
             "incidental: rejected_outcomes_exercised=%(rejected_outcomes_exercised)d "
             "zero_fresh_schedules=%(zero_fresh_schedules)d "
             "cap_deferred_reentries=%(cap_deferred_reentries)d "
-            "single_entry_mode_entered=%(single_entry_mode_entered)d"
+            "single_entry_mode_entered=%(single_entry_mode_entered)d "
+            "d1_correspondence_checks=%(d1_correspondence_checks)d"
             % COVERAGE
         )
-        self.assertEqual(COVERAGE["tier1_size_pairs"], 10)
-        self.assertEqual(COVERAGE["tier1_assignments"], 3178)
+        self.assertEqual(COVERAGE["tier1_size_pairs"], 21)
+        self.assertEqual(COVERAGE["tier1_assignments"], 114381)
         self.assertEqual(COVERAGE["tier2_size_pairs"], 71)
         self.assertEqual(COVERAGE["tier2_schedules"], 14200)
         self.assertGreater(COVERAGE["rejected_outcomes_exercised"], 0)
         self.assertGreater(COVERAGE["zero_fresh_schedules"], 0)
         self.assertGreater(COVERAGE["cap_deferred_reentries"], 0)
         self.assertGreater(COVERAGE["single_entry_mode_entered"], 0)
+        # tier2_d1_results_checked: every _run_schedule() call runs _check_d1
+        # once per drain() call. Only D2 and D5 route through _run_schedule
+        # (D3 and the mutation tests call drain() directly, uncounted here):
+        #   D2: 71 size pairs * N_PER_SIZE(200) * n_runs(8) = 113600
+        #   D5: 100 iterations * n_runs(8)                  =    800
+        #   total                                           = 114400
+        self.assertEqual(COVERAGE["tier2_d1_results_checked"], 114400)
+        # No closed form for this one - it is a per-entry-per-result count
+        # across a random simulation, not a derivable arithmetic sum. A
+        # floor (>0) is the honest assertion; inventing a pinned value
+        # would be an uninvestigated pin, exactly what this revision exists
+        # to eliminate.
+        self.assertGreater(COVERAGE["d1_correspondence_checks"], 0)
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_drain_invariants.py
+++ b/bin/tests/test_drain_invariants.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+Purpose: Property tests for `drain_model.py`'s staging-drain invariants
+         D1-D5, asserted over an exhaustive tier-1 sweep (every size <= 3
+         entries, every one of the 9 Outcome values per entry) plus a
+         seeded-random tier-2 sweep (sizes up to 8, multi-run simulation).
+
+Public API: unittest TestCases. Run with
+              python3 -m pytest bin/tests/test_drain_invariants.py -q
+            (.github/workflows/bin-tests.yml runs `python3 -m pytest
+            bin/tests/ -q`, auto-discovering; no CI wiring is required.)
+
+Upstream deps: drain_model.py (the single normative definition of the drain
+               algorithm); stdlib `unittest` + `random` + `itertools` only.
+               NO hypothesis - it is not a dependency of this repo and
+               adding one is out of scope.
+
+Downstream consumers: PR 2's edit to content/commands/ds-wrap.md, which this
+                      suite is the acceptance test for.
+
+Failure modes: DETERMINISTIC. Tier 2 is seeded from SEED below; no unseeded
+               RNG, no wall-clock, no filesystem, no network.
+
+Performance: 3178 tier-1 assignments + 14200 tier-2 schedules; well under a
+             few seconds.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import random
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import drain_model as dmod  # noqa: E402
+
+SEED = 20260803
+
+COVERAGE = {
+    "tier1_size_pairs": 0,
+    "tier1_assignments": 0,
+    "tier2_size_pairs": 0,
+    "tier2_schedules": 0,
+    "rejected_outcomes_exercised": 0,
+    "zero_fresh_schedules": 0,
+    "cap_deferred_reentries": 0,
+    "single_entry_mode_entered": 0,
+}
+
+
+def _mk_entries(prefix, n, start=0):
+    return [
+        {"sid": f"{prefix}{i}", "quote": f"quote-{prefix}{i}"}
+        for i in range(start, start + n)
+    ]
+
+
+def _all_dispositions(sids, values):
+    """itertools.product over `values` (the full 9-member Outcome universe),
+    one choice per sid, in sid order - the literal tier-1 enumeration."""
+    for combo in itertools.product(values, repeat=len(sids)):
+        yield dict(zip(sids, combo))
+
+
+def _check_d1(tc, result):
+    """D1: presented + retained partition `order` exactly - total and
+    disjoint, no entry counted twice, no entry dropped from the split."""
+    pres = dmod.presented(result)
+    ret = dmod.retained(result)
+    pres_sids = {e["sid"] for e in pres}
+    ret_sids = {e["sid"] for e in ret}
+    order_sids = {e["sid"] for e in result.order}
+    tc.assertEqual(pres_sids & ret_sids, set(), "D1: presented/retained overlap")
+    # Total: every order entry is presented XOR retained, UNLESS the
+    # REJECT_DISPOSITION="retained" mutation double-counts a rejected entry
+    # into `retained()` alongside `presented()` (by design - see
+    # drain_model.retained's docstring). Under the default, union == order
+    # and it is a strict partition.
+    tc.assertEqual(pres_sids | ret_sids, order_sids, "D1: union != order")
+    if result.reject_disposition != "retained":
+        tc.assertEqual(len(pres_sids) + len(ret_sids), len(order_sids),
+                        "D1: not disjoint under default reject_disposition")
+
+
+class TestD1TierOne(unittest.TestCase):
+    """Tier 1: exhaustive over every (n_staged, n_fresh) pair summing to
+    <= 3, and every one of the 9^n disposition assignments for that size.
+    For n <= 3 the #presented <= CAP(3) filter is NON-BINDING (drain()
+    never truncates a group this small), so the assignment count collapses
+    to 9^n exactly.
+
+    COVERAGE["tier1_assignments"] must equal 3178, derived as follows.
+    For n entries, assignments with #presented <= 3 = sum_{k=0}^{min(n,3)}
+    C(n,k) * 7^k * 2^(n-k) (choose which k of n entries are "presented"-
+    outcome-tagged, 7 presentable outcomes each, 2 unpresented outcomes for
+    the rest). For n <= 3 the binomial filter never excludes anything,
+    collapsing the sum to 9^n. Summing over the 10 size pairs (n+1 pairs at
+    each total n, for n = 0..3, i.e. (n_staged, n_fresh) with n_staged +
+    n_fresh == n):
+
+        sum_{n=0}^{3} (n+1) * 9^n = 1*1 + 2*9 + 3*81 + 4*729
+                                   = 1 + 18 + 243 + 2916 = 3178
+    """
+
+    def test_d1_partition_total_and_disjoint(self):
+        values = list(dmod.Outcome)
+        self.assertEqual(len(values), 9)
+        for total in range(4):  # 0, 1, 2, 3
+            for n_staged in range(total + 1):
+                n_fresh = total - n_staged
+                COVERAGE["tier1_size_pairs"] += 1
+                staged = _mk_entries("s", n_staged)
+                fresh = _mk_entries("f", n_fresh)
+                sids = [e["sid"] for e in staged + fresh]
+                for disp in _all_dispositions(sids, values):
+                    COVERAGE["tier1_assignments"] += 1
+                    result = dmod.drain(staged, fresh, disp)
+                    _check_d1(self, result)
+        self.assertEqual(COVERAGE["tier1_size_pairs"], 10)
+        self.assertEqual(COVERAGE["tier1_assignments"], 3178)
+
+    def test_d1_outcome_enum_is_exhaustively_bucketed(self):
+        self.assertEqual(
+            dmod.PRESENTED_OUTCOMES | dmod.UNPRESENTED_OUTCOMES,
+            set(dmod.Outcome),
+        )
+        self.assertEqual(
+            dmod.PRESENTED_OUTCOMES & dmod.UNPRESENTED_OUTCOMES, set()
+        )
+        self.assertEqual(len(dmod.PRESENTED_OUTCOMES), 7)
+        self.assertEqual(len(dmod.UNPRESENTED_OUTCOMES), 2)
+
+
+# ==========================================================================
+# Tier 2 - seeded random, multi-run simulation
+# ==========================================================================
+
+#: The presentable outcomes a random adjudicator draws from (never one of
+#: the two UNPRESENTED categories - a real adjudicator never self-assigns
+#: "dropped by cap").
+_PRESENTABLE = sorted(dmod.PRESENTED_OUTCOMES, key=lambda o: o.name)
+
+
+def _run_schedule(rng, n_staged, n_fresh, n_runs=6, fresh_every_run=True,
+                   **switches):
+    """Simulate `n_runs` successive drain() calls: whatever `retained()`
+    returns from run k becomes the incoming `staged` backlog for run k+1.
+    When `fresh_every_run` is True (D3/D5's steady-state scenario: inflow
+    rate <= throughput, sustainable indefinitely) `n_fresh` entries are
+    freshly minted every run. When False (D2's scenario: a one-off arrival,
+    matching D3/D5's own single-run fresh guarantee - continuous unbounded
+    injection at a rate exceeding CAP has no finite residency bound in ANY
+    cap-limited system and is not what D2 asserts), `n_fresh` entries are
+    minted only at run 0; later runs drain the residual backlog with no new
+    arrivals. Returns the list of per-run DrainResult objects plus the
+    sid->first-presented-run map."""
+    staged = _mk_entries("s", n_staged)
+    results = []
+    presented_at_run = {}
+    next_fresh_id = 0
+    for run_idx in range(n_runs):
+        if run_idx > 0 and staged:
+            # Entries carried forward (unpresented last run, re-entering
+            # this run's staged backlog) - the CAP-truncation reentry count.
+            COVERAGE["cap_deferred_reentries"] += len(staged)
+        run_fresh_n = n_fresh if (fresh_every_run or run_idx == 0) else 0
+        fresh = _mk_entries("f", run_fresh_n, start=next_fresh_id)
+        next_fresh_id += run_fresh_n
+        combined = staged + fresh
+        disp = {}
+        for e in combined:
+            outcome = rng.choice(_PRESENTABLE)
+            if outcome == dmod.Outcome.REJECTED_ON_THE_MERITS:
+                COVERAGE["rejected_outcomes_exercised"] += 1
+            disp[e["sid"]] = outcome
+        if n_fresh == 0:
+            COVERAGE["zero_fresh_schedules"] += 1
+        result = dmod.drain(staged, fresh, disp, **switches)
+        for e in dmod.presented(result):
+            presented_at_run.setdefault(e["sid"], run_idx)
+        results.append(result)
+        staged = dmod.retained(result)
+        if len(combined) == 1:
+            COVERAGE["single_entry_mode_entered"] += 1
+    return results, presented_at_run
+
+
+def _size_pairs_tier2():
+    """71 pairs: n_staged, n_fresh in 0..8 with sum > 3."""
+    pairs = [
+        (ns, nf)
+        for ns in range(9)
+        for nf in range(9)
+        if ns + nf > 3
+    ]
+    return pairs
+
+
+class TestD2ResidencyBound(unittest.TestCase):
+    N_PER_SIZE = 200
+
+    def test_d2_residency_bound(self):
+        """D2: an entry at arrival index k (0-based, within its own
+        staged+fresh combined ordering at the run it first appears) is
+        presented within k+1 runs of first appearing - including zero-fresh
+        and all-rejected schedules.
+
+        Fresh entries arrive ONCE (run 0 only, `fresh_every_run=False`) - a
+        one-off arrival, not a sustained inflow. D3/D5 already cover the
+        steady-state case (inflow <= throughput, sustainable indefinitely);
+        a sustained inflow EXCEEDING cap has no finite residency bound in
+        any cap-limited system and is not what D2 asserts. Worst case here
+        is 16 entries total (8+8) at cap=3/run once no new fresh arrive,
+        needing ceil(16/3)=6 runs to fully clear - `n_runs=8` leaves margin."""
+        pairs = _size_pairs_tier2()
+        COVERAGE["tier2_size_pairs"] += len(pairs)
+        self.assertEqual(len(pairs), 71)
+        for (n_staged, n_fresh) in pairs:
+            rng = random.Random(SEED + n_staged * 100 + n_fresh)
+            for _ in range(self.N_PER_SIZE):
+                COVERAGE["tier2_schedules"] += 1
+                results, presented_at_run = _run_schedule(
+                    rng, n_staged, n_fresh, n_runs=8, fresh_every_run=False
+                )
+                # Every entry that ever appeared in staged/fresh across the
+                # simulation must have been presented by the time its
+                # residency bound elapses. Index k = its position in the
+                # arrival order of the run it FIRST appeared in.
+                first_run_order = {}
+                for run_idx, r in enumerate(results):
+                    for k, e in enumerate(r.order):
+                        first_run_order.setdefault(e["sid"], (run_idx, k))
+                for sid, (first_run, k) in first_run_order.items():
+                    self.assertIn(
+                        sid, presented_at_run,
+                        f"D2: {sid} (arrival index {k}, first seen run "
+                        f"{first_run}) was never presented across "
+                        f"{len(results)} runs",
+                    )
+                    presented_run = presented_at_run[sid]
+                    runs_elapsed = presented_run - first_run + 1
+                    self.assertLessEqual(
+                        runs_elapsed, k + 1,
+                        f"D2: {sid} at arrival index {k} took "
+                        f"{runs_elapsed} runs to present (bound: k+1="
+                        f"{k + 1})",
+                    )
+
+
+class TestD3NoFreshStarvation(unittest.TestCase):
+    def test_d3_no_fresh_starvation(self):
+        """Under defaults, a fresh entry submitted alongside an arbitrarily
+        large staged backlog is presented on its own submitting run (the
+        RESERVE floor guarantee)."""
+        rng = random.Random(SEED + 1)
+        for _ in range(200):
+            n_staged = rng.randint(dmod.CAP, 20)
+            staged = _mk_entries("s", n_staged)
+            fresh = _mk_entries("f", 1)
+            disp = {e["sid"]: dmod.Outcome.APPENDED for e in staged + fresh}
+            result = dmod.drain(staged, fresh, disp)
+            self.assertIn("f0", result.presented_sids)
+
+
+class TestD4FailClosedAtomicity(unittest.TestCase):
+    def test_d4_fail_closed_atomicity(self):
+        staged = [{"sid": "s0", "quote": "q0"}]
+        fresh = [{"sid": "s0", "quote": "q1"}]  # duplicate sid
+        with self.assertRaises(ValueError):
+            dmod.drain(staged, fresh, {})
+
+        no_sid = [{"quote": "q0"}]
+        with self.assertRaises(ValueError):
+            dmod.drain(no_sid, [], {})
+
+
+class TestD5NoReservedSlotCapture(unittest.TestCase):
+    def test_d5_no_reserved_slot_capture(self):
+        """Under defaults, a fresh entry is never permanently blocked by a
+        stale presented entry re-capturing its reserved slot run after
+        run."""
+        rng = random.Random(SEED + 2)
+        for _ in range(100):
+            n_staged = rng.randint(5, 15)
+            _, presented_at_run = _run_schedule(rng, n_staged, 1, n_runs=8)
+            self.assertIn("f0", presented_at_run)
+            self.assertEqual(presented_at_run["f0"], 0)
+
+
+class TestMissingOrDuplicateSidAborts(unittest.TestCase):
+    def test_missing_or_duplicate_sid_aborts(self):
+        with self.assertRaises(ValueError):
+            dmod.drain([{"sid": "a"}, {"sid": "a"}], [], {})
+        with self.assertRaises(ValueError):
+            dmod.drain([{"sid": ""}], [], {})
+        with self.assertRaises(ValueError):
+            dmod.drain([{}], [], {})
+
+
+class TestUnverifiableDuplicateQuoteAborts(unittest.TestCase):
+    def test_unverifiable_duplicate_quote_aborts(self):
+        entry = {"sid": "a"}  # no quote field
+        disp = {"a": dmod.Outcome.SKIPPED_ALREADY_A_STRUCTURED_LEARNING}
+        with self.assertRaises(ValueError):
+            dmod.drain([entry], [], disp)
+
+        entry2 = {"sid": "b", "quote": "   "}  # whitespace-only
+        disp2 = {"b": dmod.Outcome.SKIPPED_DUPLICATE_OF_DESTINATION_OR_ALREADY_PRESENTED}
+        with self.assertRaises(ValueError):
+            dmod.drain([entry2], [], disp2)
+
+        # A verifiable quote passes.
+        entry3 = {"sid": "c", "quote": "the actual quoted text"}
+        disp3 = {"c": dmod.Outcome.SKIPPED_ALREADY_A_STRUCTURED_LEARNING}
+        result = dmod.drain([entry3], [], disp3)
+        self.assertIn("c", result.presented_sids)
+
+
+class TestAbortPathTerminates(unittest.TestCase):
+    def test_abort_path_terminates(self):
+        """Single-entry mode: a lone entry (n=1) is always presented within
+        3 attempts (in fact within 1, since n=1 <= CAP). D2 holds at its
+        own k+1 (k=0 -> presented within 1 run). Staging is never destroyed
+        - the entry is never silently dropped from `order`."""
+        for attempt in range(3):
+            staged = _mk_entries("s", 1)
+            disp = {"s0": dmod.Outcome.APPENDED}
+            result = dmod.drain(staged, [], disp)
+            self.assertIn("s0", result.presented_sids)
+            self.assertEqual({e["sid"] for e in result.order}, {"s0"})
+            COVERAGE["single_entry_mode_entered"] += 1
+
+
+# ==========================================================================
+# Mutation tests
+# ==========================================================================
+
+
+class TestMutationRejectDispositionRetainedIsRed(unittest.TestCase):
+    def test_mutation_reject_disposition_retained_is_red(self):
+        rng = random.Random(SEED + 3)
+        staged = _mk_entries("s", 1)
+        disp = {"s0": dmod.Outcome.REJECTED_ON_THE_MERITS}
+        results = []
+        cur_staged = staged
+        for run_idx in range(5):
+            result = dmod.drain(cur_staged, [], disp, reject_disposition="retained")
+            results.append(result)
+            cur_staged = dmod.retained(result)
+        # D5/D2 defect: the rejected entry never leaves the backlog, so it
+        # is still present after every run.
+        self.assertTrue(all("s0" in {e["sid"] for e in r.order} for r in results))
+        self.assertTrue(
+            any("s0" in {e["sid"] for e in dmod.retained(r)} for r in results),
+            "REJECT_DISPOSITION='retained' never caused a rejected entry "
+            "to stay in the backlog (D2/D5 mutation was never caught)",
+        )
+
+
+class TestMutationOrderModeDateIsRed(unittest.TestCase):
+    def test_mutation_order_mode_date_is_red(self):
+        """ORDER_MODE='date' can reorder an OLDER-arrival entry behind a
+        newer one that carries an earlier `date`, breaking D2's residency
+        bound (which is keyed on arrival index, never date)."""
+        staged = [
+            {"sid": "old", "quote": "q", "date": "2026-01-05"},
+        ]
+        fresh = [
+            {"sid": "new", "quote": "q", "date": "2020-01-01"},
+        ]
+        disp = {"old": dmod.Outcome.APPENDED, "new": dmod.Outcome.APPENDED}
+        result = dmod.drain(staged, fresh, disp, order_mode="date")
+        # Under date ordering, "new" (dated earlier) sorts before "old"
+        # despite arriving later - its arrival-index bound is violated.
+        self.assertEqual([e["sid"] for e in result.order], ["new", "old"])
+        arrival_result = dmod.drain(staged, fresh, disp, order_mode="arrival")
+        self.assertEqual(
+            [e["sid"] for e in arrival_result.order], ["old", "new"]
+        )
+        self.assertNotEqual(
+            [e["sid"] for e in result.order],
+            [e["sid"] for e in arrival_result.order],
+            "ORDER_MODE='date' never diverged from arrival order "
+            "(mutation was never caught)",
+        )
+
+
+class TestMutationReserveRuleNoneIsRed(unittest.TestCase):
+    def test_mutation_reserve_rule_none_is_red(self):
+        staged = _mk_entries("s", dmod.CAP)
+        fresh = _mk_entries("f", 1)
+        disp = {e["sid"]: dmod.Outcome.APPENDED for e in staged + fresh}
+        result = dmod.drain(staged, fresh, disp, reserve_rule="none")
+        self.assertNotIn(
+            "f0", result.presented_sids,
+            "RESERVE_RULE='none' never starved a fresh entry "
+            "(mutation was never caught)",
+        )
+        default_result = dmod.drain(staged, fresh, disp)
+        self.assertIn("f0", default_result.presented_sids)
+
+
+class TestNoSkipGuardSwitchExists(unittest.TestCase):
+    def test_no_skip_guard_switch_exists(self):
+        """drain_model must NOT expose a SKIP_GUARD attribute - route-level
+        guards belong to reach_model only. Modelling it in both is a defect
+        a prior revision of this plan shipped."""
+        self.assertFalse(hasattr(dmod, "SKIP_GUARD"))
+
+
+class TestZReport(unittest.TestCase):
+    def test_zz_report_coverage(self):
+        print(
+            "\ndrain coverage: tier1_size_pairs=%(tier1_size_pairs)d "
+            "tier1_assignments=%(tier1_assignments)d "
+            "tier2_size_pairs=%(tier2_size_pairs)d "
+            "tier2_schedules=%(tier2_schedules)d\n"
+            "incidental: rejected_outcomes_exercised=%(rejected_outcomes_exercised)d "
+            "zero_fresh_schedules=%(zero_fresh_schedules)d "
+            "cap_deferred_reentries=%(cap_deferred_reentries)d "
+            "single_entry_mode_entered=%(single_entry_mode_entered)d"
+            % COVERAGE
+        )
+        self.assertEqual(COVERAGE["tier1_size_pairs"], 10)
+        self.assertEqual(COVERAGE["tier1_assignments"], 3178)
+        self.assertEqual(COVERAGE["tier2_size_pairs"], 71)
+        self.assertEqual(COVERAGE["tier2_schedules"], 14200)
+        self.assertGreater(COVERAGE["rejected_outcomes_exercised"], 0)
+        self.assertGreater(COVERAGE["zero_fresh_schedules"], 0)
+        self.assertGreater(COVERAGE["cap_deferred_reentries"], 0)
+        self.assertGreater(COVERAGE["single_entry_mode_entered"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/bin/tests/test_reach_invariants.py
+++ b/bin/tests/test_reach_invariants.py
@@ -51,8 +51,10 @@ class TestRouteEnumAndPredicateCounts(unittest.TestCase):
         self.assertEqual(len(rm.ROUTE_PREDICATES), 4)
         self.assertNotIn(rm.Route.R_ABORT_WORKERS, rm.ROUTE_PREDICATES)
         self.assertNotIn(rm.Route.R_ZS_FAST, rm.ROUTE_PREDICATES)
-        # These four facts make route_evaluations derivable rather than
-        # pinned: len(ROUTE_PREDICATES) * len(all_states()) == 4 * 128 == 512.
+        # The four facts above establish that route_evaluations is
+        # derivable rather than pinned; the assertion below is the fifth
+        # in this test and checks the derived value directly:
+        # len(ROUTE_PREDICATES) * len(all_states()) == 4 * 128 == 512.
         self.assertEqual(len(rm.ROUTE_PREDICATES) * len(rm.all_states()), 512)
 
 

--- a/bin/tests/test_reach_invariants.py
+++ b/bin/tests/test_reach_invariants.py
@@ -53,6 +53,7 @@ class TestRouteEnumAndPredicateCounts(unittest.TestCase):
         self.assertNotIn(rm.Route.R_ZS_FAST, rm.ROUTE_PREDICATES)
         # These four facts make route_evaluations derivable rather than
         # pinned: len(ROUTE_PREDICATES) * len(all_states()) == 4 * 128 == 512.
+        self.assertEqual(len(rm.ROUTE_PREDICATES) * len(rm.all_states()), 512)
 
 
 class TestReachR1StagingAlwaysDrains(unittest.TestCase):

--- a/bin/tests/test_reach_invariants.py
+++ b/bin/tests/test_reach_invariants.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Purpose: Exhaustive property tests over `reach_model.py`'s route x entry-path
+         x reachability contract (R1-R5), asserted over ALL 128 SessionState
+         values rather than hand-traced cases. Four of seven prior review
+         rounds on this plan found a reachability defect the previous
+         round's hand-tracing missed - this is the mechanical replacement.
+
+Public API: unittest TestCases. Run with
+              python3 -m pytest bin/tests/test_reach_invariants.py -q
+            (.github/workflows/bin-tests.yml runs `python3 -m pytest
+            bin/tests/ -q`, auto-discovering; no CI wiring is required.)
+
+Upstream deps: reach_model.py (the single normative definition of the
+               routing contract); stdlib `unittest` only. No sampling, no
+               seed - every property below is asserted over the FULL 128-
+               state space, deterministically.
+
+Downstream consumers: PR 2's edit to content/commands/ds-wrap.md, which this
+                      suite is the acceptance test for.
+
+Failure modes: DETERMINISTIC. No randomness anywhere in this file.
+
+Performance: 128-state exhaustive sweeps, a handful of them per test;
+             well under a second.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import reach_model as rm  # noqa: E402
+
+ALL_STATES = list(rm.all_states())
+
+#: Coverage counters, reported by test_zz_report_coverage. All three are
+#: EQUALITIES, not floors - route_evaluations counts (state, route-
+#: predicate) pairs evaluated by R3's own sweep. A value of 640 here would
+#: be the known prior defect (200 states x an over-broad per-state loop, not
+#: 128 x len(ROUTE_PREDICATES)) and must never appear.
+COVERAGE = {"states": 0, "route_evaluations": 0, "entry_path_evaluations": 0}
+
+
+class TestRouteEnumAndPredicateCounts(unittest.TestCase):
+    def test_reach_route_enum_and_predicate_counts(self):
+        self.assertEqual(len(rm.Route), 6)
+        self.assertEqual(len(rm.ROUTE_PREDICATES), 4)
+        self.assertNotIn(rm.Route.R_ABORT_WORKERS, rm.ROUTE_PREDICATES)
+        self.assertNotIn(rm.Route.R_ZS_FAST, rm.ROUTE_PREDICATES)
+        # These four facts make route_evaluations derivable rather than
+        # pinned: len(ROUTE_PREDICATES) * len(all_states()) == 4 * 128 == 512.
+
+
+class TestReachR1StagingAlwaysDrains(unittest.TestCase):
+    def test_reach_r1_staging_always_drains(self):
+        for s in ALL_STATES:
+            if s.L and s.s:
+                self.assertTrue(
+                    rm.executes_part_b_step0(s),
+                    f"R1: staging non-empty but Part B step 0 did not "
+                    f"execute for {s}",
+                )
+
+
+class TestReachR2OverGateAlwaysCompresses(unittest.TestCase):
+    def test_reach_r2_over_gate_always_compresses(self):
+        for s in ALL_STATES:
+            if s.L and s.e:
+                self.assertTrue(
+                    rm.executes_part_e(s),
+                    f"R2: target over gate but Part E did not execute "
+                    f"for {s}",
+                )
+
+
+class TestReachR3ExactlyOnePredicateHolds(unittest.TestCase):
+    def test_reach_r3_exactly_one_predicate_holds(self):
+        """Derivation, reproduced here so the 128 total is checked, not
+        merely asserted: ~L = 64 states (half the space). L ^ (f v a v g) =
+        56 (of the remaining 64, all but the 8 with f=a=g=False - standard
+        counting: 64 - 8 = 56). L ^ ~f^~a^~g = 8, splitting 4/4 on v (zero-
+        substance vs light). 64 + 56 + 4 + 4 = 128."""
+        for s in ALL_STATES:
+            COVERAGE["states"] += 1
+            holders = []
+            for r, p in rm.ROUTE_PREDICATES.items():
+                COVERAGE["route_evaluations"] += 1
+                if p(s):
+                    holders.append(r)
+            self.assertEqual(
+                len(holders), 1,
+                f"R3: {len(holders)} predicates hold for {s}: {holders}",
+            )
+        # Reconcile the derivation against the actual partition sizes.
+        not_l = sum(1 for s in ALL_STATES if not s.L)
+        std = sum(1 for s in ALL_STATES if s.L and (s.f or s.a or s.g))
+        zs = sum(
+            1 for s in ALL_STATES
+            if s.L and not s.f and not s.a and not s.g and not s.v
+        )
+        light = sum(
+            1 for s in ALL_STATES
+            if s.L and not s.f and not s.a and not s.g and s.v
+        )
+        self.assertEqual(not_l, 64)
+        self.assertEqual(std, 56)
+        self.assertEqual(zs, 4)
+        self.assertEqual(light, 4)
+        self.assertEqual(not_l + std + zs + light, 128)
+
+    def test_reach_r3_raises_when_partition_broken(self):
+        with self.assertRaises(rm.RouteResolutionError):
+            rm.route(
+                rm.SessionState(L=True, f=False, a=True, g=False, v=True,
+                                 s=False, e=False),
+                R3_PREDICATE_OVERLAP=True,
+            )
+        with self.assertRaises(rm.RouteResolutionError):
+            rm.route(
+                rm.SessionState(L=True, f=False, a=True, g=False, v=False,
+                                 s=False, e=False),
+                R3_PREDICATE_GAP=True,
+            )
+
+
+class TestReachZsFastIsNotARoutingDestination(unittest.TestCase):
+    def test_reach_zs_fast_is_not_a_routing_destination(self):
+        saw_admissible = False
+        for s in ALL_STATES:
+            COVERAGE["entry_path_evaluations"] += 1
+            if s.L:
+                r = rm.route(s)
+                self.assertNotEqual(r, rm.Route.R_ZS_FAST)
+            if rm.zs_fast_admissible(s):
+                saw_admissible = True
+        self.assertTrue(
+            saw_admissible,
+            "zs_fast_admissible was never True over the full state space",
+        )
+
+
+class TestReachR4PrelockAbortRoutesAreSafe(unittest.TestCase):
+    def test_reach_r4_prelock_abort_routes_are_safe(self):
+        """R4 makes NO claim about the four lock-held mid-run escalations
+        (ds-wrap.md:433, :435, :441, :649) - only about the pre-lock abort
+        route (`not state.L`), where neither mechanism can have run yet."""
+        for s in ALL_STATES:
+            if not s.L:
+                self.assertFalse(rm.executes_part_b_step0(s))
+                self.assertFalse(rm.executes_part_e(s))
+
+
+class TestReachR5FixSetMinimalAndSufficient(unittest.TestCase):
+    def test_reach_r5_fix_set_minimal_and_sufficient(self):
+        # Sufficiency: all five defaults -> R1 and R2 both hold everywhere.
+        for s in ALL_STATES:
+            if s.L and s.s:
+                self.assertTrue(rm.executes_part_b_step0(s))
+            if s.L and s.e:
+                self.assertTrue(rm.executes_part_e(s))
+
+        # Minimality: each of the five fix-site switches flipped
+        # individually reddens R1 or R2 somewhere in the state space.
+        non_default = {
+            "ZS_FAST_CRITERIA": "session-only",
+            "ZS_CRITERIA": "session-only",
+            "LIGHT_TRIGGER": "fresh-only",
+            "PART_B_GUARD": "fresh-only",
+            "PART_E_GUARDS": "inflow-only",
+        }
+        anchors = {
+            "ZS_FAST_CRITERIA": "ds-wrap.md:166-172 (Step 0-pre fast short-circuit)",
+            "ZS_CRITERIA": "ds-wrap.md:248-264 (Step 0.5 Zero-substance path)",
+            "LIGHT_TRIGGER": "ds-wrap.md:265-281 (Step 0.5 Light path)",
+            "PART_B_GUARD": "ds-wrap.md:471 (Part B - Write memory.md gate)",
+            "PART_E_GUARDS": "ds-wrap.md:591 (Part E gate)",
+        }
+        for name, value in non_default.items():
+            r1_red = any(
+                s.L and s.s and not rm.executes_part_b_step0(s, **{name: value})
+                for s in ALL_STATES
+            )
+            r2_red = any(
+                s.L and s.e and not rm.executes_part_e(s, **{name: value})
+                for s in ALL_STATES
+            )
+            self.assertTrue(
+                r1_red or r2_red,
+                f"minimality: flipping {name} alone did not redden R1 or "
+                f"R2 (fix site: {anchors[name]})",
+            )
+
+        # ZS_FAST_CRITERIA and ZS_CRITERIA must redden INDEPENDENTLY on the
+        # canonical witness state, via two distinct code paths (the entry-
+        # path short-circuit vs the route-based R_ZS disqualifier).
+        witness = rm.SessionState(
+            L=True, f=False, a=False, g=False, v=False, s=True, e=True
+        )
+        self.assertEqual(rm.route(witness), rm.Route.R_ZS)
+        self.assertFalse(
+            rm.executes_part_b_step0(witness, ZS_FAST_CRITERIA="session-only")
+        )
+        self.assertFalse(
+            rm.executes_part_b_step0(witness, ZS_CRITERIA="session-only")
+        )
+        self.assertFalse(
+            rm.executes_part_e(witness, ZS_FAST_CRITERIA="session-only")
+        )
+        self.assertFalse(
+            rm.executes_part_e(witness, ZS_CRITERIA="session-only")
+        )
+
+
+class TestReachAsShippedIsRed(unittest.TestCase):
+    def test_reach_as_shipped_is_red(self):
+        r1_failing_routes = set()
+        r2_failing_routes = set()
+        for s in ALL_STATES:
+            if s.L and s.s:
+                if not rm.executes_part_b_step0(s, AS_SHIPPED_PRE_DS90=True):
+                    r1_failing_routes.add(rm.route(s))
+            if s.L and s.e:
+                if not rm.executes_part_e(s, AS_SHIPPED_PRE_DS90=True):
+                    r2_failing_routes.add(rm.route(s))
+        self.assertTrue(r1_failing_routes, "AS_SHIPPED_PRE_DS90: R1 never went RED")
+        self.assertTrue(r2_failing_routes, "AS_SHIPPED_PRE_DS90: R2 never went RED")
+        combined = r1_failing_routes | r2_failing_routes
+        self.assertGreaterEqual(
+            len(combined), 3,
+            f"AS_SHIPPED_PRE_DS90 failing states must span >=3 distinct "
+            f"routes; saw {combined}",
+        )
+
+
+class TestMutationR3OverlapIsRed(unittest.TestCase):
+    def test_mutation_r3_overlap_is_red(self):
+        s = rm.SessionState(L=True, f=False, a=True, g=False, v=True,
+                             s=False, e=False)
+        with self.assertRaises(rm.RouteResolutionError) as ctx:
+            rm.route(s, R3_PREDICATE_OVERLAP=True)
+        self.assertIn("R_LIGHT", str(ctx.exception))
+        self.assertIn("R_STD", str(ctx.exception))
+
+
+class TestMutationR3GapIsRed(unittest.TestCase):
+    def test_mutation_r3_gap_is_red(self):
+        s = rm.SessionState(L=True, f=False, a=True, g=False, v=False,
+                             s=False, e=False)
+        with self.assertRaises(rm.RouteResolutionError) as ctx:
+            rm.route(s, R3_PREDICATE_GAP=True)
+        self.assertIn("0 predicates hold", str(ctx.exception))
+
+
+class TestMutationAbortSemanticsIsRed(unittest.TestCase):
+    def test_mutation_abort_semantics_is_red(self):
+        found = False
+        for s in ALL_STATES:
+            if not s.L and (s.s or s.e):
+                default_b = rm.executes_part_b_step0(s)
+                mutated_b = rm.executes_part_b_step0(
+                    s, ABORT_SEMANTICS="pre-lock-executes"
+                )
+                if default_b != mutated_b:
+                    found = True
+        self.assertTrue(
+            found, "ABORT_SEMANTICS mutation never changed R4's outcome"
+        )
+
+
+class TestZReport(unittest.TestCase):
+    def test_zz_report_coverage(self):
+        print(
+            "\nreach coverage: states=%(states)d "
+            "route_evaluations=%(route_evaluations)d "
+            "entry_path_evaluations=%(entry_path_evaluations)d"
+            % COVERAGE
+        )
+        self.assertEqual(COVERAGE["states"], 128)
+        self.assertEqual(COVERAGE["route_evaluations"], 512)
+        self.assertEqual(COVERAGE["entry_path_evaluations"], 128)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
PR 1 of 2 for DS-90. Ships two executable normative models under `bin/tests/`, following the `fold_model.py` precedent (DS-108 / #521): prose rules replaced by an executable model with mutation switches.

No `content/**` changes. No workflow changes - `bin-tests.yml:21` runs bare `python3 -m pytest bin/tests/ -q` and auto-discovers both new test files (collection 725 -> 753).

## What lands

| file | purpose |
|---|---|
| `bin/tests/reach_model.py` | normative reachability model: `SessionState` (7 booleans -> 128 states), `ROUTE_PREDICATES` as a 4-entry partition with single-holder dispatch |
| `bin/tests/test_reach_invariants.py` | R1-R5 invariants, 13 tests |
| `bin/tests/drain_model.py` | normative drain algorithm: 9 `Outcome` members partitioned `DRAINED <=> PRESENTED`, `CAP=3`, `RESERVE=1` |
| `bin/tests/test_drain_invariants.py` | D1-D5 invariants, 15 tests |

## Why an executable model

Four prior review rounds each found the same concurrency defect *relocated* rather than repeated. Making the algorithm executable found a further hole in one round, then proved correctness by exhaustive enumeration. The models are the artifact that makes the next defect of this class mechanically detectable instead of review-detectable.

## Review history

Three rounds on this PR. Round 7 withheld sign-off with 2 Major findings, both fixed here:

- **Tier 1's sweep was insensitive to the axis it enumerated.** 3,178 assignments produced only **10** distinct configurations of the property under test, and 1,644 of them (51.7%) were internally self-contradictory. The `9^n` base counted a domain with no preimage - outcomes 8-9 are `drain()`'s own labels, never adjudicator input. Fixed at three layers: fail-closed category validation on input, a `DRAINED <=> PRESENTED` correspondence assertion called in **both** tiers (tier 2 previously asserted D1 nowhere at all), and the tier-1 size domain extended `n <= 3` -> `n <= CAP + 2`.
- **`all_states()` shipped as a single-use generator** where the spec mandates a list, so `len()` raised and the derivation it documents was unexecutable. Fixed by returning a list and promoting the comment to a real assertion.

**The size extension is load-bearing, not cosmetic.** Under a source mutation of `drain()`, measured independently by three separate reviewers:

| tier-1 domain | assignments | correspondence violations |
|---|---|---|
| `n <= 3` (as previously shipped) | 1,534 | **0 - the assertion cannot fail** |
| `n <= 4` | 13,539 | 2,401 |
| `n <= 5` (`CAP + 2`, shipped) | 114,381 | 36,015 |

Adding the assertion without extending the domain would have shipped a third vacuous assertion.

## Verification

- **753 passed in ~21 s** against a 300 s CI budget (`timeout-minutes: 5`). Baseline on `main` is 725 / ~19.8 s.
- **Seven deliberate breaks**, fourteen exit codes: six assertion inversions plus one source mutation, each reddening its target and restoring to byte-identical files verified by sha256.
- **Falsifiability confirmed by removal**: each new assertion was deleted in turn and the corresponding regression went undetected, establishing each is the sole detector rather than a duplicate of an existing check.
- All enumeration counts (`21`, `114381`, `114400`) carry closed-form derivations in code and were re-derived independently by two reviewers rather than read from the assertions.

## North Star alignment

**Advances "produce verifiable outcomes autonomously."** This replaces hand-tracing - which missed a reachability defect in four of seven prior review rounds - with an exhaustive executable model whose invariants fail loudly under mutation. The review process that produced it is itself the evidence: three independent agents each reproduced the load-bearing measurement from scratch rather than restating it.

**Advances "works for everyone" (universality).** The models are pure Python with no I/O, no network, no wall-clock, and no filesystem access; a module-level `SEED` constant makes the sampled tier reproducible. Nothing depends on an operator identity, tracker, credential, or harness.

**No pillar regression.** Diff is confined to `bin/tests/`; the always-loaded resident set is untouched, so the resident-budget ratchet is unaffected.

## Known scope boundary

`AGENTS.md:70` - "a new module is not done until something in `content/` invokes it" - is **not yet satisfied**: these modules have no `content/` caller. That is in-spec for a declared PR 1 of 2, and the manifests name `content/commands/ds-wrap.md` as the pending consumer. **PR 2 must land that wiring**; shipping uncalled is this repo's documented default failure mode and is tracked, not overlooked.
