### PR TITLE
chore(bin): make ~/.local/bin symlink management prefix-agnostic

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -1523,7 +1523,7 @@ ae_install_bins() {
   local linked=0
   local refreshed=0
   local skipped=0
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -e "$src_file" ]] || continue
     [[ -f "$src_file" ]] || continue
     local name

--- a/.claude/uninstall.sh
+++ b/.claude/uninstall.sh
@@ -82,7 +82,7 @@ fi
 
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -93,7 +93,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -111,7 +111,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -330,7 +330,7 @@ for skill_name in "${SKILL_NAMES[@]}"; do
     )
   fi
 done
-for src_file in "$REPO_DIR"/bin/agentic-*; do
+for src_file in "$REPO_DIR"/bin/agentic-* "$REPO_DIR"/bin/ds-*; do
   [[ -f "$src_file" ]] || continue
   AE_FINAL_DESTINATIONS+=(
     $'link\t'"$HOME/.local/bin/$(basename "$src_file")"$'\t'"$src_file"
@@ -848,7 +848,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.codex/uninstall.sh
+++ b/.codex/uninstall.sh
@@ -307,7 +307,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -318,7 +318,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -336,7 +336,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.copilot/install.sh
+++ b/.copilot/install.sh
@@ -5,7 +5,7 @@
 # Outputs: symlinks at ~/.copilot/agents -> .github/agents,
 #          ~/.copilot/prompts -> .github/prompts;
 #          writes shared ~/.claude/agentic-engineering.json activation config;
-#          links bin/agentic-* to ~/.local/bin;
+#          links bin/{agentic-,ds-}* to ~/.local/bin;
 #          prints the chat.hookFilesLocations VS Code setting snippet (user must add manually)
 # Side-effects: creates ~/.copilot/ if absent; writes activation config
 # Consumers: user runs manually; re-run after repo move to update absolute hook paths
@@ -248,7 +248,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.copilot/uninstall.sh
+++ b/.copilot/uninstall.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks (if they point at this repo)
+# Remove ~/.local/bin/agentic-* and ds-* symlinks (if they point at this repo)
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -73,7 +73,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -90,7 +90,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -584,7 +584,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.cursor/uninstall.sh
+++ b/.cursor/uninstall.sh
@@ -112,7 +112,7 @@ for f in "${removed_commands[@]+"${removed_commands[@]}"}"; do echo "  - $f"; do
 for f in "${skipped_commands[@]+"${skipped_commands[@]}"}"; do echo "  = $f"; done
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -123,7 +123,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -141,7 +141,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.gemini/install.sh
+++ b/.gemini/install.sh
@@ -483,7 +483,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.gemini/uninstall.sh
+++ b/.gemini/uninstall.sh
@@ -189,7 +189,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -200,7 +200,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -218,7 +218,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,13 @@ __pycache__/
 # repo's own tooling writes atomically (e.g. bin/agentic-config writing
 # AGENTS.md) - unpredictable exact name, but the <pid> suffix shape is fixed.
 *.tmp.[0-9]*
+
+# SIGKILL residue backstop for bin/tests/test_uninstall_ds_prefix.sh Test 2's
+# untracked fixture file, created directly under the real repo's bin/
+# (FIXTURE_NAME=ds-<epoch>-<pid>-<rand>-test-fixture). The EXIT/INT/TERM trap
+# already removes it on every catchable signal; this only covers the
+# uncatchable SIGKILL case so a stray fixture never gets swept into a
+# `git add -A`. The literal "-test-fixture" suffix keeps this from ever
+# masking a real future bin/ds-* tool: no shipped tool name ends in that
+# suffix, so this pattern can only ever match the test's own residue.
+bin/ds-*-test-fixture

--- a/.kimi/install.sh
+++ b/.kimi/install.sh
@@ -577,7 +577,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.kimi/uninstall.sh
+++ b/.kimi/uninstall.sh
@@ -43,7 +43,7 @@ for cmd_dir in "$REPO_DIR/.kimi/skills/"*/; do
 done
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -54,7 +54,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -72,7 +72,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.omp/install.sh
+++ b/.omp/install.sh
@@ -302,7 +302,7 @@ ae_install_bins() {
   local linked=0
   local refreshed=0
   local skipped=0
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -e "$src_file" ]] || continue
     [[ -f "$src_file" ]] || continue
     local name

--- a/.omp/uninstall.sh
+++ b/.omp/uninstall.sh
@@ -58,7 +58,7 @@ elif [[ -d "$SKILL_DST" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -69,7 +69,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -87,7 +87,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.openclaw/install.sh
+++ b/.openclaw/install.sh
@@ -354,7 +354,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.openclaw/uninstall.sh
+++ b/.openclaw/uninstall.sh
@@ -92,7 +92,7 @@ else:
 PYEOF
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -103,7 +103,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -121,7 +121,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.opencode/install.sh
+++ b/.opencode/install.sh
@@ -542,7 +542,7 @@ ae_install_bins() {
     mkdir -p "$bin_dst"
     path_created=true
   fi
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -f "$src_file" ]] || continue
     local name
     name="$(basename "$src_file")"

--- a/.opencode/uninstall.sh
+++ b/.opencode/uninstall.sh
@@ -75,7 +75,7 @@ echo "Removing command symlinks..."
 remove_symlinks "$HOME/.config/opencode/commands" "commands"
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -86,7 +86,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -104,7 +104,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/.pi/install.sh
+++ b/.pi/install.sh
@@ -290,7 +290,7 @@ ae_install_bins() {
   local linked=0
   local refreshed=0
   local skipped=0
-  for src_file in "$bin_src"/agentic-*; do
+  for src_file in "$bin_src"/agentic-* "$bin_src"/ds-*; do
     [[ -e "$src_file" ]] || continue
     [[ -f "$src_file" ]] || continue
     local name

--- a/.pi/uninstall.sh
+++ b/.pi/uninstall.sh
@@ -77,7 +77,7 @@ if [[ -d "$EXT_DST" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Remove ~/.local/bin/agentic-* symlinks
+# Remove ~/.local/bin/agentic-* and ds-* symlinks
 # ---------------------------------------------------------------------------
 
 echo "Removing bin symlinks from ~/.local/bin..."
@@ -88,7 +88,7 @@ if [[ ! -d "$BIN_DST" ]]; then
   echo "  [skip] ~/.local/bin not found"
 else
   _found_any=false
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -106,7 +106,7 @@ else
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 fi
 

--- a/bin/agentic-doctor
+++ b/bin/agentic-doctor
@@ -17,7 +17,13 @@ Purpose: Inspect global agentic-engineering install health and (with --fix)
          re-pointing it. The orphaned-hook check is read-only (FAIL only, no
          --fix repair - the fix is restoring the script or re-running
          install.sh). Never invokes install.sh, never touches real files or
-         foreign symlinks.
+         foreign symlinks. NOTE: the reverse ~/.local/bin stale-link check
+         (check_local_bin_stale) is checked-out-tree-relative, not just
+         rename-relative - on an older commit or a feature branch where a
+         given bin/ tool does not yet exist, --fix will remove the user's
+         PATH wrapper for it too. This is bounded and self-healing: the
+         wrapper is recreated by the forward check the next time --fix runs
+         against a checkout where the tool exists again.
 
 Public API: agentic-doctor [--fix] [--dry-run] [--cross-harness] [--json]
             --cross-harness: also validate the cross-harness team stack
@@ -684,6 +690,15 @@ def _stale_repo_bin_link_target(dst: Path, repo_dir: Path) -> str | None:
     Comparison is done against the realpath of <repo_dir>/bin (not the raw
     target's directory, which does not exist for a stale link) so a
     symlinked repo_dir still compares correctly.
+
+    Undocumented-until-now behavior this predicate drives: staleness is
+    relative to the CURRENT checkout state of repo_dir/bin, not solely to a
+    rename. On an older commit or a feature branch where a given tool does
+    not yet exist in bin/, a link to it reads as stale here and --fix will
+    remove the user's ~/.local/bin wrapper for it. This is bounded and
+    self-healing - check_local_bin_symlinks recreates the wrapper on a
+    later --fix run once the checkout is back on a commit where the tool
+    exists.
     """
     if not os.path.islink(str(dst)):
         return None
@@ -705,6 +720,16 @@ def check_local_bin_stale(doc: Doctor) -> None:
     now-missing <repo_dir>/bin script. See _stale_repo_bin_link_target for
     the exact ownership predicate and why it cannot touch operator-owned
     files.
+
+    Entries whose name matches a script CURRENTLY present in repo_dir/bin
+    (matching BIN_TOOL_PREFIXES) are skipped here even when their existing
+    target is broken - check_local_bin_symlinks (the forward check, run
+    immediately before this one) already owns repointing that link. Without
+    this skip, read-only/--dry-run mode reports two contradictory
+    recommendations for the same link (a forward repoint AND a reverse
+    removal); in live --fix mode the forward check has already re-pointed
+    the link by the time this function reads it, so it would silently
+    no-op here anyway - this skip only fixes the read-only/--dry-run report.
     """
     local_bin = _local_bin()
     if not local_bin.is_dir():
@@ -720,6 +745,14 @@ def check_local_bin_stale(doc: Doctor) -> None:
         return
 
     try:
+        current_names = {
+            p.name for p in bin_dir.iterdir()
+            if p.name.startswith(BIN_TOOL_PREFIXES) and p.is_file()
+        }
+    except Exception:
+        current_names = set()
+
+    try:
         entries = sorted(local_bin.iterdir())
     except Exception:
         doc.skip("local_bin_stale", local_bin, "could not read ~/.local/bin")
@@ -727,6 +760,9 @@ def check_local_bin_stale(doc: Doctor) -> None:
 
     found_stale = False
     for entry in entries:
+        if entry.name in current_names:
+            # Owned by check_local_bin_symlinks - see docstring above.
+            continue
         raw = _stale_repo_bin_link_target(entry, doc.repo_dir)
         if raw is None:
             continue

--- a/bin/agentic-doctor
+++ b/bin/agentic-doctor
@@ -3,7 +3,9 @@
 Purpose: Inspect global agentic-engineering install health and (with --fix)
          converge drift. Checks that managed symlinks under ~/.claude resolve
          into the canonical repo_dir, that ~/.local/bin/ wrappers exist for
-         each bin/agentic-* script, that hook commands in ~/.claude/settings.json
+         each bin/{agentic-,ds-}* script (BIN_TOOL_PREFIXES), that no stale
+         ~/.local/bin symlink points at a since-removed repo_dir/bin script
+         (reverse direction), that hook commands in ~/.claude/settings.json
          point into repo_dir, that every managed hook script referenced in
          settings.json actually exists on disk (orphaned-hook detection),
          and that the repo_dir pre-commit hook is wired. With --fix,
@@ -11,10 +13,11 @@ Purpose: Inspect global agentic-engineering install health and (with --fix)
          in settings.json (atomic read-merge-write); when the expected
          in-repo target for an ours-to-own symlink no longer exists at all
          (e.g. a renamed command), --fix DELETES the stale symlink from
-         ~/.claude/{agents,commands,skills} instead of re-pointing it. The
-         orphaned-hook check is read-only (FAIL only, no --fix repair - the
-         fix is restoring the script or re-running install.sh). Never
-         invokes install.sh, never touches real files or foreign symlinks.
+         ~/.claude/{agents,commands,skills} or ~/.local/bin instead of
+         re-pointing it. The orphaned-hook check is read-only (FAIL only, no
+         --fix repair - the fix is restoring the script or re-running
+         install.sh). Never invokes install.sh, never touches real files or
+         foreign symlinks.
 
 Public API: agentic-doctor [--fix] [--dry-run] [--cross-harness] [--json]
             --cross-harness: also validate the cross-harness team stack
@@ -36,7 +39,7 @@ Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, sys, tempfile)
                Reads ~/.agentic/agentic-engineering-config.json (repo_dir source),
                ~/.claude/settings.json (hook inspection/repair),
                ~/.claude/agents/, ~/.claude/commands/, ~/.claude/skills/.
-               Reads <repo_dir>/bin/agentic-* (bin wrapper check).
+               Reads <repo_dir>/bin/{agentic-,ds-}* (bin wrapper check).
                Reads <repo_dir>/.git/hooks/pre-commit (pre-commit check).
 
 Downstream consumers: developers diagnosing broken installs after cloning to a
@@ -92,6 +95,11 @@ def _managed_link_dirs() -> list[Path]:
         h / ".claude" / "commands",
         h / ".claude" / "skills" / "agentic-engineering",
     ]
+
+# Recognized bin/ tool basename prefixes. Both are checked so that a future
+# rename of the agentic-* family to ds-* (tracked separately - not done in
+# this change) does not silently drop tools from the local_bin checks below.
+BIN_TOOL_PREFIXES: tuple[str, ...] = ("agentic-", "ds-")
 
 # Basenames of hook scripts that live in <repo_dir>/hooks/.
 MANAGED_HOOK_BASENAMES: frozenset[str] = frozenset([
@@ -604,14 +612,14 @@ def check_local_bin_symlinks(doc: Doctor) -> None:
     try:
         scripts = sorted(
             p for p in bin_dir.iterdir()
-            if p.name.startswith("agentic-") and p.is_file()
+            if p.name.startswith(BIN_TOOL_PREFIXES) and p.is_file()
         )
     except Exception:
         doc.skip("local_bin", bin_dir, "could not read bin/")
         return
 
     if not scripts:
-        doc.skip("local_bin", bin_dir, "no agentic-* scripts found in repo_dir/bin")
+        doc.skip("local_bin", bin_dir, "no agentic-*/ds-* scripts found in repo_dir/bin")
         return
 
     local_bin = _local_bin()
@@ -644,6 +652,89 @@ def _check_bin_link(doc: Doctor, link: Path, expected_target: Path) -> None:
     else:
         t = str(resolved) if resolved else f"{raw} (broken)"
         doc.skip("local_bin", link, f"not ours - target {t} exists outside repo_dir")
+
+
+# ---------------------------------------------------------------------------
+# Check (d2): reverse direction - a ~/.local/bin symlink whose raw target is
+# rooted at <repo_dir>/bin but that target no longer exists (e.g. a tool
+# renamed or removed upstream, such as a future agentic-* -> ds-* rename).
+# The scan above (check_local_bin_symlinks) only walks repo/bin -> expected
+# link, so it can never notice a link left behind for a tool that vanished
+# from repo/bin entirely; this is the missing reverse direction.
+# ---------------------------------------------------------------------------
+
+
+def _stale_repo_bin_link_target(dst: Path, repo_dir: Path) -> str | None:
+    """Return the raw (unresolved) target string if dst is a stale link into
+    this repo's bin/ tree, else None.
+
+    Deliberately narrower than _is_ours(): _is_ours() treats ANY broken
+    symlink located under ~/.local/bin as reclaimable, which would be unsafe
+    here (a user's own broken symlink that happens to live in ~/.local/bin,
+    unrelated to this repo, must never be removed). This predicate instead
+    requires the symlink's own (unresolved) target text to be lexically
+    rooted at <repo_dir>/bin - i.e. it must have been created BY this repo's
+    install machinery pointing INTO this repo's bin/ - before it is
+    considered stale. It therefore cannot fire on:
+      - a real file (the os.path.islink guard)
+      - a live symlink whose target still exists (resolved is not None)
+      - a symlink pointing anywhere outside <repo_dir>/bin, broken or not
+        (including another DinoStack clone's bin/, or a wholly unrelated
+        broken symlink an operator created themselves)
+    Comparison is done against the realpath of <repo_dir>/bin (not the raw
+    target's directory, which does not exist for a stale link) so a
+    symlinked repo_dir still compares correctly.
+    """
+    if not os.path.islink(str(dst)):
+        return None
+    raw, resolved = _readlink_resolved(dst)
+    if resolved is not None:
+        return None  # target exists - not stale
+    if raw == "(unreadable)":
+        return None
+    candidate = Path(raw) if Path(raw).is_absolute() else dst.parent / raw
+    candidate_dir_r = Path(os.path.realpath(str(candidate.parent)))
+    bin_dir_r = Path(os.path.realpath(str(repo_dir / "bin")))
+    if candidate_dir_r != bin_dir_r:
+        return None
+    return raw
+
+
+def check_local_bin_stale(doc: Doctor) -> None:
+    """Detect (and with --fix, remove) ~/.local/bin symlinks that point at a
+    now-missing <repo_dir>/bin script. See _stale_repo_bin_link_target for
+    the exact ownership predicate and why it cannot touch operator-owned
+    files.
+    """
+    local_bin = _local_bin()
+    if not local_bin.is_dir():
+        doc.skip("local_bin_stale", local_bin, "~/.local/bin does not exist")
+        return
+
+    bin_dir = doc.repo_dir / "bin"
+    if not bin_dir.is_dir():
+        # repo_dir/bin itself is absent (e.g. mid-checkout or bad repo_dir) -
+        # do not treat every local_bin link as stale just because we cannot
+        # currently see the source tree.
+        doc.skip("local_bin_stale", bin_dir, "repo_dir/bin does not exist")
+        return
+
+    try:
+        entries = sorted(local_bin.iterdir())
+    except Exception:
+        doc.skip("local_bin_stale", local_bin, "could not read ~/.local/bin")
+        return
+
+    found_stale = False
+    for entry in entries:
+        raw = _stale_repo_bin_link_target(entry, doc.repo_dir)
+        if raw is None:
+            continue
+        found_stale = True
+        doc.remove_stale_symlink("local_bin_stale", entry, f"{raw} (broken)")
+
+    if not found_stale:
+        doc.ok("local_bin_stale", f"{local_bin}: no stale repo-bin symlinks")
 
 
 # ---------------------------------------------------------------------------
@@ -966,6 +1057,10 @@ def main() -> int:
 
     # (e) ~/.local/bin wrappers
     check_local_bin_symlinks(doc)
+
+    # (e2) reverse direction: stale ~/.local/bin symlinks into a now-missing
+    # repo_dir/bin script
+    check_local_bin_stale(doc)
 
     # (f) git pre-commit hook
     check_git_precommit(doc)

--- a/bin/tests/lib/precommit-hook-guard.sh
+++ b/bin/tests/lib/precommit-hook-guard.sh
@@ -1,0 +1,117 @@
+# shellcheck shell=bash
+# ---------------------------------------------------------------------------
+# Purpose: Shared save/restore guard for bin/tests/*.sh scripts that run a
+#          REAL adapter uninstall.sh (or install.sh) against the live repo
+#          checkout - REPO_DIR unfaked - while only $HOME is sandboxed.
+#          scripts/lib/precommit.sh resolves the git hooks directory via
+#          `git -C <repo_dir> rev-parse --git-path hooks`, which is entirely
+#          independent of $HOME. A test that fakes only $HOME still lets
+#          uninstall_precommit_hook delete this checkout's REAL
+#          <repo>/.git/hooks/pre-commit symlink (or, from inside a linked
+#          worktree, the common repo's hooks dir) - the deletion is never
+#          restored on its own. This guard snapshots the real hook before
+#          the run and restores it unconditionally afterward via the
+#          caller's own EXIT trap.
+#
+# Public API:
+#   precommit_hook_guard_save <repo_dir>
+#     Resolves the real git hooks dir for <repo_dir> and snapshots
+#     <hooks_dir>/pre-commit: whether it exists, its symlink target (if a
+#     symlink), or a byte-for-byte backup copy (if a regular file). Sets
+#     the module-global _PCG_* state consumed by
+#     precommit_hook_guard_restore. Safe to call when no hook exists, and
+#     safe to call when hooks-dir resolution fails (not a git repo) - both
+#     are treated as "nothing to protect".
+#
+#   precommit_hook_guard_restore
+#     Restores whatever precommit_hook_guard_save observed: re-creates the
+#     symlink, restores the backed-up regular file, or removes whatever is
+#     there now if nothing existed before the save. Idempotent - safe to
+#     call even if the hook was never mutated, and safe to call more than
+#     once (a second call is a no-op once state has been consumed). Removes
+#     its own temp backup file. Never aborts under `set -uo pipefail` - all
+#     conditionals use `[[ ]]` with explicit defaults.
+#
+# Upstream dependencies: git, mktemp, cp, readlink, ln. Depends on the
+#   caller having already sourced this file before calling either function.
+#
+# Downstream consumers: bin/tests/test_uninstall_ds_prefix.sh,
+#   bin/tests/test_hooks_snapshot_migration.sh (both invoke a real
+#   .claude/uninstall.sh against the live checkout with only $HOME faked).
+#
+# Failure modes: if `git rev-parse --git-path hooks` fails to resolve (not
+#   a git repo, git missing), save/restore are no-ops - there is nothing to
+#   protect in that case, consistent with scripts/lib/precommit.sh's own
+#   non-fatal failure mode.
+#
+# Performance: one `git rev-parse` + at most one `cp` per save call.
+# ---------------------------------------------------------------------------
+
+_PCG_HOOK_PATH=""
+_PCG_EXISTED=0
+_PCG_SYMLINK_TARGET=""
+_PCG_BACKUP_FILE=""
+
+# ---------------------------------------------------------------------------
+# precommit_hook_guard_save <repo_dir>
+#   See "Public API" above.
+# ---------------------------------------------------------------------------
+precommit_hook_guard_save() {
+  local repo_dir="$1"
+  local hooks_dir
+
+  _PCG_HOOK_PATH=""
+  _PCG_EXISTED=0
+  _PCG_SYMLINK_TARGET=""
+  _PCG_BACKUP_FILE=""
+
+  if ! hooks_dir="$(git -C "$repo_dir" rev-parse --git-path hooks 2>/dev/null)" || [[ -z "$hooks_dir" ]]; then
+    return 0
+  fi
+
+  # Same normalisation as scripts/lib/precommit.sh's resolve_git_hooks_dir:
+  # --git-path is relative in a normal checkout, absolute from a worktree.
+  case "$hooks_dir" in
+    /*) : ;;
+    *) hooks_dir="$repo_dir/$hooks_dir" ;;
+  esac
+
+  _PCG_HOOK_PATH="$hooks_dir/pre-commit"
+
+  if [[ -L "$_PCG_HOOK_PATH" ]]; then
+    _PCG_EXISTED=1
+    _PCG_SYMLINK_TARGET="$(readlink "$_PCG_HOOK_PATH")"
+  elif [[ -e "$_PCG_HOOK_PATH" ]]; then
+    _PCG_EXISTED=1
+    _PCG_BACKUP_FILE="$(mktemp)"
+    cp -p "$_PCG_HOOK_PATH" "$_PCG_BACKUP_FILE"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# precommit_hook_guard_restore
+#   See "Public API" above.
+# ---------------------------------------------------------------------------
+precommit_hook_guard_restore() {
+  if [[ -z "$_PCG_HOOK_PATH" ]]; then
+    return 0
+  fi
+
+  if [[ "$_PCG_EXISTED" -eq 1 ]]; then
+    if [[ -n "$_PCG_SYMLINK_TARGET" ]]; then
+      ln -sfn "$_PCG_SYMLINK_TARGET" "$_PCG_HOOK_PATH"
+    elif [[ -n "$_PCG_BACKUP_FILE" && -f "$_PCG_BACKUP_FILE" ]]; then
+      cp -p "$_PCG_BACKUP_FILE" "$_PCG_HOOK_PATH"
+    fi
+  else
+    if [[ -e "$_PCG_HOOK_PATH" || -L "$_PCG_HOOK_PATH" ]]; then
+      rm -f "$_PCG_HOOK_PATH"
+    fi
+  fi
+
+  if [[ -n "$_PCG_BACKUP_FILE" && -f "$_PCG_BACKUP_FILE" ]]; then
+    rm -f "$_PCG_BACKUP_FILE"
+  fi
+  _PCG_BACKUP_FILE=""
+  _PCG_HOOK_PATH=""
+}

--- a/bin/tests/test_agentic_doctor_ds_prefix.sh
+++ b/bin/tests/test_agentic_doctor_ds_prefix.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Purpose: Regression tests for the prefix-agnostic ~/.local/bin machinery in
+#          bin/agentic-doctor - forward discovery of both agentic-* and ds-*
+#          tools (BIN_TOOL_PREFIXES), plus the reverse-direction stale-link
+#          detection/removal (check_local_bin_stale) added alongside it.
+#          This is machinery for a LATER agentic-* -> ds-* rename; no tool
+#          is actually renamed here.
+#
+# Public API: ./bin/tests/test_agentic_doctor_ds_prefix.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, mktemp, ln, readlink.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       the bin-sh-tests CI job via the bin/tests/test_*.sh
+#                       glob (.github/workflows/bin-tests.yml).
+#
+# Failure modes: any test failure prints the failing assertion and exits 1.
+#                Tests use isolated TEMP_HOME dirs with a fake ~/.claude,
+#                fake ~/.agentic, and a fake repo bin/ - NEVER points at the
+#                real ~/.claude or ~/.local/bin.
+#
+# Performance: <2 s wall time on a developer machine.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DOCTOR="$SCRIPT_DIR/agentic-doctor"
+
+if [[ ! -x "$DOCTOR" ]]; then
+  echo "FAIL: $DOCTOR not executable" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a fake DinoStack-looking repo with a bin/ dir containing both an
+# agentic-* and a ds-* tool, plus a fake HOME with ~/.agentic config pointing
+# at it. local_bin (~/.local/bin) starts out empty unless a test populates it.
+# ---------------------------------------------------------------------------
+setup_fixture() {
+  TEMP_HOME="$(mktemp -d)"
+  FAKE_REPO="$TEMP_HOME/fake-DinoStack"
+  REAL_FAKE_REPO="$(python3 -c "import os; print(os.path.realpath('$FAKE_REPO'))")"
+
+  mkdir -p "$FAKE_REPO/.git" "$FAKE_REPO/bin"
+
+  # An existing agentic-* tool and a NEW ds-* tool, both real executable files.
+  cat > "$FAKE_REPO/bin/agentic-kept" <<'EOF'
+#!/usr/bin/env bash
+echo kept
+EOF
+  chmod +x "$FAKE_REPO/bin/agentic-kept"
+
+  cat > "$FAKE_REPO/bin/ds-newtool" <<'EOF'
+#!/usr/bin/env bash
+echo newtool
+EOF
+  chmod +x "$FAKE_REPO/bin/ds-newtool"
+
+  # A non-tool file that must NEVER be picked up by either prefix scan.
+  cat > "$FAKE_REPO/bin/_lib.py" <<'EOF'
+# shared helper, not a CLI entry point
+EOF
+
+  mkdir -p "$TEMP_HOME/.agentic"
+  cat > "$TEMP_HOME/.agentic/agentic-engineering-config.json" <<EOF
+{
+  "repo_dir": "$FAKE_REPO"
+}
+EOF
+}
+
+invoke_doctor() {
+  (
+    HOME="$TEMP_HOME"
+    export HOME
+    python3 "$DOCTOR" "$@"
+  ) > "$TEMP_HOME/.out" 2>&1
+  echo $? > "$TEMP_HOME/.exit"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: read-only scan discovers BOTH agentic-kept and ds-newtool as
+# missing ~/.local/bin links (proves prefix-agnostic forward discovery -
+# goal (b) - and that a non-prefixed file like _lib.py is never surfaced).
+# ---------------------------------------------------------------------------
+setup_fixture
+invoke_doctor
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T1: read-only exits 1 (missing local_bin links are findings)"
+else
+  _fail "T1: expected exit 1, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "FIX symlink:.*agentic-kept.*(missing)"; then
+  _pass "T1: agentic-kept discovered as a missing local_bin link"
+else
+  _fail "T1: agentic-kept not reported as missing\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "FIX symlink:.*ds-newtool.*(missing)"; then
+  _pass "T1: ds-newtool (ds-* prefix) discovered as a missing local_bin link"
+else
+  _fail "T1: ds-newtool not reported as missing - prefix-agnostic discovery broken\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "_lib.py"; then
+  _fail "T1: _lib.py must never be surfaced by the bin tool scan\n$OUT"
+else
+  _pass "T1: _lib.py correctly excluded from the bin tool scan"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 2: --fix creates ~/.local/bin symlinks for BOTH prefixes.
+# ---------------------------------------------------------------------------
+setup_fixture
+invoke_doctor --fix
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" || "$RC" == "2" ]]; then
+  _pass "T2: --fix exits 0 or 2 (fix ran)"
+else
+  _fail "T2: expected exit 0 or 2, got $RC\n$OUT"
+fi
+
+KEPT_TARGET="$(readlink "$TEMP_HOME/.local/bin/agentic-kept" 2>/dev/null || echo "(not a link)")"
+if [[ "$KEPT_TARGET" == "$FAKE_REPO/bin/agentic-kept" || "$KEPT_TARGET" == "$REAL_FAKE_REPO/bin/agentic-kept" ]]; then
+  _pass "T2: agentic-kept linked into ~/.local/bin"
+else
+  _fail "T2: agentic-kept link target is '$KEPT_TARGET'"
+fi
+
+DS_TARGET="$(readlink "$TEMP_HOME/.local/bin/ds-newtool" 2>/dev/null || echo "(not a link)")"
+if [[ "$DS_TARGET" == "$FAKE_REPO/bin/ds-newtool" || "$DS_TARGET" == "$REAL_FAKE_REPO/bin/ds-newtool" ]]; then
+  _pass "T2: ds-newtool linked into ~/.local/bin (ds-* prefix)"
+else
+  _fail "T2: ds-newtool link target is '$DS_TARGET' - prefix-agnostic install repair broken"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 3: reverse-direction stale detection - a ~/.local/bin symlink whose
+# raw target is rooted at repo_dir/bin but the target file no longer exists
+# there is detected read-only, then removed by --fix, then a second
+# read-only run exits 0 (idempotent).
+# ---------------------------------------------------------------------------
+setup_fixture
+mkdir -p "$TEMP_HOME/.local/bin"
+ln -s "$FAKE_REPO/bin/agentic-removed" "$TEMP_HOME/.local/bin/agentic-removed"
+# Deliberately do NOT create $FAKE_REPO/bin/agentic-removed - simulates a
+# tool that was renamed/removed upstream (the future ds-* rename scenario).
+
+invoke_doctor
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "1" ]]; then
+  _pass "T3 read-only: stale reverse link is a finding (exits 1)"
+else
+  _fail "T3 read-only: expected exit 1, got $RC\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "FIX symlink:.*agentic-removed.*(removed, stale)"; then
+  _pass "T3 read-only: stale reverse link reported as removal candidate"
+else
+  _fail "T3 read-only: expected a '(removed, stale)' FIX line for agentic-removed\n$OUT"
+fi
+
+rm -rf "$TEMP_HOME"
+
+setup_fixture
+mkdir -p "$TEMP_HOME/.local/bin"
+ln -s "$FAKE_REPO/bin/agentic-removed" "$TEMP_HOME/.local/bin/agentic-removed"
+
+invoke_doctor --fix
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ -L "$TEMP_HOME/.local/bin/agentic-removed" || -e "$TEMP_HOME/.local/bin/agentic-removed" ]]; then
+  _fail "T3 --fix: agentic-removed should have been removed, but still exists"
+else
+  _pass "T3 --fix: stale reverse link was removed"
+fi
+
+# Second read-only run after --fix: this stale link is gone, but agentic-kept
+# and ds-newtool are STILL missing from ~/.local/bin in this fixture (only
+# --fix was run once, on the removal target), so a full exit-0 assertion
+# would be a false negative. Assert narrowly: no local_bin_stale finding
+# remains for agentic-removed specifically.
+invoke_doctor
+OUT2=$(cat "$TEMP_HOME/.out")
+if echo "$OUT2" | grep -q "agentic-removed"; then
+  _fail "T3 idempotent: agentic-removed still appears in output after removal\n$OUT2"
+else
+  _pass "T3 idempotent: agentic-removed no longer appears (link fully gone, not recreated)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 4: reverse-direction safety - a real file, a live symlink pointing
+# elsewhere, and a broken symlink pointing OUTSIDE repo_dir/bin must never
+# be removed by check_local_bin_stale, even under --fix.
+# ---------------------------------------------------------------------------
+setup_fixture
+mkdir -p "$TEMP_HOME/.local/bin"
+
+# A real file (never a symlink) - must be left alone entirely.
+printf 'real content\n' > "$TEMP_HOME/.local/bin/realfile"
+
+# A live symlink pointing at an existing file OUTSIDE the repo - untouched.
+EXTERNAL_DIR="$TEMP_HOME/external"
+mkdir -p "$EXTERNAL_DIR"
+printf 'external\n' > "$EXTERNAL_DIR/thing"
+ln -s "$EXTERNAL_DIR/thing" "$TEMP_HOME/.local/bin/usertool"
+
+# A BROKEN symlink whose target does NOT exist and is NOT rooted at
+# repo_dir/bin (an operator's own unrelated broken link). Must be left
+# alone - this is the case _is_ours() alone would have wrongly reclaimed.
+ln -s "/nonexistent/elsewhere/thing" "$TEMP_HOME/.local/bin/foreigntool"
+
+invoke_doctor --fix
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ -f "$TEMP_HOME/.local/bin/realfile" ]] && [[ ! -L "$TEMP_HOME/.local/bin/realfile" ]]; then
+  CONTENT="$(cat "$TEMP_HOME/.local/bin/realfile")"
+  if [[ "$CONTENT" == "real content" ]]; then
+    _pass "T4: real file untouched by --fix"
+  else
+    _fail "T4: real file content changed"
+  fi
+else
+  _fail "T4: real file was removed or replaced by --fix"
+fi
+
+USERTOOL_TARGET="$(readlink "$TEMP_HOME/.local/bin/usertool" 2>/dev/null || echo "(removed)")"
+if [[ "$USERTOOL_TARGET" == "$EXTERNAL_DIR/thing" ]]; then
+  _pass "T4: live symlink pointing elsewhere untouched by --fix"
+else
+  _fail "T4: usertool symlink was changed/removed: '$USERTOOL_TARGET'"
+fi
+
+FOREIGN_TARGET="$(readlink "$TEMP_HOME/.local/bin/foreigntool" 2>/dev/null || echo "(removed)")"
+if [[ "$FOREIGN_TARGET" == "/nonexistent/elsewhere/thing" ]]; then
+  _pass "T4: broken symlink pointing outside repo_dir/bin untouched by --fix"
+else
+  _fail "T4: foreigntool (broken, non-repo target) was removed - unsafe over-reach: '$FOREIGN_TARGET'"
+fi
+
+if echo "$OUT" | grep -qE "(FIX|FAIL).*realfile"; then
+  _fail "T4: real file must never appear as a FIX/FAIL finding\n$OUT"
+else
+  _pass "T4: real file never appears as a FIX/FAIL finding"
+fi
+
+if echo "$OUT" | grep -qE "(FIX|FAIL).*foreigntool"; then
+  _fail "T4: foreign broken symlink must never appear as a FIX/FAIL finding\n$OUT"
+else
+  _pass "T4: foreign broken symlink never appears as a FIX/FAIL finding"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_agentic_doctor_ds_prefix.sh
+++ b/bin/tests/test_agentic_doctor_ds_prefix.sh
@@ -282,6 +282,74 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
+# Test 5: the "owned by the forward check" skip in check_local_bin_stale
+# (bin/agentic-doctor ~lines 724-732) must suppress the DUPLICATE reverse
+# recommendation for a link whose name matches a script still present in
+# repo_dir/bin, while leaving the forward check's own repoint recommendation
+# and repair intact.
+#
+# Fixture: ~/.local/bin/agentic-kept exists as a symlink whose raw target is
+# a DIFFERENT, missing path under repo_dir/bin (agentic-kept-old, never
+# created) - not the live repo_dir/bin/agentic-kept from setup_fixture. This
+# is the only shape that reaches BOTH checks: the forward check
+# (check_local_bin_symlinks) sees agentic-kept resolved != expected and
+# recommends a repoint; the reverse check (check_local_bin_stale), absent
+# its skip, would ALSO see a broken symlink whose raw target is lexically
+# rooted at repo_dir/bin and recommend a removal for the very same link.
+# ---------------------------------------------------------------------------
+setup_fixture
+mkdir -p "$TEMP_HOME/.local/bin"
+ln -s "$FAKE_REPO/bin/agentic-kept-old" "$TEMP_HOME/.local/bin/agentic-kept"
+# Deliberately do NOT create $FAKE_REPO/bin/agentic-kept-old.
+
+invoke_doctor
+OUT=$(cat "$TEMP_HOME/.out")
+
+AGENTIC_KEPT_FIX_COUNT=$(echo "$OUT" | grep -c "FIX symlink:.*/agentic-kept ")
+if [[ "$AGENTIC_KEPT_FIX_COUNT" == "1" ]]; then
+  _pass "T5 read-only: exactly one FIX recommendation for agentic-kept (no duplicate)"
+else
+  _fail "T5 read-only: expected exactly 1 FIX recommendation for agentic-kept, got $AGENTIC_KEPT_FIX_COUNT\n$OUT"
+fi
+
+if echo "$OUT" | grep -qE "FIX symlink:.*/agentic-kept .*-> ($FAKE_REPO|$REAL_FAKE_REPO)/bin/agentic-kept$"; then
+  _pass "T5 read-only: the one recommendation is the forward repoint, not a removal"
+else
+  _fail "T5 read-only: expected a forward repoint FIX line for agentic-kept\n$OUT"
+fi
+
+if echo "$OUT" | grep -q "FIX symlink:.*/agentic-kept .*(removed, stale)"; then
+  _fail "T5 read-only: reverse check emitted a duplicate '(removed, stale)' recommendation for agentic-kept - the owned-by-forward-check skip is missing or broken\n$OUT"
+else
+  _pass "T5 read-only: no duplicate '(removed, stale)' recommendation for agentic-kept"
+fi
+
+rm -rf "$TEMP_HOME"
+
+setup_fixture
+mkdir -p "$TEMP_HOME/.local/bin"
+ln -s "$FAKE_REPO/bin/agentic-kept-old" "$TEMP_HOME/.local/bin/agentic-kept"
+
+invoke_doctor --fix
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+
+if [[ "$RC" == "0" || "$RC" == "2" ]]; then
+  _pass "T5 --fix: exits 0 or 2 (fix ran)"
+else
+  _fail "T5 --fix: expected exit 0 or 2, got $RC\n$OUT"
+fi
+
+AGENTIC_KEPT_TARGET="$(readlink "$TEMP_HOME/.local/bin/agentic-kept" 2>/dev/null || echo "(removed)")"
+if [[ "$AGENTIC_KEPT_TARGET" == "$FAKE_REPO/bin/agentic-kept" || "$AGENTIC_KEPT_TARGET" == "$REAL_FAKE_REPO/bin/agentic-kept" ]]; then
+  _pass "T5 --fix: agentic-kept end state is REPOINTED at the live script (not removed)"
+else
+  _fail "T5 --fix: agentic-kept end state is '$AGENTIC_KEPT_TARGET' - expected a repoint to $FAKE_REPO/bin/agentic-kept, not a removal. If this failed, --fix removed a link that should have been repointed - the reverse check ran ahead of, or instead of, the forward check's repair."
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 echo

--- a/bin/tests/test_hooks_snapshot_migration.sh
+++ b/bin/tests/test_hooks_snapshot_migration.sh
@@ -18,9 +18,18 @@
 #                1. A temporary fake HOME is used per adapter; the real
 #                ~/.claude, ~/.codex, ~/.gemini, ~/.kimi, and
 #                ~/.agentic/hooks-snapshot are never touched. Each adapter's
-#                install.sh still builds against the REAL checkout (like
-#                bin/tests/test_kimi_install_symlink.sh) - only $HOME is
-#                sandboxed.
+#                install.sh/uninstall.sh still builds/runs against the REAL
+#                checkout (like bin/tests/test_kimi_install_symlink.sh) -
+#                only $HOME is sandboxed. The one exception: the .claude
+#                section's uninstall.sh run (below) also calls
+#                uninstall_precommit_hook, which resolves the git hooks
+#                directory via `git rev-parse --git-path hooks` relative to
+#                the REAL REPO_DIR, independent of $HOME faking - left
+#                unguarded it would remove this checkout's real
+#                <repo>/.git/hooks/pre-commit. That single call is saved
+#                before and restored immediately after via
+#                bin/tests/lib/precommit-hook-guard.sh (same guard used by
+#                bin/tests/test_uninstall_ds_prefix.sh).
 #
 # Performance: ~20-40 s wall time (4 adapters x 2 install.sh runs each,
 #              each run includes a real build.sh pass).
@@ -28,6 +37,9 @@
 set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 PASS=0
 FAIL=0
@@ -43,8 +55,11 @@ _pass() {
 }
 
 TMP_ROOT="$(mktemp -d)"
-_cleanup() { rm -rf "$TMP_ROOT"; }
-trap _cleanup EXIT
+_cleanup() {
+  rm -rf "$TMP_ROOT"
+  precommit_hook_guard_restore
+}
+trap _cleanup EXIT INT TERM
 
 _run_install() {
   local install_sh="$1"
@@ -175,9 +190,16 @@ cat > "$HOME_CLAUDE_UNINSTALL/.claude/settings.json" <<'EOF'
 }
 EOF
 
+# uninstall_precommit_hook (called by .claude/uninstall.sh) resolves the
+# git hooks dir independent of $HOME - save/restore the real checkout's
+# pre-commit hook around this one call (see header and
+# bin/tests/lib/precommit-hook-guard.sh).
+precommit_hook_guard_save "$REPO_DIR"
 if HOME="$HOME_CLAUDE_UNINSTALL" bash "$REPO_DIR/.claude/uninstall.sh" > "$HOME_CLAUDE_UNINSTALL/.uninstall_out" 2>&1; then
+  precommit_hook_guard_restore
   _pass "claude: uninstall.sh run succeeds"
 else
+  precommit_hook_guard_restore
   _fail "claude: uninstall.sh exited non-zero"
   cat "$HOME_CLAUDE_UNINSTALL/.uninstall_out" >&2
 fi

--- a/bin/tests/test_hooks_snapshot_migration.sh
+++ b/bin/tests/test_hooks_snapshot_migration.sh
@@ -20,16 +20,26 @@
 #                ~/.agentic/hooks-snapshot are never touched. Each adapter's
 #                install.sh/uninstall.sh still builds/runs against the REAL
 #                checkout (like bin/tests/test_kimi_install_symlink.sh) -
-#                only $HOME is sandboxed. The one exception: the .claude
-#                section's uninstall.sh run (below) also calls
-#                uninstall_precommit_hook, which resolves the git hooks
-#                directory via `git rev-parse --git-path hooks` relative to
-#                the REAL REPO_DIR, independent of $HOME faking - left
-#                unguarded it would remove this checkout's real
-#                <repo>/.git/hooks/pre-commit. That single call is saved
-#                before and restored immediately after via
+#                only $HOME is sandboxed, and these real-tree effects are
+#                NOT limited to the .claude uninstall.sh call: EVERY
+#                install.sh run in this file (.claude, .gemini, .codex,
+#                .kimi - each invoked twice, first run and idempotent
+#                second run) calls install_precommit_hook (writes
+#                <repo>/.git/hooks/pre-commit) and runs .claude/build.sh +
+#                .cursor/build.sh (regenerates adapter build artifacts in
+#                the live tree) - same three effects documented in
+#                bin/tests/test_local_bin_ds_prefix_install.sh; empirically
+#                idempotent, but none of these runs are read-only. On top
+#                of that, the .claude section's uninstall.sh run (below)
+#                also calls uninstall_precommit_hook, which resolves the
+#                git hooks directory via `git rev-parse --git-path hooks`
+#                relative to the REAL REPO_DIR, independent of $HOME faking
+#                - left unguarded it would remove this checkout's real
+#                <repo>/.git/hooks/pre-commit. That call is saved before
+#                and restored immediately after via
 #                bin/tests/lib/precommit-hook-guard.sh (same guard used by
-#                bin/tests/test_uninstall_ds_prefix.sh).
+#                bin/tests/test_uninstall_ds_prefix.sh); the guard does not
+#                cover the earlier install.sh pre-commit-hook writes above.
 #
 # Performance: ~20-40 s wall time (4 adapters x 2 install.sh runs each,
 #              each run includes a real build.sh pass).

--- a/bin/tests/test_local_bin_ds_prefix_install.sh
+++ b/bin/tests/test_local_bin_ds_prefix_install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Purpose: Regression tests for the prefix-agnostic ~/.local/bin symlink glob
+#          in every adapter install.sh (goal (a) of the agentic-* -> ds-*
+#          rename-safety machinery). No tool is renamed by this change; these
+#          tests only prove the install glob would pick up a ds-* named tool
+#          if one existed.
+#
+# Public API: ./bin/tests/test_local_bin_ds_prefix_install.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, mktemp, grep.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       the bin-sh-tests CI job via the bin/tests/test_*.sh
+#                       glob (.github/workflows/bin-tests.yml).
+#
+# Failure modes: any assertion failure prints the failing assertion and
+#                exits 1. Test 2 creates one temporary untracked file under
+#                the real repo's bin/ (bin/ds-<random>-test-fixture) and
+#                removes it via an EXIT trap - never leaves a residual file,
+#                never modifies a tracked file. Test 1/3 are read-only.
+#
+# Performance: ~3 s wall time on a developer machine (one real install.sh run).
+#
+# Regression coverage:
+#   - Test 1 (structural): each of the 12 known glob sites across the 11
+#     adapter install.sh scripts (10 single-loop adapters + .cursor + the
+#     TWO loops in .codex/install.sh) matches both "agentic-*" and "ds-*".
+#     Catches a site left un-updated by name/line, not just aggregate count.
+#   - Test 2 (functional): .claude/install.sh, run end-to-end against a fake
+#     HOME but the REAL repo bin/, actually symlinks a ds-*-named fixture
+#     tool into ~/.local/bin alongside a real agentic-* tool.
+#   - Test 3 (exclusion): the glob must not sweep in bin/tests/ or a
+#     non-executable helper module (bin/_lib.py-style file).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN_DIR="$REPO_DIR/bin"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1 (structural): every known glob site matches BOTH prefixes.
+# One (file, expected-occurrence-count) pair per adapter; .codex/install.sh
+# carries two independent loops and so expects 2.
+# ---------------------------------------------------------------------------
+declare -a SITES=(
+  ".claude/install.sh:1"
+  ".cursor/install.sh:1"
+  ".gemini/install.sh:1"
+  ".opencode/install.sh:1"
+  ".omp/install.sh:1"
+  ".kimi/install.sh:1"
+  ".pi/install.sh:1"
+  ".codex/install.sh:2"
+  ".copilot/install.sh:1"
+  ".openclaw/install.sh:1"
+)
+
+for entry in "${SITES[@]}"; do
+  file="${entry%%:*}"
+  expected="${entry##*:}"
+  # NOTE: do not name this variable "path" - it is a special zsh parameter
+  # tied to $PATH (assigning to it silently replaces PATH and breaks every
+  # subsequent command lookup, e.g. "grep: command not found", when this
+  # script is run under zsh). Use site_file instead.
+  site_file="$REPO_DIR/$file"
+  if [[ ! -f "$site_file" ]]; then
+    _fail "T1: $file not found"
+    continue
+  fi
+  # Match both the plain "$bin_src"/agentic-* / ds-* form and the
+  # .codex-specific "$REPO_DIR"/bin/agentic-* / ds-* form on the same line.
+  count="$(grep -cE 'agentic-\*[^;]*ds-\*' "$site_file" || true)"
+  if [[ "$count" -eq "$expected" ]]; then
+    _pass "T1: $file has $expected prefix-agnostic glob site(s)"
+  else
+    _fail "T1: $file expected $expected prefix-agnostic glob site(s), found $count"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 2 (functional): .claude/install.sh actually symlinks a ds-*-prefixed
+# tool. Uses the REAL repo bin/ (so REPO_DIR resolution inside install.sh
+# needs no faking) with one temporary untracked fixture file, cleaned up on
+# exit regardless of outcome.
+# ---------------------------------------------------------------------------
+FIXTURE_NAME="ds-$(date +%s)-test-fixture"
+FIXTURE_PATH="$BIN_DIR/$FIXTURE_NAME"
+FAKE_HOME=""
+
+_cleanup() {
+  [[ -n "$FIXTURE_PATH" && -f "$FIXTURE_PATH" ]] && rm -f "$FIXTURE_PATH"
+  [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]] && rm -rf "$FAKE_HOME"
+}
+trap _cleanup EXIT
+
+cat > "$FIXTURE_PATH" <<'EOF'
+#!/usr/bin/env bash
+echo ds-fixture
+EOF
+chmod +x "$FIXTURE_PATH"
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.agentic"
+
+HOME="$FAKE_HOME" bash "$REPO_DIR/.claude/install.sh" --mode=opt-out --profile=default \
+  < /dev/null > "$FAKE_HOME/.install_out" 2>&1
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  _fail "T2: .claude/install.sh exited $RC"
+  cat "$FAKE_HOME/.install_out" >&2
+fi
+
+DS_TARGET="$(readlink "$FAKE_HOME/.local/bin/$FIXTURE_NAME" 2>/dev/null || echo "(not a link)")"
+if [[ "$DS_TARGET" == "$FIXTURE_PATH" ]]; then
+  _pass "T2: ds-*-prefixed fixture tool symlinked into ~/.local/bin by install.sh"
+else
+  _fail "T2: expected ~/.local/bin/$FIXTURE_NAME -> $FIXTURE_PATH, got '$DS_TARGET'"
+fi
+
+# Sanity: a real agentic-* tool (agentic-doctor) is still symlinked too -
+# guards against a mutation that swaps prefixes instead of adding one.
+AGENTIC_TARGET="$(readlink "$FAKE_HOME/.local/bin/agentic-doctor" 2>/dev/null || echo "(not a link)")"
+if [[ "$AGENTIC_TARGET" == "$BIN_DIR/agentic-doctor" ]]; then
+  _pass "T2: existing agentic-* tool (agentic-doctor) still symlinked"
+else
+  _fail "T2: agentic-doctor not symlinked as expected: '$AGENTIC_TARGET'"
+fi
+
+rm -f "$FIXTURE_PATH"
+rm -rf "$FAKE_HOME"
+FAKE_HOME=""
+FIXTURE_PATH=""
+
+# ---------------------------------------------------------------------------
+# Test 3 (exclusion): the glob must never sweep in bin/tests/ (a directory)
+# or a non-prefixed helper file (bin/_lib.py) - re-verify the [[ -f ]] guard
+# and prefix filter are both still present at the .claude/install.sh site.
+# ---------------------------------------------------------------------------
+if [[ -f "$REPO_DIR/bin/_lib.py" ]]; then
+  if grep -A2 'for src_file in "\$bin_src"/agentic-\* "\$bin_src"/ds-\*; do' "$REPO_DIR/.claude/install.sh" \
+     | grep -q '\[\[ -f "\$src_file" \]\]'; then
+    _pass "T3: .claude/install.sh glob loop still guards on [[ -f ]] (excludes bin/tests/ directory)"
+  else
+    _fail "T3: .claude/install.sh glob loop is missing its [[ -f ]] guard"
+  fi
+else
+  _fail "T3: bin/_lib.py fixture not found - cannot verify exclusion guard context"
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_local_bin_ds_prefix_install.sh
+++ b/bin/tests/test_local_bin_ds_prefix_install.sh
@@ -17,15 +17,23 @@
 # Failure modes: any assertion failure prints the failing assertion and
 #                exits 1. Test 2 creates one temporary untracked file under
 #                the real repo's bin/ (bin/ds-<random>-test-fixture) and
-#                removes it via an EXIT trap - never leaves a residual file,
-#                never modifies a tracked file. Test 1/3 are read-only.
+#                removes it via an EXIT trap - never leaves a residual file
+#                itself, but it runs the REAL .claude/install.sh against the
+#                live repo tree with only HOME faked: that installer calls
+#                install_precommit_hook (writes <repo>/.git/hooks/pre-commit)
+#                and runs .claude/build.sh + .cursor/build.sh (regenerates
+#                adapter build artifacts in the live tree). These three
+#                effects are outside the faked HOME and land on the real
+#                checkout; empirically idempotent, but Test 2 is NOT
+#                read-only. Test 1/3 are read-only.
 #
 # Performance: ~3 s wall time on a developer machine (one real install.sh run).
 #
 # Regression coverage:
-#   - Test 1 (structural): each of the 12 known glob sites across the 11
-#     adapter install.sh scripts (10 single-loop adapters + .cursor + the
-#     TWO loops in .codex/install.sh) matches both "agentic-*" and "ds-*".
+#   - Test 1 (structural): each of the 11 known glob sites across the 10
+#     adapter install.sh scripts that manage bin/ symlinks (9 single-loop
+#     adapters + the TWO loops in .codex/install.sh; .hermes/install.sh
+#     manages no bins and is excluded) matches both "agentic-*" and "ds-*".
 #     Catches a site left un-updated by name/line, not just aggregate count.
 #   - Test 2 (functional): .claude/install.sh, run end-to-end against a fake
 #     HOME but the REAL repo bin/, actually symlinks a ds-*-named fixture

--- a/bin/tests/test_uninstall_bin_symlink.sh
+++ b/bin/tests/test_uninstall_bin_symlink.sh
@@ -1,28 +1,49 @@
 #!/usr/bin/env bash
-# Purpose: Regression test for the ~/.local/bin/agentic-* symlink removal guard
-#          added to all adapter uninstall.sh scripts.
+# Purpose: Regression test for the ~/.local/bin/agentic-*/ds-* symlink removal
+#          guard added to all adapter uninstall.sh scripts. run_bin_guard is a
+#          verbatim mirror of the for-loop block in .claude/uninstall.sh - see
+#          Test 5, which mechanically enforces that the mirror cannot silently
+#          drift from the production block again the way it did once already
+#          (round 1 widened the production glob to ds-* and left this mirror
+#          on the old single agentic-* glob with no gate to catch it).
 #
 # Public API: ./bin/tests/test_uninstall_bin_symlink.sh
 #             Exits 0 on all pass, 1 on any failure.
 #
-# Upstream deps: bash, mktemp.
+# Upstream deps: bash, mktemp, git, awk.
 #
 # Downstream consumers: developer running locally before commit; CI.
 #
 # Failure modes: any assertion failure prints the failing assertion and exits 1.
 #                A temporary fake HOME and fake repo dir are used; the real
-#                ~/.local/bin is never touched.
+#                ~/.local/bin is never touched. Test 5 reads (never writes)
+#                the real .claude/uninstall.sh and this file's own source.
 #
 # Performance: < 1 s wall time (pure shell, no network).
 #
 # Regression coverage:
-#   - fix(uninstall): remove ~/.local/bin/agentic-* symlinks pointing into the repo
-#     The guard must require a $REPO_DIR/bin/ prefix, not just $REPO_DIR, so a
-#     sibling checkout under $REPO_DIR-backup/bin/ is NOT removed. The sibling-
-#     prefix test would FAIL under the original loose guard `"$REPO_DIR"*` and
-#     must PASS after the `/bin/` boundary fix.
+#   - fix(uninstall): remove ~/.local/bin/agentic-*/ds-* symlinks pointing
+#     into the repo. The guard must require a $REPO_DIR/bin/ prefix, not just
+#     $REPO_DIR, so a sibling checkout under $REPO_DIR-backup/bin/ is NOT
+#     removed. The sibling-prefix test would FAIL under the original loose
+#     guard `"$REPO_DIR"*` and must PASS after the `/bin/` boundary fix.
+#   - Test 5 (mirror-sync guard): run_bin_guard's for-loop body must be
+#     byte-identical (modulo leading/trailing whitespace) to the current
+#     production for-loop block in .claude/uninstall.sh, so a future glob or
+#     ownership-guard change to production that is not mirrored here fails
+#     loudly instead of leaving this file's coverage silently stale.
+#   - zsh compatibility: an unmatched glob (e.g. a ~/.local/bin with no
+#     agentic-*/ds-* entries) must not abort the loop under zsh, which
+#     treats an unmatched glob as an error by default (NOMATCH) unlike bash,
+#     which leaves it as a literal string that the `[[ -e ]]` guard filters.
+#     run_bin_guard/run_bin_guard_loose opt into `nullglob` for the duration
+#     of the call, under zsh only, so an unmatched pattern expands to zero
+#     words instead of erroring - this also fixes this file's own
+#     pre-existing zsh baseline failure (Test 4), which was this exact class.
 
 set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 PASS=0
 FAIL=0
@@ -42,11 +63,27 @@ _pass() {
 # ---------------------------------------------------------------------------
 
 # run_bin_guard <REPO_DIR> <BIN_DST>
-# Executes the exact guard logic from the uninstall.sh bin-removal block.
-# Uses the tightened guard: "$REPO_DIR/bin/"*
+# Executes the exact guard logic from the uninstall.sh bin-removal block -
+# see Test 5 below, which mechanically asserts the for-loop body (from the
+# "for dst_file in ...agentic-*...ds-*...; do" line through its "done") is
+# byte-identical (modulo leading/trailing whitespace) to the current
+# production block in .claude/uninstall.sh. Do not hand-edit the loop body
+# without also updating production (or vice versa) - Test 5 will catch the
+# drift, but keep them in sync rather than relying on that as the only
+# guard-rail.
 run_bin_guard() {
   local REPO_DIR="$1"
   local BIN_DST="$2"
+
+  # zsh treats an unmatched glob as an error (NOMATCH) by default, unlike
+  # bash, which leaves it as a literal string filtered out below by the
+  # `[[ -e ]]` guard. `nullglob` makes zsh behave like bash here: an
+  # unmatched pattern expands to zero words. `local_options` auto-reverts
+  # this at function return, so it never affects the caller. No-op under
+  # bash (this whole block never executes there).
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    setopt local_options nullglob
+  fi
 
   if [[ ! -d "$BIN_DST" ]]; then
     echo "  [skip] ~/.local/bin not found"
@@ -55,7 +92,7 @@ run_bin_guard() {
 
   local _found_any=false
   local dst_file name current_target
-  for dst_file in "$BIN_DST"/agentic-*; do
+  for dst_file in "$BIN_DST"/agentic-* "$BIN_DST"/ds-*; do
     [[ -e "$dst_file" || -L "$dst_file" ]] || continue
     _found_any=true
     name="$(basename "$dst_file")"
@@ -73,16 +110,23 @@ run_bin_guard() {
     fi
   done
   if [[ "$_found_any" == false ]]; then
-    echo "  = no agentic-* entries found in ~/.local/bin"
+    echo "  = no agentic-*/ds-* entries found in ~/.local/bin"
   fi
 }
 
 # run_bin_guard_loose <REPO_DIR> <BIN_DST>
 # Executes the OLD loose guard (`"$REPO_DIR"*`) to prove the sibling-prefix
-# case would have failed under the previous code.
+# case would have failed under the previous code. Intentionally still uses
+# the single agentic-* glob (pre-widening) - this is the retired code path
+# being demonstrated, not the current production block, so it is NOT
+# covered by Test 5's equivalence check.
 run_bin_guard_loose() {
   local REPO_DIR="$1"
   local BIN_DST="$2"
+
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    setopt local_options nullglob
+  fi
 
   if [[ ! -d "$BIN_DST" ]]; then
     return
@@ -123,9 +167,16 @@ mkdir -p "$FAKE_REPO/bin" "$BIN_DST"
 
 # Target bin file that the installer would have linked
 echo '#!/bin/bash' > "$FAKE_REPO/bin/agentic-foo"
+echo '#!/bin/bash' > "$FAKE_REPO/bin/ds-foo"
 
 # Case A: REPO_DIR/bin/ symlink - MUST be removed
 ln -sfn "$FAKE_REPO/bin/agentic-foo" "$BIN_DST/agentic-foo"
+
+# Case A2: ds-*-prefixed REPO_DIR/bin/ symlink - MUST also be removed. This
+# is the direct coverage for the widened glob (Test 5 below only proves the
+# loop TEXT matches production; this proves the widened glob actually
+# behaves as intended at runtime).
+ln -sfn "$FAKE_REPO/bin/ds-foo" "$BIN_DST/ds-foo"
 
 # Case B: Unrelated repo symlink - must NOT be removed
 ln -sfn "/some/other/repo/bin/agentic-bar" "$BIN_DST/agentic-bar"
@@ -139,6 +190,12 @@ if [[ ! -e "$BIN_DST/agentic-foo" && ! -L "$BIN_DST/agentic-foo" ]]; then
   _pass "T1: REPO_DIR/bin/ symlink (agentic-foo) removed"
 else
   _fail "T1: REPO_DIR/bin/ symlink (agentic-foo) should have been removed"
+fi
+
+if [[ ! -e "$BIN_DST/ds-foo" && ! -L "$BIN_DST/ds-foo" ]]; then
+  _pass "T1: REPO_DIR/bin/ ds-*-prefixed symlink (ds-foo) removed"
+else
+  _fail "T1: REPO_DIR/bin/ ds-*-prefixed symlink (ds-foo) should have been removed"
 fi
 
 if [[ -L "$BIN_DST/agentic-bar" ]]; then
@@ -230,7 +287,11 @@ fi
 rm -rf "$FAKE_REPO3" "$FAKE_HOME3"
 
 # ---------------------------------------------------------------------------
-# Test 4: ~/.local/bin exists but has no agentic-* files - no error
+# Test 4: ~/.local/bin exists but has no agentic-*/ds-* files - no error.
+# Also the direct regression coverage for the zsh unmatched-glob class: this
+# is the case (a populated BIN_DST with zero matching entries) that used to
+# abort this file under zsh before the nullglob guard was added to
+# run_bin_guard.
 # ---------------------------------------------------------------------------
 
 FAKE_REPO4="$(mktemp -d)"
@@ -245,18 +306,62 @@ rc=$?
 set -e
 
 if [[ $rc -eq 0 ]]; then
-  _pass "T4: empty-glob (no agentic-*) handled without error"
+  _pass "T4: empty-glob (no agentic-*/ds-*) handled without error"
 else
-  _fail "T4: empty-glob caused non-zero exit ($rc)"
+  _fail "T4: empty-glob caused non-zero exit ($rc): $out4"
 fi
 
-if echo "$out4" | grep -q "no agentic-\* entries found"; then
+if echo "$out4" | grep -q "no agentic-\*/ds-\* entries found"; then
   _pass "T4: empty-glob prints expected message"
 else
   _fail "T4: empty-glob message not found in output: $out4"
 fi
 
 rm -rf "$FAKE_REPO4" "$FAKE_HOME4"
+
+# ---------------------------------------------------------------------------
+# Test 5 (mirror-sync guard): run_bin_guard's for-loop body must be
+# byte-identical (modulo per-line leading/trailing whitespace) to the
+# current production for-loop block in .claude/uninstall.sh. This is the
+# "keep in sync" enforcement this mirror lacked - it fails whenever a future
+# production change to the glob or ownership-guard logic is not mirrored
+# here, instead of silently leaving this file's coverage stale.
+#
+# Extraction: capture from the line containing the two-glob for-loop
+# declaration through its matching "done" (inclusive), then normalize by
+# stripping leading/trailing whitespace per line and dropping blank lines.
+# Applied identically to .claude/uninstall.sh (the production source of
+# truth) and to this file's own source (via $0), so it self-locates
+# run_bin_guard's loop without a hardcoded line range.
+# ---------------------------------------------------------------------------
+
+PROD_FILE="$REPO_DIR/.claude/uninstall.sh"
+SELF_FILE="$REPO_DIR/bin/tests/test_uninstall_bin_symlink.sh"
+
+_extract_glob_loop_block() {
+  awk '
+    /for dst_file in "\$BIN_DST"\/agentic-\* "\$BIN_DST"\/ds-\*; do/ { capture=1 }
+    capture { print }
+    capture && /^[[:space:]]*done[[:space:]]*$/ { exit }
+  ' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d'
+}
+
+PROD_GLOB_BLOCK="$(_extract_glob_loop_block "$PROD_FILE")"
+MIRROR_GLOB_BLOCK="$(_extract_glob_loop_block "$SELF_FILE")"
+
+if [[ -z "$PROD_GLOB_BLOCK" ]]; then
+  _fail "T5: could not locate the production for-loop block in .claude/uninstall.sh (extraction pattern stale?)"
+elif [[ -z "$MIRROR_GLOB_BLOCK" ]]; then
+  _fail "T5: could not locate the mirrored for-loop block in run_bin_guard (extraction pattern stale?)"
+elif [[ "$PROD_GLOB_BLOCK" == "$MIRROR_GLOB_BLOCK" ]]; then
+  _pass "T5: run_bin_guard's for-loop body matches .claude/uninstall.sh's production block verbatim"
+else
+  _fail "T5: run_bin_guard has drifted from .claude/uninstall.sh's production for-loop block
+--- production (.claude/uninstall.sh) ---
+$PROD_GLOB_BLOCK
+--- mirror (run_bin_guard) ---
+$MIRROR_GLOB_BLOCK"
+fi
 
 # ---------------------------------------------------------------------------
 # Results

--- a/bin/tests/test_uninstall_ds_prefix.sh
+++ b/bin/tests/test_uninstall_ds_prefix.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Purpose: Regression tests for the prefix-agnostic ~/.local/bin symlink
+#          removal glob in every adapter uninstall.sh (uninstall-side
+#          counterpart of the install-side goal (a) rename-safety machinery
+#          covered by test_local_bin_ds_prefix_install.sh). No tool is
+#          renamed by this change; these tests only prove the uninstall glob
+#          would remove a ds-* named tool's symlink if one existed.
+#
+# Public API: ./bin/tests/test_uninstall_ds_prefix.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, mktemp, grep.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       the bin-sh-tests CI job via the bin/tests/test_*.sh
+#                       glob (.github/workflows/bin-tests.yml).
+#
+# Failure modes: any assertion failure prints the failing assertion and
+#                exits 1. Test 2 creates one temporary untracked file under
+#                the real repo's bin/ (bin/ds-<random>-test-fixture) and
+#                removes it via an EXIT trap - never leaves a residual file
+#                itself, but it runs the REAL .claude/uninstall.sh against
+#                the live repo tree with only HOME faked: that uninstaller
+#                also touches $HOME/.claude/settings.json,
+#                $HOME/.claude/CLAUDE.md, and $HOME/.agentic/hooks-snapshot -
+#                all scoped under the faked HOME, never the real one. Test
+#                2 is NOT read-only with respect to the faked HOME; Test 1
+#                is read-only.
+#
+# Performance: ~3 s wall time on a developer machine (one real uninstall.sh
+#              run).
+#
+# Regression coverage:
+#   - Test 1 (structural): each of the 10 known glob sites across the 10
+#     adapter uninstall.sh scripts that manage bin/ symlinks (one loop each;
+#     .hermes/uninstall.sh manages no bins and is excluded) matches both
+#     "agentic-*" and "ds-*". Catches a site left un-updated by name/line,
+#     not just aggregate count.
+#   - Test 2 (functional): .claude/uninstall.sh, run end-to-end against a
+#     fake HOME but the REAL repo bin/, actually removes a ds-*-named
+#     fixture symlink from ~/.local/bin alongside a real agentic-* tool's
+#     symlink, and leaves a foreign (non-repo) symlink untouched.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN_DIR="$REPO_DIR/bin"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1 (structural): every known uninstall glob site matches BOTH prefixes.
+# One (file, expected-occurrence-count) pair per adapter; every adapter
+# carries exactly one loop on the uninstall side (unlike install.sh, where
+# .codex has two).
+# ---------------------------------------------------------------------------
+declare -a SITES=(
+  ".claude/uninstall.sh"
+  ".cursor/uninstall.sh"
+  ".gemini/uninstall.sh"
+  ".opencode/uninstall.sh"
+  ".omp/uninstall.sh"
+  ".kimi/uninstall.sh"
+  ".pi/uninstall.sh"
+  ".codex/uninstall.sh"
+  ".copilot/uninstall.sh"
+  ".openclaw/uninstall.sh"
+)
+
+for file in "${SITES[@]}"; do
+  # NOTE: do not name this variable "path" - it is a special zsh parameter
+  # tied to $PATH (assigning to it silently replaces PATH and breaks every
+  # subsequent command lookup, e.g. "grep: command not found", when this
+  # script is run under zsh). Use site_file instead.
+  site_file="$REPO_DIR/$file"
+  if [[ ! -f "$site_file" ]]; then
+    _fail "T1: $file not found"
+    continue
+  fi
+  # Match only the loop declaration itself, not the surrounding comment or
+  # the "no ... entries found" message line - both of those also legitimately
+  # contain "agentic-*" and "ds-*" as plain prose/output text and would
+  # otherwise inflate the count.
+  count="$(grep -cE 'for dst_file in .*agentic-\*.*ds-\*.*; do' "$site_file" || true)"
+  if [[ "$count" -eq 1 ]]; then
+    _pass "T1: $file has 1 prefix-agnostic glob site"
+  else
+    _fail "T1: $file expected 1 prefix-agnostic glob site, found $count"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 2 (functional): .claude/uninstall.sh actually removes a ds-*-prefixed
+# tool's symlink, an agentic-*-prefixed tool's symlink, and leaves a foreign
+# (non-repo) symlink alone. Uses the REAL repo bin/ (so REPO_DIR resolution
+# inside uninstall.sh needs no faking) with one temporary untracked fixture
+# file, cleaned up on exit regardless of outcome.
+# ---------------------------------------------------------------------------
+FIXTURE_NAME="ds-$(date +%s)-test-fixture"
+FIXTURE_PATH="$BIN_DIR/$FIXTURE_NAME"
+FAKE_HOME=""
+
+_cleanup() {
+  [[ -n "$FIXTURE_PATH" && -f "$FIXTURE_PATH" ]] && rm -f "$FIXTURE_PATH"
+  [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]] && rm -rf "$FAKE_HOME"
+}
+trap _cleanup EXIT
+
+cat > "$FIXTURE_PATH" <<'EOF'
+#!/usr/bin/env bash
+echo ds-fixture
+EOF
+chmod +x "$FIXTURE_PATH"
+
+FAKE_HOME="$(mktemp -d)"
+mkdir -p "$FAKE_HOME/.agentic" "$FAKE_HOME/.local/bin" "$FAKE_HOME/external"
+
+# Case A: ds-*-prefixed symlink pointing into the real repo bin/ - MUST be removed.
+ln -sfn "$FIXTURE_PATH" "$FAKE_HOME/.local/bin/$FIXTURE_NAME"
+
+# Case B: a real agentic-* tool's symlink pointing into the real repo bin/ -
+# MUST also be removed (sanity - proves the fix widened the glob, not swapped it).
+ln -sfn "$BIN_DIR/agentic-doctor" "$FAKE_HOME/.local/bin/agentic-doctor"
+
+# Case C: a foreign symlink pointing OUTSIDE the repo - must NOT be removed.
+printf 'external\n' > "$FAKE_HOME/external/thing"
+ln -sfn "$FAKE_HOME/external/thing" "$FAKE_HOME/.local/bin/agentic-foreign"
+
+HOME="$FAKE_HOME" bash "$REPO_DIR/.claude/uninstall.sh" \
+  < /dev/null > "$FAKE_HOME/.uninstall_out" 2>&1
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  _fail "T2: .claude/uninstall.sh exited $RC"
+  cat "$FAKE_HOME/.uninstall_out" >&2
+fi
+
+if [[ ! -e "$FAKE_HOME/.local/bin/$FIXTURE_NAME" && ! -L "$FAKE_HOME/.local/bin/$FIXTURE_NAME" ]]; then
+  _pass "T2: ds-*-prefixed fixture symlink removed by uninstall.sh"
+else
+  _fail "T2: expected $FAKE_HOME/.local/bin/$FIXTURE_NAME to be removed, but it still exists"
+fi
+
+if [[ ! -e "$FAKE_HOME/.local/bin/agentic-doctor" && ! -L "$FAKE_HOME/.local/bin/agentic-doctor" ]]; then
+  _pass "T2: existing agentic-* tool (agentic-doctor) symlink also removed"
+else
+  _fail "T2: agentic-doctor symlink should have been removed"
+fi
+
+if [[ -L "$FAKE_HOME/.local/bin/agentic-foreign" ]]; then
+  _pass "T2: foreign (non-repo) symlink preserved"
+else
+  _fail "T2: foreign (non-repo) symlink should NOT have been removed"
+fi
+
+rm -f "$FIXTURE_PATH"
+rm -rf "$FAKE_HOME"
+FAKE_HOME=""
+FIXTURE_PATH=""
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_uninstall_ds_prefix.sh
+++ b/bin/tests/test_uninstall_ds_prefix.sh
@@ -17,15 +17,27 @@
 #
 # Failure modes: any assertion failure prints the failing assertion and
 #                exits 1. Test 2 creates one temporary untracked file under
-#                the real repo's bin/ (bin/ds-<random>-test-fixture) and
+#                the real repo's bin/ (bin/ds-<unique>-test-fixture) and
 #                removes it via an EXIT trap - never leaves a residual file
 #                itself, but it runs the REAL .claude/uninstall.sh against
 #                the live repo tree with only HOME faked: that uninstaller
-#                also touches $HOME/.claude/settings.json,
-#                $HOME/.claude/CLAUDE.md, and $HOME/.agentic/hooks-snapshot -
-#                all scoped under the faked HOME, never the real one. Test
-#                2 is NOT read-only with respect to the faked HOME; Test 1
-#                is read-only.
+#                touches $HOME/.claude/settings.json, $HOME/.claude/CLAUDE.md,
+#                and $HOME/.agentic/hooks-snapshot, all scoped under the
+#                faked HOME - but it ALSO calls uninstall_precommit_hook,
+#                which resolves the git hooks directory via
+#                `git rev-parse --git-path hooks` relative to the REAL
+#                REPO_DIR, entirely independent of $HOME faking. Left
+#                unguarded, that call would remove THIS checkout's real
+#                <repo>/.git/hooks/pre-commit (or, from inside a linked
+#                worktree, the common repo's hooks dir) and never restore
+#                it. Test 2 saves the real pre-commit hook via
+#                bin/tests/lib/precommit-hook-guard.sh before invoking
+#                uninstall.sh and restores it unconditionally in the EXIT
+#                trap, so this is the one real effect outside the faked
+#                HOME and it is undone on every exit path (normal, failure,
+#                or signal). Test 2 is NOT read-only with respect to the
+#                faked HOME or the live pre-commit hook slot (both are
+#                exercised and restored); Test 1 is read-only.
 #
 # Performance: ~3 s wall time on a developer machine (one real uninstall.sh
 #              run).
@@ -39,12 +51,17 @@
 #   - Test 2 (functional): .claude/uninstall.sh, run end-to-end against a
 #     fake HOME but the REAL repo bin/, actually removes a ds-*-named
 #     fixture symlink from ~/.local/bin alongside a real agentic-* tool's
-#     symlink, and leaves a foreign (non-repo) symlink untouched.
+#     symlink, and leaves a foreign (non-repo) symlink untouched - and the
+#     real pre-commit hook this run touches along the way survives byte-
+#     for-byte (or symlink-target-for-symlink-target) unchanged afterward.
 
 set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 BIN_DIR="$REPO_DIR/bin"
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 PASS=0
 FAIL=0
@@ -98,17 +115,26 @@ done
 # tool's symlink, an agentic-*-prefixed tool's symlink, and leaves a foreign
 # (non-repo) symlink alone. Uses the REAL repo bin/ (so REPO_DIR resolution
 # inside uninstall.sh needs no faking) with one temporary untracked fixture
-# file, cleaned up on exit regardless of outcome.
+# file, cleaned up on exit regardless of outcome. The real pre-commit hook
+# slot this run also touches (see header) is saved before the run and
+# restored in the same EXIT trap - see bin/tests/lib/precommit-hook-guard.sh.
 # ---------------------------------------------------------------------------
-FIXTURE_NAME="ds-$(date +%s)-test-fixture"
+# FIXTURE_NAME must be genuinely unique, not just second-resolution: two
+# runs starting in the same wall-clock second (e.g. two developer machines,
+# or a fast CI matrix) would otherwise collide on the same bin/ file, and
+# each run's EXIT trap would then delete the OTHER run's still-in-use
+# fixture from the real repo's bin/. $$ (this process's PID) plus a
+# mktemp-derived suffix rules that out.
+FIXTURE_NAME="ds-$(date +%s)-$$-$(mktemp -u XXXXXX)-test-fixture"
 FIXTURE_PATH="$BIN_DIR/$FIXTURE_NAME"
 FAKE_HOME=""
 
 _cleanup() {
   [[ -n "$FIXTURE_PATH" && -f "$FIXTURE_PATH" ]] && rm -f "$FIXTURE_PATH"
   [[ -n "$FAKE_HOME" && -d "$FAKE_HOME" ]] && rm -rf "$FAKE_HOME"
+  precommit_hook_guard_restore
 }
-trap _cleanup EXIT
+trap _cleanup EXIT INT TERM
 
 cat > "$FIXTURE_PATH" <<'EOF'
 #!/usr/bin/env bash
@@ -118,6 +144,34 @@ chmod +x "$FIXTURE_PATH"
 
 FAKE_HOME="$(mktemp -d)"
 mkdir -p "$FAKE_HOME/.agentic" "$FAKE_HOME/.local/bin" "$FAKE_HOME/external"
+
+# Read-only snapshot of the real pre-commit hook slot's current state, used
+# only to assert (below, after uninstall.sh runs and the guard restores it)
+# that it survives this test byte-for-byte / target-for-target. Independent
+# of precommit_hook_guard_save's own internal state - this is the assertion
+# side, the guard call below is the protection side.
+_resolve_precommit_state() {
+  local hooks_dir
+  if ! hooks_dir="$(git -C "$REPO_DIR" rev-parse --git-path hooks 2>/dev/null)" || [[ -z "$hooks_dir" ]]; then
+    echo "(unresolved)"
+    return
+  fi
+  case "$hooks_dir" in
+    /*) : ;;
+    *) hooks_dir="$REPO_DIR/$hooks_dir" ;;
+  esac
+  local hook="$hooks_dir/pre-commit"
+  if [[ -L "$hook" ]]; then
+    readlink "$hook"
+  elif [[ -e "$hook" ]]; then
+    echo "(regular file)"
+  else
+    echo "(absent)"
+  fi
+}
+
+EXPECTED_PRECOMMIT_STATE="$(_resolve_precommit_state)"
+precommit_hook_guard_save "$REPO_DIR"
 
 # Case A: ds-*-prefixed symlink pointing into the real repo bin/ - MUST be removed.
 ln -sfn "$FIXTURE_PATH" "$FAKE_HOME/.local/bin/$FIXTURE_NAME"
@@ -137,6 +191,20 @@ RC=$?
 if [[ $RC -ne 0 ]]; then
   _fail "T2: .claude/uninstall.sh exited $RC"
   cat "$FAKE_HOME/.uninstall_out" >&2
+fi
+
+# Restore the real pre-commit hook slot NOW (not just in the EXIT trap) so
+# the assertion below runs with the live checkout already back to normal,
+# and so the window during which the real hook is absent/altered is as
+# short as possible. precommit_hook_guard_restore is idempotent, so the
+# EXIT trap's later call is a harmless no-op.
+precommit_hook_guard_restore
+
+ACTUAL_PRECOMMIT_STATE="$(_resolve_precommit_state)"
+if [[ "$ACTUAL_PRECOMMIT_STATE" == "$EXPECTED_PRECOMMIT_STATE" ]]; then
+  _pass "T2: real pre-commit hook slot restored to its pre-test state ($EXPECTED_PRECOMMIT_STATE)"
+else
+  _fail "T2: real pre-commit hook slot NOT restored - expected '$EXPECTED_PRECOMMIT_STATE', got '$ACTUAL_PRECOMMIT_STATE'"
 fi
 
 if [[ ! -e "$FAKE_HOME/.local/bin/$FIXTURE_NAME" && ! -L "$FAKE_HOME/.local/bin/$FIXTURE_NAME" ]]; then

--- a/bin/tests/test_uninstall_ds_prefix.sh
+++ b/bin/tests/test_uninstall_ds_prefix.sh
@@ -164,7 +164,13 @@ _resolve_precommit_state() {
   if [[ -L "$hook" ]]; then
     readlink "$hook"
   elif [[ -e "$hook" ]]; then
-    echo "(regular file)"
+    # Hash the content, not just presence - a regular-file hook that changed
+    # content but stayed a regular file must not read as "unchanged".
+    if command -v sha256sum >/dev/null 2>&1; then
+      echo "(regular file: $(sha256sum "$hook" | awk '{print $1}'))"
+    else
+      echo "(regular file: $(shasum -a 256 "$hook" | awk '{print $1}'))"
+    fi
   else
     echo "(absent)"
   fi


### PR DESCRIPTION
Makes `~/.local/bin` symlink management prefix-agnostic so a later PR can rename the `bin/agentic-*` family to `bin/ds-*` without orphaning every existing install. **Renames nothing.**

## Why this must land first

Three independent gaps meant a `ds-*` rename would have silently failed:

1. **Install globs are prefix-locked.** 11 loops across 10 adapter `install.sh` files hardcode `for src_file in "$bin_src"/agentic-*`. A tool named `ds-foo` matches none of them, so it would never be symlinked for anyone.
2. **`agentic-doctor` couldn't see it.** `check_local_bin_symlinks` built its expected set with `p.name.startswith("agentic-")`, so a renamed tool was invisible to its own self-repair.
3. **Nothing ever pruned a stale `~/.local/bin` symlink.** The `_ae_stale_renamed_commands` mechanism from #561 covers `~/.claude/commands/` only, and the doctor walked repo→symlink but never the reverse. After a rename, all 24 old links would dangle forever.

Review then found a fourth: the 10 `uninstall.sh` scripts glob only the old prefix, so uninstall would leave every `ds-*` wrapper dangling into a deleted repo - unhealable, because the doctor is uninstalled too. **Bin symlink management is one mechanism in three places** (install, uninstall, doctor); a partial migration is the failure mode.

## What changed

- 11 install loops and 10 uninstall loops widened to match both prefixes, with the existing `[[ -e ]] || [[ -L ]]` glob-absorption guard verified present at every site.
- `agentic-doctor` discovery is now prefix-agnostic via `BIN_TOOL_PREFIXES`, plus a new reverse-direction stale-link check reusing the existing `remove_stale_symlink` primitive.
- Read-only and `--dry-run` no longer emit contradictory repoint-and-remove recommendations for the same link. `--fix` behavior is unchanged.

**Removal predicate**, deliberately narrower than the existing `_is_ours()`: removable only if it is a symlink, AND its target does not resolve, AND its raw unresolved target is lexically rooted at `<repo_dir>/bin`. A real file, a live symlink, a broken symlink pointing outside the repo, and a second clone's `bin/` all survive `--fix` untouched - each verified by mutation, not assertion.

## Test-harness defect found and fixed

`test_uninstall_ds_prefix.sh` permanently deleted the developer's `.git/hooks/pre-commit`. Faking `HOME` does not contain it: `uninstall_precommit_hook` resolves via `git rev-parse --git-path hooks`, which returns the **common** repo's hooks dir even from a linked worktree. CI never noticed - a fresh checkout has no hook installed - so only local developers lost it, silently, along with every pre-commit gate thereafter.

Fixed with a shared `bin/tests/lib/precommit-hook-guard.sh` (save/restore across `EXIT INT TERM`, handling symlink, regular-file, and absent-before states). An independent audit found and guarded a second instance in `test_hooks_snapshot_migration.sh`.

## Verification

- 796 pytest; all 31 `bin/tests/test_*.sh` green under bash
- zsh failures **reduced from 5 to 4** - `test_uninstall_bin_symlink.sh`'s pre-existing failure was an unmatched-glob `NOMATCH` abort, fixed with function-scoped `nullglob`
- Every new assertion is mutation-proven: break it, observe RED, restore, observe GREEN. The reviewer independently reproduced each rather than accepting attestation.
- `test_uninstall_bin_symlink.sh` mirrored the production loop verbatim with no enforcing gate; it now carries a mechanical text-equivalence check against `.claude/uninstall.sh`, verified to fail on a behavior-changing edit and to fail loudly if its extraction pattern goes stale.
- Adapter drift clean (pathspec extracted verbatim from the workflow); resident budget 121006 B / 121066 B unchanged; four skill symlinks relative in the committed tree.

Three adversarial review rounds. Rounds 1 and 2 each found the defect **relocated** rather than removed - install fixed then uninstall missed; install-test manifest fixed then the uninstall test deleted the hook outright.

## Known issue, not fixed here

`scripts/lib/precommit.sh`'s re-point branch aims the real repo's `.git/hooks/pre-commit` at the **worktree's** path when run from inside a worktree, which dangles once the harness removes it. This fired three times during development and is how a checkout was found pointing at a temp worktree deleted in July. Out of scope; worth its own fix.

## North Star alignment

**Advances "works for everyone."** This is the entire point: without it, renaming the CLI family would leave every existing install with 24 dangling symlinks that `agentic-doctor --fix` could not heal, and uninstall would orphan the rest. It converts a rename that breaks every user into one that self-heals.

**Advances "produce verifiable outcomes autonomously."** A "keep in sync" comment between a test mirror and its production loop is replaced by a mechanical equivalence gate, and the previously-unguarded skip branch is now pinned by a count-based assertion that distinguishes both failure directions.

**Trade-off, stated plainly:** `agentic-doctor --fix` now deletes symlinks from the user's PATH directory, which it never did before. The predicate is tightly scoped and mutation-tested, but it is a genuinely new destructive capability and is documented as such in the manifest and `--help`. No pillar regression.
