### PR TITLE
DS-133: settle harness delegation suppression as unsupported configuration

### DIFF
--- a/.copilot/references/delegation-detail.md
+++ b/.copilot/references/delegation-detail.md
@@ -23,7 +23,8 @@ Purpose: Detailed delegation-model reference blocks extracted from
 
 Public API: Read-only reference document. Cross-referenced from:
             content/sections/02-delegation.md (inline pointers replacing
-            each verbose block).
+            each verbose block); hooks/AGENTS.md (two inbound pointers into
+            the Harness-Injected Instruction Conflicts section).
 
 Upstream deps: content/sections/02-delegation.md (parent section; read
                that section first for the full delegation model overview,
@@ -165,7 +166,7 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template below are the fix, applied by the operator.
 
 Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
 

--- a/.copilot/references/delegation-detail.md
+++ b/.copilot/references/delegation-detail.md
@@ -11,7 +11,9 @@ Purpose: Detailed delegation-model reference blocks extracted from
          before-Architect rules (incl shared-utility-MANDATORY and Parallel
          Investigators); Harness-Injected Instruction Conflicts (collision
          catalog, delegation-suppression subsection, notice template,
-         operator remedies, harness-vs-model diagnostic);
+         operator remedies, harness-vs-model diagnostic, DS-133
+         unsupported-configuration policy and rejected consequence-detector
+         record);
          Learnings pipeline; Worker preamble + execution contract template;
          AskUserQuestion and Operator Decisions enforcement mechanics (hook
          wiring, detection limits, kill switch); Operator Decisions block
@@ -147,7 +149,7 @@ Parent clause: `content/sections/02-delegation.md` §Host-harness instruction co
 | Collision | Harness default (paraphrase) | AE locus | Resolution |
 |---|---|---|---|
 | **Approval scope** | "approval in one context doesn't extend to the next" | `content/sections/02-delegation.md` §Standing authorizations; `content/rules/conventions.md` §Git Workflow, Conductor preflight step 7 | The listed hygiene operations are durably authorized, so the harness carve-out is satisfied rather than overridden. An operator correction that an operation is routine updates the standing norm and is not instance-scoped. |
-| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation beyond the existing rule is out of scope for DS-132 and tracked separately as DS-133. |
+| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation was settled in DS-133: unsupported configuration, no detection, no degraded mode. |
 | **Act vs ask** | "confirm first for outward-facing or hard-to-reverse actions" | `content/sections/02-delegation.md` Hard-stop branch and Surface-and-proceed branch | Already arbitrated - the two branches partition the space by irreversibility. What was missing was the detection prompt and a definition of "pre-authorized", both now supplied. No new arbitration rule is added. |
 | **Self-correction depth** | "avoid excessive self-correction; don't ruminate or give a detailed account of the mistake" | `content/references/conductor-operating-rules.md` §learnings-agent; `content/references/capture-classification.md` | When the operator *asks* why a rule was not followed, a causal account of the mechanism is the requested answer. The defect is the wrong kind of answer, not merely a short one - a rule restatement in place of a cause is a non-answer at any length. A written LRN/KNW entry is not conversational rumination, so capture classification is unaffected. Cross-reference the third disjunct of the new kernel detection prompt (`or a restatement of the rule feels like a sufficient answer to why you broke it`), which is phrased to fire on exactly this substitution. |
 
@@ -163,7 +165,11 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-Remediation beyond this rule - activation-preflight detection of the suppression, and any documented degraded mode - is deliberately out of scope here and is tracked separately as DS-133.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+
+Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
+
+**A consequence-detector was specified and rejected; the reason is recorded so it need not be re-derived.** The idea was to stop asking "is spawning suppressed?" and instead report when a session committed shippable files with zero `spawn_start` events on record - a cause-agnostic fact about the session's own artifacts, emitted by hook code so that a compromised conductor's own judgment is not load-bearing. It fails on attribution rather than on capability inference: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant shapes satisfy the predicate. A session doing nothing but its mandated base-sync and `git pull --ff-only` picks up a teammate's freshly merged commits. A cross-session loop resuming at a later phase squash-merges work whose engineer and Skeptic ran under a prior session's identifier, and the base-sync fast-forward at that phase's tail lands the resulting commit locally - the merge is the mechanism, not authorship. The landed squash commit is dated at merge time yet contains work reviewed under a prior session's identifier: fresh by date, foreign by authorship. A mandated `gh pr update-branch --rebase` rewrites committer dates and pulls an entire prior branch into any time window. So the detector would fire on mandated hygiene and on resumed reviewed work, which is the outcome the enforcement-hook prohibition above already names, at lower cost and with the same effect on operator attention. Surviving a compromised conductor is necessary but not sufficient: the surviving code still has to evaluate something it can compute. If a per-session commit-attribution signal is ever established, this analysis is the starting point rather than a settled bar.
 
 **Notice template (unconditional branch).** When the directive is unconditional and spawning genuinely fails, emit at the first user-facing turn:
 
@@ -179,7 +185,7 @@ unreviewed.
 [phase: delegation-suppressed]
 ```
 
-This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md:80` has a trigger computed at preflight on every session. It is **not** one of those four and must not be added to that count.
+This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md` §Session Context and Memory, the "stacked first-user-turn notices" line, has a trigger computed at preflight on every session. It is **not** one of those five and must not be added to that count.
 
 **Harness-vs-model diagnostic.** Before attributing a compliance regression (the model ignoring delegation rules) to a model-version change, distinguish harness-cause from model-cause: run the identical prompt in a plain local terminal session versus the suspect entrypoint. Only a local-complies / other-fails split implicates the harness (an injected system prompt outranking the methodology); if both fail identically, the regression is model-side and should be investigated as such.
 

--- a/.cursor/references/delegation-detail.md
+++ b/.cursor/references/delegation-detail.md
@@ -23,7 +23,8 @@ Purpose: Detailed delegation-model reference blocks extracted from
 
 Public API: Read-only reference document. Cross-referenced from:
             content/sections/02-delegation.md (inline pointers replacing
-            each verbose block).
+            each verbose block); hooks/AGENTS.md (two inbound pointers into
+            the Harness-Injected Instruction Conflicts section).
 
 Upstream deps: content/sections/02-delegation.md (parent section; read
                that section first for the full delegation model overview,
@@ -165,7 +166,7 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template below are the fix, applied by the operator.
 
 Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
 

--- a/.cursor/references/delegation-detail.md
+++ b/.cursor/references/delegation-detail.md
@@ -11,7 +11,9 @@ Purpose: Detailed delegation-model reference blocks extracted from
          before-Architect rules (incl shared-utility-MANDATORY and Parallel
          Investigators); Harness-Injected Instruction Conflicts (collision
          catalog, delegation-suppression subsection, notice template,
-         operator remedies, harness-vs-model diagnostic);
+         operator remedies, harness-vs-model diagnostic, DS-133
+         unsupported-configuration policy and rejected consequence-detector
+         record);
          Learnings pipeline; Worker preamble + execution contract template;
          AskUserQuestion and Operator Decisions enforcement mechanics (hook
          wiring, detection limits, kill switch); Operator Decisions block
@@ -147,7 +149,7 @@ Parent clause: `content/sections/02-delegation.md` §Host-harness instruction co
 | Collision | Harness default (paraphrase) | AE locus | Resolution |
 |---|---|---|---|
 | **Approval scope** | "approval in one context doesn't extend to the next" | `content/sections/02-delegation.md` §Standing authorizations; `content/rules/conventions.md` §Git Workflow, Conductor preflight step 7 | The listed hygiene operations are durably authorized, so the harness carve-out is satisfied rather than overridden. An operator correction that an operation is routine updates the standing norm and is not instance-scoped. |
-| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation beyond the existing rule is out of scope for DS-132 and tracked separately as DS-133. |
+| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation was settled in DS-133: unsupported configuration, no detection, no degraded mode. |
 | **Act vs ask** | "confirm first for outward-facing or hard-to-reverse actions" | `content/sections/02-delegation.md` Hard-stop branch and Surface-and-proceed branch | Already arbitrated - the two branches partition the space by irreversibility. What was missing was the detection prompt and a definition of "pre-authorized", both now supplied. No new arbitration rule is added. |
 | **Self-correction depth** | "avoid excessive self-correction; don't ruminate or give a detailed account of the mistake" | `content/references/conductor-operating-rules.md` §learnings-agent; `content/references/capture-classification.md` | When the operator *asks* why a rule was not followed, a causal account of the mechanism is the requested answer. The defect is the wrong kind of answer, not merely a short one - a rule restatement in place of a cause is a non-answer at any length. A written LRN/KNW entry is not conversational rumination, so capture classification is unaffected. Cross-reference the third disjunct of the new kernel detection prompt (`or a restatement of the rule feels like a sufficient answer to why you broke it`), which is phrased to fire on exactly this substitution. |
 
@@ -163,7 +165,11 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-Remediation beyond this rule - activation-preflight detection of the suppression, and any documented degraded mode - is deliberately out of scope here and is tracked separately as DS-133.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+
+Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
+
+**A consequence-detector was specified and rejected; the reason is recorded so it need not be re-derived.** The idea was to stop asking "is spawning suppressed?" and instead report when a session committed shippable files with zero `spawn_start` events on record - a cause-agnostic fact about the session's own artifacts, emitted by hook code so that a compromised conductor's own judgment is not load-bearing. It fails on attribution rather than on capability inference: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant shapes satisfy the predicate. A session doing nothing but its mandated base-sync and `git pull --ff-only` picks up a teammate's freshly merged commits. A cross-session loop resuming at a later phase squash-merges work whose engineer and Skeptic ran under a prior session's identifier, and the base-sync fast-forward at that phase's tail lands the resulting commit locally - the merge is the mechanism, not authorship. The landed squash commit is dated at merge time yet contains work reviewed under a prior session's identifier: fresh by date, foreign by authorship. A mandated `gh pr update-branch --rebase` rewrites committer dates and pulls an entire prior branch into any time window. So the detector would fire on mandated hygiene and on resumed reviewed work, which is the outcome the enforcement-hook prohibition above already names, at lower cost and with the same effect on operator attention. Surviving a compromised conductor is necessary but not sufficient: the surviving code still has to evaluate something it can compute. If a per-session commit-attribution signal is ever established, this analysis is the starting point rather than a settled bar.
 
 **Notice template (unconditional branch).** When the directive is unconditional and spawning genuinely fails, emit at the first user-facing turn:
 
@@ -179,7 +185,7 @@ unreviewed.
 [phase: delegation-suppressed]
 ```
 
-This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md:80` has a trigger computed at preflight on every session. It is **not** one of those four and must not be added to that count.
+This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md` §Session Context and Memory, the "stacked first-user-turn notices" line, has a trigger computed at preflight on every session. It is **not** one of those five and must not be added to that count.
 
 **Harness-vs-model diagnostic.** Before attributing a compliance regression (the model ignoring delegation rules) to a model-version change, distinguish harness-cause from model-cause: run the identical prompt in a plain local terminal session versus the suspect entrypoint. Only a local-complies / other-fails split implicates the harness (an injected system prompt outranking the methodology); if both fail identically, the regression is model-side and should be investigated as such.
 

--- a/.gemini/references/delegation-detail.md
+++ b/.gemini/references/delegation-detail.md
@@ -23,7 +23,8 @@ Purpose: Detailed delegation-model reference blocks extracted from
 
 Public API: Read-only reference document. Cross-referenced from:
             content/sections/02-delegation.md (inline pointers replacing
-            each verbose block).
+            each verbose block); hooks/AGENTS.md (two inbound pointers into
+            the Harness-Injected Instruction Conflicts section).
 
 Upstream deps: content/sections/02-delegation.md (parent section; read
                that section first for the full delegation model overview,
@@ -165,7 +166,7 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template below are the fix, applied by the operator.
 
 Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
 

--- a/.gemini/references/delegation-detail.md
+++ b/.gemini/references/delegation-detail.md
@@ -11,7 +11,9 @@ Purpose: Detailed delegation-model reference blocks extracted from
          before-Architect rules (incl shared-utility-MANDATORY and Parallel
          Investigators); Harness-Injected Instruction Conflicts (collision
          catalog, delegation-suppression subsection, notice template,
-         operator remedies, harness-vs-model diagnostic);
+         operator remedies, harness-vs-model diagnostic, DS-133
+         unsupported-configuration policy and rejected consequence-detector
+         record);
          Learnings pipeline; Worker preamble + execution contract template;
          AskUserQuestion and Operator Decisions enforcement mechanics (hook
          wiring, detection limits, kill switch); Operator Decisions block
@@ -147,7 +149,7 @@ Parent clause: `content/sections/02-delegation.md` §Host-harness instruction co
 | Collision | Harness default (paraphrase) | AE locus | Resolution |
 |---|---|---|---|
 | **Approval scope** | "approval in one context doesn't extend to the next" | `content/sections/02-delegation.md` §Standing authorizations; `content/rules/conventions.md` §Git Workflow, Conductor preflight step 7 | The listed hygiene operations are durably authorized, so the harness carve-out is satisfied rather than overridden. An operator correction that an operation is routine updates the standing norm and is not instance-scoped. |
-| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation beyond the existing rule is out of scope for DS-132 and tracked separately as DS-133. |
+| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation was settled in DS-133: unsupported configuration, no detection, no degraded mode. |
 | **Act vs ask** | "confirm first for outward-facing or hard-to-reverse actions" | `content/sections/02-delegation.md` Hard-stop branch and Surface-and-proceed branch | Already arbitrated - the two branches partition the space by irreversibility. What was missing was the detection prompt and a definition of "pre-authorized", both now supplied. No new arbitration rule is added. |
 | **Self-correction depth** | "avoid excessive self-correction; don't ruminate or give a detailed account of the mistake" | `content/references/conductor-operating-rules.md` §learnings-agent; `content/references/capture-classification.md` | When the operator *asks* why a rule was not followed, a causal account of the mechanism is the requested answer. The defect is the wrong kind of answer, not merely a short one - a rule restatement in place of a cause is a non-answer at any length. A written LRN/KNW entry is not conversational rumination, so capture classification is unaffected. Cross-reference the third disjunct of the new kernel detection prompt (`or a restatement of the rule feels like a sufficient answer to why you broke it`), which is phrased to fire on exactly this substitution. |
 
@@ -163,7 +165,11 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-Remediation beyond this rule - activation-preflight detection of the suppression, and any documented degraded mode - is deliberately out of scope here and is tracked separately as DS-133.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+
+Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
+
+**A consequence-detector was specified and rejected; the reason is recorded so it need not be re-derived.** The idea was to stop asking "is spawning suppressed?" and instead report when a session committed shippable files with zero `spawn_start` events on record - a cause-agnostic fact about the session's own artifacts, emitted by hook code so that a compromised conductor's own judgment is not load-bearing. It fails on attribution rather than on capability inference: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant shapes satisfy the predicate. A session doing nothing but its mandated base-sync and `git pull --ff-only` picks up a teammate's freshly merged commits. A cross-session loop resuming at a later phase squash-merges work whose engineer and Skeptic ran under a prior session's identifier, and the base-sync fast-forward at that phase's tail lands the resulting commit locally - the merge is the mechanism, not authorship. The landed squash commit is dated at merge time yet contains work reviewed under a prior session's identifier: fresh by date, foreign by authorship. A mandated `gh pr update-branch --rebase` rewrites committer dates and pulls an entire prior branch into any time window. So the detector would fire on mandated hygiene and on resumed reviewed work, which is the outcome the enforcement-hook prohibition above already names, at lower cost and with the same effect on operator attention. Surviving a compromised conductor is necessary but not sufficient: the surviving code still has to evaluate something it can compute. If a per-session commit-attribution signal is ever established, this analysis is the starting point rather than a settled bar.
 
 **Notice template (unconditional branch).** When the directive is unconditional and spawning genuinely fails, emit at the first user-facing turn:
 
@@ -179,7 +185,7 @@ unreviewed.
 [phase: delegation-suppressed]
 ```
 
-This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md:80` has a trigger computed at preflight on every session. It is **not** one of those four and must not be added to that count.
+This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md` §Session Context and Memory, the "stacked first-user-turn notices" line, has a trigger computed at preflight on every session. It is **not** one of those five and must not be added to that count.
 
 **Harness-vs-model diagnostic.** Before attributing a compliance regression (the model ignoring delegation rules) to a model-version change, distinguish harness-cause from model-cause: run the identical prompt in a plain local terminal session versus the suspect entrypoint. Only a local-complies / other-fails split implicates the harness (an injected system prompt outranking the methodology); if both fail identically, the regression is model-side and should be investigated as such.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -2852,7 +2852,9 @@ Purpose: Detailed delegation-model reference blocks extracted from
          before-Architect rules (incl shared-utility-MANDATORY and Parallel
          Investigators); Harness-Injected Instruction Conflicts (collision
          catalog, delegation-suppression subsection, notice template,
-         operator remedies, harness-vs-model diagnostic);
+         operator remedies, harness-vs-model diagnostic, DS-133
+         unsupported-configuration policy and rejected consequence-detector
+         record);
          Learnings pipeline; Worker preamble + execution contract template;
          AskUserQuestion and Operator Decisions enforcement mechanics (hook
          wiring, detection limits, kill switch); Operator Decisions block
@@ -2988,7 +2990,7 @@ Parent clause: `content/sections/02-delegation.md` §Host-harness instruction co
 | Collision | Harness default (paraphrase) | AE locus | Resolution |
 |---|---|---|---|
 | **Approval scope** | "approval in one context doesn't extend to the next" | `content/sections/02-delegation.md` §Standing authorizations; `content/rules/conventions.md` §Git Workflow, Conductor preflight step 7 | The listed hygiene operations are durably authorized, so the harness carve-out is satisfied rather than overridden. An operator correction that an operation is routine updates the standing norm and is not instance-scoped. |
-| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation beyond the existing rule is out of scope for DS-132 and tracked separately as DS-133. |
+| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation was settled in DS-133: unsupported configuration, no detection, no degraded mode. |
 | **Act vs ask** | "confirm first for outward-facing or hard-to-reverse actions" | `content/sections/02-delegation.md` Hard-stop branch and Surface-and-proceed branch | Already arbitrated - the two branches partition the space by irreversibility. What was missing was the detection prompt and a definition of "pre-authorized", both now supplied. No new arbitration rule is added. |
 | **Self-correction depth** | "avoid excessive self-correction; don't ruminate or give a detailed account of the mistake" | `content/references/conductor-operating-rules.md` §learnings-agent; `content/references/capture-classification.md` | When the operator *asks* why a rule was not followed, a causal account of the mechanism is the requested answer. The defect is the wrong kind of answer, not merely a short one - a rule restatement in place of a cause is a non-answer at any length. A written LRN/KNW entry is not conversational rumination, so capture classification is unaffected. Cross-reference the third disjunct of the new kernel detection prompt (`or a restatement of the rule feels like a sufficient answer to why you broke it`), which is phrased to fire on exactly this substitution. |
 
@@ -3004,7 +3006,11 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-Remediation beyond this rule - activation-preflight detection of the suppression, and any documented degraded mode - is deliberately out of scope here and is tracked separately as DS-133.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+
+Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
+
+**A consequence-detector was specified and rejected; the reason is recorded so it need not be re-derived.** The idea was to stop asking "is spawning suppressed?" and instead report when a session committed shippable files with zero `spawn_start` events on record - a cause-agnostic fact about the session's own artifacts, emitted by hook code so that a compromised conductor's own judgment is not load-bearing. It fails on attribution rather than on capability inference: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant shapes satisfy the predicate. A session doing nothing but its mandated base-sync and `git pull --ff-only` picks up a teammate's freshly merged commits. A cross-session loop resuming at a later phase squash-merges work whose engineer and Skeptic ran under a prior session's identifier, and the base-sync fast-forward at that phase's tail lands the resulting commit locally - the merge is the mechanism, not authorship. The landed squash commit is dated at merge time yet contains work reviewed under a prior session's identifier: fresh by date, foreign by authorship. A mandated `gh pr update-branch --rebase` rewrites committer dates and pulls an entire prior branch into any time window. So the detector would fire on mandated hygiene and on resumed reviewed work, which is the outcome the enforcement-hook prohibition above already names, at lower cost and with the same effect on operator attention. Surviving a compromised conductor is necessary but not sufficient: the surviving code still has to evaluate something it can compute. If a per-session commit-attribution signal is ever established, this analysis is the starting point rather than a settled bar.
 
 **Notice template (unconditional branch).** When the directive is unconditional and spawning genuinely fails, emit at the first user-facing turn:
 
@@ -3020,7 +3026,7 @@ unreviewed.
 [phase: delegation-suppressed]
 ```
 
-This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md:80` has a trigger computed at preflight on every session. It is **not** one of those four and must not be added to that count.
+This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md` §Session Context and Memory, the "stacked first-user-turn notices" line, has a trigger computed at preflight on every session. It is **not** one of those five and must not be added to that count.
 
 **Harness-vs-model diagnostic.** Before attributing a compliance regression (the model ignoring delegation rules) to a model-version change, distinguish harness-cause from model-cause: run the identical prompt in a plain local terminal session versus the suspect entrypoint. Only a local-complies / other-fails split implicates the harness (an injected system prompt outranking the methodology); if both fail identically, the regression is model-side and should be investigated as such.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -2864,7 +2864,8 @@ Purpose: Detailed delegation-model reference blocks extracted from
 
 Public API: Read-only reference document. Cross-referenced from:
             content/sections/02-delegation.md (inline pointers replacing
-            each verbose block).
+            each verbose block); hooks/AGENTS.md (two inbound pointers into
+            the Harness-Injected Instruction Conflicts section).
 
 Upstream deps: content/sections/02-delegation.md (parent section; read
                that section first for the full delegation model overview,
@@ -3006,7 +3007,7 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template below are the fix, applied by the operator.
 
 Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
 

--- a/content/references/delegation-detail.md
+++ b/content/references/delegation-detail.md
@@ -23,7 +23,8 @@ Purpose: Detailed delegation-model reference blocks extracted from
 
 Public API: Read-only reference document. Cross-referenced from:
             content/sections/02-delegation.md (inline pointers replacing
-            each verbose block).
+            each verbose block); hooks/AGENTS.md (two inbound pointers into
+            the Harness-Injected Instruction Conflicts section).
 
 Upstream deps: content/sections/02-delegation.md (parent section; read
                that section first for the full delegation model overview,
@@ -165,7 +166,7 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template below are the fix, applied by the operator.
 
 Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
 

--- a/content/references/delegation-detail.md
+++ b/content/references/delegation-detail.md
@@ -11,7 +11,9 @@ Purpose: Detailed delegation-model reference blocks extracted from
          before-Architect rules (incl shared-utility-MANDATORY and Parallel
          Investigators); Harness-Injected Instruction Conflicts (collision
          catalog, delegation-suppression subsection, notice template,
-         operator remedies, harness-vs-model diagnostic);
+         operator remedies, harness-vs-model diagnostic, DS-133
+         unsupported-configuration policy and rejected consequence-detector
+         record);
          Learnings pipeline; Worker preamble + execution contract template;
          AskUserQuestion and Operator Decisions enforcement mechanics (hook
          wiring, detection limits, kill switch); Operator Decisions block
@@ -147,7 +149,7 @@ Parent clause: `content/sections/02-delegation.md` §Host-harness instruction co
 | Collision | Harness default (paraphrase) | AE locus | Resolution |
 |---|---|---|---|
 | **Approval scope** | "approval in one context doesn't extend to the next" | `content/sections/02-delegation.md` §Standing authorizations; `content/rules/conventions.md` §Git Workflow, Conductor preflight step 7 | The listed hygiene operations are durably authorized, so the harness carve-out is satisfied rather than overridden. An operator correction that an operation is routine updates the standing norm and is not instance-scoped. |
-| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation beyond the existing rule is out of scope for DS-132 and tracked separately as DS-133. |
+| **Delegation suppression** | "do not call the AgentTool unless the user requested it" | `content/sections/02-delegation.md` §Delegation | See the Delegation suppression (Collision 2) subsection below. Remediation was settled in DS-133: unsupported configuration, no detection, no degraded mode. |
 | **Act vs ask** | "confirm first for outward-facing or hard-to-reverse actions" | `content/sections/02-delegation.md` Hard-stop branch and Surface-and-proceed branch | Already arbitrated - the two branches partition the space by irreversibility. What was missing was the detection prompt and a definition of "pre-authorized", both now supplied. No new arbitration rule is added. |
 | **Self-correction depth** | "avoid excessive self-correction; don't ruminate or give a detailed account of the mistake" | `content/references/conductor-operating-rules.md` §learnings-agent; `content/references/capture-classification.md` | When the operator *asks* why a rule was not followed, a causal account of the mechanism is the requested answer. The defect is the wrong kind of answer, not merely a short one - a rule restatement in place of a cause is a non-answer at any length. A written LRN/KNW entry is not conversational rumination, so capture classification is unaffected. Cross-reference the third disjunct of the new kernel detection prompt (`or a restatement of the rule feels like a sufficient answer to why you broke it`), which is phrased to fire on exactly this substitution. |
 
@@ -163,7 +165,11 @@ Where the directive is conditional ("unless the user requested it"), the conditi
 
 Where the directive is unconditional and spawning genuinely fails, the conductor states that plainly at its first user-facing turn, with a remedy, rather than silently degrading into a direct implementer.
 
-Remediation beyond this rule - activation-preflight detection of the suppression, and any documented degraded mode - is deliberately out of scope here and is tracked separately as DS-133.
+**Policy: unsupported configuration, not a degraded mode (DS-133).** Detection of the suppression is not implemented. AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. An affected session is an unsupported configuration, and the remedies listed with the notice template above are the fix, applied by the operator.
+
+Three reasons stand behind that, and any future proposal to detect suppression has to answer all three rather than route around them. First, the activation preflight is bound to three file reads with no LLM reasoning (`content/sections/01-activation-preflight.md`, opening paragraph of §Activation preflight), and an injected directive has no file to read. Second, the capability has no payload representation and is not derivable from an on-disk artifact - the enforcement-hook prohibition above states this for hooks, and while that sentence is hook-scoped, the absence of a signal it relies on is a fact about the session rather than about hooks, so relocating the same inference to another layer does not create the signal. Third, the observed failure is *soft*: the model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case, already handled by the unconditional branch above.
+
+**A consequence-detector was specified and rejected; the reason is recorded so it need not be re-derived.** The idea was to stop asking "is spawning suppressed?" and instead report when a session committed shippable files with zero `spawn_start` events on record - a cause-agnostic fact about the session's own artifacts, emitted by hook code so that a compromised conductor's own judgment is not load-bearing. It fails on attribution rather than on capability inference: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant shapes satisfy the predicate. A session doing nothing but its mandated base-sync and `git pull --ff-only` picks up a teammate's freshly merged commits. A cross-session loop resuming at a later phase squash-merges work whose engineer and Skeptic ran under a prior session's identifier, and the base-sync fast-forward at that phase's tail lands the resulting commit locally - the merge is the mechanism, not authorship. The landed squash commit is dated at merge time yet contains work reviewed under a prior session's identifier: fresh by date, foreign by authorship. A mandated `gh pr update-branch --rebase` rewrites committer dates and pulls an entire prior branch into any time window. So the detector would fire on mandated hygiene and on resumed reviewed work, which is the outcome the enforcement-hook prohibition above already names, at lower cost and with the same effect on operator attention. Surviving a compromised conductor is necessary but not sufficient: the surviving code still has to evaluate something it can compute. If a per-session commit-attribution signal is ever established, this analysis is the starting point rather than a settled bar.
 
 **Notice template (unconditional branch).** When the directive is unconditional and spawning genuinely fails, emit at the first user-facing turn:
 
@@ -179,7 +185,7 @@ unreviewed.
 [phase: delegation-suppressed]
 ```
 
-This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md:80` has a trigger computed at preflight on every session. It is **not** one of those four and must not be added to that count.
+This notice is condition-scoped, not a session-start notice: it fires only on an affected entrypoint, whereas every notice in the stacked tally at `content/rules/conventions.md` §Session Context and Memory, the "stacked first-user-turn notices" line, has a trigger computed at preflight on every session. It is **not** one of those five and must not be added to that count.
 
 **Harness-vs-model diagnostic.** Before attributing a compliance regression (the model ignoring delegation rules) to a model-version change, distinguish harness-cause from model-cause: run the identical prompt in a plain local terminal session versus the suspect entrypoint. Only a local-complies / other-fails split implicates the harness (an injected system prompt outranking the methodology); if both fail identically, the regression is model-side and should be investigated as such.
 

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -130,3 +130,5 @@ permitted action class is a deadlock, not stricter enforcement. The worked
 instance - why no hook may deny conductor Read/Grep/Glob to force delegation -
 is `content/references/delegation-detail.md` §Harness-Injected Instruction
 Conflicts.
+
+The non-hook layers were settled separately: see `content/references/delegation-detail.md` §Delegation suppression (Collision 2).


### PR DESCRIPTION
## Summary

Settles harness delegation suppression as an **unsupported configuration**, and records why detecting it is not possible so a future ticket does not rebuild the dead end.

DS-132 catalogued four collisions between a Claude Code harness system prompt and AE's rules. Collision 2 (delegation suppression) was split out to this ticket because its remediation is a policy call, not a doc edit: when a harness tells the conductor not to spawn subagents, every AE review gate is bypassed and the operator is handed unreviewed Elevated work.

**The answer is (b): unsupported configuration.** AE does not refuse to activate, does not offer a degraded-mode switch, and does not claim to notice suppression. The remedies already documented with the notice template are the fix, applied by the operator.

### Why option (a) - preflight detection plus a degraded mode - is not implementable

Three independent reasons, all now recorded in the reference so a future proposal has to answer them rather than route around them:

1. **The activation preflight is bound to three file reads with no LLM reasoning.** An injected system-prompt directive has no file to read.
2. **The capability has no payload representation and is not derivable from an on-disk artifact.** The enforcement-hook prohibition already states this for hooks; that sentence is hook-scoped, but the absence of a signal it relies on is a fact about the session, so relocating the same inference to another layer does not create the signal.
3. **The observed failure is soft.** The model is discouraged and complies, so no spawn is attempted and no error exists to classify. A hard spawn failure is a different case and DS-132 already handles it.

### A consequence-detector was designed in full, then falsified

The ticket's most useful output. Rather than asking "is spawning suppressed?" (unanswerable), the design asked "did shippable work ship with zero review?" - a cause-agnostic fact about the session's own artifacts, emitted by hook code so a compromised conductor's judgment is not load-bearing.

It fails on **attribution**: `spawn_start` events are keyed by `session_uuid`, git commits carry no session identity, and every proxy bridging the two is confounded. Three fully compliant session shapes satisfy the predicate:

- a session doing nothing but its mandated base-sync and `git pull --ff-only`, picking up a teammate's freshly merged commits;
- a cross-session loop resuming at a later phase, whose squash-merge lands via the base-sync fast-forward - fresh by date, foreign by authorship;
- a mandated `gh pr update-branch --rebase`, which rewrites committer dates and pulls an entire prior branch into any time window.

So it would fire on mandated hygiene and on resumed reviewed work - the exact failure the enforcement-hook prohibition already names, at lower cost and with the same effect on operator attention. That analysis is recorded verbatim in the reference, with the successor path stated: if a per-session commit-attribution signal is ever established, this is the starting point rather than a settled bar.

## What changed

- `content/references/delegation-detail.md` - the policy, the three reasons, and the rejected-detector record inside §Delegation suppression (Collision 2); the collision-catalog row updated so it no longer says the question is open; a stale `conventions.md:80` citation replaced with a content anchor; a `four` -> `five` count corrected; the module manifest updated.
- `hooks/AGENTS.md` - one pointer line, not a restated conclusion.
- Four adapter mirrors regenerated.

**Resident set: byte-unchanged.** `total: 121006`, threshold 121066, headroom 60 B. `check-drift` green with `.methodology-baseline.sha256` untouched. Everything here lives in `content/references/**`, which is not resident.

## Known and accepted

`content/sections/02-delegation.md:90` enumerates this subsection's contents and is now incomplete - it does not list the policy or the rejected-detector record. This is omission, not falsity: every item it names still exists. It is unfixable under the 0-byte resident budget and is **accepted knowingly** rather than overlooked, recorded here so a later doc-sync review does not spend a round rediscovering it.

**This ticket ships nothing that fires.** That is the honest outcome. Every prose remedy addresses the conductor, which is the party the harness compromised - a conductor talked out of spawning is also talked out of noticing. The only layer that survives is hook code, and no computable predicate is available to it. An affected operator is protected by the DS-132 notice on the hard-failure branch and by nothing on the soft branch.

## Test plan

- [x] Resident budget byte-unchanged (`total: 121006`), `THRESHOLD` untouched
- [x] `check-methodology-drift` green; `.methodology-baseline.sha256` absent from the diff
- [x] No path under `content/sections/` or `content/rules/` in the diff
- [x] Both content scanners green (`test_learnings_agent_capture_model_spec.py`, `test_skeptic_open_enum_spec.py`)
- [x] `bin/tests` green - 796 passed
- [x] Hooks JS, shell, and Python legs all green
- [x] Adapter drift clean under the pathspec copied verbatim from `adapter-sync.yml`, including the five `.github/*` entries `build-all.sh` omits
- [x] `check-codex-skill-sync` OK (4 skills)
- [x] `grep 'tracked separately as DS-133'` returns nothing; `grep 'one of those five'` returns one hit; heading set unchanged
- [x] No em dashes; symlinks relative; DCO signed-off with matching raw author email

## North Star alignment

- **Pillar(s) advanced (see docs/overview/vision.md):** **2 (produce verifiable outcomes autonomously)**, by closing an open remediation fork with a recorded answer instead of leaving it to be re-derived per session. Secondarily **1 (guard operator attention)**: the rejected-detector record prevents a future ticket from shipping a mechanism that would have fired on mandated `git pull` and on resumed reviewed work, which is a direct attention tax.

- **Trade-off or pillar this could regress, if any:** This ships nothing that fires, so it does not close the gap it documents - an operator on an affected entrypoint is no better protected than before. That is a real limitation, named above rather than hidden. The alternative considered (the consequence-detector) would have regressed Pillar 1 outright by firing on compliant sessions, so shipping nothing is the better of the two available outcomes, not a good one. Minor documentation debt is also accepted: the enumeration at `content/sections/02-delegation.md:90` is left incomplete under the 0-byte resident budget, recorded above.

## Review rigor

- Brief / Plan path: held out-of-tree (`docs/planning/` is gitignored in this repo)
- Plan review: 3 rounds before sign-off. Round 1 descoped the entire code half on evidence (2 Critical); rounds 2 and 3 corrected sourcing, a leaking carve-out, and a false supporting clause.
- Notable: round 3 caught that a proposed clause was not only wrong but self-undercutting - had it been true, the shape it described would not have been a false positive at all, and a future author reasoning from it would have rebuilt the detector.
- One round-2 finding was contested by the architect and adjudicated in its favour after direct verification (the reviewer was off by one line).
- Findings summary: Critical 0, Major 0 outstanding.
