### PR TITLE
fix(memory): correct auto-memory index claim and make it retrievable

### DIFF
--- a/.claude/commands/ds-memory-update.md
+++ b/.claude/commands/ds-memory-update.md
@@ -16,13 +16,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.cursor/commands/ds-memory-update.md
+++ b/.cursor/commands/ds-memory-update.md
@@ -10,13 +10,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.gemini/commands/ds-memory-update.toml
+++ b/.gemini/commands/ds-memory-update.toml
@@ -16,13 +16,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.github/prompts/ds-memory-update.prompt.md
+++ b/.github/prompts/ds-memory-update.prompt.md
@@ -13,13 +13,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -17752,13 +17752,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.openclaw/skills/ds-memory-update/SKILL.md
+++ b/.openclaw/skills/ds-memory-update/SKILL.md
@@ -15,13 +15,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/.opencode/commands/ds-memory-update.md
+++ b/.opencode/commands/ds-memory-update.md
@@ -14,13 +14,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 

--- a/bin/agentic-memory
+++ b/bin/agentic-memory
@@ -35,7 +35,11 @@ from datetime import date, datetime
 from pathlib import Path
 
 EVENTS_PATH = Path(".agentic/events.jsonl")
-MEMORY_PATHS = [Path("MEMORY.md"), Path(".agentic/memory.md")]
+MEMORY_PATHS = [
+    Path("MEMORY.md"),
+    Path(".agentic/memory.md"),
+    Path(".agentic/memory/MEMORY.md"),
+]
 CONTEXT_PATH = Path(".agentic/context.md")
 
 

--- a/bin/tests/test_agentic_memory.py
+++ b/bin/tests/test_agentic_memory.py
@@ -258,6 +258,47 @@ def test_query_memory_md_topic():
     print("PASS test_query_memory_md_topic")
 
 
+def test_query_memory_auto_memory_fallback():
+    """When root MEMORY.md is absent, memory query falls back to the auto-memory index."""
+    with tempfile.TemporaryDirectory() as tmp:
+        auto_memory = Path(tmp) / ".agentic" / "memory"
+        auto_memory.mkdir(parents=True)
+        (auto_memory / "MEMORY.md").write_text(
+            "## Auto-memory\nHarness-injected index.\n\n"
+            "## Decisions\nFallback works.\n"
+        )
+
+        # Uses the real MEMORY_PATHS (relative paths resolved against tmp cwd),
+        # with root MEMORY.md and .agentic/memory.md absent.
+        rc, out, _ = _capture_query(
+            _make_query_args(keyword="fallback", source="MEMORY.md"),
+            tmp,
+        )
+
+        assert rc == 0
+        assert "Decisions" in out, f"Expected auto-memory section in output: {out!r}"
+    print("PASS test_query_memory_auto_memory_fallback")
+
+
+def test_query_memory_root_wins_precedence():
+    """Root MEMORY.md outranks the auto-memory index (first-match-wins preserved)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "MEMORY.md").write_text("## Root\nCurated project memory.\n")
+        auto_memory = Path(tmp) / ".agentic" / "memory"
+        auto_memory.mkdir(parents=True)
+        (auto_memory / "MEMORY.md").write_text("## Auto\nShould not win.\n")
+
+        rc, out, _ = _capture_query(
+            _make_query_args(keyword="root", source="MEMORY.md"),
+            tmp,
+        )
+
+        assert rc == 0
+        assert "Root" in out, f"Expected root MEMORY.md section in output: {out!r}"
+        assert "Auto" not in out, f"Auto-memory index should not outrank root MEMORY.md: {out!r}"
+    print("PASS test_query_memory_root_wins_precedence")
+
+
 def test_query_missing_source_warning_on_stderr():
     """Missing source files produce a warning on stderr, not a crash."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -390,6 +431,8 @@ if __name__ == "__main__":
     test_query_events_last_filter()
     test_query_memory_md_keyword()
     test_query_memory_md_topic()
+    test_query_memory_auto_memory_fallback()
+    test_query_memory_root_wins_precedence()
     test_query_missing_source_warning_on_stderr()
     test_query_malformed_jsonl_skipped()
     test_turns_no_context_returns_zero()

--- a/content/commands/ds-memory-update.md
+++ b/content/commands/ds-memory-update.md
@@ -10,13 +10,7 @@ When a project-affecting decision has been confirmed in conversation, the main a
 
 **Before spawning:** The canonical MEMORY.md path is `<cwd>/MEMORY.md` (loaded at session start via the `@MEMORY.md` import in the project root `CLAUDE.md`). Pass this path to the Worker as `$MEMORY_PATH`. `<cwd>/MEMORY.md` is committed by default for consumer projects scaffolded by `/ds-init-project`; in the DinoStack repo itself it is intentionally gitignored (DS-129), so this write is local-only here and never reaches a PR.
 
-**Orphan data warning:** If `<cwd>/.agentic/memory/MEMORY.md` exists, it was written by a prior buggy version of this command. Its content is NOT auto-injected by Claude Code. Surface this to the operator before spawning:
-
-```
-WARNING: orphaned memory file at .agentic/memory/MEMORY.md detected. Content is not auto-injected. Review manually and merge into <cwd>/MEMORY.md if needed.
-```
-
-Do NOT auto-merge the orphaned file.
+**Auto-memory index:** `<cwd>/.agentic/memory/MEMORY.md` is the Claude Code auto-memory index, wired via `autoMemoryDirectory` in `.claude/settings.local.json` and auto-injected into session context by the harness. It is distinct from `<cwd>/MEMORY.md`, the curated project memory file this command manages. The two stores are separate - do not merge them.
 
 **What to pass as context:** A concise summary of the decision - 1-3 sentences covering what was decided, why, and any key tradeoffs.
 


### PR DESCRIPTION
## Summary
- Fix a stale accuracy claim in `/ds-memory-update`: it asserted `.agentic/memory/MEMORY.md` (the Claude Code auto-memory index, wired via `autoMemoryDirectory`) "is NOT auto-injected" and told operators to merge it into root `MEMORY.md`. Both are false - the harness auto-injects the index, and it is a distinct store from the curated project `MEMORY.md` this command manages. Replaced with an accurate note; the warning code block and the "Do NOT auto-merge" line were removed.
- Make the auto-memory index retrievable: `bin/agentic-memory` omitted `.agentic/memory/MEMORY.md` from `MEMORY_PATHS`. Added it as the lowest-precedence entry so the CLI falls back to it when neither root `MEMORY.md` nor `.agentic/memory.md` exists. First-match-wins semantics and the precedence of the two existing paths are unchanged (DS-131 load-bearing). No directory walk of `.agentic/memory/*.md` entry files.
- Rebuilt all 11 adapters so command copies stay in sync; added two `bin/tests` cases covering the fallback and root-precedence.

## Test plan
- `bash scripts/build-all.sh` - all 11 adapters built; adapter-dir diff is exactly the 7 regenerated ds-memory-update outputs (verified no stale text remains in any adapter copy).
- Hooks JS suite: 44/44 pass.
- `python3 -m pytest bin/tests/ -q`: 850 passed.
- Shell bin-tests: 35/35 pass.
- Runtime smoke: CLI query against a temp dir with only `.agentic/memory/MEMORY.md` present returns its content; with root `MEMORY.md` present, root wins.
- Skeptic sign-off: full diff review, mutation-checked the fallback test (reverting `MEMORY_PATHS` to the 2-path list makes `test_query_memory_auto_memory_fallback` fail), fresh adapter build byte-matches the committed copies. Zero findings.

## North Star alignment
- **Universality (works for everyone):** no operator identity, workspace, tracker, or local setup is baked in. The new `MEMORY_PATHS` entry is a plain cwd-relative fallback that resolves identically for any consumer project; the doc note describes the auto-memory mechanism accurately without implying the file always exists or is always injected.
- **Guard operator attention:** removes a false attention tax (an "orphan" warning about a file that is live and harness-injected) and a destructive merge instruction.
- **Evidence-beats-description:** the fix is pinned by a mutation-confirmed regression test, not prose.
- No new ceremony, no new surface, no irreversible operations.