### PR TITLE
feat(memory): bounded retrieval output caps for agentic-memory

### DIFF
--- a/bin/agentic-memory
+++ b/bin/agentic-memory
@@ -8,8 +8,14 @@ Public API: agentic-memory query [keyword] [--since YYYY-MM-DD]
                       [--until YYYY-MM-DD] [--type event_type]
                       [--agent agent_name] [--last N]
                       [--source MEMORY.md|events.jsonl|context.md]
-                      [--topic topic]
-            agentic-memory turns --last N
+                      [--topic topic] [--max-items N] [--max-chars N]
+            agentic-memory turns --last N   (N must be <= 200)
+
+Retrieval caps: query output is bounded per source to at most 20 matched
+               items and 8000 rendered characters by default. When a cap
+               bites, a non-silent "... truncated:" marker line is appended
+               to that source block. --max-items 0 or --max-chars 0 (or a
+               negative value) disables the respective cap.
 
 Upstream deps: Python 3 stdlib only (argparse, datetime, json, re, sys,
                pathlib). No external dependencies.
@@ -19,7 +25,8 @@ Downstream consumers: content/commands/ds-memory-update.md (command spec);
 
 Failure modes: missing source files -> warning to stderr, skipped;
                malformed JSONL -> line skipped, warning to stderr;
-               no matches -> "No results found" to stdout, exit 0.
+               no matches -> "No results found" to stdout, exit 0;
+               turns --last N > 200 -> error to stderr, exit 2.
                Never raises to the caller.
 
 Performance: O(file size). Linear scan of each source file.
@@ -41,6 +48,10 @@ MEMORY_PATHS = [
     Path(".agentic/memory/MEMORY.md"),
 ]
 CONTEXT_PATH = Path(".agentic/context.md")
+
+DEFAULT_MAX_ITEMS = 20
+DEFAULT_MAX_CHARS = 8000
+MAX_TURNS_CEILING = 200
 
 
 def _parse_iso_date(s: str) -> date:
@@ -311,6 +322,52 @@ def _format_turns(turns: list[tuple[str, str]]) -> str:
     return "\n".join(lines)
 
 
+def _cap_source(
+    matched: list,
+    formatter,
+    *,
+    max_items: int,
+    max_chars: int,
+) -> tuple[str, str | None]:
+    """Bound a rendered source block by per-source item and char caps.
+
+    Applies the item cap to the matched items first, renders the kept items
+    with ``formatter``, then bounds the rendered markdown by the char cap.
+    Returns ``(bounded_markdown, marker)`` where ``marker`` is None when no
+    cap bit. A non-silent ``... truncated:`` marker line is returned whenever
+    items or characters were dropped, so bounded recall is never silent.
+    ``max_items``/``max_chars`` <= 0 disable the respective cap.
+    """
+    kept = matched
+    if max_items > 0 and len(matched) > max_items:
+        kept = matched[:max_items]
+
+    rendered = formatter(kept)
+
+    truncated_items = len(matched) - len(kept)
+    truncated_chars = 0
+    bounded = rendered
+    if max_chars > 0 and len(rendered) > max_chars:
+        bounded = rendered[:max_chars]
+        truncated_chars = len(rendered) - max_chars
+
+    if not truncated_items and not truncated_chars:
+        return rendered, None
+
+    parts = []
+    if truncated_items:
+        item_label = "item" if truncated_items == 1 else "items"
+        parts.append(f"{truncated_items} more {item_label}")
+    if truncated_chars:
+        char_label = "char" if truncated_chars == 1 else "chars"
+        parts.append(f"{truncated_chars} more {char_label}")
+    marker = (
+        f"... truncated: {'; '.join(parts)}; "
+        "narrow your query or raise --max-items / --max-chars"
+    )
+    return bounded, marker
+
+
 def cmd_query(args: argparse.Namespace) -> int:
     keyword: str | None = args.keyword
     since = _parse_iso_date(args.since) if args.since else None
@@ -320,6 +377,8 @@ def cmd_query(args: argparse.Namespace) -> int:
     last: int | None = args.last
     source: str | None = args.source
     topic: str | None = args.topic
+    max_items: int = args.max_items
+    max_chars: int = args.max_chars
 
     outputs: list[str] = []
     has_error = False
@@ -346,7 +405,10 @@ def cmd_query(args: argparse.Namespace) -> int:
             print(err, file=sys.stderr)
             has_error = True
         elif results:
-            outputs.append(_format_events(results))
+            block, marker = _cap_source(
+                results, _format_events, max_items=max_items, max_chars=max_chars
+            )
+            outputs.append(block + ("\n" + marker if marker else ""))
 
     if "memory" in sources:
         results, err = _read_memory(MEMORY_PATHS, keyword=keyword, topic=topic)
@@ -354,7 +416,10 @@ def cmd_query(args: argparse.Namespace) -> int:
             print(err, file=sys.stderr)
             has_error = True
         elif results:
-            outputs.append(_format_memory(results))
+            block, marker = _cap_source(
+                results, _format_memory, max_items=max_items, max_chars=max_chars
+            )
+            outputs.append(block + ("\n" + marker if marker else ""))
 
     if "context" in sources:
         results, err = _read_context(CONTEXT_PATH, keyword=keyword, last=last)
@@ -362,7 +427,10 @@ def cmd_query(args: argparse.Namespace) -> int:
             print(err, file=sys.stderr)
             has_error = True
         elif results:
-            outputs.append(_format_context(results))
+            block, marker = _cap_source(
+                results, _format_context, max_items=max_items, max_chars=max_chars
+            )
+            outputs.append(block + ("\n" + marker if marker else ""))
 
     if not outputs:
         print("No results found")
@@ -374,6 +442,12 @@ def cmd_query(args: argparse.Namespace) -> int:
 
 def cmd_turns(args: argparse.Namespace) -> int:
     last: int = args.last
+    if last > MAX_TURNS_CEILING:
+        print(
+            f"Error: --last must be <= {MAX_TURNS_CEILING} (got {last})",
+            file=sys.stderr,
+        )
+        return 2
     turns, err = _read_context(CONTEXT_PATH, last=last)
     if err:
         print(err, file=sys.stderr)
@@ -410,10 +484,31 @@ def main(argv: list[str]) -> int:
     query_parser.add_argument(
         "--topic", help="Topic filter for MEMORY.md section headings"
     )
+    query_parser.add_argument(
+        "--max-items",
+        type=int,
+        default=DEFAULT_MAX_ITEMS,
+        help=(
+            f"Max matched items returned per source (default {DEFAULT_MAX_ITEMS}; "
+            "0 or a negative value disables the cap)"
+        ),
+    )
+    query_parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=DEFAULT_MAX_CHARS,
+        help=(
+            f"Max rendered chars emitted per source (default {DEFAULT_MAX_CHARS}; "
+            "0 or a negative value disables the cap)"
+        ),
+    )
 
     turns_parser = subparsers.add_parser("turns", help="Show recent turns from context.md")
     turns_parser.add_argument(
-        "--last", type=int, default=5, help="Number of recent turns to show"
+        "--last",
+        type=int,
+        default=5,
+        help=f"Number of recent turns to show (max {MAX_TURNS_CEILING})",
     )
 
     args = parser.parse_args(argv[1:])

--- a/bin/tests/test_agentic_memory.py
+++ b/bin/tests/test_agentic_memory.py
@@ -86,6 +86,8 @@ def _make_query_args(**kwargs) -> types.SimpleNamespace:
         "last": None,
         "source": None,
         "topic": None,
+        "max_items": 20,
+        "max_chars": 8000,
     }
     defaults.update(kwargs)
     return types.SimpleNamespace(**defaults)
@@ -423,6 +425,197 @@ def test_event_to_date_bad_input_returns_none():
     print("PASS test_event_to_date_bad_input_returns_none")
 
 
+def test_query_item_cap_truncates_and_marks():
+    """Item cap bounds a large result set and emits the non-silent marker."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        lines = [_make_event(f"ev_{i}", f"2026-05-{i + 1:02d}T10:00:00Z") for i in range(30)]
+        events.write_text("\n".join(lines) + "\n")
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_items=5),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        assert "ev_0" in out, f"first kept item should appear: {out!r}"
+        assert "ev_5" not in out, f"item beyond the cap should be excluded: {out!r}"
+        assert "... truncated: 25 more items" in out, f"expected item-cap marker: {out!r}"
+    print("PASS test_query_item_cap_truncates_and_marks")
+
+
+def test_query_char_cap_truncates_and_marks():
+    """Char budget bounds a large rendered output and emits the marker."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        big = "x" * 20000
+        events.write_text(_make_event("huge", "2026-05-01T10:00:00Z", task_id=big) + "\n")
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            rc, out, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_chars=200),
+                tmp,
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert rc == 0
+        assert "... truncated:" in out, f"expected char-cap marker: {out!r}"
+        assert "more chars" in out, f"expected char count in marker: {out!r}"
+        assert big not in out, f"full oversized payload should not be emitted: {out!r}"
+    print("PASS test_query_char_cap_truncates_and_marks")
+
+
+def test_query_max_items_override_raise_and_lower():
+    """--max-items overrides the default item cap (raise, lower, disable)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        lines = [_make_event(f"ev_{i}", f"2026-05-{i + 1:02d}T10:00:00Z") for i in range(30)]
+        events.write_text("\n".join(lines) + "\n")
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            _, out_raise, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_items=50), tmp
+            )
+            _, out_lower, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_items=3), tmp
+            )
+            _, out_zero, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_items=0), tmp
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert "truncated" not in out_raise, f"raised cap should not truncate: {out_raise!r}"
+        assert "... truncated: 27 more items" in out_lower, f"lowered cap should truncate: {out_lower!r}"
+        assert "truncated" not in out_zero, f"0 should disable the cap: {out_zero!r}"
+        assert "ev_29" in out_raise and "ev_29" in out_zero
+        assert "ev_29" not in out_lower
+    print("PASS test_query_max_items_override_raise_and_lower")
+
+
+def test_query_max_chars_override_raise_and_lower():
+    """--max-chars overrides the default char budget (raise, lower, disable)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        big = "y" * 30000
+        events.write_text(_make_event("huge", "2026-05-01T10:00:00Z", task_id=big) + "\n")
+
+        old_events = _mod.EVENTS_PATH
+        _mod.EVENTS_PATH = events
+        try:
+            _, out_raise, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_chars=100000), tmp
+            )
+            _, out_lower, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_chars=150), tmp
+            )
+            _, out_zero, _ = _capture_query(
+                _make_query_args(source="events.jsonl", max_chars=0), tmp
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+
+        assert "truncated" not in out_raise, f"raised budget should not truncate: {out_raise!r}"
+        assert "... truncated:" in out_lower and "more chars" in out_lower, (
+            f"lowered budget should truncate with marker: {out_lower!r}"
+        )
+        assert "truncated" not in out_zero, f"0 should disable the cap: {out_zero!r}"
+        assert big in out_raise and big in out_zero
+        assert big not in out_lower
+    print("PASS test_query_max_chars_override_raise_and_lower")
+
+
+def test_query_small_result_byte_identical_to_no_caps():
+    """Small results with default caps match no-cap output byte-for-byte."""
+    with tempfile.TemporaryDirectory() as tmp:
+        agentic = Path(tmp) / ".agentic"
+        agentic.mkdir()
+        events = agentic / "events.jsonl"
+        events.write_text(
+            _make_event("spawn_start", "2026-05-01T10:00:00Z", agent="engineer", task_id="T-1") + "\n"
+            + _make_event("spawn_complete", "2026-05-01T10:01:00Z", agent="skeptic", task_id="T-2") + "\n"
+        )
+        (agentic / "context.md").write_text("## Turn 1\nUser asked something.\n")
+        memory = Path(tmp) / "MEMORY.md"
+        memory.write_text("## Architecture\nWe use Python for all CLIs.\n")
+
+        old_events = _mod.EVENTS_PATH
+        old_paths = _mod.MEMORY_PATHS
+        old_ctx = _mod.CONTEXT_PATH
+        _mod.EVENTS_PATH = events
+        _mod.MEMORY_PATHS = [memory]
+        _mod.CONTEXT_PATH = agentic / "context.md"
+        try:
+            _, out_default, _ = _capture_query(
+                _make_query_args(max_items=20, max_chars=8000), tmp
+            )
+            _, out_nocap, _ = _capture_query(
+                _make_query_args(max_items=0, max_chars=0), tmp
+            )
+        finally:
+            _mod.EVENTS_PATH = old_events
+            _mod.MEMORY_PATHS = old_paths
+            _mod.CONTEXT_PATH = old_ctx
+
+        assert out_default == out_nocap, (
+            "default-cap output must equal no-cap output for small results\n"
+            f"default: {out_default!r}\nnocap: {out_nocap!r}"
+        )
+    print("PASS test_query_small_result_byte_identical_to_no_caps")
+
+
+def test_turns_last_ceiling_rejects_large_n():
+    """turns --last N refuses N above the ceiling with a clear error."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = Path(tmp) / "context.md"
+        ctx.write_text("## Turn 1\nUser asked something.\n")
+        old_ctx = _mod.CONTEXT_PATH
+        _mod.CONTEXT_PATH = ctx
+        try:
+            rc, out, err = _capture_turns(types.SimpleNamespace(last=201), tmp)
+        finally:
+            _mod.CONTEXT_PATH = old_ctx
+
+        assert rc == 2, f"Expected rc=2 for N above ceiling, got {rc}"
+        assert "Error" in err and "200" in err, f"Expected clear error: {err!r}"
+    print("PASS test_turns_last_ceiling_rejects_large_n")
+
+
+def test_turns_last_ceiling_allows_boundary():
+    """turns --last 200 is accepted (the ceiling boundary)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = Path(tmp) / "context.md"
+        ctx.write_text("## Turn 1\nUser asked something.\n")
+        old_ctx = _mod.CONTEXT_PATH
+        _mod.CONTEXT_PATH = ctx
+        try:
+            rc, out, _ = _capture_turns(types.SimpleNamespace(last=200), tmp)
+        finally:
+            _mod.CONTEXT_PATH = old_ctx
+
+        assert rc == 0, f"Expected rc=0 at the ceiling boundary, got {rc}"
+        assert "User asked something" in out
+    print("PASS test_turns_last_ceiling_allows_boundary")
+
+
 if __name__ == "__main__":
     test_query_no_sources_returns_zero()
     test_query_events_jsonl_keyword_match()
@@ -441,4 +634,11 @@ if __name__ == "__main__":
     test_split_turns_blank_line_heuristic()
     test_event_to_date_parses_iso()
     test_event_to_date_bad_input_returns_none()
+    test_query_item_cap_truncates_and_marks()
+    test_query_char_cap_truncates_and_marks()
+    test_query_max_items_override_raise_and_lower()
+    test_query_max_chars_override_raise_and_lower()
+    test_query_small_result_byte_identical_to_no_caps()
+    test_turns_last_ceiling_rejects_large_n()
+    test_turns_last_ceiling_allows_boundary()
     print("All agentic-memory tests passed.")


### PR DESCRIPTION
## Summary
- Add per-source retrieval output caps to `bin/agentic-memory query`: at most 20 matched items and 8000 rendered chars per source by default.
- Truncation is non-silent: a trailing `... truncated: N more item(s)[; M more char(s)]; narrow your query or raise --max-items / --max-chars` marker line is appended per source when a cap bites; no marker when nothing is dropped.
- New flags `--max-items N` and `--max-chars N` override the defaults; 0 or a negative value disables the respective cap (documented in help/usage and module docstring).
- `turns --last N` now refuses N > 200 with `Error: --last must be <= 200 (got N)` on stderr and exit code 2.
- No new dependencies (stdlib only). Query filtering semantics, MEMORY_PATHS first-match-wins order, and the `.agentic/memory/MEMORY.md` fallback (#574) are untouched.
- Small-result output is byte-identical to the previous CLI (verified with diff against the pre-change binary on events/memory/turns fixtures).

This is a concrete borrow of the TencentDB-Agent-Memory "retrieval output caps" mechanism - bounded recall so memory never overwhelms the context it is recalled into.

## Test plan
- 7 new tests in bin/tests/test_agentic_memory.py covering item-cap truncation + marker, char-cap truncation + marker, both flag overrides (raise/lower/disable), byte-identical small result, and the turns ceiling (reject 201, accept 200).
- Mutation-checked: reverting `_cap_source` to a no-op removes the marker and lets the capped-out item through (item-cap test fails); dropping the item cap fails items + override tests; dropping the char cap fails char + override; removing the ceiling fails the rejects test.
- Full suite: `python3 -m pytest bin/tests/ -q` -> 857 passed. Shell bin-tests: all 31 pass.
- Skeptic sign-off: full diff review, independent byte-diff of pre/post-change binaries (stdout + stderr identical on small queries), live cap-boundary probing, mutation testing of all 7 tests, consumer check (`ds-memory-update.md` invocations all stay inside caps). 0 Critical/Major, 4 Minor (non-blocking: `--last N` item-cap retention direction is disclosed-by-marker; pyproject.toml stale line-ref comment is inert; tests bypass argparse; spawn-template drift).

## North Star alignment
- **Universality (works for everyone):** no operator identity, workspace, tracker, or local setup is baked in. Pure stdlib, cwd-relative, resolves identically for any consumer project.
- **Guard operator attention:** bounded recall keeps deliberate retrieval compact and predictable - a broad query can no longer dump a large file into context.
- **Evidence-beats-description:** every cap behavior is pinned by a mutation-confirmed regression test and a byte-identity check against the prior CLI.
- No new ceremony, no new surface, no irreversible operations.