### PR TITLE
fix(hooks): correct post-merge stale text and close the ballot-classifier corpus gap

### DIFF
--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -210,22 +210,22 @@ Regression corpus: hooks/tests/test-corpus-abdication.py is the permanent
                   built, never reached a measurable shape. Hard-gate/surface-
                   and-proceed suppression and code-fence/blockquote exclusion
                   must be present from first authoring, not bolted on after
-                  review. None of the corpus's 34 rows contain an
-                  "## Operator decisions" heading or a "(recommended)"/
-                  "Recommendation:" marker, so none exercise a ballot
-                  classifier's path, leaving Groups 3/5/7 as the floor for
-                  the OTHER rejected attempts only; a revival must add a
-                  compliant ALLOW row and a genuine co-equal-ballot BLOCK
-                  row, and must route through a dedicated reason constant
-                  that does not carry an unconditional "proceed now"
-                  directive. A per-item, fence-masking design with a
-                  dedicated non-"proceed now" reason exists at
-                  feat/prose-ballot-guard (PR #519) - per its PR body, 0
-                  Critical findings across three Skeptic rounds, and it
-                  passes this corpus - but it deliberately exempts its
-                  ballot check from the negative gate and does not handle
-                  ">"-blockquote headings, so it does not itself satisfy the
-                  two requirements above; that tension is unresolved.
+                  review. A revival needed to add a compliant ALLOW row
+                  and a genuine co-equal-ballot BLOCK row to this corpus,
+                  and to route through a dedicated reason constant that
+                  does not carry an unconditional "proceed now" directive.
+                  A per-item, fence-masking design with a dedicated
+                  non-"proceed now" reason (_is_prose_ballot /
+                  _BALLOT_REASON) shipped in a950bdd4 (PR #519) - per its
+                  PR body, 0 Critical findings across three Skeptic
+                  rounds, and it passes this corpus. Groups 3/5/7 remain
+                  the floor for the OTHER rejected attempts; Group 8 below
+                  now carries the compliant ALLOW row and the genuine
+                  co-equal-ballot BLOCK row this revival required, closing
+                  that gap. Two limitations remain, both deliberate and
+                  documented at _is_prose_ballot's own docstring: it
+                  deliberately exempts its ballot check from the negative
+                  gate, and it does not recognize ">"-blockquote headings.
                4. Widening the destructive gate with
                   drop/alter table|column|index|database|schema: measured
                   13/13 false suppressions.

--- a/hooks/enforce-no-abdication.py
+++ b/hooks/enforce-no-abdication.py
@@ -223,9 +223,9 @@ Regression corpus: hooks/tests/test-corpus-abdication.py is the permanent
                   now carries the compliant ALLOW row and the genuine
                   co-equal-ballot BLOCK row this revival required, closing
                   that gap. Two limitations remain, both deliberate and
-                  documented at _is_prose_ballot's own docstring: it
-                  deliberately exempts its ballot check from the negative
-                  gate, and it does not recognize ">"-blockquote headings.
+                  known: the negative-gate exemption (self-documented at
+                  _is_prose_ballot's own docstring) and the absent
+                  ">"-blockquote heading handling.
                4. Widening the destructive gate with
                   drop/alter table|column|index|database|schema: measured
                   13/13 false suppressions.

--- a/hooks/tests/test-corpus-abdication.py
+++ b/hooks/tests/test-corpus-abdication.py
@@ -23,22 +23,22 @@ Purpose: Permanent regression corpus for hooks/enforce-no-abdication.py. This
               built, never reached a measurable shape. Hard-gate/surface-
               and-proceed suppression and code-fence/blockquote exclusion
               must be present from first authoring, not bolted on after
-              review. Zero of this corpus's 34 rows contain an
-              "## Operator decisions" heading or a "(recommended)"/
-              "Recommendation:" marker, so none exercise a ballot
-              classifier's path, leaving Groups 3/5/7 as the floor for
-              the OTHER rejected attempts only; a revival must add a
-              compliant ALLOW row and a genuine co-equal-ballot BLOCK row,
-              and must route through a dedicated reason constant that
-              does not carry an unconditional "proceed now" directive.
-              This does NOT cover a per-item, fence-masking classifier with
-              a dedicated non-"proceed now" reason - feat/prose-ballot-guard
-              (PR #519) is that design, per its PR body 0 Critical findings
-              across three Skeptic rounds, and it passes this corpus - but
-              it deliberately exempts its ballot check from the negative
-              gate and does not handle ">"-blockquote headings, so it does
-              not itself satisfy the two requirements above; that tension
-              is unresolved.
+              review. A revival needed to add a compliant ALLOW row and a
+              genuine co-equal-ballot BLOCK row to this corpus, and to
+              route through a dedicated reason constant that does not
+              carry an unconditional "proceed now" directive. A per-item,
+              fence-masking design with a dedicated non-"proceed now"
+              reason (_is_prose_ballot / _BALLOT_REASON) shipped in
+              a950bdd4 (PR #519) - per its PR body, 0 Critical findings
+              across three Skeptic rounds, and it passes this corpus.
+              Groups 3/5/7 remain the floor for the OTHER rejected
+              attempts; Group 8 below now carries the compliant ALLOW row
+              and the genuine co-equal-ballot BLOCK row this revival
+              required, closing that gap. Two limitations remain, both
+              deliberate and documented at _is_prose_ballot's own
+              docstring: it deliberately exempts its ballot check from the
+              negative gate, and it does not recognize ">"-blockquote
+              headings.
            4. Widening the destructive negative gate with
               `drop/alter table|column|index|database|schema`: measured
               13/13 FALSE SUPPRESSIONS - it stops catching real abdication on
@@ -376,6 +376,49 @@ CORPUS.append((
     "g7-01",
     "ordinary_completion_allow",
     "Filed the two follow-up tickets as DS-201 and DS-202. Learnings captured to memory.",
+    False,
+))
+
+# --- Group 8: prose-ballot classifier (_is_prose_ballot / _BALLOT_REASON) --
+# Closes the gap rejected attempt #3 left open (see the Purpose docstring
+# above): this classifier shipped in a950bdd4 (PR #519) and, until these
+# rows, nothing in this corpus exercised its "## Operator decisions" +
+# unmarked-item path at all. All three values below are MEASURED against
+# the real hook, not assumed - see the header comment on each row.
+#
+# g8-00: a genuine co-equal ballot - 2 items, neither carries a
+# "(Recommended)" or "Recommendation:" marker. Measured to BLOCK.
+CORPUS.append((
+    "g8-00",
+    "prose_ballot_block",
+    "Fixed the login bug and added a regression test.\n\n"
+    "## Operator decisions\n\n"
+    "- Proceed with approach A for the retry policy - unclear which is preferred.\n"
+    "- Proceed with approach B for the cache eviction window - unclear which is preferred.",
+    True,
+))
+# g8-01: a compliant block - 2 items, each carries a recommendation marker
+# (one "(Recommended)" suffix, one "Recommendation:" lead-in). Measured to
+# ALLOW - a compliant author is never punished by this check.
+CORPUS.append((
+    "g8-01",
+    "prose_ballot_compliant_allow",
+    "Fixed the login bug and added a regression test.\n\n"
+    "## Operator decisions\n\n"
+    "- Proceed with approach A for the retry policy (Recommended) - matches the existing pattern in src/foo.ts.\n"
+    "- Proceed with approach B for the cache eviction window. Recommendation: use a 5 minute TTL to match the session cache.",
+    False,
+))
+# g8-02: a single decision item with a marker. Pins that a lone recommended
+# decision never trips the ballot check (the rule bans co-equal ballots,
+# not surfacing one genuine decision - see _is_prose_ballot's docstring).
+# Measured to ALLOW.
+CORPUS.append((
+    "g8-02",
+    "prose_ballot_single_item_allow",
+    "Fixed the login bug and added a regression test.\n\n"
+    "## Operator decisions\n\n"
+    "- Proceed with approach A for the retry policy (Recommended) - matches the existing pattern in src/foo.ts.",
     False,
 ))
 

--- a/hooks/tests/test-corpus-abdication.py
+++ b/hooks/tests/test-corpus-abdication.py
@@ -35,10 +35,9 @@ Purpose: Permanent regression corpus for hooks/enforce-no-abdication.py. This
               attempts; Group 8 below now carries the compliant ALLOW row
               and the genuine co-equal-ballot BLOCK row this revival
               required, closing that gap. Two limitations remain, both
-              deliberate and documented at _is_prose_ballot's own
-              docstring: it deliberately exempts its ballot check from the
-              negative gate, and it does not recognize ">"-blockquote
-              headings.
+              deliberate and known: the negative-gate exemption
+              (self-documented at _is_prose_ballot's own docstring) and
+              the absent ">"-blockquote heading handling.
            4. Widening the destructive negative gate with
               `drop/alter table|column|index|database|schema`: measured
               13/13 FALSE SUPPRESSIONS - it stops catching real abdication on


### PR DESCRIPTION
Corrects two files that describe PR #519's ballot classifier as an unmerged candidate on a branch. It merged as `a950bdd4` three days ago; the text now describes live shipped code in third person. Also closes the corpus gap that should have gated that merge.

## What was wrong

The identical stale paragraph sat in `hooks/enforce-no-abdication.py` and `hooks/tests/test-corpus-abdication.py`, wrong in three ways:

1. **Referred to `feat/prose-ballot-guard (PR #519)` as an alternative design that "exists at" a branch** - that design *is* the file. Now `shipped in a950bdd4 (PR #519)`; the branch name is gone, since branches get pruned and SHAs do not.
2. **Claimed it "does not satisfy the two requirements above" - it satisfies one.** `_BALLOT_REASON` is a dedicated constant whose directive is "revise the Operator decisions block", not the unconditional "proceed now" of `_ABDICATION_REASON`. The requirement was met; the text said otherwise.
3. **Framed two known limitations as unresolved pre-merge tension**, which reads as "should this ship at all" about code that shipped. They are now stated as deliberate, documented limitations of the shipped design: the negative-gate exemption (self-documented in `_is_prose_ballot`'s own docstring, a reasoned choice) and the absent `>`-blockquote heading handling.

## Corpus gap closed

The classifier went live with **zero** of the corpus's 34 rows containing an `## Operator decisions` heading or a recommendation marker, so no row exercised its code path. The governing plan required two such rows before shipping. Adds Group 8, each row **measured against the real hook before pinning**, not predicted:

| row | shape | measured |
|---|---|---|
| g8-00 | genuine 2-item ballot, no markers | BLOCK |
| g8-01 | 2-item block, both marked | ALLOW |
| g8-02 | single marked item | ALLOW |

All three matched prediction; none had to be pinned against expectation. Corpus is now 37 rows.

Note the classifier was never untested - `hooks/tests/test-enforce-no-abdication.py` already carries a thorough ballot suite. The gap was specific to the artifact the plan named as the floor.

## Evidence

Gate proven able to fail before shipping: flipping `g8-00`'s expectation produced `FAIL g8-00 ... expect_block=False actual=True` and exit 1; restored, exit 0, 37/37.

`test-corpus-abdication.py`, `test-enforce-no-abdication.py`, `test-enforce-stall-detection.py` all exit 0. `check-resident-budget.sh` OK at 121043 B / 121066 B, unchanged (no `content/**` touched). Diff is exactly 2 files, both under `hooks/`. DCO verified against raw `%ae`.

## Sweep result (no changes made)

Because `content/sections/02-delegation.md:82` now mandates a `(Recommended)`/`Recommendation:` marker on every item, an old-style marker-less block would block at runtime. Swept `content/**`, `docs/**`, `README.md`, `CONTRIBUTING.md`, `.claude/**` for examples teaching that shape: **none found.** The only example block is `content/references/conductor-turn-format.md:57-58`, which is single-item and so never trips the check (it requires 2+ unmarked items). Every other hit is prose describing the rule. No follow-up needed.

## North Star alignment

- **Verifiable outcomes over asserted ones** - a live guard gains a regression floor in the artifact designated as its floor, with each row's expectation measured rather than assumed, and the suite demonstrated able to fail.
- **Guard operator attention** - removes text that would send the next reader chasing a merged PR as if it were an open candidate, and stops a false claim that a met requirement is unmet.
- **Works for everyone** - stdlib only, no identity, path, tracker, or platform assumption; hooks are outside the resident set so no session pays for this.
- **Low friction / proportionality** - named explicitly, because a prior review found this workstream regressed it. Both fixes land in one PR touching only the two files already at issue; the doc sweep is report-only precisely to avoid pulling `content/**` and its budget cost into scope. Headroom is currently 23 B, which is its own reason not to widen this.
- **No enforcement floor removed** - zero behavioral change to the hook; the docstring edit cannot execute and the corpus only adds rows.
