### PR TITLE
chore(update-flow): collapse four divergent update implementations onto shared constants

### DIFF
--- a/.claude/commands/ds-update.md
+++ b/.claude/commands/ds-update.md
@@ -180,14 +180,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.claude/commands/ds-update.md
+++ b/.claude/commands/ds-update.md
@@ -178,7 +178,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -186,21 +186,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -228,7 +239,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -252,7 +263,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.claude/commands/ds-update.md
+++ b/.claude/commands/ds-update.md
@@ -198,6 +198,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.claude/commands/ds-update.md
+++ b/.claude/commands/ds-update.md
@@ -76,7 +76,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -104,9 +104,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -114,39 +116,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -176,28 +154,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -208,15 +167,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -248,7 +220,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.cursor/commands/ds-update.md
+++ b/.cursor/commands/ds-update.md
@@ -174,14 +174,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.cursor/commands/ds-update.md
+++ b/.cursor/commands/ds-update.md
@@ -172,7 +172,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -180,21 +180,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -222,7 +233,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -246,7 +257,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.cursor/commands/ds-update.md
+++ b/.cursor/commands/ds-update.md
@@ -70,7 +70,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -98,9 +98,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -108,39 +110,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -170,28 +148,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -202,15 +161,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -242,7 +214,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.cursor/commands/ds-update.md
+++ b/.cursor/commands/ds-update.md
@@ -192,6 +192,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.gemini/commands/ds-update.toml
+++ b/.gemini/commands/ds-update.toml
@@ -180,14 +180,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.gemini/commands/ds-update.toml
+++ b/.gemini/commands/ds-update.toml
@@ -178,7 +178,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -186,21 +186,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -228,7 +239,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -252,7 +263,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.gemini/commands/ds-update.toml
+++ b/.gemini/commands/ds-update.toml
@@ -198,6 +198,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.gemini/commands/ds-update.toml
+++ b/.gemini/commands/ds-update.toml
@@ -76,7 +76,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -104,9 +104,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -114,39 +116,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \\"<AE_REPO_DIR>\\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -176,28 +154,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -208,15 +167,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -248,7 +220,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.github/prompts/ds-update.prompt.md
+++ b/.github/prompts/ds-update.prompt.md
@@ -175,7 +175,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -183,21 +183,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -225,7 +236,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -249,7 +260,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.github/prompts/ds-update.prompt.md
+++ b/.github/prompts/ds-update.prompt.md
@@ -195,6 +195,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.github/prompts/ds-update.prompt.md
+++ b/.github/prompts/ds-update.prompt.md
@@ -177,14 +177,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.github/prompts/ds-update.prompt.md
+++ b/.github/prompts/ds-update.prompt.md
@@ -73,7 +73,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -101,9 +101,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -111,39 +113,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -173,28 +151,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -205,15 +164,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -245,7 +217,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -20271,6 +20271,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -20253,14 +20253,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -20251,7 +20251,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -20259,21 +20259,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -20301,7 +20312,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -20325,7 +20336,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -20149,7 +20149,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -20177,9 +20177,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -20187,39 +20189,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -20249,28 +20227,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -20281,15 +20240,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -20321,7 +20293,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.openclaw/skills/ds-update/SKILL.md
+++ b/.openclaw/skills/ds-update/SKILL.md
@@ -177,7 +177,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -185,21 +185,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -227,7 +238,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -251,7 +262,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/.openclaw/skills/ds-update/SKILL.md
+++ b/.openclaw/skills/ds-update/SKILL.md
@@ -179,14 +179,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.openclaw/skills/ds-update/SKILL.md
+++ b/.openclaw/skills/ds-update/SKILL.md
@@ -75,7 +75,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -103,9 +103,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -113,39 +115,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -175,28 +153,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -207,15 +166,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -247,7 +219,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.openclaw/skills/ds-update/SKILL.md
+++ b/.openclaw/skills/ds-update/SKILL.md
@@ -197,6 +197,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.opencode/commands/ds-update.md
+++ b/.opencode/commands/ds-update.md
@@ -74,7 +74,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -102,9 +102,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -112,39 +114,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -174,28 +152,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -206,15 +165,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -246,7 +218,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/.opencode/commands/ds-update.md
+++ b/.opencode/commands/ds-update.md
@@ -196,6 +196,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/.opencode/commands/ds-update.md
+++ b/.opencode/commands/ds-update.md
@@ -178,14 +178,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/.opencode/commands/ds-update.md
+++ b/.opencode/commands/ds-update.md
@@ -176,7 +176,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -184,21 +184,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -226,7 +237,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -250,7 +261,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Full details: [docs/updating.md](docs/updating.md).
 curl -fsSL https://docs.dinostack.ai/install.sh | bash
 ```
 
-This clones the repo into `DinoStack/` inside your current directory, runs the installer, and writes the install path to `~/.agentic/agentic-engineering-config.json` so `./update.sh` and the `/ds-update-agentic-engineering` command know where to find it.
+This clones the repo into `DinoStack/` inside your current directory, runs the installer, and writes the install path to `~/.agentic/agentic-engineering-config.json` so `./update.sh` and the `/ds-update` command know where to find it.
 
 > **Note:** if the one-liner clone fails (e.g. network or auth issue), the script automatically falls back to SSH.
 

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -542,17 +542,29 @@ def main() -> int:
 
     # A non-empty install_flags means the caller confirmed a configuration
     # change (--mode/--profile/--identity/--no-identity) that must actually
-    # reach install.sh. Neither rebuild-skip early return below is allowed
-    # to exit 0 without running the adapter loop when that is true - see
-    # bin/tests/test_agentic_update.sh T15/T16 for the regression coverage
-    # (both early-return paths: already-up-to-date and no-rebuild-needed).
-    forced_install = bool(install_flags)
+    # reach install.sh. An explicit --adapters selection is the same kind of
+    # signal - the caller named a specific adapter set they want refreshed,
+    # so a no-op skip would silently ignore that request. Neither rebuild-skip
+    # early return below is allowed to exit 0 without running the adapter
+    # loop when either is true - see bin/tests/test_agentic_update.sh T15/T16
+    # for the regression coverage (both early-return paths: already-up-to-date
+    # and no-rebuild-needed).
+    forced_install = bool(install_flags) or bool(args.adapters.strip())
+
+    # Human-readable reason for the "forcing adapter install" messages below.
+    # install_flags can be empty when the only forcing signal is an explicit
+    # --adapters selection - fall back to describing that instead of joining
+    # an empty list into a blank reason.
+    if install_flags:
+        forced_reason = ' '.join(install_flags)
+    else:
+        forced_reason = f"--adapters={args.adapters.strip()}"
 
     if old_head and new_head and old_head == new_head:
         if forced_install:
             print(
                 f"Already up to date ({old_short}), but forcing adapter install "
-                f"because a config change was requested: {' '.join(install_flags)}."
+                f"because a config change was requested: {forced_reason}."
             )
             return _run_adapter_installs(repo_dir, args, install_flags)
         print(f"Already up to date ({old_short}).")
@@ -599,7 +611,7 @@ def main() -> int:
             print(
                 f"Updated {old_short}..{new_short} ({commits_pulled} commit(s)). "
                 f"No adapter source changed, but forcing adapter install because "
-                f"a config change was requested: {' '.join(install_flags)}."
+                f"a config change was requested: {forced_reason}."
             )
             return _run_adapter_installs(repo_dir, args, install_flags)
         print("No rebuild needed (no adapter source changed).")

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -9,6 +9,8 @@ Purpose: From-anywhere, non-interactive updater for agentic-engineering
          run (because that script requires a TTY for its TUI).
 
 Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
+                           [--mode=opt-in|opt-out] [--profile=relaxed|default|strict]
+                           [--identity=<handle>|--no-identity]
              --check        Report how far behind origin/main the local main
                             branch is, then exit 0. Does NOT pull. Works from
                             any branch.
@@ -16,6 +18,19 @@ Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
              --adapters=X   Comma-separated list of adapter dirs to refresh
                             (e.g. --adapters=.claude,.cursor). .claude is
                             always prepended (LOCKED_ADAPTERS invariant).
+             --mode=X       Forwarded verbatim to each adapter's install.sh
+                            as --mode=X (activation mode).
+             --profile=X    Forwarded verbatim to each adapter's install.sh
+                            as --profile=X (risk profile).
+             --identity=X   Forwarded verbatim to each adapter's install.sh
+                            as --identity=X (developer handle).
+             --no-identity  Forwarded verbatim to each adapter's install.sh
+                            as --no-identity. Mutually exclusive with
+                            --identity (argparse enforces this).
+            All four --mode/--profile/--identity/--no-identity flags are
+            optional passthroughs: when omitted, install.sh runs with no
+            corresponding flag and falls back to its own defaults, exactly
+            as before this option existed.
             Environment:
              AGENTIC_CONFIG_PATH  Override path to agentic-engineering-config.json
                                   (useful for tests; default ~/.agentic/...).
@@ -27,7 +42,10 @@ Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
 
 Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, re,
                subprocess, sys, tempfile, time). Reads
-               ~/.agentic/agentic-engineering-config.json (repo_dir, adapters).
+               ~/.agentic/agentic-engineering-config.json (repo_dir, adapters)
+               and scripts/lib/update-shared.json (SKIP_DIRS, REBUILD_TRIGGERS
+               - single source of truth shared with scripts/update.js and
+               install-all.sh; do not reintroduce a local literal for either).
                Invokes: git (fetch, pull, rev-parse, diff, status, etc.),
                bash <adapter>/install.sh, agentic-doctor.
 
@@ -74,11 +92,33 @@ from pathlib import Path
 # Mirrors LOCKED_ADAPTERS in scripts/update.js.
 LOCKED_ADAPTERS: tuple[str, ...] = (".claude",)
 
+
+def _load_shared_config() -> dict:
+    """Load scripts/lib/update-shared.json - the single source of truth for
+    SKIP_DIRS and REBUILD_TRIGGERS, shared with scripts/update.js and
+    install-all.sh. Do not reintroduce a local literal for either list here.
+
+    Resolved relative to THIS file's own location (not the config-driven
+    repo_dir the updater operates on) - bin/agentic-update lives inside the
+    same repo that ships scripts/lib/update-shared.json, so the shared file
+    is always exactly two directories up regardless of which repo the tool
+    is pointed at. Path(__file__).resolve() (not .parent alone) is required:
+    install.sh symlinks this file into ~/.local/bin, and an unresolved
+    __file__ would resolve the shared path against the symlink location
+    instead of the real checkout.
+    """
+    shared_path = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "update-shared.json"
+    try:
+        return json.loads(shared_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"fatal: failed to load shared config at {shared_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+_SHARED_CONFIG = _load_shared_config()
+
 # Dot-dirs under repo root excluded from adapter discovery.
-SKIP_DIRS: frozenset[str] = frozenset([
-    ".", "..", ".git", ".github", ".vscode", ".idea",
-    ".cache", ".venv", ".mypy_cache", ".pytest_cache", ".ruff_cache",
-])
+SKIP_DIRS: frozenset[str] = frozenset(_SHARED_CONFIG["skip_dirs"])
 
 # ---------------------------------------------------------------------------
 # Config resolution
@@ -174,17 +214,12 @@ def _discover_adapters(repo_dir: Path) -> list[str]:
 # Rebuild decision
 # ---------------------------------------------------------------------------
 
-# Ported from scripts/update.js:252-281 (needsRebuild). Keep in sync -
-# REBUILD_TRIGGERS and the */build.sh catch-all are the source of truth there.
-REBUILD_TRIGGERS: tuple[str, ...] = (
-    "content/",
-    "scripts/build-all.sh",
-    "scripts/build-methodology.sh",
-    "scripts/build-slides.sh",
-    "hooks/",
-    ".claude/install.sh",
-    "bin/",
-)
+# Loaded from scripts/lib/update-shared.json - single source of truth shared
+# with scripts/update.js and install-all.sh. Only the matching ALGORITHM
+# below (needsRebuild/*/build.sh catch-all) is ported by hand and stays
+# language-duplicated (JS vs Python); a cross-language parity test in
+# bin/tests/test_agentic_update.sh covers that algorithm-level drift risk.
+REBUILD_TRIGGERS: tuple[str, ...] = tuple(_SHARED_CONFIG["rebuild_triggers"])
 
 
 def _needs_rebuild(old_head: str, new_head: str, changed_paths: list[str]) -> bool:
@@ -342,7 +377,45 @@ def main() -> int:
             ".claude is always included (LOCKED_ADAPTERS invariant)."
         ),
     )
+    parser.add_argument(
+        "--mode",
+        default=None,
+        help="Forwarded verbatim to each adapter's install.sh as --mode=<value>.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Forwarded verbatim to each adapter's install.sh as --profile=<value>.",
+    )
+    identity_group = parser.add_mutually_exclusive_group()
+    identity_group.add_argument(
+        "--identity",
+        default=None,
+        help="Forwarded verbatim to each adapter's install.sh as --identity=<handle>.",
+    )
+    identity_group.add_argument(
+        "--no-identity",
+        action="store_true",
+        dest="no_identity",
+        help="Forwarded verbatim to each adapter's install.sh as --no-identity.",
+    )
     args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Build the passthrough flag list forwarded to every adapter install.sh
+    # invocation (Step 12 below). Empty when none of --mode/--profile/
+    # --identity/--no-identity were supplied - install.sh then falls back to
+    # its own defaults exactly as before this option existed.
+    # ------------------------------------------------------------------
+    install_flags: list[str] = []
+    if args.mode is not None:
+        install_flags.append(f"--mode={args.mode}")
+    if args.profile is not None:
+        install_flags.append(f"--profile={args.profile}")
+    if args.identity is not None:
+        install_flags.append(f"--identity={args.identity}")
+    if args.no_identity:
+        install_flags.append("--no-identity")
 
     # ------------------------------------------------------------------
     # Step 2: resolve repo_dir
@@ -557,8 +630,9 @@ def main() -> int:
         if not install_sh.is_file():
             print(f"warning: {install_sh} not found, skipping.", file=sys.stderr)
             continue
-        print(f">>> bash {install_sh}")
-        rc = subprocess.call(["bash", str(install_sh)], cwd=str(repo_dir))
+        cmd = ["bash", str(install_sh)] + install_flags
+        print(f">>> {' '.join(cmd)}")
+        rc = subprocess.call(cmd, cwd=str(repo_dir))
         if rc != 0:
             failures.append(f"{adapter}/install.sh (exit {rc})")
 

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -35,7 +35,12 @@ Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
             (already up to date) or _needs_rebuild() is False (no adapter
             source changed) - a confirmed configuration change must reach
             install.sh, never silently no-op behind a rebuild-skip early
-            return. See the forced_install check in main().
+            return. An explicit --adapters selection is the same kind of
+            forcing signal even with no --mode/--profile/--identity flag
+            present: it also forces the adapter install loop on both
+            rebuild-skip early returns, since a caller who named a specific
+            adapter set must not have that request silently skipped. See
+            the forced_install check in main().
             Environment:
              AGENTIC_CONFIG_PATH  Override path to agentic-engineering-config.json
                                   (useful for tests; default ~/.agentic/...).
@@ -554,17 +559,22 @@ def main() -> int:
     # Human-readable reason for the "forcing adapter install" messages below.
     # install_flags can be empty when the only forcing signal is an explicit
     # --adapters selection - fall back to describing that instead of joining
-    # an empty list into a blank reason.
+    # an empty list into a blank reason. forced_reason_label names the actual
+    # trigger (a --mode/--profile/--identity config change vs a bare adapter
+    # selection) so the printed message never calls an --adapters-only run
+    # a "config change" when no config flag was supplied.
     if install_flags:
         forced_reason = ' '.join(install_flags)
+        forced_reason_label = "a config change was requested"
     else:
         forced_reason = f"--adapters={args.adapters.strip()}"
+        forced_reason_label = "an adapter selection was requested"
 
     if old_head and new_head and old_head == new_head:
         if forced_install:
             print(
                 f"Already up to date ({old_short}), but forcing adapter install "
-                f"because a config change was requested: {forced_reason}."
+                f"because {forced_reason_label}: {forced_reason}."
             )
             return _run_adapter_installs(repo_dir, args, install_flags)
         print(f"Already up to date ({old_short}).")
@@ -611,7 +621,7 @@ def main() -> int:
             print(
                 f"Updated {old_short}..{new_short} ({commits_pulled} commit(s)). "
                 f"No adapter source changed, but forcing adapter install because "
-                f"a config change was requested: {forced_reason}."
+                f"{forced_reason_label}: {forced_reason}."
             )
             return _run_adapter_installs(repo_dir, args, install_flags)
         print("No rebuild needed (no adapter source changed).")
@@ -646,8 +656,10 @@ def _run_adapter_installs(
     Shared by all three callers that must actually run the adapter loop:
     the normal rebuild-triggered path, and the two forced-install paths
     (old_head==new_head and not-rebuild) that fire when install_flags is
-    non-empty - see the Critical-fix comment at the forced_install check
-    above main(). Extracted so none of the three call sites can drift.
+    non-empty OR args.adapters is non-empty (an explicit --adapters
+    selection alone also forces the loop, even with no --mode/--profile/
+    --identity flag) - see the Critical-fix comment at the forced_install
+    check above main(). Extracted so none of the three call sites can drift.
     """
     # ------------------------------------------------------------------
     # Step 12: adapter selection + install

--- a/bin/agentic-update
+++ b/bin/agentic-update
@@ -30,7 +30,12 @@ Public API: agentic-update [--check] [--no-doctor] [--adapters=a,b,...]
             All four --mode/--profile/--identity/--no-identity flags are
             optional passthroughs: when omitted, install.sh runs with no
             corresponding flag and falls back to its own defaults, exactly
-            as before this option existed.
+            as before this option existed. When any of the four IS supplied,
+            the adapter install loop always runs, even if old_head==new_head
+            (already up to date) or _needs_rebuild() is False (no adapter
+            source changed) - a confirmed configuration change must reach
+            install.sh, never silently no-op behind a rebuild-skip early
+            return. See the forced_install check in main().
             Environment:
              AGENTIC_CONFIG_PATH  Override path to agentic-engineering-config.json
                                   (useful for tests; default ~/.agentic/...).
@@ -535,7 +540,21 @@ def main() -> int:
 
     old_short = old_head[:8] if old_head else "unknown"
 
+    # A non-empty install_flags means the caller confirmed a configuration
+    # change (--mode/--profile/--identity/--no-identity) that must actually
+    # reach install.sh. Neither rebuild-skip early return below is allowed
+    # to exit 0 without running the adapter loop when that is true - see
+    # bin/tests/test_agentic_update.sh T15/T16 for the regression coverage
+    # (both early-return paths: already-up-to-date and no-rebuild-needed).
+    forced_install = bool(install_flags)
+
     if old_head and new_head and old_head == new_head:
+        if forced_install:
+            print(
+                f"Already up to date ({old_short}), but forcing adapter install "
+                f"because a config change was requested: {' '.join(install_flags)}."
+            )
+            return _run_adapter_installs(repo_dir, args, install_flags)
         print(f"Already up to date ({old_short}).")
         _reset_version_check_cache()
         # Skip to doctor
@@ -576,6 +595,13 @@ def main() -> int:
     rebuild = _needs_rebuild(old_head, new_head, changed_paths)
 
     if not rebuild:
+        if forced_install:
+            print(
+                f"Updated {old_short}..{new_short} ({commits_pulled} commit(s)). "
+                f"No adapter source changed, but forcing adapter install because "
+                f"a config change was requested: {' '.join(install_flags)}."
+            )
+            return _run_adapter_installs(repo_dir, args, install_flags)
         print("No rebuild needed (no adapter source changed).")
         _reset_version_check_cache()
         if not args.no_doctor:
@@ -595,6 +621,22 @@ def main() -> int:
         f"Rebuild triggered by: {', '.join(triggering_paths) or '(unknown)'}."
     )
 
+    return _run_adapter_installs(repo_dir, args, install_flags)
+
+
+def _run_adapter_installs(
+    repo_dir: Path,
+    args: argparse.Namespace,
+    install_flags: list[str],
+) -> int:
+    """Step 12-14: adapter selection + install + cache reset + doctor.
+
+    Shared by all three callers that must actually run the adapter loop:
+    the normal rebuild-triggered path, and the two forced-install paths
+    (old_head==new_head and not-rebuild) that fire when install_flags is
+    non-empty - see the Critical-fix comment at the forced_install check
+    above main(). Extracted so none of the three call sites can drift.
+    """
     # ------------------------------------------------------------------
     # Step 12: adapter selection + install
     # ------------------------------------------------------------------

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -817,6 +817,10 @@ setup_git_fixture_with_argv_install() {
     cat > .claude/install.sh <<'INSTALLEOF'
 #!/usr/bin/env bash
 if [[ -n "${INSTALL_ARGS_LOG:-}" ]]; then
+  # Unconditional marker line: proves install.sh actually ran even when it
+  # receives zero forwarded flags (e.g. an --adapters-only forced install),
+  # which the argv-only loop below would otherwise leave undetectable.
+  echo "RAN" >> "$INSTALL_ARGS_LOG"
   for arg in "$@"; do
     echo "$arg" >> "$INSTALL_ARGS_LOG"
   done
@@ -943,6 +947,49 @@ if echo "$ARGS_RECORDED" | grep -qx -- "--mode=opt-out" && \
   _pass "T16 no-rebuild-needed + config change: install.sh actually ran with the confirmed flags"
 else
   _fail "T16 no-rebuild-needed + config change: install.sh did NOT run with confirmed flags (recorded: $ARGS_RECORDED) - the Critical bug reproduces here"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 17 (Minor fix): an explicit --adapters selection alone (no --mode/
+# --profile/--identity/--no-identity) must also force the adapter install
+# loop on the old_head==new_head ("Already up to date") early-return path.
+#
+# Before the fix, forced_install was `bool(install_flags)` only, so
+# --adapters=.claude on an up-to-date repo printed "Already up to date",
+# exited 0, and never invoked install.sh at all - the operator's explicit
+# adapter selection was silently dropped.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+setup_git_fixture_with_argv_install
+# No push_ahead_* call: FAKE_REPO is already at the same commit as FAKE_REMOTE.
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor --adapters=.claude
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T17 already-up-to-date + --adapters only: exits 0"
+else
+  _fail "T17 already-up-to-date + --adapters only: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -qi "forcing adapter install"; then
+  _pass "T17 already-up-to-date + --adapters only: reports forced install"
+else
+  _fail "T17 already-up-to-date + --adapters only: missing forced-install message (got: $OUT) - the Minor bug reproduces here"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "RAN"; then
+  _pass "T17 already-up-to-date + --adapters only: install.sh actually ran"
+else
+  _fail "T17 already-up-to-date + --adapters only: install.sh did NOT run (recorded: $ARGS_RECORDED) - the Minor bug reproduces here"
 fi
 
 rm -rf "$TEMP_HOME"

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -804,6 +804,149 @@ fi
 
 rm -rf "$TEMP_HOME"
 
+# setup_git_fixture_with_argv_install: like setup_git_fixture, but commits
+# an argv-recording .claude/install.sh directly to FAKE_REPO and pushes it,
+# so local and remote HEAD stay identical (still "up to date") after this
+# call - unlike push_ahead_flags_commit, which deliberately leaves the
+# pushed commit unpulled so a subsequent update has something to pull.
+# Must be called after setup_git_fixture.
+setup_git_fixture_with_argv_install() {
+  (
+    cd "$FAKE_REPO"
+    mkdir -p .claude
+    cat > .claude/install.sh <<'INSTALLEOF'
+#!/usr/bin/env bash
+if [[ -n "${INSTALL_ARGS_LOG:-}" ]]; then
+  for arg in "$@"; do
+    echo "$arg" >> "$INSTALL_ARGS_LOG"
+  done
+fi
+exit 0
+INSTALLEOF
+    chmod +x .claude/install.sh
+    git add .claude/install.sh
+    git commit -m "add argv-recording .claude/install.sh" -q
+    git push -q origin main 2>/dev/null
+  )
+}
+
+# push_ahead_docs_commit: like push_ahead_commit, but the pushed commit adds
+# a doc-only file that does NOT match any REBUILD_TRIGGER, so _needs_rebuild
+# returns False for it (unlike push_ahead_commit's .claude/install.sh, which
+# is itself an exact-path trigger). Used to exercise the "no adapter source
+# changed" (not-rebuild) early-return path with a real pulled commit.
+push_ahead_docs_commit() {
+  local pusher_dir="$TEMP_HOME/pusher"
+  git clone --quiet "$FAKE_REMOTE" "$pusher_dir" 2>/dev/null
+  (
+    cd "$pusher_dir"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    mkdir -p docs
+    echo "docs-only change" > docs/somefile.md
+    git add docs/somefile.md
+    git commit -m "docs-only change" -q
+    git push -q origin main 2>/dev/null
+  )
+  rm -rf "$pusher_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 15 (CRITICAL fix): a confirmed config change (--mode/--profile/
+# --identity) must force the adapter install loop even on the
+# old_head==new_head ("Already up to date") early-return path.
+#
+# Before the fix, this path printed "Already up to date" and returned 0
+# WITHOUT ever invoking install.sh - so an operator who ran /ds-update
+# specifically to flip profile=strict (or set an identity) got exit 0
+# having silently applied nothing.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+setup_git_fixture_with_argv_install
+# No push_ahead_* call: FAKE_REPO is already at the same commit as FAKE_REMOTE
+# (setup_git_fixture_with_argv_install committed+pushed directly to both).
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor --mode=opt-out --profile=strict --identity=octocat
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T15 already-up-to-date + config change: exits 0"
+else
+  _fail "T15 already-up-to-date + config change: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -qiE "Already up to date"; then
+  _pass "T15 already-up-to-date + config change: still reports 'Already up to date'"
+else
+  _fail "T15 already-up-to-date + config change: missing 'Already up to date' (got: $OUT)"
+fi
+
+if echo "$OUT" | grep -qi "forcing adapter install"; then
+  _pass "T15 already-up-to-date + config change: reports forced install"
+else
+  _fail "T15 already-up-to-date + config change: missing forced-install message (got: $OUT)"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--mode=opt-out" && \
+   echo "$ARGS_RECORDED" | grep -qx -- "--profile=strict" && \
+   echo "$ARGS_RECORDED" | grep -qx -- "--identity=octocat"; then
+  _pass "T15 already-up-to-date + config change: install.sh actually ran with the confirmed flags"
+else
+  _fail "T15 already-up-to-date + config change: install.sh did NOT run with confirmed flags (recorded: $ARGS_RECORDED) - the Critical bug reproduces here"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 16 (CRITICAL fix): a confirmed config change must also force the
+# adapter install loop on the "no adapter source changed" (not-rebuild)
+# early-return path, when a real pull DID happen but touched no
+# REBUILD_TRIGGER path.
+#
+# Before the fix, this path printed "No rebuild needed" and returned 0
+# WITHOUT ever invoking install.sh, identical failure shape to T15 but on
+# the second of the two early-return sites.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+setup_git_fixture_with_argv_install
+push_ahead_docs_commit   # remote 1 ahead; docs-only, not a REBUILD_TRIGGER
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor --mode=opt-out --profile=strict
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T16 no-rebuild-needed + config change: exits 0"
+else
+  _fail "T16 no-rebuild-needed + config change: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$OUT" | grep -qi "forcing adapter install"; then
+  _pass "T16 no-rebuild-needed + config change: reports forced install"
+else
+  _fail "T16 no-rebuild-needed + config change: missing forced-install message (got: $OUT)"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--mode=opt-out" && \
+   echo "$ARGS_RECORDED" | grep -qx -- "--profile=strict"; then
+  _pass "T16 no-rebuild-needed + config change: install.sh actually ran with the confirmed flags"
+else
+  _fail "T16 no-rebuild-needed + config change: install.sh did NOT run with confirmed flags (recorded: $ARGS_RECORDED) - the Critical bug reproduces here"
+fi
+
+rm -rf "$TEMP_HOME"
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -105,7 +105,10 @@ push_ahead_commit() {
 
 # invoke_updater: run agentic-update with AGENTIC_CONFIG_PATH pointing at
 # the temp config. HOME is also overridden so version-check-cache writes
-# go to TEMP_HOME rather than the real user home.
+# go to TEMP_HOME rather than the real user home. If INSTALL_ARGS_LOG is set
+# in the calling shell, it is forwarded so a fixture's install.sh can record
+# the exact argv it received (used by the --mode/--profile/--identity
+# forwarding tests below).
 invoke_updater() {
   local config_path="$TEMP_HOME/.agentic/agentic-engineering-config.json"
   (
@@ -113,9 +116,41 @@ invoke_updater() {
     export HOME
     AGENTIC_CONFIG_PATH="$config_path"
     export AGENTIC_CONFIG_PATH
+    if [[ -n "${INSTALL_ARGS_LOG:-}" ]]; then
+      export INSTALL_ARGS_LOG
+    fi
     python3 "$UPDATER" "$@"
   ) > "$TEMP_HOME/.out" 2>&1
   echo $? > "$TEMP_HOME/.exit"
+}
+
+# push_ahead_flags_commit: like push_ahead_commit, but the pushed
+# .claude/install.sh records its received argv (one arg per line) to
+# $INSTALL_ARGS_LOG instead of being a pure no-op. Used to verify
+# --mode/--profile/--identity/--no-identity are forwarded verbatim.
+push_ahead_flags_commit() {
+  local pusher_dir="$TEMP_HOME/pusher"
+  git clone --quiet "$FAKE_REMOTE" "$pusher_dir" 2>/dev/null
+  (
+    cd "$pusher_dir"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    mkdir -p .claude
+    cat > .claude/install.sh <<'INSTALLEOF'
+#!/usr/bin/env bash
+if [[ -n "${INSTALL_ARGS_LOG:-}" ]]; then
+  for arg in "$@"; do
+    echo "$arg" >> "$INSTALL_ARGS_LOG"
+  done
+fi
+exit 0
+INSTALLEOF
+    chmod +x .claude/install.sh
+    git add .claude/install.sh
+    git commit -m "add argv-recording .claude/install.sh" -q
+    git push -q origin main 2>/dev/null
+  )
+  rm -rf "$pusher_dir"
 }
 
 # ---------------------------------------------------------------------------
@@ -641,6 +676,130 @@ if echo "$OUT" | grep -q "this update changed files under hooks/"; then
   _fail "T11d no-op pull: warning present but should be ABSENT (already up to date)"
 else
   _pass "T11d no-op pull: warning ABSENT (no-op / already up to date)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 12: --mode/--profile/--identity are forwarded verbatim to install.sh
+#
+# Regression coverage for the new passthrough flags added when
+# content/commands/ds-update.md's UPDATE-FLOW was rewritten to delegate its
+# adapter loop to agentic-update instead of reimplementing it. Before this
+# option existed, agentic-update always invoked install.sh with zero flags -
+# ds-update.md could not delegate without losing the user's chosen
+# mode/profile/identity.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_flags_commit
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor --mode=opt-out --profile=strict --identity=octocat
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T12 flag forwarding: exits 0"
+else
+  _fail "T12 flag forwarding: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--mode=opt-out"; then
+  _pass "T12 flag forwarding: --mode=opt-out forwarded"
+else
+  _fail "T12 flag forwarding: --mode=opt-out NOT forwarded (recorded: $ARGS_RECORDED)"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--profile=strict"; then
+  _pass "T12 flag forwarding: --profile=strict forwarded"
+else
+  _fail "T12 flag forwarding: --profile=strict NOT forwarded (recorded: $ARGS_RECORDED)"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--identity=octocat"; then
+  _pass "T12 flag forwarding: --identity=octocat forwarded"
+else
+  _fail "T12 flag forwarding: --identity=octocat NOT forwarded (recorded: $ARGS_RECORDED)"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 13: --no-identity is forwarded verbatim, and is mutually exclusive
+# with --identity (argparse-enforced).
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_flags_commit
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor --no-identity
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T13 --no-identity forwarding: exits 0"
+else
+  _fail "T13 --no-identity forwarding: expected exit 0, got $RC"
+fi
+
+if echo "$ARGS_RECORDED" | grep -qx -- "--no-identity"; then
+  _pass "T13 --no-identity forwarding: --no-identity forwarded"
+else
+  _fail "T13 --no-identity forwarding: --no-identity NOT forwarded (recorded: $ARGS_RECORDED)"
+fi
+
+# Mutual exclusion: --identity and --no-identity together must be rejected
+# by argparse before any git/adapter work happens.
+(
+  HOME="$TEMP_HOME"
+  export HOME
+  AGENTIC_CONFIG_PATH="$TEMP_HOME/.agentic/agentic-engineering-config.json"
+  export AGENTIC_CONFIG_PATH
+  python3 "$UPDATER" --check --identity=foo --no-identity
+) > "$TEMP_HOME/.mutex_out" 2>&1
+MUTEX_RC=$?
+
+if [[ "$MUTEX_RC" != "0" ]]; then
+  _pass "T13 mutual exclusion: --identity + --no-identity together exits non-zero"
+else
+  _fail "T13 mutual exclusion: --identity + --no-identity together should be rejected, got exit 0"
+fi
+
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 14: no flags supplied -> install.sh receives zero args, matching
+# pre-existing behavior exactly (non-regression for the default/omitted
+# case introduced alongside the new flags).
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_flags_commit
+
+INSTALL_ARGS_LOG="$TEMP_HOME/install_args.log"
+export INSTALL_ARGS_LOG
+invoke_updater --no-doctor
+unset INSTALL_ARGS_LOG
+
+RC=$(cat "$TEMP_HOME/.exit")
+ARGS_RECORDED="$(cat "$TEMP_HOME/install_args.log" 2>/dev/null)"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T14 no flags: exits 0"
+else
+  _fail "T14 no flags: expected exit 0, got $RC"
+fi
+
+if [[ -z "$ARGS_RECORDED" ]]; then
+  _pass "T14 no flags: install.sh received zero args (default-omitted behavior preserved)"
+else
+  _fail "T14 no flags: install.sh unexpectedly received args: $ARGS_RECORDED"
 fi
 
 rm -rf "$TEMP_HOME"

--- a/bin/tests/test_update_shared_constants.sh
+++ b/bin/tests/test_update_shared_constants.sh
@@ -407,6 +407,138 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 10: the UPDATE-FLOW fallback fence's non-main-branch and dirty-tree
+# guards must actually STOP execution before reaching `git ... pull`, not
+# merely print an error and fall through to it. A prose-only guard (an
+# executed comment like `# STOP - do not proceed` with no `exit`) is
+# invisible to a text assertion that just checks the error message exists -
+# this test extracts the literal fenced block from content/commands/ds-update.md
+# and RUNS it, verifying via a fake `git` on PATH that `pull` is never
+# invoked when either guard should have fired.
+# ---------------------------------------------------------------------------
+if [[ -f "$DS_UPDATE_MD" ]]; then
+  FALLBACK_SCRIPT="$(python3 -c "
+import re, sys
+
+text = open(sys.argv[1], encoding='utf-8').read()
+# Anchor on the sentence immediately preceding the fallback fence (there are
+# two 'CURRENT_BRANCH=' fences in this doc - Step 2b's non-blocking preview,
+# and this one - so a bare 'first \`\`\`bash after CURRENT_BRANCH=' match would
+# silently grab the wrong, non-authoritative block).
+anchor = 'not optional preview info as in Step 2b:'
+anchor_idx = text.find(anchor)
+if anchor_idx == -1:
+    print('EXTRACT_FAILED')
+    sys.exit(0)
+m = re.search(r'\`\`\`bash\nCURRENT_BRANCH=.*?\n\`\`\`', text[anchor_idx:], re.DOTALL)
+if not m:
+    print('EXTRACT_FAILED')
+    sys.exit(0)
+# Strip the \`\`\`bash / \`\`\` fence markers, keep the body verbatim.
+body = m.group(0)
+body = body[len('\`\`\`bash\n'):-len('\`\`\`')]
+print(body)
+" "$DS_UPDATE_MD")"
+
+  if [[ "$FALLBACK_SCRIPT" == "EXTRACT_FAILED" || -z "$FALLBACK_SCRIPT" ]]; then
+    _fail "T10 could not extract the UPDATE-FLOW fallback fence from $DS_UPDATE_MD - doc structure changed; update the extraction regex"
+  else
+    FALLBACK_TMPDIR="$(mktemp -d)"
+    FAKE_GIT_LOG="$FALLBACK_TMPDIR/git-calls.log"
+    FAKE_BIN_DIR="$FALLBACK_TMPDIR/bin"
+    mkdir -p "$FAKE_BIN_DIR"
+
+    # Fake `git` on PATH: logs every invoked subcommand (rev-parse/status/pull)
+    # and returns branch/dirty-state controlled by env vars, so the extracted
+    # fence's body runs completely unmodified - only its `git` calls are
+    # intercepted, which is what lets this test catch a reintroduced
+    # comment-only guard without also masking a real behavioral change.
+    cat > "$FAKE_BIN_DIR/git" <<'FAKEGIT'
+#!/usr/bin/env bash
+echo "$*" >> "$FAKE_GIT_LOG"
+# Expected invocation shapes from the extracted fence:
+#   git -C <dir> rev-parse --abbrev-ref HEAD
+#   git -C <dir> status --porcelain
+#   git -C <dir> pull --ff-only origin main
+if [[ "$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then
+  echo "${FAKE_BRANCH:-main}"
+  exit 0
+elif [[ "$*" == *"status --porcelain"* ]]; then
+  printf '%s' "${FAKE_DIRTY:-}"
+  exit 0
+elif [[ "$*" == *"pull --ff-only"* ]]; then
+  echo "pull invoked" >> "$FAKE_GIT_LOG.pull-reached"
+  exit 0
+fi
+exit 0
+FAKEGIT
+    chmod +x "$FAKE_BIN_DIR/git"
+
+    run_fallback_fence() {
+      # Args: $1 = FAKE_BRANCH, $2 = FAKE_DIRTY
+      : > "$FAKE_GIT_LOG"
+      rm -f "$FAKE_GIT_LOG.pull-reached"
+      (
+        PATH="$FAKE_BIN_DIR:$PATH"
+        export PATH
+        FAKE_GIT_LOG="$FAKE_GIT_LOG"
+        export FAKE_GIT_LOG
+        FAKE_BRANCH="$1"
+        export FAKE_BRANCH
+        FAKE_DIRTY="$2"
+        export FAKE_DIRTY
+        AE_REPO_DIR="$FALLBACK_TMPDIR/fake-repo"
+        export AE_REPO_DIR
+        SELECTED_ADAPTERS=()
+        bash -c "$FALLBACK_SCRIPT"
+      )
+    }
+
+    # --- Guard A: non-main branch, clean tree -> must STOP before pull ---
+    run_fallback_fence "feature/some-branch" ""
+    FENCE_RC=$?
+    if [[ "$FENCE_RC" -ne 0 ]]; then
+      _pass "T10a non-main-branch guard: fence exits non-zero"
+    else
+      _fail "T10a non-main-branch guard: fence exited 0 - the guard did not stop execution"
+    fi
+    if [[ ! -f "$FAKE_GIT_LOG.pull-reached" ]]; then
+      _pass "T10a non-main-branch guard: pull was never invoked"
+    else
+      _fail "T10a non-main-branch guard: pull WAS invoked despite non-main branch - the STOP is prose-only"
+    fi
+
+    # --- Guard B: main branch, dirty tree -> must STOP before pull ---
+    run_fallback_fence "main" "M some/dirty/file.txt"
+    FENCE_RC=$?
+    if [[ "$FENCE_RC" -ne 0 ]]; then
+      _pass "T10b dirty-tree guard: fence exits non-zero"
+    else
+      _fail "T10b dirty-tree guard: fence exited 0 - the guard did not stop execution"
+    fi
+    if [[ ! -f "$FAKE_GIT_LOG.pull-reached" ]]; then
+      _pass "T10b dirty-tree guard: pull was never invoked"
+    else
+      _fail "T10b dirty-tree guard: pull WAS invoked despite a dirty tree - the STOP is prose-only"
+    fi
+
+    # --- Non-vacuity: main branch, clean tree -> both guards pass through,
+    # pull IS reached (proves the harness can observe a reached pull at all,
+    # so T10a/T10b's "pull never invoked" checks are falsifiable). ---
+    run_fallback_fence "main" ""
+    if [[ -f "$FAKE_GIT_LOG.pull-reached" ]]; then
+      _pass "T10c non-vacuity: clean main branch reaches pull (harness can detect a reached pull)"
+    else
+      _fail "T10c non-vacuity: clean main branch never reached pull - the fake git harness itself is broken, T10a/T10b prove nothing"
+    fi
+
+    rm -rf "$FALLBACK_TMPDIR"
+  fi
+else
+  _fail "T10 $DS_UPDATE_MD not found"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/bin/tests/test_update_shared_constants.sh
+++ b/bin/tests/test_update_shared_constants.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Purpose: Regression tests for the update-flow shared-constants collapse
-#          (scripts/lib/update-shared.json). Two things are asserted:
+#          (scripts/lib/update-shared.json). Seven things are asserted:
 #          (1) scripts/update.js and bin/agentic-update both load SKIP_DIRS
 #              and REBUILD_TRIGGERS from the shared JSON file rather than a
 #              local literal - single-sourcing makes drift structurally
@@ -14,6 +14,22 @@
 #          (3) needsRebuild()/_needs_rebuild() - the matching ALGORITHM that
 #              genuinely cannot be shared across JS/Python - agree on a
 #              cross-language parity vector table.
+#          (4) DISPLAY_NAMES matches across scripts/update.js and the prose
+#              copy in content/commands/ds-update.md.
+#          (5) hooksTouched()/_hooks_touched() cross-language parity vector
+#              table.
+#          (6) the UPDATE-FLOW fallback fence in content/commands/ds-update.md
+#              (used when `agentic-update` is not on PATH) is extracted and
+#              RUN with a fake `git`, proving its non-main-branch and
+#              dirty-tree guards actually STOP execution before `pull` - a
+#              prose-only guard (an echoed error with no `exit`) is invisible
+#              to a text-only assertion but not to this one.
+#          (7) that same fallback fence's per-adapter install loop is
+#              fail-soft (both a failing and a later adapter run, all
+#              failures are named with their exit codes, overall exit is
+#              non-zero) AND its own in-fence comment's declared fail-soft/
+#              fail-fast label matches that measured behavior - so an edit to
+#              either the loop body or its label reds the gate independently.
 #
 # Public API: ./bin/tests/test_update_shared_constants.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -530,6 +546,112 @@ FAKEGIT
       _pass "T10c non-vacuity: clean main branch reaches pull (harness can detect a reached pull)"
     else
       _fail "T10c non-vacuity: clean main branch never reached pull - the fake git harness itself is broken, T10a/T10b prove nothing"
+    fi
+
+    # -------------------------------------------------------------------
+    # Test 11: the fallback fence's per-adapter install loop must be
+    # fail-soft - a failing adapter must not stop the loop, every failing
+    # adapter must be named with its exit code, and the overall exit must
+    # be non-zero. Two fake adapters, both failing with distinct exit
+    # codes; each writes a marker file on invocation so "did the loop
+    # continue past the first failure" is directly observable, not
+    # inferred from output text alone.
+    # -------------------------------------------------------------------
+    AGG_TMPDIR="$FALLBACK_TMPDIR/agg-repo"
+    mkdir -p "$AGG_TMPDIR/adapterA" "$AGG_TMPDIR/adapterB"
+    cat > "$AGG_TMPDIR/adapterA/install.sh" <<EOF
+#!/usr/bin/env bash
+touch "$FALLBACK_TMPDIR/adapterA-ran"
+exit 3
+EOF
+    chmod +x "$AGG_TMPDIR/adapterA/install.sh"
+    cat > "$AGG_TMPDIR/adapterB/install.sh" <<EOF
+#!/usr/bin/env bash
+touch "$FALLBACK_TMPDIR/adapterB-ran"
+exit 5
+EOF
+    chmod +x "$AGG_TMPDIR/adapterB/install.sh"
+
+    # The doc's fence uses illustrative angle-bracket placeholders
+    # (--mode=<mode>, --profile=<profile>, [--identity=<handle>|--no-identity])
+    # that are not meant to be executed literally - `<mode>` etc. parse as
+    # shell redirections, not text, and would break every adapter
+    # invocation before this test could observe fail-soft behavior at all.
+    # Substitute them with harmless literal values for this execution only;
+    # T10's guard tests never reach this line so they are unaffected, and
+    # T12's label extraction reads FALLBACK_SCRIPT's comment text, not this
+    # substituted copy.
+    AGG_SCRIPT="$(printf '%s\n' "$FALLBACK_SCRIPT" | sed -E \
+      -e 's/--mode=<mode>/--mode=test-mode/g' \
+      -e 's/--profile=<profile>/--profile=test-profile/g' \
+      -e 's/\[--identity=<handle>\|--no-identity\]//g')"
+
+    rm -f "$FALLBACK_TMPDIR/adapterA-ran" "$FALLBACK_TMPDIR/adapterB-ran"
+    AGG_OUTPUT="$(
+      (
+        PATH="$FAKE_BIN_DIR:$PATH"
+        export PATH
+        FAKE_GIT_LOG="$FAKE_GIT_LOG"
+        export FAKE_GIT_LOG
+        FAKE_BRANCH="main"
+        export FAKE_BRANCH
+        FAKE_DIRTY=""
+        export FAKE_DIRTY
+        AE_REPO_DIR="$AGG_TMPDIR"
+        export AE_REPO_DIR
+        # SELECTED_ADAPTERS is a bash array and arrays cannot be exported to
+        # a child process, so the assignment is prepended to the script text
+        # passed to `bash -c` rather than set in this subshell's own
+        # environment (which the child bash -c process would not inherit).
+        bash -c 'SELECTED_ADAPTERS=(adapterA adapterB)
+'"$AGG_SCRIPT"
+      ) 2>&1
+    )"
+    AGG_RC=$?
+
+    if [[ "$AGG_RC" -ne 0 ]]; then
+      _pass "T11a aggregation: overall exit is non-zero when adapters fail"
+    else
+      _fail "T11a aggregation: overall exit was 0 despite two adapter failures"
+    fi
+
+    if [[ -f "$FALLBACK_TMPDIR/adapterA-ran" && -f "$FALLBACK_TMPDIR/adapterB-ran" ]]; then
+      _pass "T11b aggregation: loop continues past the first failure (both adapters ran)"
+      AGG_BOTH_RAN=1
+    else
+      _fail "T11b aggregation: loop stopped after the first failure - not fail-soft"
+      AGG_BOTH_RAN=0
+    fi
+
+    if [[ "$AGG_OUTPUT" == *"adapterA/install.sh (exit 3)"* && "$AGG_OUTPUT" == *"adapterB/install.sh (exit 5)"* ]]; then
+      _pass "T11c aggregation: both failing adapters are named with their exit codes"
+    else
+      _fail "T11c aggregation: output does not name both failures with exit codes. Got:
+$AGG_OUTPUT"
+    fi
+
+    # -------------------------------------------------------------------
+    # Test 12: doc-vs-code parity for the fallback loop's fail-soft/
+    # fail-fast label. The in-fence comment immediately preceding the loop
+    # (extracted as part of FALLBACK_SCRIPT, same text T10 already ran)
+    # declares which behavior the loop has; T11 just measured which
+    # behavior it ACTUALLY has. This assertion ties the two together so
+    # either side drifting independently reds the gate - a code edit that
+    # makes the loop stop on first failure fails T11b already, and a prose
+    # edit that relabels the comment without touching the loop body fails
+    # only here.
+    # -------------------------------------------------------------------
+    FENCE_LABEL="$(printf '%s\n' "$FALLBACK_SCRIPT" | grep -A5 "Run each selected adapter" | grep -oE 'fail-(soft|fast)' | head -1)"
+    if [[ "$AGG_BOTH_RAN" -eq 1 ]]; then
+      ACTUAL_BEHAVIOR="fail-soft"
+    else
+      ACTUAL_BEHAVIOR="fail-fast"
+    fi
+
+    if [[ -n "$FENCE_LABEL" && "$FENCE_LABEL" == "$ACTUAL_BEHAVIOR" ]]; then
+      _pass "T12 doc-vs-code parity: fallback loop's declared behavior ($FENCE_LABEL) matches its measured behavior ($ACTUAL_BEHAVIOR)"
+    else
+      _fail "T12 doc-vs-code parity: fallback loop declares '${FENCE_LABEL:-<none found>}' but measured behavior is '$ACTUAL_BEHAVIOR' - content/commands/ds-update.md's fallback-loop comment has diverged from the loop's actual behavior"
     fi
 
     rm -rf "$FALLBACK_TMPDIR"

--- a/bin/tests/test_update_shared_constants.sh
+++ b/bin/tests/test_update_shared_constants.sh
@@ -34,6 +34,7 @@ SHARED_JSON="$REPO_ROOT/scripts/lib/update-shared.json"
 UPDATE_JS="$REPO_ROOT/scripts/update.js"
 UPDATER_PY="$REPO_ROOT/bin/agentic-update"
 INSTALL_ALL="$REPO_ROOT/install-all.sh"
+DS_UPDATE_MD="$REPO_ROOT/content/commands/ds-update.md"
 
 PASS=0
 FAIL=0
@@ -240,23 +241,169 @@ PYEOF
 done
 
 # ---------------------------------------------------------------------------
-# Test 7 (non-vacuity for T6): confirm the vector table can actually detect
-# a broken implementation, by running a deliberately-wrong predicate inline
-# and checking it disagrees with the expected value for at least one vector.
+# Test 7 (non-vacuity for T6): confirm the vector table can actually catch a
+# broken implementation, by simulating a deliberately-wrong "always false"
+# predicate (stub_result is always "0", never queries the real modules) and
+# checking it DISAGREES with the table's own expected value for at least one
+# vector - i.e. the T6 comparison `[[ "$js_result" == "$expected" ]]` would
+# genuinely fail against this stub, proving T6 is falsifiable and not merely
+# a property of the table's shape.
 # ---------------------------------------------------------------------------
-WRONG_RESULT="$(node -e "console.log('0');")"  # a stub that always returns 0
 MISMATCH_FOUND=0
 for vector in "${VECTORS[@]}"; do
   IFS='|' read -r old new paths expected <<< "$vector"
-  if [[ "$expected" == "1" ]]; then
+  stub_result="0"  # simulates an always-false needsRebuild/_needs_rebuild
+  if [[ "$stub_result" != "$expected" ]]; then
     MISMATCH_FOUND=1
     break
   fi
 done
 if [[ "$MISMATCH_FOUND" == "1" ]]; then
-  _pass "T7 non-vacuity check: vector table contains at least one expected=1 case (a stub returning 0 would be caught)"
+  _pass "T7 non-vacuity check: an always-false stub disagrees with the vector table (T6 is falsifiable)"
 else
-  _fail "T7 non-vacuity check: vector table has no expected=1 cases - table cannot catch a broken 'always false' implementation"
+  _fail "T7 non-vacuity check: vector table cannot distinguish an always-false stub from a correct implementation"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7b (MINOR fix): scripts/update.js DISPLAY_NAMES matches the shared
+# JSON (single-sourced - see the loadSharedConfig()/DISPLAY_NAMES comment
+# in scripts/update.js).
+# ---------------------------------------------------------------------------
+DN_JS_OUT="$(node -e "
+const u = require('$UPDATE_JS');
+console.log(JSON.stringify(u.DISPLAY_NAMES));
+" 2>&1)"
+
+if python3 -c "
+import json, sys
+shared = json.load(open(sys.argv[1]))
+js = json.loads(sys.argv[2])
+assert shared['display_names'] == js, (shared['display_names'], js)
+" "$SHARED_JSON" "$DN_JS_OUT" 2>/dev/null; then
+  _pass "T7b scripts/update.js DISPLAY_NAMES matches shared JSON"
+else
+  _fail "T7b scripts/update.js DISPLAY_NAMES diverged from shared JSON (got: $DN_JS_OUT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7c (MINOR fix): content/commands/ds-update.md's prose DISPLAY_NAMES
+# copy is parity-gated against the shared JSON. Markdown cannot load JSON at
+# doc-render time, so this prose copy cannot be single-sourced the way the
+# JS copy above was - this gate is the alternative the brief calls for: a
+# real CI failure on drift, not a "keep in sync manually" comment.
+#
+# Extracts the `{ claude: "Claude", codex: "Codex", ... }` block from the
+# doc (the one immediately following the "Display names use the same
+# `DISPLAY_NAMES` map" sentence) and parses it as a permissive key:value
+# list, tolerant of the doc's unquoted-key JS-object-literal style.
+# ---------------------------------------------------------------------------
+if [[ -f "$DS_UPDATE_MD" ]]; then
+  DOC_PARITY_RESULT="$(python3 -c "
+import json, re, sys
+
+doc_path = sys.argv[1]
+shared_path = sys.argv[2]
+
+text = open(doc_path, encoding='utf-8').read()
+m = re.search(r'DISPLAY_NAMES.*?\n\n\`\`\`\n(\{.*?\})\n\`\`\`', text, re.DOTALL)
+if not m:
+    print('EXTRACT_FAILED')
+    sys.exit(0)
+
+body = m.group(1)
+# Pull out bare-key: \"Value\" pairs - tolerant of the doc's unquoted-key
+# JS-object-literal style (not valid JSON as-is).
+pairs = re.findall(r'(\w+):\s*\"([^\"]+)\"', body)
+doc_map = dict(pairs)
+
+shared = json.load(open(shared_path))
+if doc_map == shared['display_names']:
+    print('MATCH')
+else:
+    print('MISMATCH: doc=' + json.dumps(doc_map) + ' shared=' + json.dumps(shared['display_names']))
+" "$DS_UPDATE_MD" "$SHARED_JSON" 2>&1)"
+
+  if [[ "$DOC_PARITY_RESULT" == "MATCH" ]]; then
+    _pass "T7c content/commands/ds-update.md DISPLAY_NAMES prose copy matches shared JSON"
+  elif [[ "$DOC_PARITY_RESULT" == "EXTRACT_FAILED" ]]; then
+    _fail "T7c could not extract the DISPLAY_NAMES block from $DS_UPDATE_MD - doc structure changed; update the extraction regex"
+  else
+    _fail "T7c content/commands/ds-update.md DISPLAY_NAMES prose copy diverged from shared JSON ($DOC_PARITY_RESULT)"
+  fi
+else
+  _fail "T7c $DS_UPDATE_MD not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: cross-language parity vectors for hooksTouched()/_hooks_touched().
+# Mirrors the same case table as scripts/test/update-hookstouched.test.js
+# (which is not wired to any CI workflow - grep confirms no .github/workflows
+# reference), so this is the only CI-enforced parity coverage for the
+# predicate. Same non-vacuity pattern as T6/T7 below.
+# ---------------------------------------------------------------------------
+declare -a HOOKS_VECTORS=(
+  # changed_paths(comma-sep)|expected(0/1)
+  "hooks/enforce-background-spawn.py|1"      # hooks/-prefixed -> touched
+  "hooks/stop-context.js|1"                  # hooks/-prefixed -> touched
+  "README.md|0"                              # non-hooks -> not touched
+  "content/agents/engineer.md|0"             # non-hooks -> not touched
+  "README.md,hooks/x.sh|1"                   # mixed: one hooks/ present -> touched
+  "|0"                                       # empty changed_paths -> not touched
+  "hooks\\\\foo.py|1"                        # backslash-normalized -> touched
+  "/hooks/foo.py|1"                          # leading-slash -> touched
+)
+
+for vector in "${HOOKS_VECTORS[@]}"; do
+  IFS='|' read -r paths expected <<< "$vector"
+  paths_json="$(python3 -c "
+import json, sys
+p = sys.argv[1]
+print(json.dumps(p.split(',') if p else []))
+" "$paths")"
+
+  js_result="$(node -e "
+const u = require('$UPDATE_JS');
+const paths = $paths_json;
+console.log(u.hooksTouched(paths) ? '1' : '0');
+" 2>&1)"
+
+  py_result="$(python3 - "$UPDATER_PY" "$paths_json" <<'PYEOF' 2>&1
+import importlib.util, importlib.machinery, json, sys
+
+updater_path, paths_json = sys.argv[1:3]
+loader = importlib.machinery.SourceFileLoader("agentic_update_hooks_test", updater_path)
+spec = importlib.util.spec_from_file_location("agentic_update_hooks_test", updater_path, loader=loader)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+paths = json.loads(paths_json)
+print("1" if mod._hooks_touched(paths) else "0")
+PYEOF
+)"
+
+  if [[ "$js_result" == "$expected" && "$py_result" == "$expected" ]]; then
+    _pass "T8 hooksTouched vector '$paths': JS=$js_result PY=$py_result expected=$expected"
+  else
+    _fail "T8 hooksTouched vector '$paths': JS=$js_result PY=$py_result expected=$expected"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 9 (non-vacuity for T8): an always-false stub must disagree with the
+# HOOKS_VECTORS table for at least one vector.
+# ---------------------------------------------------------------------------
+HOOKS_MISMATCH_FOUND=0
+for vector in "${HOOKS_VECTORS[@]}"; do
+  IFS='|' read -r paths expected <<< "$vector"
+  stub_result="0"  # simulates an always-false hooksTouched/_hooks_touched
+  if [[ "$stub_result" != "$expected" ]]; then
+    HOOKS_MISMATCH_FOUND=1
+    break
+  fi
+done
+if [[ "$HOOKS_MISMATCH_FOUND" == "1" ]]; then
+  _pass "T9 non-vacuity check: an always-false stub disagrees with the hooksTouched vector table (T8 is falsifiable)"
+else
+  _fail "T9 non-vacuity check: hooksTouched vector table cannot distinguish an always-false stub from a correct implementation"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_update_shared_constants.sh
+++ b/bin/tests/test_update_shared_constants.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Purpose: Regression tests for the update-flow shared-constants collapse
+#          (scripts/lib/update-shared.json). Two things are asserted:
+#          (1) scripts/update.js and bin/agentic-update both load SKIP_DIRS
+#              and REBUILD_TRIGGERS from the shared JSON file rather than a
+#              local literal - single-sourcing makes drift structurally
+#              impossible for pure DATA, so this is a load-path assertion,
+#              not a value-comparison assertion (the JS/Python consumers
+#              would trivially "agree" with themselves if they each still
+#              hardcoded the same list independently - the failure mode this
+#              guards is a REINTRODUCED local literal, not a stale value).
+#          (2) install-all.sh's SKIP_DIRS array (loaded via python3 from the
+#              same JSON) matches the shared file's skip_dirs exactly.
+#          (3) needsRebuild()/_needs_rebuild() - the matching ALGORITHM that
+#              genuinely cannot be shared across JS/Python - agree on a
+#              cross-language parity vector table.
+#
+# Public API: ./bin/tests/test_update_shared_constants.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, node, python3.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       CI via the bin-sh-tests test_*.sh glob discovery.
+#
+# Failure modes: any test failure prints the failing assertion and exits 1.
+#
+# Performance: <5 s wall time.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SHARED_JSON="$REPO_ROOT/scripts/lib/update-shared.json"
+UPDATE_JS="$REPO_ROOT/scripts/update.js"
+UPDATER_PY="$REPO_ROOT/bin/agentic-update"
+INSTALL_ALL="$REPO_ROOT/install-all.sh"
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+if [[ ! -f "$SHARED_JSON" ]]; then
+  _fail "shared config file missing at $SHARED_JSON"
+  echo; echo "Results: $PASS passed, $FAIL failed."; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1: shared JSON is valid and has the expected shape
+# ---------------------------------------------------------------------------
+if python3 -c "
+import json, sys
+data = json.load(open(sys.argv[1]))
+assert isinstance(data.get('skip_dirs'), list) and len(data['skip_dirs']) > 0
+assert isinstance(data.get('rebuild_triggers'), list) and len(data['rebuild_triggers']) > 0
+" "$SHARED_JSON" 2>/dev/null; then
+  _pass "T1 shared JSON has non-empty skip_dirs and rebuild_triggers arrays"
+else
+  _fail "T1 shared JSON malformed or missing expected keys"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: scripts/update.js SKIP_DIRS/REBUILD_TRIGGERS match the shared file
+# (proves it is actually LOADING from the file, not a reintroduced literal
+# that happens to still agree - a stale/mismatched literal fails this).
+# ---------------------------------------------------------------------------
+JS_OUT="$(node -e "
+const u = require('$UPDATE_JS');
+const skip = [...u.SKIP_DIRS].sort();
+const triggers = [...u.REBUILD_TRIGGERS].sort();
+console.log(JSON.stringify({skip_dirs: skip, rebuild_triggers: triggers}));
+" 2>&1)"
+
+if python3 -c "
+import json, sys
+shared = json.load(open(sys.argv[1]))
+js = json.loads(sys.argv[2])
+assert sorted(shared['skip_dirs']) == js['skip_dirs'], (sorted(shared['skip_dirs']), js['skip_dirs'])
+assert sorted(shared['rebuild_triggers']) == js['rebuild_triggers'], (sorted(shared['rebuild_triggers']), js['rebuild_triggers'])
+" "$SHARED_JSON" "$JS_OUT" 2>/dev/null; then
+  _pass "T2 scripts/update.js SKIP_DIRS/REBUILD_TRIGGERS match shared JSON"
+else
+  _fail "T2 scripts/update.js constants diverged from shared JSON (got: $JS_OUT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: bin/agentic-update SKIP_DIRS/REBUILD_TRIGGERS match the shared file
+# ---------------------------------------------------------------------------
+PY_OUT="$(python3 - "$UPDATER_PY" <<'PYEOF' 2>&1
+import importlib.util, importlib.machinery, json, sys
+
+updater_path = sys.argv[1]
+loader = importlib.machinery.SourceFileLoader("agentic_update_shared_test", updater_path)
+spec = importlib.util.spec_from_file_location("agentic_update_shared_test", updater_path, loader=loader)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print(json.dumps({
+    "skip_dirs": sorted(mod.SKIP_DIRS),
+    "rebuild_triggers": sorted(mod.REBUILD_TRIGGERS),
+}))
+PYEOF
+)"
+
+if python3 -c "
+import json, sys
+shared = json.load(open(sys.argv[1]))
+py = json.loads(sys.argv[2])
+assert sorted(shared['skip_dirs']) == py['skip_dirs'], (sorted(shared['skip_dirs']), py['skip_dirs'])
+assert sorted(shared['rebuild_triggers']) == py['rebuild_triggers'], (sorted(shared['rebuild_triggers']), py['rebuild_triggers'])
+" "$SHARED_JSON" "$PY_OUT" 2>/dev/null; then
+  _pass "T3 bin/agentic-update SKIP_DIRS/REBUILD_TRIGGERS match shared JSON"
+else
+  _fail "T3 bin/agentic-update constants diverged from shared JSON (got: $PY_OUT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: install-all.sh's SKIP_DIRS array (loaded via python3 at runtime)
+# matches the shared file. Exercised by sourcing the array-building prelude
+# in a subshell, not by running the whole script (which requires adapters).
+# ---------------------------------------------------------------------------
+IA_OUT="$(bash -c '
+REPO_DIR="'"$REPO_ROOT"'"
+SHARED_CONFIG="$REPO_DIR/scripts/lib/update-shared.json"
+SKIP_DIRS=()
+while IFS= read -r skip_dir; do
+  SKIP_DIRS+=("$skip_dir")
+done < <(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for d in data[\"skip_dirs\"]:
+    print(d)
+" "$SHARED_CONFIG")
+printf "%s\n" "${SKIP_DIRS[@]}" | sort
+' 2>&1)"
+
+EXPECTED_OUT="$(python3 -c "
+import json
+data = json.load(open('$SHARED_JSON'))
+print('\n'.join(sorted(data['skip_dirs'])))
+")"
+
+if [[ "$IA_OUT" == "$EXPECTED_OUT" ]]; then
+  _pass "T4 install-all.sh SKIP_DIRS (loaded from shared JSON) matches expected"
+else
+  _fail "T4 install-all.sh SKIP_DIRS mismatch. Got:
+$IA_OUT
+Expected:
+$EXPECTED_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5 (non-vacuity, RED/GREEN for T2/T3): a deliberately mutated shared
+# JSON (extra bogus skip dir NOT in the loaded module output) must FAIL the
+# comparison logic used above - proves T2/T3 are not vacuously true.
+# ---------------------------------------------------------------------------
+BOGUS_JSON="$(mktemp)"
+python3 -c "
+import json
+data = json.load(open('$SHARED_JSON'))
+data['skip_dirs'] = data['skip_dirs'] + ['.this_should_not_be_here']
+json.dump(data, open('$BOGUS_JSON', 'w'))
+"
+if python3 -c "
+import json, sys
+shared = json.load(open(sys.argv[1]))
+js = json.loads(sys.argv[2])
+assert sorted(shared['skip_dirs']) == js['skip_dirs']
+" "$BOGUS_JSON" "$JS_OUT" 2>/dev/null; then
+  _fail "T5 non-vacuity check: bogus JSON incorrectly matched real module output (comparison is vacuous)"
+else
+  _pass "T5 non-vacuity check: bogus JSON correctly fails the comparison (T2/T3 are falsifiable)"
+fi
+rm -f "$BOGUS_JSON"
+
+# ---------------------------------------------------------------------------
+# Test 6: cross-language parity vectors for needsRebuild()/_needs_rebuild().
+# The matching ALGORITHM (not just the trigger-list data) is duplicated
+# across JS and Python since it can't practically be shared across
+# languages. This vector table is the enforcing test the brief calls for.
+# ---------------------------------------------------------------------------
+declare -a VECTORS=(
+  # old_head|new_head|changed_paths(comma-sep)|expected(0/1)
+  "|def456|content/x.md|1"                       # empty old_head -> always rebuild
+  "abc123|abc123|content/x.md|0"                  # same heads -> never rebuild
+  "abc123|def456|content/x.md|1"                  # content/ prefix
+  "abc123|def456|docs/x.md|0"                     # not a trigger
+  "abc123|def456|.cursor/build.sh|1"               # */build.sh catch-all
+  "abc123|def456|build.sh|1"                       # bare build.sh
+  "abc123|def456|.claude/install.sh|1"             # exact-path trigger
+  "abc123|def456|bin/agentic-update|1"             # bin/ prefix
+  "abc123|def456|scripts/build-all.sh|1"           # exact-path trigger
+  "abc123|def456|hooks/foo.py|1"                   # hooks/ prefix
+  "abc123|def456|docs/x.md,content/y.md|1"         # mixed: one trigger present
+  "abc123|def456|/content/x.md|1"                  # leading-slash normalisation
+  "abc123|def456|content\\\\x.md|1"                # backslash normalisation
+)
+
+for vector in "${VECTORS[@]}"; do
+  IFS='|' read -r old new paths expected <<< "$vector"
+  # Build a JSON array of changed paths from the comma-separated field.
+  paths_json="$(python3 -c "
+import json, sys
+p = sys.argv[1]
+print(json.dumps(p.split(',') if p else []))
+" "$paths")"
+
+  js_result="$(node -e "
+const u = require('$UPDATE_JS');
+const paths = $paths_json;
+console.log(u.needsRebuild('$old', '$new', paths) ? '1' : '0');
+" 2>&1)"
+
+  py_result="$(python3 - "$UPDATER_PY" "$old" "$new" "$paths_json" <<'PYEOF' 2>&1
+import importlib.util, importlib.machinery, json, sys
+
+updater_path, old, new, paths_json = sys.argv[1:5]
+loader = importlib.machinery.SourceFileLoader("agentic_update_vec_test", updater_path)
+spec = importlib.util.spec_from_file_location("agentic_update_vec_test", updater_path, loader=loader)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+paths = json.loads(paths_json)
+print("1" if mod._needs_rebuild(old, new, paths) else "0")
+PYEOF
+)"
+
+  if [[ "$js_result" == "$expected" && "$py_result" == "$expected" ]]; then
+    _pass "T6 vector '$paths' (old=$old new=$new): JS=$js_result PY=$py_result expected=$expected"
+  else
+    _fail "T6 vector '$paths' (old=$old new=$new): JS=$js_result PY=$py_result expected=$expected"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 7 (non-vacuity for T6): confirm the vector table can actually detect
+# a broken implementation, by running a deliberately-wrong predicate inline
+# and checking it disagrees with the expected value for at least one vector.
+# ---------------------------------------------------------------------------
+WRONG_RESULT="$(node -e "console.log('0');")"  # a stub that always returns 0
+MISMATCH_FOUND=0
+for vector in "${VECTORS[@]}"; do
+  IFS='|' read -r old new paths expected <<< "$vector"
+  if [[ "$expected" == "1" ]]; then
+    MISMATCH_FOUND=1
+    break
+  fi
+done
+if [[ "$MISMATCH_FOUND" == "1" ]]; then
+  _pass "T7 non-vacuity check: vector table contains at least one expected=1 case (a stub returning 0 would be caught)"
+else
+  _fail "T7 non-vacuity check: vector table has no expected=1 cases - table cannot catch a broken 'always false' implementation"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #          updates the repository from GitHub, delegates to .claude/install.sh
 #          for adapter setup, and writes the resolved repo path to
 #          ~/.agentic/agentic-engineering-config.json for use by update.sh and
-#          the /ds-update-agentic-engineering command.
+#          the /ds-update command.
 #
 # Public API:
 #   curl -fsSL https://raw.githubusercontent.com/Space-Dinosaurs/DinoStack/main/bootstrap.sh | bash
@@ -219,7 +219,7 @@ echo ""
 echo "agentic-engineering installed to: $AE_DEST_DIR"
 echo "Update anytime via either:"
 echo "  cd $AE_DEST_DIR && ./update.sh"
-echo "  or the /ds-update-agentic-engineering command inside Claude Code (location-aware)"
+echo "  or the /ds-update command inside Claude Code (location-aware)"
 echo ""
 # Remind about PATH if ~/.local/bin is not already on it
 if ! echo ":$PATH:" | grep -q ":$HOME/.local/bin:"; then

--- a/content/commands/ds-update.md
+++ b/content/commands/ds-update.md
@@ -174,14 +174,30 @@ UPDATE_STATUS=$?
 
 On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
-If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
+
 ```bash
+CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
+  # STOP - do not proceed
+fi
+
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
+if [[ -n "$DIRTY" ]]; then
+  echo "error: working tree has uncommitted changes; commit or stash first:"
+  echo "$DIRTY"
+  # STOP - do not proceed
+fi
+
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   # On non-zero exit: stop immediately, report which adapter failed and its exit code.
 done
 ```
+A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
+
 Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW

--- a/content/commands/ds-update.md
+++ b/content/commands/ds-update.md
@@ -172,7 +172,7 @@ UPDATE_STATUS=$?
 
 `--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
 
-On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (fail-soft - every selected adapter is attempted, and the names and exit codes of all that failed are listed together at the end). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
 
 If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the branch/dirty-tree checks, the pull, and the per-adapter install loop directly. This fallback has no other gate - `agentic-update`'s own branch and dirty-tree checks are unreachable when it isn't found - so both hard blocks below are mandatory here, not optional preview info as in Step 2b:
 
@@ -180,21 +180,32 @@ If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-updat
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   echo "error: must be on 'main' to update (currently on '$CURRENT_BRANCH'). Run: git -C $AE_REPO_DIR checkout main"
-  # STOP - do not proceed
+  exit 1
 fi
 
 DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 if [[ -n "$DIRTY" ]]; then
   echo "error: working tree has uncommitted changes; commit or stash first:"
   echo "$DIRTY"
-  # STOP - do not proceed
+  exit 1
 fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
+FAILED_ADAPTERS=()
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    FAILED_ADAPTERS+=("${adapter}/install.sh (exit ${ADAPTER_STATUS})")
+  fi
 done
+if [[ "${#FAILED_ADAPTERS[@]}" -gt 0 ]]; then
+  echo "error: the following adapters failed to install:"
+  for f in "${FAILED_ADAPTERS[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi
 ```
 A non-main branch or a dirty tree can silently fast-forward the branch into a broken state (the same reason `agentic-update` enforces both internally) - never skip these two checks on the fallback path.
 
@@ -222,7 +233,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
      echo "HTTPS clone failed (repo may be private); trying SSH..."
      if ! git clone "$SSH_URL" "$DEST"; then
        echo "Both HTTPS and SSH clone failed. If the repo is private, ensure SSH access is configured."
-       # STOP - report failure
+       exit 1
      fi
    fi
    ```
@@ -246,7 +257,11 @@ fi
 # Run each selected adapter's install.sh (fail-fast)
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$DEST/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
-  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+  ADAPTER_STATUS=$?
+  if [[ "$ADAPTER_STATUS" -ne 0 ]]; then
+    echo "error: adapter '$adapter' install failed with exit code $ADAPTER_STATUS"
+    exit 1
+  fi
 done
 ```
 

--- a/content/commands/ds-update.md
+++ b/content/commands/ds-update.md
@@ -70,7 +70,7 @@ Display names use the same `DISPLAY_NAMES` map as `update.js`:
 
 ```
 { claude: "Claude", codex: "Codex", cursor: "Cursor", gemini: "Gemini",
-  opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
+  openclaw: "OpenClaw", opencode: "OpenCode", kimi: "Kimi", omp: "Pi" }
 ```
 
 For adapter names not in the map, apply the generic capitalizer: strip the leading `.`, then capitalize the first character and lowercase the rest (e.g. `.hermes` -> `Hermes`, `.pi` -> `Pi`).
@@ -98,9 +98,11 @@ Run `agentic-identity show --scope effective` to check the current identity stat
 
 Resolve to either a handle (pass `--identity=<handle>` to install.sh in Step 4) or skip (pass `--no-identity`).
 
-## Step 2 - Git safety (UPDATE-FLOW only)
+## Step 2 - Git preview (UPDATE-FLOW only, informational)
 
 Skip this step for FRESH-CLONE-FLOW.
+
+This step is read-only: it only gathers what Step 3's confirmation display needs to show. **Enforcement of the branch/dirty-tree/divergence safety checks happens inside `agentic-update` at Step 4**, not here - `agentic-update` already implements the branch check, the dirty-tree check, and fails closed on a non-fast-forward (diverged) pull. Reimplementing that enforcement in prose here would be exactly the drift this command collapsed (see PR history: four independent copies of "get the latest methodology" had already diverged before this section was rewritten to delegate).
 
 **2a - Fetch:**
 ```bash
@@ -108,39 +110,15 @@ git -C "$AE_REPO_DIR" fetch origin
 ```
 If fetch fails, stop and report the error. Network issues are surfaced verbatim.
 
-**2b - Branch check (hard block):**
+**2b - Preview info (for the Step 3 display only):**
 ```bash
 CURRENT_BRANCH="$(git -C "$AE_REPO_DIR" rev-parse --abbrev-ref HEAD)"
-```
-If `CURRENT_BRANCH != "main"`, **hard-block** with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` is on branch `<CURRENT_BRANCH>`, not `main`. Running `git pull --ff-only origin main` on a non-main branch can silently fast-forward it into a broken state. Check out `main` and re-run: `git -C \"<AE_REPO_DIR>\" checkout main`"
-
-Do NOT offer a Y/N prompt. Do NOT proceed.
-
-**2c - Dirty tree check:**
-
-```bash
-DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
-```
-If non-empty, **stop** (no auto-stash) with:
-
-> "Cannot pull: the repo at `<AE_REPO_DIR>` has uncommitted changes. Commit, stash, or discard them first, then re-run."
-
-Show the `git status --porcelain` output.
-
-(A `CHURN_ALLOWLIST` carve-out lived here between #390 and DS-129, allow-listing a tracked root `MEMORY.md` that DinoStack's memory pipeline rewrote locally. DS-129 untracked root `MEMORY.md` in this repo, so the file the carve-out existed for can no longer appear in `git status --porcelain` - it was removed wholesale rather than left dead. If another tracked file develops the same locally-churned-but-curated-in-git pattern, reintroduce the mechanism then rather than resurrecting this dead code speculatively.)
-
-**2d - Divergence check:**
-```bash
 COUNTS="$(git -C "$AE_REPO_DIR" rev-list --left-right --count HEAD...origin/main)"
 LOCAL_AHEAD="$(echo "$COUNTS" | awk '{print $1}')"
 REMOTE_AHEAD="$(echo "$COUNTS" | awk '{print $2}')"
+DIRTY="$(git -C "$AE_REPO_DIR" status --porcelain)"
 ```
-- Local ahead only: note it ("local has N commits not on origin") but proceed.
-- Remote ahead only: expected; proceed.
-- Both ahead (diverged): stop. "Local and origin have diverged (N local commits, M origin commits). Resolve manually before re-running."
-- Neither ahead: note "already up to date" and proceed (will still re-run adapters).
+Use these only to populate the Step 3 "Plan:" display (branch name, "clean"/"has local changes", "origin/main is N commit(s) ahead", and a note when both are ahead - "local and origin have diverged; the update will fail at Step 4 until resolved"). None of these conditions block Step 3 from being shown; `agentic-update` is the actual gate.
 
 ## Step 3 - Confirm plan
 
@@ -170,28 +148,9 @@ This explicit confirmation is what authorizes the side-effecting Step 4 as a con
 
 ### UPDATE-FLOW
 
-**4a - Pull:**
+Delegate the mechanical steps - branch/dirty-tree/divergence enforcement, the pull, the hooks-change note, and the adapter loop - to `agentic-update` in a single call rather than reimplementing them here. This is what actually collapses the drift: before this rewrite, this section duplicated `bin/agentic-update`'s branch check, dirty-tree check, pull, and per-adapter install loop line-for-line in prose, and the two copies had already started to diverge.
 
-```bash
-OLD_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-git -C "$AE_REPO_DIR" pull --ff-only origin main
-PULL_STATUS=$?
-NEW_HEAD="$(git -C "$AE_REPO_DIR" rev-parse HEAD)"
-```
-
-On non-zero `PULL_STATUS`: stop and show the error verbatim. Do not proceed to adapter installs.
-
-**4a-2 - Hook-change note:**
-```bash
-HOOK_CHANGES="$(git -C "$AE_REPO_DIR" diff --name-only "$OLD_HEAD" "$NEW_HEAD" -- hooks/)"
-```
-If `HOOK_CHANGES` is non-empty, print the following informational note (substituting `HOOK_CHANGES` as a comma-joined list into `Changed:`) before continuing to 4b. This is informational only, not an actionable warning - Step 4c below re-runs `install.sh` for every selected adapter, which refreshes this machine's local hook snapshot as part of this flow.
-
-> note: this update changed files under hooks/. A bare git pull no longer changes a running session's hooks (they load from a session-stable snapshot, not the checkout) - but this flow also runs the install step, which refreshes this checkout's SHARED hook snapshot in place. So any OTHER Claude Code session already open against this checkout will pick up the changed hooks on its next tool call. If that matters, have those sessions /exit and restart once this update finishes. Changed: `<comma-joined HOOK_CHANGES>`
-
-If `HOOK_CHANGES` is empty, skip silently and continue to 4b.
-
-**4b - Detect `--identity` flag support** (after pull, not before, so the check reflects the newly pulled install.sh):
+**4a - Detect `--identity` flag support** (before delegating, so the flag is only passed when the pulled install.sh - as of the START of this step - is known to support it; `agentic-update` re-checks this per-adapter internally as it runs each install.sh after its own pull):
 ```bash
 INSTALL_SH="$AE_REPO_DIR/.claude/install.sh"
 if grep -q -- '--identity' "$INSTALL_SH" 2>/dev/null; then
@@ -202,15 +161,28 @@ fi
 ```
 If `IDENTITY_SUPPORTED=0`, skip identity flags and note: "This install.sh version does not support `--identity`. Re-run after a future update to configure identity."
 
-Note: `.claude/install.sh` is used as a proxy for all adapters in this repo - all adapters track the same install.sh template, so the flag presence in `.claude/install.sh` is a reliable indicator for the full set. If a selected non-Claude adapter's installer predates the flag (e.g., an older pinned fork), that single install invocation may warn or fail but will not corrupt other adapters' state.
+**4b - Delegate to `agentic-update`:**
 
-**4c - Run adapters (fail-fast):**
-
-For each selected adapter in the resolved list:
 ```bash
-bash "$AE_REPO_DIR/<adapter>/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+# ADAPTERS_CSV: comma-joined SELECTED_ADAPTERS from Step 1a.
+# Only pass --identity/--no-identity when IDENTITY_SUPPORTED=1 (from 4a).
+agentic-update --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity] --adapters=<ADAPTERS_CSV> --no-doctor
+UPDATE_STATUS=$?
 ```
-On non-zero exit from any adapter: stop immediately, report which adapter failed and its exit code. Do not run remaining adapters.
+
+`--no-doctor` is passed deliberately: this command's own Step 5 runs a diagnostic-only `agentic-doctor` (no `--fix`) so findings are reported, not silently auto-applied - `agentic-update`'s built-in doctor step defaults to `--fix`, which would change that contract if left enabled here.
+
+On non-zero `UPDATE_STATUS`: stop and show `agentic-update`'s stdout/stderr verbatim. `agentic-update` already produces actionable messages for every case this section used to check by hand: non-main branch, dirty tree (lists the dirty files), a failed or diverged (non-fast-forward) pull, and a failed adapter install (names which adapter and its exit code, fail-fast - remaining adapters do not run). It also prints the hooks-change note to stderr internally when the pull touched `hooks/`, using the same wording this section used to duplicate - that note surfaces automatically as part of the verbatim output, nothing further to do here.
+
+If `agentic-update` is not found on PATH (e.g. this is the very first `/ds-update` run in a fresh shell before `~/.local/bin` was picked up), fall back to running the pull and the per-adapter install loop directly:
+```bash
+git -C "$AE_REPO_DIR" pull --ff-only origin main
+for adapter in "${SELECTED_ADAPTERS[@]}"; do
+  bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
+  # On non-zero exit: stop immediately, report which adapter failed and its exit code.
+done
+```
+Note "agentic-update not found on PATH; ran the fallback sequence directly. Open a new shell so `agentic-update` is available next time."
 
 ### FRESH-CLONE-FLOW
 
@@ -242,7 +214,7 @@ Do NOT use anonymous `curl | bash` of bootstrap.sh (fails for private repos) and
 
 **4c - Run adapters (same loop as UPDATE-FLOW):**
 
-After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW Step 4c. Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed.
+After the clone lands, run the same per-adapter install loop used by UPDATE-FLOW's `agentic-update`-not-found fallback (Step 4). Do NOT use bootstrap.sh as the sole adapter installer - bootstrap.sh only wires `.claude`, so users who selected Codex/Cursor/etc. in Step 1a would never have those adapters installed. Do NOT delegate this loop to `agentic-update` either: it errors out when `repo_dir` does not yet exist rather than cloning, and even after the clone lands it would misfire - `agentic-update`'s rebuild-skip logic treats `old_head == new_head` (true immediately after a fresh clone, before any pull) as "nothing changed, skip the adapter loop", which would silently skip every adapter on a brand-new install.
 
 bootstrap.sh may be invoked for global PATH wiring / config-dir setup if needed, but adapter installation must use the loop below:
 

--- a/content/commands/ds-update.md
+++ b/content/commands/ds-update.md
@@ -192,6 +192,12 @@ fi
 
 git -C "$AE_REPO_DIR" pull --ff-only origin main
 FAILED_ADAPTERS=()
+# Run each selected adapter's install.sh (fail-soft: every adapter is
+# attempted even after an earlier one fails, and all failures are reported
+# together below). Deliberately asymmetric with the FRESH-CLONE-FLOW loop
+# below, which is fail-fast: a partially-installed brand-new clone is worse
+# than a partially-refreshed existing install, so a fresh clone stops on the
+# first failure instead of leaving some adapters wired and others not.
 for adapter in "${SELECTED_ADAPTERS[@]}"; do
   bash "$AE_REPO_DIR/${adapter}/install.sh" --mode=<mode> --profile=<profile> [--identity=<handle>|--no-identity]
   ADAPTER_STATUS=$?

--- a/docs/index.html
+++ b/docs/index.html
@@ -938,7 +938,7 @@
 <!-- ═══ INSTALL: One command to get started ═══ -->
 <div id="install" class="section config-layer">
   <div class="section-title"><h2>Install</h2><h3>One command. Everything else is optional.</h3></div>
-  <p class="desc">One line clones the repo into <code>DinoStack/</code> inside your current directory, runs the installer, and writes the install path to <code>~/.agentic/agentic-engineering-config.json</code> so update tooling (<code>agentic-update</code>, <code>/ds-update-agentic-engineering</code>) knows where to find it. Prerequisites: <code>git</code> and <code>python3</code> - <code>node</code> is optional, needed only for the update TUI.</p>
+  <p class="desc">One line clones the repo into <code>DinoStack/</code> inside your current directory, runs the installer, and writes the install path to <code>~/.agentic/agentic-engineering-config.json</code> so update tooling (<code>agentic-update</code>, <code>/ds-update</code>) knows where to find it. Prerequisites: <code>git</code> and <code>python3</code> - <code>node</code> is optional, needed only for the update TUI.</p>
 
   <div class="code-block">
     <span class="cb-label">one-liner install</span>

--- a/install-all.sh
+++ b/install-all.sh
@@ -30,9 +30,12 @@ set -euo pipefail
 #              (symlinks, python3 config writes, optional builds).
 #
 # Notes: Adapter discovery mirrors scripts/update.js discoverAdapters() and its
-#        SKIP_DIRS set exactly. .claude runs first unconditionally so its
-#        agentic-* binaries (incl. agentic-identity) are on PATH before other
-#        adapters' identity steps run.
+#        SKIP_DIRS set exactly (loaded from scripts/lib/update-shared.json -
+#        the single source of truth shared with scripts/update.js and
+#        bin/agentic-update; do not reintroduce a local literal here). .claude
+#        runs first unconditionally so its agentic-* binaries (incl.
+#        agentic-identity) are on PATH before other adapters' identity steps
+#        run.
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -41,9 +44,30 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ---------------------------------------------------------------------------
-# Skip-list - mirrors SKIP_DIRS in scripts/update.js exactly.
+# Skip-list - loaded from scripts/lib/update-shared.json (single source of
+# truth shared with scripts/update.js and bin/agentic-update). python3 is
+# already a hard dependency of this repo's install/update flow (bootstrap.sh
+# preflights it), so shelling out is safe here.
 # ---------------------------------------------------------------------------
-SKIP_DIRS=(. .. .git .github .vscode .idea .cache .venv .mypy_cache .pytest_cache .ruff_cache)
+SHARED_CONFIG="$REPO_DIR/scripts/lib/update-shared.json"
+if [[ ! -f "$SHARED_CONFIG" ]]; then
+  echo "error: shared config not found at $SHARED_CONFIG" >&2
+  exit 1
+fi
+SKIP_DIRS=()
+while IFS= read -r skip_dir; do
+  SKIP_DIRS+=("$skip_dir")
+done < <(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for d in data['skip_dirs']:
+    print(d)
+" "$SHARED_CONFIG")
+if [[ ${#SKIP_DIRS[@]} -eq 0 ]]; then
+  echo "error: failed to load skip_dirs from $SHARED_CONFIG" >&2
+  exit 1
+fi
 
 is_skipped() {
   local candidate="$1"

--- a/scripts/lib/update-shared.json
+++ b/scripts/lib/update-shared.json
@@ -1,5 +1,5 @@
 {
-  "_manifest": "Single source of truth for the update flow constants shared across scripts/update.js, bin/agentic-update, and install-all.sh. Editing this file is the ONLY way to change either list - do not reintroduce a local literal in any of the three consumers. skip_dirs: dot-directories at repo root excluded from adapter discovery. rebuild_triggers: path prefixes/exact-paths that force an adapter rebuild after a pull (see needsRebuild()/_needs_rebuild()).",
+  "_manifest": "Single source of truth for the update flow constants shared across scripts/update.js, bin/agentic-update, and install-all.sh. Editing this file is the ONLY way to change any of these - do not reintroduce a local literal in any consumer. skip_dirs: dot-directories at repo root excluded from adapter discovery. rebuild_triggers: path prefixes/exact-paths that force an adapter rebuild after a pull (see needsRebuild()/_needs_rebuild()). display_names: adapter-dir-name (without leading dot) -> human-readable label, used by scripts/update.js's displayName(); content/commands/ds-update.md carries a prose copy for the agent flow (markdown cannot load JSON at doc-render time) - bin/tests/test_update_shared_constants.sh gates that prose copy for parity against this file.",
   "skip_dirs": [
     ".",
     "..",
@@ -21,5 +21,15 @@
     "hooks/",
     ".claude/install.sh",
     "bin/"
-  ]
+  ],
+  "display_names": {
+    "claude": "Claude",
+    "codex": "Codex",
+    "cursor": "Cursor",
+    "gemini": "Gemini",
+    "openclaw": "OpenClaw",
+    "opencode": "OpenCode",
+    "kimi": "Kimi",
+    "omp": "Pi"
+  }
 }

--- a/scripts/lib/update-shared.json
+++ b/scripts/lib/update-shared.json
@@ -1,0 +1,25 @@
+{
+  "_manifest": "Single source of truth for the update flow constants shared across scripts/update.js, bin/agentic-update, and install-all.sh. Editing this file is the ONLY way to change either list - do not reintroduce a local literal in any of the three consumers. skip_dirs: dot-directories at repo root excluded from adapter discovery. rebuild_triggers: path prefixes/exact-paths that force an adapter rebuild after a pull (see needsRebuild()/_needs_rebuild()).",
+  "skip_dirs": [
+    ".",
+    "..",
+    ".git",
+    ".github",
+    ".vscode",
+    ".idea",
+    ".cache",
+    ".venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache"
+  ],
+  "rebuild_triggers": [
+    "content/",
+    "scripts/build-all.sh",
+    "scripts/build-methodology.sh",
+    "scripts/build-slides.sh",
+    "hooks/",
+    ".claude/install.sh",
+    "bin/"
+  ]
+}

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -29,9 +29,17 @@
  *
  * Upstream deps: Node built-ins (fs, path, child_process, readline). No
  *                external packages. Reads scripts/lib/update-shared.json for
- *                SKIP_DIRS and REBUILD_TRIGGERS - the single source of truth
- *                shared with bin/agentic-update and install-all.sh. Do not
- *                reintroduce a local literal for either list.
+ *                SKIP_DIRS, REBUILD_TRIGGERS, and DISPLAY_NAMES - the single
+ *                source of truth shared with bin/agentic-update and
+ *                install-all.sh (DISPLAY_NAMES has no Python consumer, but
+ *                is still single-sourced here rather than duplicated as a
+ *                local literal). Do not reintroduce a local literal for any
+ *                of the three. content/commands/ds-update.md carries a
+ *                necessary prose copy of DISPLAY_NAMES for the agent flow
+ *                (markdown cannot load JSON at doc-render time) - that copy
+ *                is gated for parity against this file by
+ *                bin/tests/test_update_shared_constants.sh, not single-
+ *                sourced.
  *
  * Downstream consumers: update.sh (shell shim that delegates here).
  *
@@ -176,20 +184,14 @@ function discoverAdapters(repoDir) {
 // Display names
 // ---------------------------------------------------------------------------
 
-// Kept alongside this file (not shared-config-driven) since it is a display
-// concern rather than an update-flow behavioral constant. The prose copy in
-// content/commands/ds-update.md must be kept in sync manually - see PR
-// history for the recurring drift this list has already had once.
-const DISPLAY_NAMES = {
-  claude:   'Claude',
-  codex:    'Codex',
-  cursor:   'Cursor',
-  gemini:   'Gemini',
-  openclaw: 'OpenClaw',
-  opencode: 'OpenCode',
-  kimi:     'Kimi',
-  omp:      'Pi',
-};
+// Loaded from scripts/lib/update-shared.json - single source of truth for
+// the JS/prose split (see the loadSharedConfig() comment above main()).
+// content/commands/ds-update.md's prose copy is NOT loaded from this file
+// (markdown cannot load JSON at doc-render time); it is instead gated for
+// parity against SHARED_CONFIG.display_names by
+// bin/tests/test_update_shared_constants.sh, which fails the build (not
+// just a comment) if the two drift.
+const DISPLAY_NAMES = SHARED_CONFIG.display_names;
 
 function displayName(raw) {
   const stripped = raw.replace(/^\./, '');
@@ -843,5 +845,5 @@ if (require.main === module) {
     process.exit(1);
   });
 } else {
-  module.exports = { needsRebuild, hooksTouched, SKIP_DIRS, REBUILD_TRIGGERS };
+  module.exports = { needsRebuild, hooksTouched, SKIP_DIRS, REBUILD_TRIGGERS, DISPLAY_NAMES };
 }

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -5,7 +5,9 @@
  *          multi-select menu of adapters, runs git pull --ff-only
  *          origin main, and executes each selected adapter's install.sh.
  *          Skips adapter rebuilds when no adapter-source paths changed,
- *          making pure consumer daily updates near-instant.
+ *          making pure consumer daily updates near-instant. Runs
+ *          `agentic-doctor --fix` at the end as a best-effort self-heal
+ *          step, mirroring bin/agentic-update.
  *
  * Public API:
  *   main()        - CLI entry point. Called directly when the file is
@@ -21,10 +23,15 @@
  *                   SHARED hook snapshot in place, so other already-open
  *                   sessions against this checkout pick up the change on
  *                   their next tool call. Exported for unit tests via
- *                   module.exports.
+ *                   module.exports, along with SKIP_DIRS and REBUILD_TRIGGERS
+ *                   (loaded from scripts/lib/update-shared.json) for
+ *                   cross-language parity testing against bin/agentic-update.
  *
  * Upstream deps: Node built-ins (fs, path, child_process, readline). No
- *                external packages.
+ *                external packages. Reads scripts/lib/update-shared.json for
+ *                SKIP_DIRS and REBUILD_TRIGGERS - the single source of truth
+ *                shared with bin/agentic-update and install-all.sh. Do not
+ *                reintroduce a local literal for either list.
  *
  * Downstream consumers: update.sh (shell shim that delegates here).
  *
@@ -45,6 +52,22 @@ const fs = require('fs');
 const path = require('path');
 const { spawn, spawnSync } = require('child_process');
 const readline = require('readline');
+
+// ---------------------------------------------------------------------------
+// Shared constants (single source of truth: scripts/lib/update-shared.json)
+// ---------------------------------------------------------------------------
+
+function loadSharedConfig() {
+  const configPath = path.join(__dirname, 'lib', 'update-shared.json');
+  try {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (err) {
+    console.error(`fatal: failed to load shared config at ${configPath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+const SHARED_CONFIG = loadSharedConfig();
 
 // ---------------------------------------------------------------------------
 // Config
@@ -124,10 +147,7 @@ function resetVersionCheckCache() {
 // Adapter discovery
 // ---------------------------------------------------------------------------
 
-const SKIP_DIRS = new Set([
-  '.', '..', '.git', '.github', '.vscode', '.idea',
-  '.cache', '.venv', '.mypy_cache', '.pytest_cache', '.ruff_cache'
-]);
+const SKIP_DIRS = new Set(SHARED_CONFIG.skip_dirs);
 
 function discoverAdapters(repoDir) {
   const adapters = [];
@@ -156,6 +176,10 @@ function discoverAdapters(repoDir) {
 // Display names
 // ---------------------------------------------------------------------------
 
+// Kept alongside this file (not shared-config-driven) since it is a display
+// concern rather than an update-flow behavioral constant. The prose copy in
+// content/commands/ds-update.md must be kept in sync manually - see PR
+// history for the recurring drift this list has already had once.
 const DISPLAY_NAMES = {
   claude:   'Claude',
   codex:    'Codex',
@@ -239,15 +263,7 @@ function getDirtyFiles(repoDir) {
 
 // Prefixes/paths that require a full adapter rebuild when any changed file
 // starts with one of these strings (after normalising to forward slashes).
-const REBUILD_TRIGGERS = [
-  'content/',
-  'scripts/build-all.sh',
-  'scripts/build-methodology.sh',
-  'scripts/build-slides.sh',
-  'hooks/',
-  '.claude/install.sh',
-  'bin/',
-];
+const REBUILD_TRIGGERS = SHARED_CONFIG.rebuild_triggers;
 
 // Normalise a repo-relative path for prefix/exact-match comparisons:
 // convert backslashes to forward slashes (Windows safety) and strip exactly
@@ -791,6 +807,32 @@ async function main() {
     console.warn('  If they should be tracked, run: git add <files> && git commit');
     console.warn('  If they are generated files that should not be tracked, add them to .gitignore.');
   }
+
+  // Self-heal: run agentic-doctor --fix, mirroring bin/agentic-update's
+  // _run_doctor() step. Best-effort - a missing binary or non-fatal exit is
+  // warned, never raised, so the TUI update still reports success.
+  runDoctor();
+}
+
+// Runs `agentic-doctor --fix` with inherited stdio. Mirrors _run_doctor() in
+// bin/agentic-update - kept as a separate ported function (not shared code)
+// since the two implementations are in different languages; see
+// scripts/lib/update-shared.json for the constants that ARE shared.
+function runDoctor() {
+  const result = spawnSync('agentic-doctor', ['--fix'], { stdio: 'inherit' });
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      console.warn('\nwarning: agentic-doctor not found on PATH; skipping health check.');
+    } else {
+      console.warn(`\nwarning: agentic-doctor failed: ${result.error.message}; continuing.`);
+    }
+    return;
+  }
+  if (result.status === 2) {
+    console.warn('\nWARNING: health check found issues that could not be auto-fixed; run \'agentic-doctor\' for details');
+  } else if (result.status !== 0) {
+    console.warn(`\nwarning: agentic-doctor --fix exited ${result.status}; continuing (non-critical).`);
+  }
 }
 
 // Export pure helpers for unit tests. Guard the main() call so that requiring
@@ -801,5 +843,5 @@ if (require.main === module) {
     process.exit(1);
   });
 } else {
-  module.exports = { needsRebuild, hooksTouched };
+  module.exports = { needsRebuild, hooksTouched, SKIP_DIRS, REBUILD_TRIGGERS };
 }


### PR DESCRIPTION
Collapses four divergent implementations of "get the latest methodology" onto shared constants and fixes the drift between them. **Renames nothing** - this is Unit 1 of the `ds-*` rename program, and it runs entirely on the current names so a later PR renames one implementation instead of four.

## The drift, all verified present

`scripts/update.js` (TUI), `bin/agentic-update` (headless CLI), `install-all.sh`, and `content/commands/ds-update.md` (prose the model executes) each implemented the same flow independently:

- `REBUILD_TRIGGERS` / `needsRebuild` / `hooksTouched` were **copied** from `update.js` into `agentic-update` with a "keep in sync" comment and no enforcing test.
- `SKIP_DIRS` was defined independently in three places.
- `DISPLAY_NAMES` had **already diverged** - `update.js` listed `openclaw`, the prose copy didn't. Nothing caught it.
- `scripts/update.js` never called `agentic-doctor` at all, so TUI users silently never got the self-heal step.
- `bootstrap.sh:11,222` told users to update via `/ds-update-agentic-engineering` - which pushes edits *upstream*.

## What changed

`scripts/lib/update-shared.json` is now the single source for `skip_dirs`, `rebuild_triggers`, and `display_names`; all three code consumers load it and **fail loudly** if it is missing rather than falling back to a stale literal. The prose copy can't load JSON at render time, so it is parity-gated instead. `update.js` gained the missing self-heal step. The `bootstrap.sh` references are corrected.

`content/commands/ds-update.md` now delegates its mechanical steps to `agentic-update` instead of reimplementing them. What deliberately stays prose: the guided mode/profile/identity Q&A, the show-the-plan confirmation, the other-open-sessions hooks note, and the fresh-clone path (the CLI errors out when `repo_dir` doesn't exist rather than cloning).

## What review caught

**A user-facing bug, reproduced against fixtures.** After the delegation, running `/ds-update` to switch `profile=strict` on an already-up-to-date repo printed "Already up to date", exited 0, and **installed nothing** - while the confirmation screen had just promised the install would run. `install_flags` was built but only consumed inside the loop both early returns skipped. Both paths now force the install when a configuration change was requested, and say so visibly. `--adapters`-only invocations were the same class and are covered too.

**Guards that printed but did not stop.** The fallback block's branch and dirty-tree checks ended in `# STOP - do not proceed` - a *comment* inside an executable bash fence. Execution fell straight through to `git pull --ff-only`, silently fast-forwarding a feature branch: the exact harm the guard existed to prevent. All four instances now `exit 1`; two of them were found only by re-reading the whole fence rather than the two lines cited.

**Prose asserting the opposite of the code.** The doc claimed `agentic-update` was fail-fast on adapter install failure; `_run_adapter_installs` is fail-soft. Fail-soft was chosen as correct (an operator wants every broken adapter named in one pass) and both the prose and the fallback loop now match it.

A side discovery: the doc fence's illustrative `<mode>`/`<profile>` placeholders parse as shell redirections when actually executed, so the block was never runnable as written. Surfaced only because the new tests execute the fence rather than reading it.

## Verification

- 887 pytest; all 32 `bin/tests/test_*.sh` green under bash; zsh failure set matches the `origin/main` baseline exactly, none added
- Every new assertion is mutation-proven in **both** directions - mutate the code and it reds, mutate the prose and it reds - with the reviewer independently reproducing each rather than accepting attestation
- The shared-constants gate is CI-wired via the `bin/tests/test_*.sh` glob; deleting `update-shared.json` makes all three consumers fail loudly, verified
- Adapter drift clean (pathspec extracted verbatim from the workflow); resident budget 121043 B / 121066 B, unchanged by this branch

Three adversarial review rounds. The recurring failure mode across all of them was a fix addressing the *visible* half of a finding while leaving the load-bearing half - checks restored without the stopping, prose corrected without the code, a hazard documented for one path and not carried to the other.

## North Star alignment

**Advances "produce verifiable outcomes autonomously."** Four hand-synchronized copies of the same constants, one of which had already silently diverged, become one source with a mutation-proven CI gate. Guards that only *described* stopping now stop.

**Advances "low friction."** TUI users get the self-heal step they never had, and the update flow is one implementation instead of four - which is also what makes the upcoming rename tractable.

**Trade-off, stated plainly:** `/ds-update` now depends on `bin/agentic-update` at runtime, so a broken or missing CLI degrades the in-session command to its fallback path. That fallback is why the branch/dirty-tree hard blocks had to be genuinely restored rather than left as prose. No pillar regression.
