### PR TITLE
test(harness): knowledge-commit fixtures and harness support (unit 1)

### DIFF
--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -6,23 +6,45 @@ on:
       - main
 permissions:
   contents: read
+# TIMEOUT POLICY (all three jobs below).
+#
+# A job's `started_at` is stamped at RUNNER ASSIGNMENT, not at first-step
+# execution, so a job-level `timeout-minutes` can be consumed entirely by queue
+# wait. That is not hypothetical here: python-bin-tests was cancelled on this
+# repo having recorded `steps: []` - no step ever ran - and bin-sh-tests was
+# cancelled the same way on main (run 31115638748, sha f81b63c0). The suites
+# themselves finish in well under a minute.
+#
+# So: job-level `timeout-minutes` is a BACKSTOP ONLY (20), and every real work
+# step carries its own `timeout-minutes`, which starts when the step starts and
+# is therefore immune to acquisition delay. Do not "fix" a queue-starvation
+# cancellation by raising the job timeout alone - that trades a fast silent
+# failure for a slow one and leaves the steps unbounded.
 jobs:
   python-bin-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
+    env:
+      # Keep partial output if the job is force-killed anyway.
+      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - run: pip install pytest pyyaml
+      # pytest-timeout converts an unbounded subprocess stall anywhere in
+      # bin/tests/ into ONE failing test with a stack trace at the exact call,
+      # instead of a killed job with no usable log.
+      - run: pip install pytest pytest-timeout pyyaml
       - name: install zsh (required for the bash/zsh parity matrix in test_phase8_telemetry_shell.py)
         run: sudo apt-get update && sudo apt-get install -y zsh
-      - run: python3 -m pytest bin/tests/ -q
+      - run: python3 -m pytest bin/tests/ -q --timeout=60 --timeout-method=thread
+        timeout-minutes: 5
       - name: floor collected test_phase8_telemetry_shell.py count at 18
         # 9 test functions x 2 shells (bash, zsh) = 18 collected IDs. Adding or
         # removing a test function in bin/tests/test_phase8_telemetry_shell.py
         # obliges updating the floor below in the same PR.
+        timeout-minutes: 2
         run: |
           python3 -m pytest bin/tests/test_phase8_telemetry_shell.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 18) { print "expected >= 18 collected tests (9 functions x 2 shells), got " $1; exit 1 } }'
       - name: floor collected test_qa_knowledge_capture_shell.py count at 52
@@ -31,6 +53,7 @@ jobs:
         # or removing a test function in
         # bin/tests/test_qa_knowledge_capture_shell.py obliges updating the
         # floor below in the same PR.
+        timeout-minutes: 2
         run: |
           python3 -m pytest bin/tests/test_qa_knowledge_capture_shell.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 52) { print "expected >= 52 collected tests (17 functions x 3 shells + 1 static), got " $1; exit 1 } }'
       - name: floor collected test_knowledge_harness_smoke.py count at 30
@@ -39,19 +62,23 @@ jobs:
         # removing a test function in
         # bin/tests/test_knowledge_harness_smoke.py obliges updating the floor
         # below in the same PR.
+        timeout-minutes: 2
         run: |
           python3 -m pytest bin/tests/test_knowledge_harness_smoke.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 30) { print "expected >= 30 collected tests (13 functions x 2 shells + 4 static), got " $1; exit 1 } }'
   # Python hook tests live here (shared python toolchain with bin-tests); JS/sh
   # hook tests live in hooks-tests.yml.
   hooks-python-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
+    env:
+      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - name: run Python hook tests
+        timeout-minutes: 5
         run: |
           set -e
           count=0
@@ -71,7 +98,9 @@ jobs:
   # across other dirs (different naming convention, previously unwired anywhere).
   bin-sh-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
+    env:
+      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -81,6 +110,11 @@ jobs:
       - name: install zsh (required for bash/zsh parity assertion in test_check_resident_budget.sh)
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: run shell bin tests
+        # This step measured 4m56s against the old 5-minute JOB timeout on a
+        # single PR, and was cancelled outright on main under queue pressure.
+        # 8 minutes is real headroom for the step's own runtime; queue wait no
+        # longer counts against it.
+        timeout-minutes: 8
         run: |
           set -e
           # bin/tests/test_codex_hooks_resolve.sh is also run by adapter-sync.yml -

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -33,14 +33,14 @@ jobs:
         # floor below in the same PR.
         run: |
           python3 -m pytest bin/tests/test_qa_knowledge_capture_shell.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 52) { print "expected >= 52 collected tests (17 functions x 3 shells + 1 static), got " $1; exit 1 } }'
-      - name: floor collected test_knowledge_harness_smoke.py count at 28
-        # 15 test functions - 13 parametrized x {bash, zsh} (26) plus 2 static,
-        # shell-independent assertions (2) = 28 collected IDs. Adding or
+      - name: floor collected test_knowledge_harness_smoke.py count at 30
+        # 17 test functions - 13 parametrized x {bash, zsh} (26) plus 4 static,
+        # shell-independent assertions (4) = 30 collected IDs. Adding or
         # removing a test function in
         # bin/tests/test_knowledge_harness_smoke.py obliges updating the floor
         # below in the same PR.
         run: |
-          python3 -m pytest bin/tests/test_knowledge_harness_smoke.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 28) { print "expected >= 28 collected tests (13 functions x 2 shells + 2 static), got " $1; exit 1 } }'
+          python3 -m pytest bin/tests/test_knowledge_harness_smoke.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 30) { print "expected >= 30 collected tests (13 functions x 2 shells + 4 static), got " $1; exit 1 } }'
   # Python hook tests live here (shared python toolchain with bin-tests); JS/sh
   # hook tests live in hooks-tests.yml.
   hooks-python-tests:

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -33,6 +33,14 @@ jobs:
         # floor below in the same PR.
         run: |
           python3 -m pytest bin/tests/test_qa_knowledge_capture_shell.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 52) { print "expected >= 52 collected tests (17 functions x 3 shells + 1 static), got " $1; exit 1 } }'
+      - name: floor collected test_knowledge_harness_smoke.py count at 28
+        # 15 test functions - 13 parametrized x {bash, zsh} (26) plus 2 static,
+        # shell-independent assertions (2) = 28 collected IDs. Adding or
+        # removing a test function in
+        # bin/tests/test_knowledge_harness_smoke.py obliges updating the floor
+        # below in the same PR.
+        run: |
+          python3 -m pytest bin/tests/test_knowledge_harness_smoke.py --collect-only -q | grep -c '::test_' | awk '{ if ($1 < 28) { print "expected >= 28 collected tests (13 functions x 2 shells + 2 static), got " $1; exit 1 } }'
   # Python hook tests live here (shared python toolchain with bin-tests); JS/sh
   # hook tests live in hooks-tests.yml.
   hooks-python-tests:

--- a/bin/tests/fixtures/knowledge_harness_smoke.md
+++ b/bin/tests/fixtures/knowledge_harness_smoke.md
@@ -1,0 +1,95 @@
+# Knowledge-harness smoke block (test fixture, not methodology prose)
+
+This file exists solely so `bin/tests/test_knowledge_harness_smoke.py` can
+prove that a **second** `@harness:`-marked block can be extracted and executed
+by `bin/tests/lib/md_shell_extract.py` against the knowledge fixtures in
+`bin/tests/lib/git_fixture.py`. It is deliberately NOT under `content/`: it is
+throwaway test input, carries no methodology obligation, and must never be
+built into an adapter.
+
+The block below is a stand-in shaped like a knowledge-commit block (probe the
+remote, classify each knowledge file, stage, commit, push) so the fixtures are
+exercised through the same git surface a real block would use. It is not the
+real block and nothing depends on its behavior beyond this test module.
+
+```bash
+# @harness:knowledge-smoke
+set -u
+
+# Q2 probe: $BRANCH_NAME must arrive as a shell ASSIGNMENT, so awk -v sees it
+# and awk ENVIRON[] does not.
+echo "SMOKE_BRANCH_ASSIGNED=[$BRANCH_NAME]"
+echo "SMOKE_AWK_V=[$(awk -v x="$BRANCH_NAME" 'BEGIN{print x}')]"
+echo "SMOKE_AWK_ENVIRON=[$(awk 'BEGIN{print ENVIRON["BRANCH_NAME"]}')]"
+
+# Q4 probe: does `s+0` on an EMPTY (but present) file emit "0" or nothing?
+EMPTY_PROBE="$REPO/.smoke-empty-probe"
+: > "$EMPTY_PROBE"
+echo "SMOKE_AWK_EMPTY_FILE=[$(awk '{s += $2} END {print s+0}' "$EMPTY_PROBE")]"
+
+if git -C "$REPO" remote get-url origin >/dev/null 2>&1; then
+  echo "SMOKE_HAS_REMOTE=1"
+  if git -C "$REPO" fetch -q origin; then
+    echo "SMOKE_FETCH=ok"
+  else
+    echo "SMOKE_FETCH=fail"
+  fi
+  if git -C "$REPO" rev-parse --verify -q "refs/remotes/origin/$BRANCH_NAME" >/dev/null; then
+    echo "SMOKE_REVPARSE=ok"
+  else
+    echo "SMOKE_REVPARSE=fail"
+  fi
+else
+  echo "SMOKE_HAS_REMOTE=0"
+fi
+
+STAGED=0
+for f in MEMORY.md decisions.md .agentic/learnings.md; do
+  if [ ! -f "$REPO/$f" ]; then
+    echo "SMOKE_FILE $f=missing"
+    continue
+  fi
+  if git -C "$REPO" check-ignore -q -- "$f"; then
+    echo "SMOKE_FILE $f=ignored"
+    continue
+  fi
+  if git -C "$REPO" cat-file -e "HEAD:$f" 2>/dev/null; then
+    # MANDATORY before diff-index: a file rewritten with identical content has
+    # a newer mtime than the index records, and `diff-index --quiet` trusts
+    # stat data over content outside git's racily-clean window - so it reports
+    # an UNCHANGED file as changed. Exits non-zero when entries needed
+    # updating, which is not an error here.
+    git -C "$REPO" update-index -q --refresh >/dev/null 2>&1 || true
+    if git -C "$REPO" diff-index --quiet HEAD -- "$f"; then
+      echo "SMOKE_FILE $f=identical"
+      continue
+    fi
+    NUMSTAT=$(git -C "$REPO" diff --numstat HEAD -- "$f")
+    ADDED=$(echo "$NUMSTAT" | awk '{print $1+0}')
+    DELETED=$(echo "$NUMSTAT" | awk '{print $2+0}')
+    echo "SMOKE_FILE $f=modified +$ADDED -$DELETED"
+  else
+    echo "SMOKE_FILE $f=untracked"
+  fi
+  git -C "$REPO" add -- "$f"
+  STAGED=$((STAGED + 1))
+done
+echo "SMOKE_STAGED=$STAGED"
+
+if [ "$STAGED" -gt 0 ]; then
+  if git -C "$REPO" commit -q -s -m "chore(knowledge): smoke $BRANCH_NAME"; then
+    echo "SMOKE_COMMIT=ok"
+  else
+    echo "SMOKE_COMMIT=fail"
+  fi
+  if git -C "$REPO" remote get-url origin >/dev/null 2>&1; then
+    if git -C "$REPO" push -q origin "HEAD:refs/heads/$BRANCH_NAME"; then
+      echo "SMOKE_PUSH=ok"
+    else
+      echo "SMOKE_PUSH=fail"
+    fi
+  else
+    echo "SMOKE_PUSH=skipped-no-remote"
+  fi
+fi
+```

--- a/bin/tests/lib/git_fixture.py
+++ b/bin/tests/lib/git_fixture.py
@@ -65,6 +65,10 @@ Failure modes: builders raise via subprocess.CalledProcessError (check=True
                skewed past the index's), so a block under test must
                `git update-index --refresh` before trusting
                `git diff-index --quiet` - see _write_file()'s docstring.
+               install_git_stub() refuses a second install on the same
+               fixture (it would delegate to the first stub and recurse
+               forever), and GitStub.argv_lines() raises on a malformed
+               record rather than returning a wrong invocation count.
 
 Performance: standard; each builder does a handful of local git commands
              (~10-50ms) against a pytest tmp_path. The knowledge builders add
@@ -171,9 +175,22 @@ KNOWLEDGE_MODES = ("modified", "identical", "absent", "fewer_lines")
 # preceding fetch).
 PUSH_REJECT_MESSAGE = "AE-FIXTURE-PUSH-REJECTED"
 
-# Field separator used inside the git stub's argv log. \x1f (US) cannot occur
-# in a git subcommand or a fixture path, so parsing is unambiguous.
+# Framing for the git stub's argv log.
+#
+# Records are terminated by \x1e (RS) and fields separated by \x1f (US) -
+# NEWLINE IS NOT A DELIMITER at either level. That is not a stylistic choice:
+# git arguments routinely contain newlines (a `commit-tree -m "$MSG"` whose
+# message carries a blank line and a DCO trailer is the canonical case), and
+# newline-framed records split one such invocation into three, inflating
+# len(argv_lines()) and injecting a phantom entry into subcommands() with
+# nothing to detect it.
+#
+# Each record additionally carries its own argc as field 2, so a record that
+# does get split - by an argument containing a literal \x1e, or by any future
+# framing regression - fails the field-count check in
+# GitStub.argv_lines() LOUDLY instead of being mis-parsed silently.
 _ARGV_SEP = "\x1f"
+_ARGV_RECORD_SEP = "\x1e"
 
 
 @dataclass
@@ -200,14 +217,40 @@ class GitStub:
     fail_exit_code: int = 1
 
     def argv_lines(self) -> list[list[str]]:
-        """Every recorded invocation as [subcommand, *full_argv]."""
+        """Every recorded invocation as [subcommand, *full_argv].
+
+        Records are \\x1e-terminated and fields \\x1f-separated, so an argument
+        containing newlines (a multi-line commit message, say) stays inside
+        one record. The per-record argc is validated: a malformed record
+        raises rather than silently yielding a wrong invocation count."""
         if not self.log_path.exists():
             return []
+        raw = self.log_path.read_text(encoding="utf-8")
         out: list[list[str]] = []
-        for line in self.log_path.read_text(encoding="utf-8").splitlines():
-            if line == "":
+        for record in raw.split(_ARGV_RECORD_SEP):
+            if record == "":
                 continue
-            out.append(line.split(_ARGV_SEP))
+            fields = record.split(_ARGV_SEP)
+            if len(fields) < 2:
+                raise AssertionError(
+                    f"malformed git-stub record (expected at least "
+                    f"subcommand + argc, got {fields!r}) in {self.log_path}"
+                )
+            subcommand, argc_field, args = fields[0], fields[1], fields[2:]
+            try:
+                argc = int(argc_field)
+            except ValueError:
+                raise AssertionError(
+                    f"malformed git-stub record: argc field {argc_field!r} is "
+                    f"not an integer, in record {record!r}"
+                ) from None
+            if len(args) != argc:
+                raise AssertionError(
+                    f"malformed git-stub record: argc says {argc} but {len(args)} "
+                    f"argument fields are present - the log framing is broken "
+                    f"(record: {record!r})"
+                )
+            out.append([subcommand, *args])
         return out
 
     def subcommands(self) -> list[str]:
@@ -688,13 +731,21 @@ for a in "$@"; do
   esac
 done
 
-# ONE single-write append per invocation (never a sequence of printf calls
-# sharing one redirect) so two stub processes can never interleave a partial
-# record into the log.
+# ONE record per invocation, written with ONE append (never a sequence of
+# printf calls sharing a redirect, which two concurrent stub processes could
+# interleave).
+#
+# The record is \037-separated and \036-TERMINATED. Newline is deliberately
+# NOT a delimiter: git arguments contain newlines (`commit-tree -m "$MSG"`
+# with a blank line and a DCO trailer), and newline framing would split one
+# invocation into several records that the reader cannot tell apart from
+# several invocations. argc ($#) is recorded as field 2 so the reader can
+# detect any record that did get split.
 AE_STUB_US=$(printf '\037')
-line="$sub"
+AE_STUB_RS=$(printf '\036')
+line="$sub$AE_STUB_US$#"
 for a in "$@"; do line="$line$AE_STUB_US$a"; done
-printf '%s\n' "$line" >> "$AE_STUB_LOG"
+printf '%s%s' "$line" "$AE_STUB_RS" >> "$AE_STUB_LOG"
 
 if [ -n "$AE_STUB_FAIL_SUBCMD" ] && [ "$sub" = "$AE_STUB_FAIL_SUBCMD" ]; then
   printf 'AE-GIT-STUB: forced failure for subcommand %s (exit %s)\n' \
@@ -703,6 +754,19 @@ if [ -n "$AE_STUB_FAIL_SUBCMD" ] && [ "$sub" = "$AE_STUB_FAIL_SUBCMD" ]; then
 fi
 exec "$AE_STUB_REAL_GIT" "$@"
 """
+
+
+_GIT_STUB_FINGERPRINT = "AE_STUB_REAL_GIT="
+
+
+def _is_git_stub(path: Path) -> bool:
+    """True when path is one of this module's git stubs (not the real git
+    binary), detected by a marker in its text. Binary git reads as bytes that
+    fail to decode, which is the False case."""
+    try:
+        return _GIT_STUB_FINGERPRINT in path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return False
 
 
 def install_git_stub(
@@ -725,6 +789,21 @@ def install_git_stub(
 
     bin_dir = bin_dir or (fixture.repo_dir.parent / "git-stub-bin")
     bin_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fail closed on a SECOND install against the same fixture. The first
+    # install prepends its bin_dir to fixture.env["PATH"], so `git` now
+    # resolves to the stub - a second install would write
+    # AE_STUB_REAL_GIT='<stub>' into the stub and every git call would recurse
+    # forever. Observed: a hang until a 15s test timeout, appending to the
+    # argv log on every iteration. Checked two ways because a caller-supplied
+    # bin_dir defeats the path comparison on its own.
+    if Path(real_git).parent == bin_dir or _is_git_stub(Path(real_git)):
+        raise AssertionError(
+            f"install_git_stub() would delegate to another stub ({real_git}) "
+            f"and recurse forever - it has already been installed on this "
+            f"fixture. Install it once; pass fail_subcommand on that call, or "
+            f"build a second fixture."
+        )
     log_path = bin_dir / "argv.log"
     log_path.write_text("", encoding="utf-8")
 

--- a/bin/tests/lib/git_fixture.py
+++ b/bin/tests/lib/git_fixture.py
@@ -1,45 +1,88 @@
 """
-Purpose: Builds hermetic, disposable git repo fixtures that reproduce the six
-         shapes of consumer/project state the Phase 8 commit-and-telemetry
-         shell block (@harness:phase8-commit-and-telemetry in
-         content/commands/ds-implement-ticket.md) can
-         run against: the DinoStack repo itself, an /ds-init-project-scaffolded
-         consumer repo, a single-engineer worktree (WORKTREE_PATH-resolved PR
-         checkout), a fan-out primary checkout, an unconfirmed-identity
-         operator, and a confirmed identity with no git user.* config. Built
-         for bin/tests/test_phase8_telemetry_shell.py.
+Purpose: Builds hermetic, disposable git repo fixtures that reproduce the
+         shapes of consumer/project state the shell blocks embedded in the
+         methodology's markdown can run against. Two families live here:
+         (a) the six Phase 8 commit-and-telemetry shapes
+         (@harness:phase8-commit-and-telemetry in
+         content/commands/ds-implement-ticket.md) - the DinoStack repo itself,
+         an /ds-init-project-scaffolded consumer repo, a single-engineer
+         worktree (WORKTREE_PATH-resolved PR checkout), a fan-out primary
+         checkout, an unconfirmed-identity operator, and a confirmed identity
+         with no git user.* config; and (b) four knowledge-commit shapes,
+         which add a real bare `origin` remote plus seeded MEMORY.md /
+         decisions.md / .agentic/learnings.md state so a block that commits
+         and pushes knowledge files onto a PR branch can be exercised end to
+         end (including a push that is rejected by the remote).
 
 Public API: Fixture (dataclass: repo_dir, worktree_dir, branch_name,
-            developer, env)
+            developer, env, origin_dir)
+            GitStub (dataclass: bin_dir, log_path, fail_subcommand,
+            fail_exit_code; .argv_lines(), .subcommands(), .was_attempted())
             build_dinostack_shape(tmp_path) -> Fixture
             build_consumer_shape(tmp_path) -> Fixture
             build_worktree_shape(tmp_path) -> Fixture
             build_fanout_shape(tmp_path) -> Fixture
             build_no_identity_shape(tmp_path) -> Fixture
             build_identity_no_gitconfig_shape(tmp_path) -> Fixture
+            build_knowledge_consumer_shape(tmp_path, modes=None) -> Fixture
+            build_knowledge_dinostack_shape(tmp_path) -> Fixture
+            build_knowledge_no_remote_shape(tmp_path, modes=None) -> Fixture
+            build_knowledge_push_reject_shape(tmp_path, modes=None) -> Fixture
+            add_bare_origin(fixture) -> Path
+            seed_knowledge_baseline(fixture, modes) -> None
+            apply_knowledge_local(fixture, modes) -> None
+            install_push_reject_hook(fixture, message=...) -> Path
+            install_git_stub(fixture, fail_subcommand=None,
+                             fail_exit_code=1) -> GitStub
+            KNOWLEDGE_FILES, KNOWLEDGE_MODES, PUSH_REJECT_MESSAGE
+            CONSUMER_GITIGNORE, DINOSTACK_GITIGNORE,
+            DINOSTACK_KNOWLEDGE_GITIGNORE
 
-Upstream deps: stdlib only (subprocess, dataclasses, pathlib). Shells out to
-               the system `git` binary. Does not touch the developer's real
-               $HOME, ~/.gitconfig, or /etc/gitconfig - every fixture pins
-               HOME to a fixture-local temp dir, GIT_CONFIG_NOSYSTEM=1, and a
-               fixture-local GIT_CONFIG_GLOBAL so no ambient git identity,
-               init.defaultBranch, gpgsign setting, or ~/.nvm/nvm.sh (which
-               would otherwise prepend to PATH ahead of the agentic-identity
-               stub dir) can leak in.
+Upstream deps: stdlib only (subprocess, dataclasses, pathlib, shutil).
+               Shells out to the system `git` binary. Does not touch the
+               developer's real $HOME, ~/.gitconfig, or /etc/gitconfig - every
+               fixture pins HOME to a fixture-local temp dir,
+               GIT_CONFIG_NOSYSTEM=1, and a fixture-local GIT_CONFIG_GLOBAL so
+               no ambient git identity, init.defaultBranch, gpgsign setting,
+               or ~/.nvm/nvm.sh (which would otherwise prepend to PATH ahead
+               of the agentic-identity stub dir) can leak in. The bare
+               `origin` added by add_bare_origin() is a sibling directory on
+               the same filesystem - still no network access.
 
-Downstream consumers: bin/tests/test_phase8_telemetry_shell.py
+Downstream consumers: bin/tests/test_phase8_telemetry_shell.py,
+               bin/tests/test_qa_knowledge_capture_shell.py,
+               bin/tests/test_knowledge_harness_smoke.py
 
 Failure modes: builders raise via subprocess.CalledProcessError (check=True
                everywhere) if any setup git command fails - a broken fixture
                must not silently produce a misleading test result. No network
                access; every repo is git-init'd locally, never cloned.
+               apply_knowledge_local() additionally asserts that each file's
+               requested mode is consistent with whether that file is present
+               at the branch tip, so a mis-specified fixture fails loudly
+               rather than producing a shape the test then mis-describes. It
+               also leaves every file it writes STAT-DIRTY on purpose (mtime
+               skewed past the index's), so a block under test must
+               `git update-index --refresh` before trusting
+               `git diff-index --quiet` - see _write_file()'s docstring.
 
 Performance: standard; each builder does a handful of local git commands
-             (~10-50ms) against a pytest tmp_path.
+             (~10-50ms) against a pytest tmp_path. The knowledge builders add
+             a bare init plus a push/fetch round trip (still local).
+
+Note on BRANCH_NAME: the six Phase 8 builders export BRANCH_NAME into
+             Fixture.env because the Phase 8 harness passes it that way. The
+             four knowledge builders deliberately do NOT - in production
+             $BRANCH_NAME in those blocks is a conductor-substituted shell
+             ASSIGNMENT, not an exported variable, so exporting it in a
+             fixture would make an `awk ENVIRON["BRANCH_NAME"]` lookup resolve
+             in test and empty in production. Inject it with
+             md_shell_extract.with_shell_assignments() instead.
 """
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 from dataclasses import dataclass
@@ -90,6 +133,48 @@ DINOSTACK_GITIGNORE = """\
 !/.agentic/team.yml
 """
 
+# The subset of DinoStack's own root `.gitignore` that governs all THREE
+# knowledge files, not just the `.agentic/` umbrella. Verified verbatim
+# against the live root .gitignore of this repo (the `/.agentic/*` +
+# `!/.agentic/team.yml` pair, the `/decisions.md` rule, and the `/MEMORY.md`
+# rule - interleaving comments omitted, rule ORDER preserved because git
+# ignore matching is last-match-wins).
+#
+# Deliberately NOT a reuse of DINOSTACK_GITIGNORE above: that constant covers
+# only `.agentic/`, so under it MEMORY.md and decisions.md would be TRACKABLE
+# and a "DinoStack shape" fixture built from it would silently exercise the
+# consumer path for two of the three knowledge files.
+DINOSTACK_KNOWLEDGE_GITIGNORE = """\
+/.agentic/*
+!/.agentic/team.yml
+/decisions.md
+/MEMORY.md
+"""
+
+# The three knowledge files a knowledge-commit block operates on, in the order
+# the methodology consistently names them.
+KNOWLEDGE_FILES = ("MEMORY.md", "decisions.md", ".agentic/learnings.md")
+
+# Per-file local-state modes accepted by seed_knowledge_baseline() /
+# apply_knowledge_local(). Each is independently selectable per file.
+#   "modified"    - tracked at the tip, local copy differs (extra line)
+#   "identical"   - tracked at the tip, local copy byte-identical
+#   "absent"      - NOT present at the tip at all; exists only locally
+#   "fewer_lines" - tracked at the tip, local copy is a strict prefix (so a
+#                   revert-guard has real deletions to detect)
+KNOWLEDGE_MODES = ("modified", "identical", "absent", "fewer_lines")
+
+# Emitted to stderr by the pre-receive hook installed by
+# install_push_reject_hook(). Distinguishable from any real git error so a
+# test can prove the push reached the remote and was rejected THERE, rather
+# than failing earlier (e.g. an unreachable remote, which would also fail the
+# preceding fetch).
+PUSH_REJECT_MESSAGE = "AE-FIXTURE-PUSH-REJECTED"
+
+# Field separator used inside the git stub's argv log. \x1f (US) cannot occur
+# in a git subcommand or a fixture path, so parsing is unambiguous.
+_ARGV_SEP = "\x1f"
+
 
 @dataclass
 class Fixture:
@@ -98,6 +183,39 @@ class Fixture:
     branch_name: str
     developer: str
     env: dict[str, str]
+    # Populated by add_bare_origin(); None means the fixture has no remote.
+    origin_dir: Optional[Path] = None
+
+
+@dataclass
+class GitStub:
+    """Handle for the tee-and-delegate `git` stub installed by
+    install_git_stub(). The stub records every invocation's full argv then
+    exec's the real git, so a long block's other git calls keep working while
+    one chosen subcommand can be forced to a chosen exit code."""
+
+    bin_dir: Path
+    log_path: Path
+    fail_subcommand: Optional[str] = None
+    fail_exit_code: int = 1
+
+    def argv_lines(self) -> list[list[str]]:
+        """Every recorded invocation as [subcommand, *full_argv]."""
+        if not self.log_path.exists():
+            return []
+        out: list[list[str]] = []
+        for line in self.log_path.read_text(encoding="utf-8").splitlines():
+            if line == "":
+                continue
+            out.append(line.split(_ARGV_SEP))
+        return out
+
+    def subcommands(self) -> list[str]:
+        """The resolved subcommand of every recorded invocation, in order."""
+        return [parts[0] for parts in self.argv_lines()]
+
+    def was_attempted(self, subcommand: str) -> bool:
+        return subcommand in self.subcommands()
 
 
 def _run(args: list[str], cwd: Path, env: dict[str, str]) -> None:
@@ -334,3 +452,402 @@ def build_identity_no_gitconfig_shape(tmp_path: Path) -> Fixture:
     env["BRANCH_NAME"] = branch_name
     env["WORKTREE_PATH"] = ""
     return Fixture(repo_dir, None, branch_name, developer, env)
+
+
+# ---------------------------------------------------------------------------
+# Knowledge-commit fixtures: bare origin, seeded knowledge files, git stub.
+#
+# These compose. add_bare_origin() / seed_knowledge_baseline() /
+# apply_knowledge_local() / install_push_reject_hook() / install_git_stub()
+# each take a Fixture and can be layered onto ANY builder above - including
+# build_identity_no_gitconfig_shape() - rather than requiring a new builder
+# per combination. The four build_knowledge_* builders below are the named
+# combinations a knowledge-commit block needs; they are thin compositions of
+# these primitives, not independent implementations.
+# ---------------------------------------------------------------------------
+
+
+def _commit_env(env: dict[str, str]) -> dict[str, str]:
+    out = dict(env)
+    out["GIT_AUTHOR_NAME"] = DUMMY_NAME
+    out["GIT_AUTHOR_EMAIL"] = DUMMY_EMAIL
+    out["GIT_COMMITTER_NAME"] = DUMMY_NAME
+    out["GIT_COMMITTER_EMAIL"] = DUMMY_EMAIL
+    return out
+
+
+def _knowledge_baseline(rel_path: str) -> str:
+    """Five-line baseline body. Multi-line so a "fewer lines" local variant is
+    a strict prefix with real deletions for a revert-guard to detect."""
+    return (
+        f"# {rel_path}\n"
+        f"baseline line 1 ({rel_path})\n"
+        f"baseline line 2 ({rel_path})\n"
+        f"baseline line 3 ({rel_path})\n"
+        f"baseline line 4 ({rel_path})\n"
+    )
+
+
+def _knowledge_local(rel_path: str, mode: str) -> str:
+    base = _knowledge_baseline(rel_path)
+    if mode == "identical":
+        return base
+    if mode == "modified":
+        return base + f"local-only edit ({rel_path})\n"
+    if mode == "fewer_lines":
+        return "".join(base.splitlines(keepends=True)[:2])
+    if mode == "absent":
+        # Present only locally, never at the tip - distinct content so a test
+        # cannot confuse it with a tracked file's baseline.
+        return f"# {rel_path}\nuntracked-at-tip local content ({rel_path})\n"
+    raise ValueError(f"unknown knowledge mode {mode!r}; expected one of {KNOWLEDGE_MODES}")
+
+
+def _normalize_modes(modes: Optional[dict[str, str]]) -> dict[str, str]:
+    resolved = {rel: "modified" for rel in KNOWLEDGE_FILES}
+    for rel, mode in (modes or {}).items():
+        if rel not in KNOWLEDGE_FILES:
+            raise ValueError(f"unknown knowledge file {rel!r}; expected one of {KNOWLEDGE_FILES}")
+        if mode not in KNOWLEDGE_MODES:
+            raise ValueError(f"unknown knowledge mode {mode!r}; expected one of {KNOWLEDGE_MODES}")
+        resolved[rel] = mode
+    return resolved
+
+
+# Seconds to push a written file's mtime past the index's recorded mtime. Any
+# value > 1 works; the point is to leave git's "racily clean" window (an entry
+# whose mtime is within the same second as the index write is re-checked by
+# CONTENT, outside it git trusts the stat data alone).
+_STAT_DIRTY_SKEW_SECONDS = 10
+
+
+def _write_file(
+    repo_dir: Path, rel_path: str, content: str, stat_dirty: bool = False
+) -> Path:
+    """Write content to repo_dir/rel_path.
+
+    With stat_dirty=True the file's mtime is pushed clearly past the index's,
+    which makes `git diff-index --quiet HEAD` report the file as CHANGED even
+    when its content is byte-identical - git compares stat data, not content,
+    for entries outside the racily-clean window (`git diff-index` docs: with
+    --quiet it "may return 1 for a file that has not actually changed"; run
+    `git update-index --refresh` first).
+
+    This is deliberately NOT hidden. Without the skew the behavior is a
+    genuine RACE - identical-content files were classified "identical" ~70% of
+    runs and "modified" ~30% here, purely on whether the write landed in the
+    same second as the index write. Forcing the skew makes the harder branch
+    the ONLY branch, so a block that omits the index refresh fails every time
+    instead of one run in three. Production has the same exposure: a knowledge
+    writer that rewrites a file with unchanged content leaves exactly this
+    state."""
+    path = repo_dir / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if stat_dirty:
+        stamp = path.stat().st_mtime + _STAT_DIRTY_SKEW_SECONDS
+        os.utime(path, (stamp, stamp))
+    return path
+
+
+def _is_tracked_at_head(repo_dir: Path, rel_path: str, env: dict[str, str]) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "cat-file", "-e", f"HEAD:{rel_path}"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def seed_knowledge_baseline(fixture: Fixture, modes: Optional[dict[str, str]] = None) -> None:
+    """Commit the BASELINE version of every knowledge file whose mode is not
+    "absent". Must run BEFORE add_bare_origin() so the push carries it - that
+    ordering is what makes an "identical to the tip" local file possible."""
+    resolved = _normalize_modes(modes)
+    staged = False
+    for rel_path in KNOWLEDGE_FILES:
+        if resolved[rel_path] == "absent":
+            continue
+        _write_file(fixture.repo_dir, rel_path, _knowledge_baseline(rel_path))
+        _run(["git", "add", "--", rel_path], cwd=fixture.repo_dir, env=fixture.env)
+        staged = True
+    if staged:
+        _run(
+            ["git", "commit", "-q", "-m", "seed knowledge baseline"],
+            cwd=fixture.repo_dir,
+            env=_commit_env(fixture.env),
+        )
+
+
+def apply_knowledge_local(fixture: Fixture, modes: Optional[dict[str, str]] = None) -> None:
+    """Overwrite each knowledge file on disk with its per-mode LOCAL variant.
+
+    Fails closed: a mode that claims the file is tracked at the tip when it is
+    not (or vice versa) raises, so a fixture can never quietly produce a shape
+    different from the one the test describes."""
+    resolved = _normalize_modes(modes)
+    for rel_path in KNOWLEDGE_FILES:
+        mode = resolved[rel_path]
+        tracked = _is_tracked_at_head(fixture.repo_dir, rel_path, fixture.env)
+        if mode == "absent" and tracked:
+            raise AssertionError(
+                f"fixture invariant violated: {rel_path} is mode 'absent' but IS "
+                f"present at the branch tip - pass the same modes dict to "
+                f"seed_knowledge_baseline()"
+            )
+        if mode != "absent" and not tracked:
+            raise AssertionError(
+                f"fixture invariant violated: {rel_path} is mode {mode!r} but is "
+                f"NOT present at the branch tip - call seed_knowledge_baseline() "
+                f"with the same modes dict before apply_knowledge_local()"
+            )
+        _write_file(
+            fixture.repo_dir, rel_path, _knowledge_local(rel_path, mode), stat_dirty=True
+        )
+
+
+def add_bare_origin(fixture: Fixture) -> Path:
+    """Give the fixture a real remote: a sibling bare repo, `origin` pointing
+    at it, the fixture branch pushed with upstream tracking, and a completed
+    fetch (so `origin/<branch>` resolves). Returns the bare repo path and
+    records it on fixture.origin_dir. Hermeticity is preserved - the bare repo
+    is a sibling directory under the same tmp_path and inherits the fixture's
+    GIT_CONFIG_NOSYSTEM / GIT_CONFIG_GLOBAL / LC_ALL env; no network."""
+    origin_dir = fixture.repo_dir.parent / "origin.git"
+    _run(
+        ["git", "init", "-q", "--bare", "-b", fixture.branch_name, str(origin_dir)],
+        cwd=fixture.repo_dir.parent,
+        env=fixture.env,
+    )
+    _run(["git", "remote", "add", "origin", str(origin_dir)], cwd=fixture.repo_dir, env=fixture.env)
+    _run(
+        ["git", "push", "-q", "-u", "origin", fixture.branch_name],
+        cwd=fixture.repo_dir,
+        env=_commit_env(fixture.env),
+    )
+    _run(["git", "fetch", "-q", "origin"], cwd=fixture.repo_dir, env=fixture.env)
+    fixture.origin_dir = origin_dir
+    return origin_dir
+
+
+def install_push_reject_hook(fixture: Fixture, message: str = PUSH_REJECT_MESSAGE) -> Path:
+    """Install a `pre-receive` hook on the fixture's bare origin that writes
+    `message` to stderr and exits 1.
+
+    This construction is deliberate. A "repoint origin at a broken path"
+    variant does NOT work for testing a push-rejection branch: `git fetch`
+    against a nonexistent remote fails FIRST, so a block that fetches before
+    it pushes never reaches its push. With a pre-receive hook, fetch and
+    `rev-parse origin/<branch>` both still succeed and only the push fails -
+    which is the shape a real protected-branch / server-hook rejection has.
+
+    CAVEAT (measured, not assumed): the hook only fires when the push actually
+    carries a ref update. A no-op push short-circuits client-side with
+    "Everything up-to-date" and exit 0, never contacting the hook. So a test
+    that wants to observe the rejection must push something new - a fresh
+    commit, or a throwaway ref."""
+    if fixture.origin_dir is None:
+        raise AssertionError("install_push_reject_hook() requires add_bare_origin() first")
+    hook = fixture.origin_dir / "hooks" / "pre-receive"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text(
+        "#!/bin/sh\n"
+        "# Fixture hook: reject every push (bin/tests/lib/git_fixture.py).\n"
+        f'echo "{message}" >&2\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return hook
+
+
+# Body of the tee-and-delegate `git` stub. Kept as a module-level template so
+# the shell is readable as shell instead of as escaped Python string
+# concatenation. Substituted fields are quoted by install_git_stub().
+_GIT_STUB_TEMPLATE = r"""#!/bin/sh
+# Tee-and-delegate git stub, installed by bin/tests/lib/git_fixture.py.
+# Records this invocation's full argv, then exec's the REAL git binary.
+AE_STUB_LOG='__LOG__'
+AE_STUB_REAL_GIT='__REAL_GIT__'
+AE_STUB_FAIL_SUBCMD='__FAIL_SUBCMD__'
+AE_STUB_FAIL_CODE='__FAIL_CODE__'
+
+# Resolve the SUBCOMMAND by skipping git's global options. A naive "$1" would
+# report "-C" for every `git -C "$REPO" ...` call, which is how the blocks
+# under test invoke git.
+sub=''
+skip=0
+for a in "$@"; do
+  if [ "$skip" = 1 ]; then skip=0; continue; fi
+  case "$a" in
+    -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) skip=1 ;;
+    --*=*) ;;
+    -*) ;;
+    *) sub="$a"; break ;;
+  esac
+done
+
+# ONE single-write append per invocation (never a sequence of printf calls
+# sharing one redirect) so two stub processes can never interleave a partial
+# record into the log.
+AE_STUB_US=$(printf '\037')
+line="$sub"
+for a in "$@"; do line="$line$AE_STUB_US$a"; done
+printf '%s\n' "$line" >> "$AE_STUB_LOG"
+
+if [ -n "$AE_STUB_FAIL_SUBCMD" ] && [ "$sub" = "$AE_STUB_FAIL_SUBCMD" ]; then
+  printf 'AE-GIT-STUB: forced failure for subcommand %s (exit %s)\n' \
+    "$sub" "$AE_STUB_FAIL_CODE" >&2
+  exit "$AE_STUB_FAIL_CODE"
+fi
+exec "$AE_STUB_REAL_GIT" "$@"
+"""
+
+
+def install_git_stub(
+    fixture: Fixture,
+    fail_subcommand: Optional[str] = None,
+    fail_exit_code: int = 1,
+    bin_dir: Optional[Path] = None,
+) -> GitStub:
+    """PATH-shadow `git` with a tee-and-delegate stub: it records the full
+    argv of every invocation, then `exec`s the REAL git binary (resolved to an
+    absolute path at install time, so there is no recursion). Optionally
+    forces one chosen subcommand to a chosen exit code while every other git
+    call in the block still works - which is what lets a long block be driven
+    down one specific failure branch, and what lets a test prove a command was
+    never ATTEMPTED (GitStub.was_attempted)."""
+    real_git = shutil.which("git", path=fixture.env.get("PATH", os.environ.get("PATH", "")))
+    if real_git is None:
+        raise AssertionError("no real `git` on PATH for the stub to delegate to")
+    real_git = str(Path(real_git).resolve())
+
+    bin_dir = bin_dir or (fixture.repo_dir.parent / "git-stub-bin")
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    log_path = bin_dir / "argv.log"
+    log_path.write_text("", encoding="utf-8")
+
+    for value, label in ((str(log_path), "log path"), (real_git, "git path")):
+        if "'" in value:
+            raise AssertionError(f"{label} contains a single quote, which would break the stub")
+    if fail_subcommand is not None and "'" in fail_subcommand:
+        raise AssertionError("fail_subcommand contains a single quote")
+
+    stub = bin_dir / "git"
+    stub.write_text(
+        _GIT_STUB_TEMPLATE.replace("__LOG__", str(log_path))
+        .replace("__REAL_GIT__", real_git)
+        .replace("__FAIL_SUBCMD__", fail_subcommand or "")
+        .replace("__FAIL_CODE__", str(fail_exit_code)),
+        encoding="utf-8",
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    fixture.env["PATH"] = f"{bin_dir}{os.pathsep}{fixture.env['PATH']}"
+    return GitStub(bin_dir, log_path, fail_subcommand, fail_exit_code)
+
+
+def _knowledge_env(fixture_env: dict[str, str], repo_dir: Path) -> None:
+    """Populate the env a knowledge-commit block reads. BRANCH_NAME is
+    deliberately ABSENT - see the module manifest's "Note on BRANCH_NAME"."""
+    fixture_env["REPO"] = str(repo_dir)
+    fixture_env["WORKTREE_PATH"] = ""
+    fixture_env.pop("BRANCH_NAME", None)
+
+
+def _build_knowledge_base(
+    tmp_path: Path, branch_name: str, developer: str, gitignore: str
+) -> Fixture:
+    repo_dir = tmp_path / "repo"
+    env = _base_env(tmp_path, DUMMY_NAME, DUMMY_EMAIL)
+    _init_repo(repo_dir, branch_name, env)
+    _write_gitignore(repo_dir, gitignore, env)
+    _stub_agentic_identity(tmp_path / "stub-bin", env, developer)
+    _knowledge_env(env, repo_dir)
+    return Fixture(repo_dir, None, branch_name, developer, env)
+
+
+def build_knowledge_consumer_shape(
+    tmp_path: Path, modes: Optional[dict[str, str]] = None
+) -> Fixture:
+    """(A) Consumer repo: all three knowledge files are TRACKABLE under the
+    /ds-init-project gitignore, a real bare `origin` exists, and each file is
+    seeded at the tip then locally varied per `modes` (default: all
+    "modified"). The positive path for a knowledge-commit block."""
+    resolved = _normalize_modes(modes)
+    fixture = _build_knowledge_base(
+        tmp_path, "feature/harness-knowledge-a", "dev-knowledge", CONSUMER_GITIGNORE
+    )
+    seed_knowledge_baseline(fixture, resolved)
+    add_bare_origin(fixture)
+    apply_knowledge_local(fixture, resolved)
+    return fixture
+
+
+def build_knowledge_dinostack_shape(tmp_path: Path) -> Fixture:
+    """(B) DinoStack itself: all three knowledge files exist on disk and ALL
+    THREE are gitignored, so nothing is committable. Uses
+    DINOSTACK_KNOWLEDGE_GITIGNORE, not DINOSTACK_GITIGNORE - the latter
+    ignores only `.agentic/`, which would leave MEMORY.md and decisions.md
+    trackable and silently make this the consumer shape for two of three."""
+    fixture = _build_knowledge_base(
+        tmp_path,
+        "feature/harness-knowledge-b",
+        "dev-knowledge-dinostack",
+        DINOSTACK_KNOWLEDGE_GITIGNORE,
+    )
+    add_bare_origin(fixture)
+    for rel_path in KNOWLEDGE_FILES:
+        _write_file(fixture.repo_dir, rel_path, _knowledge_local(rel_path, "absent"))
+        result = subprocess.run(
+            ["git", "-C", str(fixture.repo_dir), "check-ignore", "-q", "--", rel_path],
+            env=fixture.env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"fixture invariant violated: {rel_path} is NOT ignored under "
+                f"DINOSTACK_KNOWLEDGE_GITIGNORE (git check-ignore rc="
+                f"{result.returncode}) - this shape requires all three ignored"
+            )
+    return fixture
+
+
+def build_knowledge_no_remote_shape(
+    tmp_path: Path, modes: Optional[dict[str, str]] = None
+) -> Fixture:
+    """(C) Consumer gitignore, knowledge files seeded and locally varied, but
+    NO remote at all - `git remote get-url origin` fails, so a block's push
+    path must never be reached."""
+    resolved = _normalize_modes(modes)
+    fixture = _build_knowledge_base(
+        tmp_path,
+        "feature/harness-knowledge-c",
+        "dev-knowledge-no-remote",
+        CONSUMER_GITIGNORE,
+    )
+    seed_knowledge_baseline(fixture, resolved)
+    apply_knowledge_local(fixture, resolved)
+    return fixture
+
+
+def build_knowledge_push_reject_shape(
+    tmp_path: Path, modes: Optional[dict[str, str]] = None
+) -> Fixture:
+    """(D) Same as (A) plus a `pre-receive` hook on the bare origin that exits
+    1 - fetch and `rev-parse origin/<branch>` still succeed, only the push
+    fails. See install_push_reject_hook() for why the "broken remote path"
+    variant does not work here."""
+    resolved = _normalize_modes(modes)
+    fixture = _build_knowledge_base(
+        tmp_path,
+        "feature/harness-knowledge-d",
+        "dev-knowledge-reject",
+        CONSUMER_GITIGNORE,
+    )
+    seed_knowledge_baseline(fixture, resolved)
+    add_bare_origin(fixture)
+    install_push_reject_hook(fixture)
+    apply_knowledge_local(fixture, resolved)
+    return fixture

--- a/bin/tests/lib/git_fixture.py
+++ b/bin/tests/lib/git_fixture.py
@@ -261,8 +261,31 @@ class GitStub:
         return subcommand in self.subcommands()
 
 
+# Every subprocess in this module is bounded and has stdin closed.
+#
+# timeout: an unbounded git call that stalls (a credential or terminal prompt,
+# a hung hook) escalates into a killed CI job with no usable log. Bounded, it
+# is one TimeoutExpired at the exact call site. 30s is ~1000x the observed
+# runtime of any git command here.
+#
+# stdin=DEVNULL: a git that decides to prompt gets EOF and fails instead of
+# waiting forever. pytest's own fd capture already points fd 0 at devnull, but
+# that protection VANISHES under `-s` / `-p no:capture` - which is precisely
+# how someone will run this suite while debugging the next stall.
+_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+
 def _run(args: list[str], cwd: Path, env: dict[str, str]) -> None:
-    subprocess.run(args, cwd=str(cwd), env=env, check=True, capture_output=True, text=True)
+    subprocess.run(
+        args,
+        cwd=str(cwd),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+    )
 
 
 def _base_env(tmp_path: Path, user_name: Optional[str], user_email: Optional[str]) -> dict[str, str]:
@@ -285,6 +308,17 @@ def _base_env(tmp_path: Path, user_name: Optional[str], user_email: Optional[str
     env["GIT_CONFIG_GLOBAL"] = str(global_gitconfig)
     env["LC_ALL"] = "C"
     env["LANG"] = "C"
+    # Never let git block on a prompt. GIT_CONFIG_NOSYSTEM=1 plus the
+    # fixture-local GIT_CONFIG_GLOBAL already mean no credential or askpass
+    # helper is inherited TODAY, but nothing asserted that and nothing would
+    # catch a regression - and the failure mode is a subprocess that waits
+    # forever, which is the most expensive kind. These four make a prompt
+    # impossible rather than merely unreachable: a prompting git now fails
+    # fast instead of hanging.
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = ""
+    env["SSH_ASKPASS"] = ""
+    env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
     # Drop any AUTHOR/COMMITTER identity inherited from the calling process
     # (e.g. this test suite's own CI commit env) unless a fixture opts back
     # in (build_identity_no_gitconfig_shape).
@@ -599,6 +633,8 @@ def _is_tracked_at_head(repo_dir: Path, rel_path: str, env: dict[str, str]) -> b
         env=env,
         capture_output=True,
         text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     )
     return result.returncode == 0
 
@@ -883,6 +919,8 @@ def build_knowledge_dinostack_shape(tmp_path: Path) -> Fixture:
             env=fixture.env,
             capture_output=True,
             text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode != 0:
             raise AssertionError(

--- a/bin/tests/lib/md_shell_extract.py
+++ b/bin/tests/lib/md_shell_extract.py
@@ -1,24 +1,39 @@
 """
-Purpose: Extracts and mutates fenced ```bash blocks out of a markdown command
-         file (specifically content/commands/ds-implement-ticket.md) so their
-         shell can be executed against real git fixtures in a pytest suite,
-         instead of only ever being read as prose. Built for
-         bin/tests/test_phase8_telemetry_shell.py, which exercises the Phase 8
-         commit-and-telemetry block.
+Purpose: Extracts and mutates fenced ```bash blocks out of a markdown file
+         (content/commands/ds-implement-ticket.md,
+         content/references/qa-gate.md, and test-local fixture markdown) so
+         their shell can be executed against real git fixtures in a pytest
+         suite, instead of only ever being read as prose. Originally built for
+         bin/tests/test_phase8_telemetry_shell.py (the Phase 8
+         commit-and-telemetry block); now shared by every `@harness:`-marked
+         block.
 
 Public API: extract_marked_block(md_path, marker) -> str
-            render(block_text) -> str
+            render(block_text) -> str          [Phase 8 ONLY - see below]
             apply_transform(block_text, anchor, transform_fn) -> str
             with_completion_marker(rendered_script) -> str
+            with_shell_assignments(script, assignments) -> str
             syntax_check(rendered_script, shell) -> subprocess.CompletedProcess
             line_containing(text, substr) -> str
             PLACEHOLDER_WHITELIST: dict[str, str]
             COMPLETION_MARKER: str
             HarnessExtractionError, HarnessTransformError
 
+render() IS NOT GENERIC. PLACEHOLDER_WHITELIST is global, not per-marker, and
+         holds three Phase-8-specific keys; render() is fail-closed PRE-render
+         (each key must appear exactly once in the block) so it RAISES
+         HarnessExtractionError on any block that does not contain all three -
+         including a block with zero placeholders. A new consumer must NOT
+         call render(); use extract_marked_block() plus its own single-token
+         substitution, then with_shell_assignments() /
+         with_completion_marker(). Precedent:
+         bin/tests/test_qa_knowledge_capture_shell.py._script().
+
 Upstream deps: stdlib only (re, subprocess, tempfile, os).
 
-Downstream consumers: bin/tests/test_phase8_telemetry_shell.py
+Downstream consumers: bin/tests/test_phase8_telemetry_shell.py (the only
+            render() caller), bin/tests/test_qa_knowledge_capture_shell.py,
+            bin/tests/test_knowledge_harness_smoke.py
 
 Failure modes: every extraction/render/transform step is fail-closed - 0 or
                >1 matches raises rather than silently picking one. This
@@ -123,18 +138,17 @@ def extract_marked_block(md_path: str, marker: str) -> str:
     if len(matches) == 0:
         raise HarnessExtractionError(
             f"marker '{target}' not found in any ```bash block in {md_path} "
-            f"(expected exactly 1 match, got 0). Remedy: update the anchor in "
-            f"bin/tests/lib/md_shell_extract.py to match the new prose; this "
-            f"harness tests Phase 8's telemetry-commit shell, see "
-            f"bin/tests/test_phase8_telemetry_shell.py."
+            f"(expected exactly 1 match, got 0). Remedy: restore the "
+            f"'{target}' comment as the first non-blank line of the block "
+            f"under test, or update the marker in the test module that "
+            f"requested it."
         )
     if len(matches) > 1:
         raise HarnessExtractionError(
             f"marker '{target}' matched {len(matches)} ```bash blocks in "
-            f"{md_path} (expected exactly 1). Remedy: update the anchor in "
-            f"bin/tests/lib/md_shell_extract.py to match the new prose; this "
-            f"harness tests Phase 8's telemetry-commit shell, see "
-            f"bin/tests/test_phase8_telemetry_shell.py."
+            f"{md_path} (expected exactly 1). Remedy: markers must be unique "
+            f"per file - rename one of the duplicates and update the test "
+            f"module that requested it."
         )
     return matches[0]
 
@@ -232,6 +246,40 @@ def with_completion_marker(rendered_script: str) -> str:
     if not script.endswith("\n"):
         script += "\n"
     return script + f'echo "{COMPLETION_MARKER}"\n'
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def with_shell_assignments(script: str, assignments: dict[str, str]) -> str:
+    """Prepend `NAME='value'` lines to script - a plain shell ASSIGNMENT, not
+    an `export`, and not an entry in the subprocess environment.
+
+    This distinction is load-bearing, not cosmetic. In production the
+    conductor substitutes values like $BRANCH_NAME into these blocks as bare
+    assignments, so an `awk 'BEGIN{print ENVIRON["BRANCH_NAME"]}'` lookup
+    inside the block resolves EMPTY. A test that instead passes BRANCH_NAME
+    via subprocess.run(env=...) exports it, so that same lookup resolves - and
+    the test passes over a production path that is broken. Injecting here
+    reproduces the production shape exactly; the value must be absent from the
+    subprocess env for the reproduction to hold.
+
+    Values are single-quoted with the standard POSIX '"'"' escape, so any
+    value is safe.
+    """
+    lines: list[str] = []
+    for name, value in assignments.items():
+        if not _IDENTIFIER_RE.match(name):
+            raise HarnessTransformError(
+                f"{name!r} is not a valid shell variable name - refusing to "
+                f"build an assignment that would be a syntax error"
+            )
+        quoted = "'" + str(value).replace("'", "'\"'\"'") + "'"
+        lines.append(f"{name}={quoted}")
+    prefix = "\n".join(lines)
+    if prefix:
+        prefix += "\n"
+    return prefix + script
 
 
 def syntax_check(rendered_script: str, shell: str) -> subprocess.CompletedProcess:

--- a/bin/tests/lib/md_shell_extract.py
+++ b/bin/tests/lib/md_shell_extract.py
@@ -167,11 +167,17 @@ def render(block_text: str) -> str:
         if count != 1:
             raise HarnessExtractionError(
                 f"placeholder '{key}' occurs {count} times in the extracted "
-                f"block (expected exactly 1). Remedy: update "
-                f"PLACEHOLDER_WHITELIST in bin/tests/lib/md_shell_extract.py "
-                f"to match content/commands/ds-implement-ticket.md; this "
-                f"harness tests Phase 8's telemetry-commit shell, see "
-                f"bin/tests/test_phase8_telemetry_shell.py."
+                f"block (expected exactly 1). render() is for the Phase 8 "
+                f"block ONLY - PLACEHOLDER_WHITELIST is global, not "
+                f"per-marker. If this is another block, do NOT add keys to "
+                f"the whitelist (that would break Phase 8's render call "
+                f"sites): bypass render() and do your own substitution on top "
+                f"of extract_marked_block(), as "
+                f"bin/tests/test_qa_knowledge_capture_shell.py._script() and "
+                f"bin/tests/test_knowledge_harness_smoke.py do. If this IS "
+                f"the Phase 8 block, update PLACEHOLDER_WHITELIST in "
+                f"bin/tests/lib/md_shell_extract.py to match "
+                f"content/commands/ds-implement-ticket.md."
             )
 
     rendered = block_text

--- a/bin/tests/lib/md_shell_extract.py
+++ b/bin/tests/lib/md_shell_extract.py
@@ -295,10 +295,15 @@ def syntax_check(rendered_script: str, shell: str) -> subprocess.CompletedProces
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(rendered_script)
+        # Bounded and stdin-closed for the same reason as every subprocess in
+        # bin/tests/lib/git_fixture.py: an unbounded stall becomes a killed CI
+        # job with no log, and pytest's fd-0 capture disappears under `-s`.
         return subprocess.run(
             [shell, "-n", path],
             capture_output=True,
             text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
         )
     finally:
         os.remove(path)

--- a/bin/tests/test_knowledge_harness_smoke.py
+++ b/bin/tests/test_knowledge_harness_smoke.py
@@ -17,8 +17,8 @@ Purpose: Proves the knowledge-commit test harness works before any
          emits "0", not nothing.
 
 Public API: none (pytest test module; 13 parametrized functions x {bash, zsh}
-            = 26 collected IDs, plus 2 static shell-independent assertions =
-            28 - see the collected-count floor in
+            = 26 collected IDs, plus 4 static shell-independent assertions =
+            30 - see the collected-count floor in
             .github/workflows/bin-tests.yml).
 
 Upstream deps: bin/tests/lib/md_shell_extract.py, bin/tests/lib/git_fixture.py,
@@ -151,7 +151,13 @@ def test_render_raises_on_this_block_so_consumers_must_bypass_it():
         )
     with pytest.raises(mse.HarnessExtractionError) as excinfo:
         mse.render(block)
-    assert "occurs 0 times" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "occurs 0 times" in message
+    # The raise must send a new consumer to the BYPASS, not to editing the
+    # global whitelist - adding keys there would break Phase 8's render call
+    # sites, and this is precisely the raise a new consumer hits first.
+    assert "bypass render()" in message, message
+    assert "do NOT add keys to the whitelist" in message, message
 
 
 def test_extraction_is_non_vacuous():
@@ -425,6 +431,75 @@ def test_consumer_shape_push_actually_lands_on_origin(tmp_path, shell):
 # ---------------------------------------------------------------------------
 # Q3. Tee-and-delegate git stub.
 # ---------------------------------------------------------------------------
+
+
+def test_git_stub_log_keeps_a_multiline_argument_in_one_record(tmp_path):
+    """Regression guard: a git argument containing newlines must not split
+    one invocation into several log records.
+
+    `commit-tree -m "$MSG"` with a blank line and a DCO trailer is the exact
+    shape a knowledge-commit block builds. Under newline-framed records this
+    produced THREE entries for ONE invocation, a phantom
+    'Signed-off-by: ...' entry in subcommands(), and an inflated
+    len(argv_lines()) - with nothing to detect it. Records are now
+    \\x1e-terminated and carry their own argc.
+
+    Shell-independent: this exercises the stub itself, not a shell block."""
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    stub = git_fixture.install_git_stub(fixture)
+    msg = "chore(knowledge): capture MEMORY.md\n\nSigned-off-by: A B <a@b.c>\n"
+
+    tree = subprocess.run(
+        ["git", "-C", str(fixture.repo_dir), "write-tree"],
+        env=fixture.env,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    proc = subprocess.run(
+        ["git", "-C", str(fixture.repo_dir), "commit-tree", tree, "-p", "HEAD", "-m", msg],
+        env=fixture.env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    lines = stub.argv_lines()
+    assert len(lines) == 2, f"expected exactly 2 recorded invocations, got {lines!r}"
+    assert stub.subcommands() == ["write-tree", "commit-tree"], (
+        f"no phantom entries permitted: {stub.subcommands()!r}"
+    )
+    commit_tree = lines[1]
+    assert commit_tree[-1] == msg, (
+        "the multi-line -m argument must round-trip byte-exact inside its "
+        f"record, got {commit_tree[-1]!r}"
+    )
+    assert commit_tree == [
+        "commit-tree",
+        "-C",
+        str(fixture.repo_dir),
+        "commit-tree",
+        tree,
+        "-p",
+        "HEAD",
+        "-m",
+        msg,
+    ]
+
+
+def test_git_stub_cannot_be_installed_twice(tmp_path):
+    """A second install would resolve `git` to the first stub and recurse
+    forever (observed: a hang until a 15s timeout, growing the argv log every
+    iteration). It must raise instead - a fixture that hangs would burn the
+    whole python-bin-tests job with no diagnostic."""
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    git_fixture.install_git_stub(fixture)
+    with pytest.raises(AssertionError, match="recurse forever"):
+        git_fixture.install_git_stub(fixture)
+    # Also caught when the caller supplies a different bin_dir, where the
+    # parent-directory comparison alone would not fire.
+    with pytest.raises(AssertionError, match="recurse forever"):
+        git_fixture.install_git_stub(fixture, bin_dir=tmp_path / "second-stub-bin")
 
 
 @pytest.mark.parametrize("shell", SHELLS)

--- a/bin/tests/test_knowledge_harness_smoke.py
+++ b/bin/tests/test_knowledge_harness_smoke.py
@@ -58,6 +58,16 @@ MEMORY = "MEMORY.md"
 DECISIONS = "decisions.md"
 LEARNINGS = ".agentic/learnings.md"
 
+# Every subprocess in this module is bounded and stdin-closed. A per-call
+# timeout LARGER than the CI step budget can never fire usefully - two 120s
+# calls alone exceeded the old 5-minute job limit, so the job died before any
+# timeout produced a diagnostic. These are sized to fail inside the step and
+# under pytest-timeout's own 60s per-test limit, leaving a stack trace at the
+# exact call. stdin=DEVNULL keeps a prompting git from blocking under
+# `-s` / `-p no:capture`, where pytest's fd-0 capture is absent.
+BLOCK_TIMEOUT_SECONDS = 30
+GIT_TIMEOUT_SECONDS = 30
+
 
 def _shell_or_skip(shell: str) -> str:
     """Skip locally when a shell is missing; hard-fail in CI so the zsh half
@@ -93,7 +103,8 @@ def _run_block(fixture: git_fixture.Fixture, shell: str) -> subprocess.Completed
         env=fixture.env,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=BLOCK_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     )
 
 
@@ -133,6 +144,8 @@ def _git(fixture: git_fixture.Fixture, *args: str, cwd: Path | None = None):
         env=fixture.env,
         capture_output=True,
         text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     )
 
 
@@ -227,7 +240,8 @@ def test_exported_branch_name_would_populate_environ(tmp_path, shell):
         env=env,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=BLOCK_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     )
     _assert_completed(result)
     assert _field(result.stdout, "SMOKE_AWK_ENVIRON") == fixture.branch_name
@@ -455,12 +469,16 @@ def test_git_stub_log_keeps_a_multiline_argument_in_one_record(tmp_path):
         capture_output=True,
         text=True,
         check=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     ).stdout.strip()
     proc = subprocess.run(
         ["git", "-C", str(fixture.repo_dir), "commit-tree", tree, "-p", "HEAD", "-m", msg],
         env=fixture.env,
         capture_output=True,
         text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
     )
     assert proc.returncode == 0, proc.stderr
 

--- a/bin/tests/test_knowledge_harness_smoke.py
+++ b/bin/tests/test_knowledge_harness_smoke.py
@@ -1,0 +1,506 @@
+"""
+Purpose: Proves the knowledge-commit test harness works before any
+         knowledge-commit block exists to test. Executes a throwaway
+         second `@harness:`-marked block
+         (bin/tests/fixtures/knowledge_harness_smoke.md, marker
+         `knowledge-smoke`) end to end against the four new
+         build_knowledge_* fixtures under both bash and zsh, and pins the
+         answers to the four harness questions that blocked the
+         knowledge-commit test plan: (1) md_shell_extract.render() is
+         Phase-8-only and RAISES on a zero-placeholder block, so new
+         consumers must bypass it; (2) a value can be injected as a
+         non-exported shell assignment (awk -v sees it, awk ENVIRON[] does
+         not - which is the production shape); (3) a tee-and-delegate `git`
+         stub can force one subcommand to fail while a dozen other git calls
+         in the same block still work, and can prove a command was never
+         attempted; (4) `awk '{s += $2} END {print s+0}'` on an empty file
+         emits "0", not nothing.
+
+Public API: none (pytest test module; 13 parametrized functions x {bash, zsh}
+            = 26 collected IDs, plus 2 static shell-independent assertions =
+            28 - see the collected-count floor in
+            .github/workflows/bin-tests.yml).
+
+Upstream deps: bin/tests/lib/md_shell_extract.py, bin/tests/lib/git_fixture.py,
+               bin/tests/fixtures/knowledge_harness_smoke.md.
+
+Downstream consumers: .github/workflows/bin-tests.yml (python-bin-tests job).
+
+Failure modes: n/a (test module). Every fixture claim is asserted against
+               ACTUAL git state (check-ignore / cat-file / rev-parse / a real
+               push against the bare origin), never against the builder's own
+               return value - a builder that lies about the shape it produced
+               is exactly the failure this module exists to exclude.
+
+Performance: standard; each test builds one or two temp git repos with a bare
+             origin and runs one subprocess shell invocation.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lib.git_fixture as git_fixture  # noqa: E402
+import lib.md_shell_extract as mse  # noqa: E402
+
+MD_PATH = Path(__file__).resolve().parent / "fixtures" / "knowledge_harness_smoke.md"
+MARKER = "knowledge-smoke"
+
+SHELLS = ["bash", "zsh"]
+
+MEMORY = "MEMORY.md"
+DECISIONS = "decisions.md"
+LEARNINGS = ".agentic/learnings.md"
+
+
+def _shell_or_skip(shell: str) -> str:
+    """Skip locally when a shell is missing; hard-fail in CI so the zsh half
+    of the matrix can never be silently dropped (see the same guard in
+    test_phase8_telemetry_shell.py)."""
+    if shutil.which(shell) is None:
+        if os.environ.get("CI"):
+            pytest.fail(f"{shell} not found in CI - the python-bin-tests job must install it")
+        pytest.skip(f"{shell} not found on this machine")
+    return shell
+
+
+def _raw_block() -> str:
+    return mse.extract_marked_block(str(MD_PATH), MARKER)
+
+
+def _run_block(fixture: git_fixture.Fixture, shell: str) -> subprocess.CompletedProcess:
+    """Execute the smoke block with BRANCH_NAME injected as a NON-exported
+    shell assignment, and assert it is absent from the subprocess env - if it
+    leaked into the env, the ENVIRON[] half of the Q2 assertion would pass
+    for the wrong reason."""
+    assert "BRANCH_NAME" not in fixture.env, (
+        "BRANCH_NAME must not be in the fixture env - it is injected as a "
+        "non-exported shell assignment so the block reproduces production"
+    )
+    script = mse.with_shell_assignments(
+        mse.with_completion_marker(_raw_block()),
+        {"BRANCH_NAME": fixture.branch_name},
+    )
+    return subprocess.run(
+        [shell, "-c", script],
+        cwd=str(fixture.repo_dir),
+        env=fixture.env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _assert_completed(result: subprocess.CompletedProcess) -> None:
+    assert mse.COMPLETION_MARKER in result.stdout, (
+        f"block did not run to completion.\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+
+def _field(stdout: str, key: str) -> str:
+    """Value of the single `KEY=[value]`-shaped probe line."""
+    prefix = f"{key}=["
+    hits = [ln for ln in stdout.splitlines() if ln.startswith(prefix)]
+    assert len(hits) == 1, f"expected exactly 1 {key} line, got {hits!r}"
+    return hits[0][len(prefix) : -1]
+
+
+def _plain_field(stdout: str, key: str) -> str:
+    """Value of the single `KEY=value`-shaped probe line (no brackets)."""
+    prefix = f"{key}="
+    hits = [ln for ln in stdout.splitlines() if ln.startswith(prefix)]
+    assert len(hits) == 1, f"expected exactly 1 {key} line, got {hits!r}"
+    return hits[0][len(prefix) :]
+
+
+def _file_state(stdout: str, rel_path: str) -> str:
+    prefix = f"SMOKE_FILE {rel_path}="
+    hits = [ln for ln in stdout.splitlines() if ln.startswith(prefix)]
+    assert len(hits) == 1, f"expected exactly 1 SMOKE_FILE line for {rel_path}, got {hits!r}"
+    return hits[0][len(prefix) :]
+
+
+def _git(fixture: git_fixture.Fixture, *args: str, cwd: Path | None = None):
+    return subprocess.run(
+        ["git", "-C", str(cwd or fixture.repo_dir), *args],
+        env=fixture.env,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Q1 (static). render() is Phase-8-only: it raises on a zero-placeholder
+# block, so a new consumer must bypass it. Pinned mechanically so a future
+# change to render()'s contract cannot silently invalidate the manifest note.
+# ---------------------------------------------------------------------------
+
+
+def test_render_raises_on_this_block_so_consumers_must_bypass_it():
+    block = _raw_block()
+    for key in mse.PLACEHOLDER_WHITELIST:
+        assert key not in block, (
+            f"this fixture block must contain NO Phase 8 placeholder; found {key!r}"
+        )
+    with pytest.raises(mse.HarnessExtractionError) as excinfo:
+        mse.render(block)
+    assert "occurs 0 times" in str(excinfo.value)
+
+
+def test_extraction_is_non_vacuous():
+    block = _raw_block()
+    lines = block.splitlines()
+    assert len(lines) > 40, f"expected >40 lines, got {len(lines)}"
+    for anchor in ("SMOKE_AWK_ENVIRON", "diff-index", "push -q origin", "check-ignore"):
+        assert anchor in block, f"expected literal anchor {anchor!r} in extracted block"
+
+
+# ---------------------------------------------------------------------------
+# A second @harness: marker extracts, parses, and executes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_second_marker_extracts_parses_and_executes(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    check = mse.syntax_check(_raw_block(), shell)
+    assert check.returncode == 0, check.stderr
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _plain_field(result.stdout, "SMOKE_COMMIT") == "ok", result.stdout
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "ok", result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Q2. BRANCH_NAME injected as a non-exported shell assignment.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_branch_name_is_assigned_not_exported(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _field(result.stdout, "SMOKE_BRANCH_ASSIGNED") == fixture.branch_name
+    assert _field(result.stdout, "SMOKE_AWK_V") == fixture.branch_name, (
+        "awk -v must see the assigned value"
+    )
+    assert _field(result.stdout, "SMOKE_AWK_ENVIRON") == "", (
+        "awk ENVIRON[\"BRANCH_NAME\"] must be EMPTY - a non-empty value means "
+        "the variable was exported, so the test would pass over a production "
+        "path where it is only assigned"
+    )
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_exported_branch_name_would_populate_environ(tmp_path, shell):
+    """Both-directions control for the assertion above: with BRANCH_NAME in
+    the subprocess ENV instead, ENVIRON["BRANCH_NAME"] DOES resolve. Without
+    this, an ENVIRON lookup that is empty for some unrelated reason (a
+    stripped env, an awk that does not implement ENVIRON) would make the
+    assertion above pass vacuously."""
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    env = dict(fixture.env)
+    env["BRANCH_NAME"] = fixture.branch_name
+    script = mse.with_shell_assignments(
+        mse.with_completion_marker(_raw_block()), {"BRANCH_NAME": fixture.branch_name}
+    )
+    result = subprocess.run(
+        [shell, "-c", script],
+        cwd=str(fixture.repo_dir),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    _assert_completed(result)
+    assert _field(result.stdout, "SMOKE_AWK_ENVIRON") == fixture.branch_name
+
+
+# ---------------------------------------------------------------------------
+# Q4. awk sum over an EMPTY file.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_awk_sum_on_empty_file_emits_zero_not_nothing(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _field(result.stdout, "SMOKE_AWK_EMPTY_FILE") == "0", (
+        "an empty-vs-zero guard would have an UNREACHABLE empty arm for a "
+        "present-but-empty file: `s+0` forces numeric context and prints 0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder shape assertions - against actual git state, not the return value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_consumer_shape_supports_independent_per_file_modes(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    modes = {MEMORY: "identical", DECISIONS: "absent", LEARNINGS: "fewer_lines"}
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path, modes)
+
+    # Actual git state, independent of the block.
+    assert _git(fixture, "cat-file", "-e", f"HEAD:{MEMORY}").returncode == 0
+    assert _git(fixture, "cat-file", "-e", f"HEAD:{DECISIONS}").returncode != 0, (
+        "'absent' must mean absent from the branch tip, not merely modified"
+    )
+    assert _git(fixture, "cat-file", "-e", f"HEAD:{LEARNINGS}").returncode == 0
+    # Compare CONTENT, not `diff-index --quiet`: the fixture deliberately
+    # leaves an identical file stat-dirty, and diff-index --quiet reports a
+    # stat-dirty entry as changed without inspecting its content (see
+    # test_identical_file_survives_a_stat_dirty_mtime).
+    assert (fixture.repo_dir / MEMORY).read_text(encoding="utf-8") == _git(
+        fixture, "show", f"HEAD:{MEMORY}"
+    ).stdout, "'identical' must be byte-identical to the tip"
+    tip_lines = len(_git(fixture, "show", f"HEAD:{LEARNINGS}").stdout.splitlines())
+    local_lines = len((fixture.repo_dir / LEARNINGS).read_text(encoding="utf-8").splitlines())
+    assert local_lines < tip_lines, (
+        f"'fewer_lines' must have fewer lines than the tip ({local_lines} vs {tip_lines})"
+    )
+
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _file_state(result.stdout, MEMORY) == "identical"
+    assert _file_state(result.stdout, DECISIONS) == "untracked"
+    assert _file_state(result.stdout, LEARNINGS).startswith("modified +0 -"), result.stdout
+    deleted = int(_file_state(result.stdout, LEARNINGS).rsplit("-", 1)[1])
+    assert deleted == tip_lines - local_lines
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_identical_file_survives_a_stat_dirty_mtime(tmp_path, shell):
+    """Regression guard for a real flake this harness produced before the
+    fixture forced the condition: a file rewritten with IDENTICAL content has
+    an mtime newer than the index's, and `git diff-index --quiet HEAD` trusts
+    stat data over content outside git's racily-clean window - so it reports
+    the file as changed. Left racy, "identical" was reported ~70% of runs and
+    "modified +0 -0" ~30%. The fixture now forces the stat-dirty state and the
+    block must `git update-index --refresh` before diff-index; drop that
+    refresh and this test fails every run rather than one in three."""
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path, {MEMORY: "identical"})
+
+    # The fixture really is stat-dirty: content matches the tip byte for byte,
+    # but the working file's mtime is ahead of the index's.
+    assert _git(fixture, "show", f"HEAD:{MEMORY}").stdout == (
+        fixture.repo_dir / MEMORY
+    ).read_text(encoding="utf-8")
+    # `git ls-files --debug` prints "  mtime: <secs>:<nanos>".
+    index_mtime = float(
+        _git(fixture, "ls-files", "--debug", "--", MEMORY)
+        .stdout.split("mtime:")[1]
+        .split()[0]
+        .split(":")[0]
+    )
+    assert (fixture.repo_dir / MEMORY).stat().st_mtime > index_mtime + 1, (
+        "fixture invariant: the identical file's mtime must be clearly ahead "
+        "of the index's, or this test is not exercising the stat-dirty branch"
+    )
+
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _file_state(result.stdout, MEMORY) == "identical", (
+        "an unchanged file must not be classified as changed just because it "
+        "was rewritten - the block must refresh the index before diff-index"
+    )
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_dinostack_shape_ignores_all_three_knowledge_files(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_dinostack_shape(tmp_path)
+
+    for rel_path in git_fixture.KNOWLEDGE_FILES:
+        assert (fixture.repo_dir / rel_path).exists(), f"{rel_path} must exist on disk"
+        assert _git(fixture, "check-ignore", "-q", "--", rel_path).returncode == 0, (
+            f"{rel_path} must be ignored under DINOSTACK_KNOWLEDGE_GITIGNORE"
+        )
+
+    before = _git(fixture, "rev-parse", "HEAD").stdout.strip()
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    for rel_path in git_fixture.KNOWLEDGE_FILES:
+        assert _file_state(result.stdout, rel_path) == "ignored"
+    assert _plain_field(result.stdout, "SMOKE_STAGED") == "0"
+    assert _git(fixture, "rev-parse", "HEAD").stdout.strip() == before, (
+        "nothing is committable on the DinoStack shape"
+    )
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_no_remote_shape_has_no_remote_and_never_pushes(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_no_remote_shape(tmp_path)
+    assert fixture.origin_dir is None
+    assert _git(fixture, "remote").stdout.strip() == "", "this shape must have NO remote"
+
+    stub = git_fixture.install_git_stub(fixture)
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _plain_field(result.stdout, "SMOKE_HAS_REMOTE") == "0"
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "skipped-no-remote"
+    assert not stub.was_attempted("push"), (
+        f"push must never be attempted without a remote; log: {stub.subcommands()}"
+    )
+    assert stub.was_attempted("add"), (
+        "control: the stub DID record other subcommands, so the absence of "
+        "'push' above is a real absence and not an empty log"
+    )
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_push_reject_shape_fails_only_at_push(tmp_path, shell):
+    """The load-bearing claim about this fixture's construction: with a
+    pre-receive hook, `fetch` and `rev-parse origin/<branch>` BOTH succeed and
+    only `push` fails. A "repoint origin at a broken path" variant would fail
+    at fetch, so the block would never reach its push."""
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_push_reject_shape(tmp_path)
+
+    fetch = _git(fixture, "fetch", "origin")
+    assert fetch.returncode == 0, f"fetch must succeed: {fetch.stderr}"
+    revparse = _git(fixture, "rev-parse", "--verify", f"refs/remotes/origin/{fixture.branch_name}")
+    assert revparse.returncode == 0, f"rev-parse must succeed: {revparse.stderr}"
+    # Probe onto a THROWAWAY ref, not the fixture branch: at this point local
+    # HEAD equals the remote tip, and a no-op push short-circuits with
+    # "Everything up-to-date" and exit 0 WITHOUT ever invoking the remote's
+    # pre-receive hook. A throwaway ref is a genuine ref update, so the hook
+    # runs; the push is rejected, so the remote is left unchanged.
+    push = _git(fixture, "push", "origin", "HEAD:refs/heads/ae-fixture-probe")
+    assert push.returncode != 0, "push must be rejected by the pre-receive hook"
+    assert git_fixture.PUSH_REJECT_MESSAGE in push.stderr, push.stderr
+    assert (
+        _git(
+            fixture, "rev-parse", "--verify", "ae-fixture-probe", cwd=fixture.origin_dir
+        ).returncode
+        != 0
+    ), "a rejected push must leave the remote unchanged"
+
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _plain_field(result.stdout, "SMOKE_FETCH") == "ok"
+    assert _plain_field(result.stdout, "SMOKE_REVPARSE") == "ok"
+    assert _plain_field(result.stdout, "SMOKE_COMMIT") == "ok"
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "fail"
+    assert git_fixture.PUSH_REJECT_MESSAGE in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_consumer_shape_push_actually_lands_on_origin(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    assert fixture.origin_dir is not None
+    before = _git(fixture, "rev-parse", fixture.branch_name, cwd=fixture.origin_dir).stdout.strip()
+
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "ok", result.stderr
+
+    after = _git(fixture, "rev-parse", fixture.branch_name, cwd=fixture.origin_dir).stdout.strip()
+    assert after != before, "the bare origin's branch tip must have advanced"
+    local = _git(fixture, "rev-parse", "HEAD").stdout.strip()
+    assert after == local
+    subject = _git(
+        fixture, "log", "-1", "--format=%s", fixture.branch_name, cwd=fixture.origin_dir
+    ).stdout.strip()
+    assert subject == f"chore(knowledge): smoke {fixture.branch_name}"
+
+
+# ---------------------------------------------------------------------------
+# Q3. Tee-and-delegate git stub.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_git_stub_records_argv_and_delegates_to_real_git(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    stub = git_fixture.install_git_stub(fixture)
+
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    # Delegation actually happened: the block's commit and push both worked.
+    assert _plain_field(result.stdout, "SMOKE_COMMIT") == "ok"
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "ok", result.stderr
+
+    lines = stub.argv_lines()
+    assert len(lines) >= 12, f"expected >= 12 recorded git calls, got {len(lines)}"
+    subs = set(stub.subcommands())
+    for expected in ("remote", "fetch", "rev-parse", "check-ignore", "cat-file",
+                     "diff-index", "add", "commit", "push"):
+        assert expected in subs, f"{expected!r} missing from recorded subcommands {sorted(subs)}"
+    # Full argv is recorded, not just the subcommand.
+    push_line = [parts for parts in lines if parts[0] == "push"][0]
+    assert push_line[1] == "-C" and push_line[2] == str(fixture.repo_dir), push_line
+    assert f"HEAD:refs/heads/{fixture.branch_name}" in push_line
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_git_stub_forces_one_subcommand_while_others_still_work(tmp_path, shell):
+    """Both directions: the SAME fixture shape reports MEMORY.md as
+    'identical' with an unforced stub, and as 'modified' once `diff-index`
+    alone is forced to exit 1 - while `commit` and `push` in the same block
+    still succeed through the real git."""
+    shell = _shell_or_skip(shell)
+    # MEMORY.md identical, the other two genuinely modified - so the block has
+    # real work to commit and push in BOTH arms, and the only difference
+    # between them is diff-index's verdict on MEMORY.md.
+    modes = {MEMORY: "identical", DECISIONS: "modified", LEARNINGS: "modified"}
+
+    control_dir = tmp_path / "control"
+    control_dir.mkdir()
+    control = git_fixture.build_knowledge_consumer_shape(control_dir, modes)
+    git_fixture.install_git_stub(control)
+    control_result = _run_block(control, shell)
+    _assert_completed(control_result)
+    assert _file_state(control_result.stdout, MEMORY) == "identical"
+    assert _plain_field(control_result.stdout, "SMOKE_STAGED") == "2"
+    assert _plain_field(control_result.stdout, "SMOKE_PUSH") == "ok", control_result.stderr
+
+    forced_dir = tmp_path / "forced"
+    forced_dir.mkdir()
+    forced = git_fixture.build_knowledge_consumer_shape(forced_dir, modes)
+    stub = git_fixture.install_git_stub(forced, fail_subcommand="diff-index", fail_exit_code=1)
+    forced_result = _run_block(forced, shell)
+    _assert_completed(forced_result)
+    assert _file_state(forced_result.stdout, MEMORY) == "modified +0 -0", forced_result.stdout
+    assert _plain_field(forced_result.stdout, "SMOKE_STAGED") == "3"
+    assert _plain_field(forced_result.stdout, "SMOKE_COMMIT") == "ok", (
+        "commit must still reach the real git - only diff-index is forced"
+    )
+    assert _plain_field(forced_result.stdout, "SMOKE_PUSH") == "ok", forced_result.stderr
+    assert stub.was_attempted("diff-index")
+    assert "AE-GIT-STUB: forced failure for subcommand diff-index" in forced_result.stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_git_stub_can_force_push_to_a_chosen_exit_code(tmp_path, shell):
+    shell = _shell_or_skip(shell)
+    fixture = git_fixture.build_knowledge_consumer_shape(tmp_path)
+    stub = git_fixture.install_git_stub(fixture, fail_subcommand="push", fail_exit_code=7)
+
+    before = _git(fixture, "rev-parse", fixture.branch_name, cwd=fixture.origin_dir).stdout.strip()
+    result = _run_block(fixture, shell)
+    _assert_completed(result)
+    assert _plain_field(result.stdout, "SMOKE_FETCH") == "ok", "fetch is untouched by the force"
+    assert _plain_field(result.stdout, "SMOKE_COMMIT") == "ok"
+    assert _plain_field(result.stdout, "SMOKE_PUSH") == "fail"
+    assert stub.was_attempted("push")
+    after = _git(fixture, "rev-parse", fixture.branch_name, cwd=fixture.origin_dir).stdout.strip()
+    assert after == before, "the forced push must not have reached the real git"


### PR DESCRIPTION
Test-harness groundwork for the knowledge-commit feature. **No `content/` changes, no methodology prose** - this unit builds the fixtures and harness support that a follow-up Phase 11e unit will need, and answers four questions empirically that three rounds of plan review could only speculate about.

## Why this landed first

The Phase 11e plan was blocked three times. Round 3's findings were **entirely in the test specifications, none in the shell logic** - reviewers were arguing about a harness nobody had run. Building it first replaced that speculation with executed evidence, and immediately surfaced three defects prose review had no way to find.

## What it found

- **`render()` raises on any block with zero `PLACEHOLDER_WHITELIST` keys.** The whitelist is global, not per-marker, and fail-closed pre-render. "Model your tests on `test_phase8_telemetry_shell.py`" walks straight into this at all 18 of its `render()` call sites. Documented the bypass rather than making the whitelist per-marker, which would have churned Phase 8 for no gain. A third consumer (`test_qa_knowledge_capture_shell.py`) had already hit the same wall independently.
- **A no-op push short-circuits client-side** (`Everything up-to-date`, exit 0) and never contacts the `pre-receive` hook. The planned push-failure test would have passed vacuously.
- **`git diff-index --quiet HEAD` is not a reliable unchanged-check.** A byte-identical rewrite has an mtime past the index, and outside git's racily-clean window git trusts stat data over content: `identical` ~70% of runs, `modified +0 -0` ~30%. The fixture now forces the stat-dirty state deterministically and the block must `git update-index -q --refresh` first. Phase 11e's per-file gating uses exactly this comparison, so the harness will catch it there.

## What it adds

- Bare-origin support, knowledge-file seeding (4 per-file modes: differs / identical / absent-from-tip / fewer-lines), `DINOSTACK_KNOWLEDGE_GITIGNORE`, and 4 `build_knowledge_*` builders.
- `with_shell_assignments()` - injects a value as a **non-exported** shell assignment, reproducing production where `$BRANCH_NAME` is substituted rather than exported. Without it, an `awk ENVIRON[...]` defect passes its test while failing in production.
- A tee-and-delegate `git` stub that records argv then execs real git, with per-subcommand forced failure.
- 30 tests, `\x1e`-framed argv records with per-record argc validation, double-install guard.

Existing builders untouched; `PLACEHOLDER_WHITELIST` and `render()` behavior unchanged.

## Verification

- Full suite **917 passed**. Floors verified live: smoke 30, phase8 18, qa 52.
- **15 mutations, all confirmed RED.** One (M15) came back green on first attempt - the mutation was weak, not the assertion; re-targeted and confirmed red.
- 10 consecutive smoke-suite runs, no flake.
- Skeptic review: 0 Critical, 1 Major, 3 Minor - all resolved. The Major was argv-log framing: unescaped newlines split one invocation into three records, and Phase 11e's own multi-line DCO commit message is exactly that shape.

## North Star alignment

- **Verifiable outcomes autonomously** - advances it directly. Replaces three rounds of prose speculation about harness behavior with executed evidence, and makes a methodology shell block mechanically verifiable rather than review-only.
- **Works for everyone** - neutral. Test-only code, no operator-facing surface, no identity/tracker/harness assumptions. Fixtures are hermetic (`GIT_CONFIG_NOSYSTEM`, fixture-local `GIT_CONFIG_GLOBAL`, `LC_ALL=C`, no network, everything under `tmp_path`).
- No pillar regressed.

---

## CI timeout hardening (added after a runner-starvation incident on this PR)

`python-bin-tests` was cancelled on this branch at exactly 10 minutes. It was **not** a hang in this diff: the job recorded `steps: []`, so no step ever executed. The account was in runner starvation (23 runs queued, 1 executing), and `10:00` is `timeout-minutes: 5` plus GitHub's 5-minute cancellation grace, consumed entirely by runner acquisition. The suite runs green in ~56s under CI's exact invocation.

Two mechanisms are worth knowing, and the workflow now carries a comment explaining them so nobody "fixes" the next queue cancellation by raising a job timeout alone:

- A job's `started_at` is stamped at **runner assignment**, not first-step execution, so job-level `timeout-minutes` can be fully consumed by queue wait. Only **step-level** timeouts measure real work.
- `.steps | length == 0` on a cancelled job is categorical proof no step ran (cancelled jobs normally retain step records), which cleanly separates infra failure from a code hang.

This was already biting the repo independently of this PR: `bin-sh-tests` ran 4m56s against its own 5-minute job timeout here, and was **already cancelled once on `main`** (run `31115638748`).

Changes: job timeouts 5 -> 20 as backstops, step-level timeouts on every work step, `pytest-timeout` (`--timeout=60 --timeout-method=thread`) so any future stall becomes one red test with a stack trace instead of a killed job with no log, `PYTHONUNBUFFERED: 1`, `timeout=30` + `stdin=subprocess.DEVNULL` on all 9 `subprocess.run` sites (AST-audited, not grepped), and no-prompt git env vars in `_base_env`.

**Verified by making a timeout fire, in three arms with a control** - a green suite proves nothing about a timeout that never triggers. With a `sleep 999` git on the fixture PATH: **(A)** all bounds present -> terminated 60.6s with `TimeoutExpired ... timed out after 30 seconds`; **(B)** harness timeouts stripped, pytest-timeout only -> terminated 60.2s via the plugin; **(C)** control, both stripped -> **hung past 90s**. Arm C is what proves A and B terminated because of the bounds rather than because the sleeping git never took effect.
