### PR TITLE
docs(slides): add product-discovery to writing-agents list (7, was 6)

### DIFF
--- a/docs/slides/agent-team-slides.html
+++ b/docs/slides/agent-team-slides.html
@@ -798,7 +798,7 @@ hr {
 <li>Spawned into their own <strong>isolated worktree</strong> - their own files, their own context</li>
 <li>Given a <strong>structured brief</strong> - goal, constraints, acceptance criteria, non-goals</li>
 <li>Do their narrow job and return a <strong>structured result</strong> - not raw transcript</li>
-<li>Most agents are read-only analysis/planning. <code>engineer</code>, <code>adr-generator</code>, <code>release-orchestrator</code>, <code>learning-extractor</code>, <code>learnings-agent</code>, and <code>wrap-ticket</code> write files.</li>
+<li>Most agents are read-only analysis/planning. <code>engineer</code>, <code>adr-generator</code>, <code>release-orchestrator</code>, <code>learning-extractor</code>, <code>learnings-agent</code>, <code>wrap-ticket</code>, and <code>product-discovery</code> write files.</li>
 </ul>
 <div class="callout">
 The main thread never sees their raw work - only their conclusion. That's the whole point: heavy work without heavy context.

--- a/docs/slides/agent-team-slides.md
+++ b/docs/slides/agent-team-slides.md
@@ -249,7 +249,7 @@ Think of named agents as a small team of specialists you can dispatch. The main 
 - Spawned into their own **isolated worktree** - their own files, their own context
 - Given a **structured brief** - goal, constraints, acceptance criteria, non-goals
 - Do their narrow job and return a **structured result** - not raw transcript
-- Most agents are read-only analysis/planning. `engineer`, `adr-generator`, `release-orchestrator`, `learning-extractor`, `learnings-agent`, and `wrap-ticket` write files.
+- Most agents are read-only analysis/planning. `engineer`, `adr-generator`, `release-orchestrator`, `learning-extractor`, `learnings-agent`, `wrap-ticket`, and `product-discovery` write files.
 
 <div class="callout">
 The main thread never sees their raw work - only their conclusion. That's the whole point: heavy work without heavy context.


### PR DESCRIPTION
Follow-up to #590: docs/slides/agent-team-slides listed 6 writing agents; the tools: frontmatter ground truth is 7 (product-discovery was missing). HTML regenerated via scripts/build-slides.sh (Skeptic byte-verified against a fresh render, not hand-edited).

Skeptic sign-off: 0 Critical, 0 Major, 1 Minor (pre-existing contradiction in content/references/agent-team.md:11, handled in a separate follow-up).