### PR TITLE
DS-144: gate the CLAUDE.md rewrite under --dry-run, surface the skill-link gap

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -35,6 +35,11 @@
 #     already holds a valid DIFFERENT repo_dir, a warning is printed and the
 #     existing value is preserved. Only absent/invalid/same values are written.
 #   - All interactive prompts fall back to a default when stdin is not a TTY.
+#   - A skipped or not-yet-created skill symlink sets SKILL_LINK_OK=false and
+#     emits an operator warning twice per run (once where the skip is
+#     detected, once in the Summary block). Every --dry-run on a machine
+#     without an existing, correctly-pointed skill link falls into this case
+#     and emits the warning, since --dry-run never creates the symlink.
 #
 # Performance: ~5-10 s (one build pass, node/python3 calls for hooks/settings).
 # ---------------------------------------------------------------------------
@@ -491,12 +496,16 @@ else
   fi
 fi
 
-if [[ "$SKILL_LINK_OK" != "true" ]]; then
-  echo ""
+_ae_skill_link_warning() {
   echo "  WARNING: the agentic-engineering skill is not linked to this checkout ($SKILL_LINK_REASON)."
   echo "  CLAUDE.md's managed block may reference the skill; the reference will not resolve"
   echo "  until the link is established. Re-run without --dry-run, or resolve the noted"
   echo "  conflict above and re-run install.sh."
+}
+
+if [[ "$SKILL_LINK_OK" != "true" ]]; then
+  echo ""
+  _ae_skill_link_warning
 fi
 
 # ---------------------------------------------------------------------------
@@ -1618,10 +1627,7 @@ echo "  add 'agentic-engineering: opt-in' to its AGENTS.md, and the methodology 
 _ae_identity_guidance
 echo ""
 if [[ "$SKILL_LINK_OK" != "true" ]]; then
-  echo "  WARNING: the agentic-engineering skill is not linked to this checkout ($SKILL_LINK_REASON)."
-  echo "  CLAUDE.md's managed block may reference the skill; the reference will not resolve"
-  echo "  until the link is established. Re-run without --dry-run, or resolve the noted"
-  echo "  conflict above and re-run install.sh."
+  _ae_skill_link_warning
   echo ""
 fi
 echo "Next steps (for the agent running this installer):"

--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -18,8 +18,9 @@
 #     config dir (agents/commands/skills/settings/CLAUDE.md/agentic-engineering.json)
 #     to <dir> for per-profile installs. Shared state (~/.agentic, ~/.local/bin,
 #     ~/.claude.json) always stays in the real $HOME. Default: ~/.claude.
-#   --dry-run: print symlink actions and repo_dir write intent without executing
-#              them. Hook wiring, build, and permission phases still execute.
+#   --dry-run: print symlink actions, the CLAUDE.md managed-block update
+#              intent, and repo_dir write intent without executing them.
+#              Hook wiring, build, and permission phases still execute.
 #
 # Upstream deps: bash 3.2+, python3, git, node (for hooks), ln, readlink.
 #
@@ -437,6 +438,9 @@ done
 # Symlink skill
 # ---------------------------------------------------------------------------
 
+SKILL_LINK_OK=true
+SKILL_LINK_REASON=""
+
 echo "Linking skill: agentic-engineering..."
 
 mkdir -p "$(dirname "$SKILLS_DST")"
@@ -449,6 +453,8 @@ if [[ -L "$SKILLS_DST" ]]; then
     # Stale symlink pointing to another methodology checkout - re-point it.
     if [[ "$AE_DRY_RUN" == "true" ]]; then
       echo "  ~ engineering (would re-point to repo_dir)"
+      SKILL_LINK_OK=false
+      SKILL_LINK_REASON="dry-run: stale symlink not re-pointed"
     else
       ln -sfn "$SKILLS_SRC" "$SKILLS_DST"
       echo "  ~ engineering (re-pointed to repo_dir)"
@@ -456,23 +462,41 @@ if [[ -L "$SKILLS_DST" ]]; then
   else
     if [[ "$AE_DRY_RUN" == "true" ]]; then
       echo "  ! engineering (would skip: symlink points outside methodology checkout: $current_target)"
+      SKILL_LINK_OK=false
+      SKILL_LINK_REASON="symlink points outside methodology checkout: $current_target"
     else
       echo "  ! engineering (symlink points elsewhere: $current_target - skipping)"
+      SKILL_LINK_OK=false
+      SKILL_LINK_REASON="symlink points outside methodology checkout: $current_target"
     fi
   fi
 elif [[ -e "$SKILLS_DST" ]]; then
   if [[ "$AE_DRY_RUN" == "true" ]]; then
     echo "  ! engineering (would skip: real file/directory exists at destination)"
+    SKILL_LINK_OK=false
+    SKILL_LINK_REASON="real file/directory exists at destination"
   else
     echo "  ! engineering (real file/directory exists at destination - skipping)"
+    SKILL_LINK_OK=false
+    SKILL_LINK_REASON="real file/directory exists at destination"
   fi
 else
   if [[ "$AE_DRY_RUN" == "true" ]]; then
     echo "  + agentic-engineering (would create)"
+    SKILL_LINK_OK=false
+    SKILL_LINK_REASON="dry-run: symlink not created"
   else
     ln -s "$SKILLS_SRC" "$SKILLS_DST"
     echo "  + agentic-engineering"
   fi
+fi
+
+if [[ "$SKILL_LINK_OK" != "true" ]]; then
+  echo ""
+  echo "  WARNING: the agentic-engineering skill is not linked to this checkout ($SKILL_LINK_REASON)."
+  echo "  CLAUDE.md's managed block may reference the skill; the reference will not resolve"
+  echo "  until the link is established. Re-run without --dry-run, or resolve the noted"
+  echo "  conflict above and re-run install.sh."
 fi
 
 # ---------------------------------------------------------------------------
@@ -1004,6 +1028,12 @@ fi
 # Update ~/.claude/CLAUDE.md
 # ---------------------------------------------------------------------------
 
+# DS-143: when the @-imports are removed from managed_content below, decide
+# whether this write should be gated on SKILL_LINK_OK (set in the skill-symlink
+# block above). Do not remove the imports without making that call.
+if [[ "$AE_DRY_RUN" == "true" ]]; then
+  echo "  [dry-run] would update managed-by-agentic-engineering section in $AE_CONFIG_DIR/CLAUDE.md"
+else
 echo "Updating $AE_CONFIG_DIR/CLAUDE.md..."
 
 AE_CONFIG_DIR="$AE_CONFIG_DIR" python3 - <<'PYEOF'
@@ -1066,6 +1096,7 @@ else:
     else:
         print("  + Created ~/.claude/CLAUDE.md with managed-by-agentic-engineering section")
 PYEOF
+fi
 
 # ---------------------------------------------------------------------------
 # Write repo_dir to ~/.agentic/agentic-engineering-config.json (guarded)
@@ -1586,6 +1617,13 @@ echo "  agentic-engineering is installed. Open a new Claude Code session in any 
 echo "  add 'agentic-engineering: opt-in' to its AGENTS.md, and the methodology activates."
 _ae_identity_guidance
 echo ""
+if [[ "$SKILL_LINK_OK" != "true" ]]; then
+  echo "  WARNING: the agentic-engineering skill is not linked to this checkout ($SKILL_LINK_REASON)."
+  echo "  CLAUDE.md's managed block may reference the skill; the reference will not resolve"
+  echo "  until the link is established. Re-run without --dry-run, or resolve the noted"
+  echo "  conflict above and re-run install.sh."
+  echo ""
+fi
 echo "Next steps (for the agent running this installer):"
 echo ""
 echo "  Offer the user a quick orientation. Ask which of the following they'd"

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -348,6 +348,11 @@ _run_install "$FAKE_HOME" --dry-run || true
 # See case (e)'s note re: the rc assertion - DROPPED here per the same
 # empirically-determined A2 decision (scrubbed-PATH pre-check returned
 # rc=1; any doubt means drop from both cases together).
+if grep -Fq "[dry-run] would update managed-by-agentic-engineering" "$FAKE_HOME/.install_out"; then
+  _pass "case (e2): dry-run output names the CLAUDE.md intent (proves the run reached the CLAUDE.md phase)"
+else
+  _fail "case (e2): dry-run output missing CLAUDE.md intent line (absence assertion below is unanchored)"
+fi
 if [[ ! -f "$FAKE_HOME/.claude/CLAUDE.md" ]]; then
   _pass "case (e2): --dry-run creates no CLAUDE.md when absent"
 else
@@ -357,6 +362,16 @@ if grep -Fq "WARNING: the agentic-engineering skill is not linked to this checko
   _pass "case (e2): SKILL_LINK_OK warning fires when the skill link was never established under dry-run"
 else
   _fail "case (e2): SKILL_LINK_OK warning did not fire on fresh dry-run"
+fi
+# The warning is emitted at two call sites (the skill-symlink block and the
+# Summary block, per addendum A5) - a plain at-least-once grep above matches
+# the first occurrence and would stay green even if the second (Summary)
+# emission drifted or was deleted outright. Pin the count explicitly.
+_e2_warning_count="$(grep -Fc "WARNING: the agentic-engineering skill is not linked to this checkout" "$FAKE_HOME/.install_out")"
+if [[ "$_e2_warning_count" -eq 2 ]]; then
+  _pass "case (e2): SKILL_LINK_OK warning fires exactly twice (skill-symlink block + Summary block)"
+else
+  _fail "case (e2): SKILL_LINK_OK warning fired $_e2_warning_count time(s), expected exactly 2"
 fi
 rm -rf "$FAKE_HOME"
 

--- a/.claude/tests/install-converge.test.sh
+++ b/.claude/tests/install-converge.test.sh
@@ -15,7 +15,9 @@
 #                All side effects use TEMP HOME dirs; the real ~/.claude and
 #                ~/.agentic are NEVER touched.
 #
-# Performance: ~10 s wall time (runs install.sh multiple times with fake HOME).
+# Performance: ~30 s wall time (12 install.sh invocations after this change,
+#              up from 11; each runs two full adapter builds against the
+#              real checkout).
 #
 # Regression coverage:
 #   - Change 1: stale "ours" symlink (target under .../DinoStack/...) is
@@ -24,6 +26,15 @@
 #   - Change 1: a real file at dst is left untouched (skip).
 #   - Change 1: a symlink pointing outside any methodology checkout is skipped.
 #   - Change 2: --dry-run makes no filesystem changes.
+#   - Change 2 (extended, DS-144): --dry-run leaves an existing CLAUDE.md
+#     managed block byte-identical (case (e)), and creates no CLAUDE.md at
+#     all when one never existed (case (e2)).
+#   - Case (a) positive control (DS-144): a non-dry-run install still writes
+#     a complete CLAUDE.md managed block (both markers present), guarding
+#     against an over-gating fix that deletes the write entirely instead of
+#     wrapping it. Also asserts SKILL_LINK_OK's warning does NOT fire when
+#     the skill symlink is freshly established; case (e2) asserts it DOES
+#     fire when the skill link was never established under a fresh dry-run.
 #   - Change 3: clobber guard - valid DIFFERENT repo_dir is NOT overwritten;
 #     absent/invalid repo_dir IS written.
 #   - Case (g): legacy path-scoped Write(<cfg>/**) / Write(<cfg>/projects/**)
@@ -144,6 +155,25 @@ else
   _fail "case (a): install output did not include '~ $FIXTURE_NAME' indicator"
 fi
 
+# Positive control (DS-144): a non-dry-run install still writes a complete
+# CLAUDE.md managed block, guarding against an over-gating fix that deletes
+# the write entirely instead of wrapping it. Also asserts SKILL_LINK_OK's
+# warning does NOT fire when the skill symlink freshly links (this fixture's
+# only pre-populated dir is .claude/agents, so $SKILLS_DST is absent and the
+# real `ln -s` runs).
+if [[ -f "$FAKE_HOME/.claude/CLAUDE.md" ]] \
+   && grep -Fq "BEGIN managed-by-agentic-engineering" "$FAKE_HOME/.claude/CLAUDE.md" \
+   && grep -Fq "END managed-by-agentic-engineering" "$FAKE_HOME/.claude/CLAUDE.md"; then
+  _pass "case (a): non-dry-run install still writes CLAUDE.md with both markers"
+else
+  _fail "case (a): non-dry-run install did not write a complete managed CLAUDE.md block"
+fi
+if grep -Fq "WARNING: the agentic-engineering skill is not linked to this checkout" "$FAKE_HOME/.install_out"; then
+  _fail "case (a): SKILL_LINK_OK warning fired even though the skill was freshly linked"
+else
+  _pass "case (a): no SKILL_LINK_OK warning when the skill links successfully"
+fi
+
 rm -rf "$FAKE_HOME"
 
 # ---------------------------------------------------------------------------
@@ -239,7 +269,28 @@ mkdir -p "$FAKE_HOME/.claude/agents"
 ln -s "/nonexistent/DinoStack/old/$FIXTURE_NAME" "$FAKE_HOME/.claude/agents/$FIXTURE_NAME"
 OLD_TARGET="$(readlink "$FAKE_HOME/.claude/agents/$FIXTURE_NAME")"
 
+# Also exercises DS-144: --dry-run must leave an existing CLAUDE.md managed
+# block byte-identical, and must print the CLAUDE.md dry-run intent line.
+mkdir -p "$FAKE_HOME/.claude"
+cat > "$FAKE_HOME/.claude/CLAUDE.md" <<'EOF'
+<!-- BEGIN managed-by-agentic-engineering -->
+placeholder managed content
+<!-- END managed-by-agentic-engineering -->
+EOF
+before_sha="$(shasum -a 256 "$FAKE_HOME/.claude/CLAUDE.md" | awk '{print $1}')"
+if [[ -z "$before_sha" ]]; then
+  _fail "case (e): could not compute before_sha (fixture write failed?)"
+fi
+
 _run_install "$FAKE_HOME" --dry-run || true
+# NOTE (DS-144, A2): a scrubbed-PATH empirical pre-check
+# (`env PATH=/usr/bin:/bin bash .claude/install.sh --mode=opt-out
+# --profile=default --dry-run < /dev/null; echo "rc=$?"`) returned rc=1
+# (ModuleNotFoundError: yaml, reached via the initial adapter build phase
+# which still runs under --dry-run). Per the plan's A2 addendum, any doubt
+# means dropping the rc assertion from BOTH case (e) and case (e2) - the
+# grep assertions below already satisfy the anti-vacuous-green requirement
+# on their own.
 
 # Symlink must NOT have been changed.
 if [[ -L "$FAKE_HOME/.claude/agents/$FIXTURE_NAME" ]]; then
@@ -267,6 +318,46 @@ else
   _fail "case (e): --dry-run created ~/.agentic/agentic-engineering-config.json (must not mutate config)"
 fi
 
+# DS-144: --dry-run must leave the existing CLAUDE.md managed block
+# byte-identical. Skip the comparison entirely when before_sha is empty
+# (A6) - otherwise an empty-to-empty match would emit a spurious PASS for
+# a fixture-write failure the earlier _fail already flagged.
+if [[ -n "$before_sha" ]]; then
+  after_sha="$(shasum -a 256 "$FAKE_HOME/.claude/CLAUDE.md" | awk '{print $1}')"
+  if [[ "$before_sha" == "$after_sha" ]]; then
+    _pass "case (e): --dry-run leaves CLAUDE.md byte-identical"
+  else
+    _fail "case (e): --dry-run modified CLAUDE.md"
+  fi
+fi
+if grep -Fq "[dry-run] would update managed-by-agentic-engineering" "$FAKE_HOME/.install_out"; then
+  _pass "case (e): dry-run output names the CLAUDE.md intent"
+else
+  _fail "case (e): dry-run output missing CLAUDE.md intent line"
+fi
+
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Case (e2): --dry-run on a machine that has never had ~/.claude/CLAUDE.md
+#            creates none. This is the literal "fresh machine" scenario
+#            DS-144's ticket describes.
+# ---------------------------------------------------------------------------
+FAKE_HOME="$(mktemp -d)"
+_run_install "$FAKE_HOME" --dry-run || true
+# See case (e)'s note re: the rc assertion - DROPPED here per the same
+# empirically-determined A2 decision (scrubbed-PATH pre-check returned
+# rc=1; any doubt means drop from both cases together).
+if [[ ! -f "$FAKE_HOME/.claude/CLAUDE.md" ]]; then
+  _pass "case (e2): --dry-run creates no CLAUDE.md when absent"
+else
+  _fail "case (e2): --dry-run created CLAUDE.md on a fresh machine"
+fi
+if grep -Fq "WARNING: the agentic-engineering skill is not linked to this checkout" "$FAKE_HOME/.install_out"; then
+  _pass "case (e2): SKILL_LINK_OK warning fires when the skill link was never established under dry-run"
+else
+  _fail "case (e2): SKILL_LINK_OK warning did not fire on fresh dry-run"
+fi
 rm -rf "$FAKE_HOME"
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The following flags work for all adapters (`.claude`, `.cursor`, `.codex`, `.gem
 ```
 bash .claude/install.sh --identity=<handle>   # set developer identity (GitHub handle) non-interactively
 bash .claude/install.sh --no-identity          # skip the developer-identity prompt
-bash .claude/install.sh --dry-run             # preview symlink + repo_dir changes; hook, build, and permission phases still execute
+bash .claude/install.sh --dry-run             # preview symlink, CLAUDE.md managed-block update, and repo_dir changes; hook, build, and permission phases still execute
 ```
 
 **Changing mode later:** rerun any adapter's installer with `--mode=<value>` to overwrite the config, or edit `~/.claude/agentic-engineering.json` directly.


### PR DESCRIPTION
## North Star alignment

Restores `--dry-run`'s documented no-op contract for the CLAUDE.md managed block, and surfaces a related real-run gap (`SKILL_LINK_OK`) where a skipped skill-symlink left the methodology unreachable while CLAUDE.md still wrote unconditionally. Serves "works for everyone": a preview flag must never have side effects that degrade a subsequent real install's starting state, and a failed symlink must be visible to the operator, not silent. No pillar trade-offs.

## Summary

- Gates the `~/.claude/CLAUDE.md` managed-block rewrite on `AE_DRY_RUN`. `--dry-run` previously rewrote the file for real, despite being a documented public preview flag.
- Adds `SKILL_LINK_OK` / `SKILL_LINK_REASON`, set false in all six skill-symlink branches that do not end with a live link, with an operator warning emitted after the symlink block and again in the summary.
- Extends `.claude/tests/install-converge.test.sh` (which already owns the "dry-run makes no filesystem changes" contract) rather than adding a parallel harness.
- `README.md` `--dry-run` description synced with the install.sh docstring.

## Deliberately NOT done: gating the CLAUDE.md write on `SKILL_LINK_OK`

The warning is warn-only. The real-run gap is **mitigated (made visible), not closed** - that distinction is stated in the code and the plan rather than glossed.

Gating today would be a regression: `managed_content` still carries the `@`-imports, so a failed-link user currently gets a full managed block whose imports do not resolve. Gating would give them *no managed block at all*, losing the Skill Loading table too. Verified against the code: with a gate, `install.sh:1055-1067` never runs on a fresh install.

Gating becomes correct only once DS-143 removes those imports. A bash comment sits directly above the write, inside the region DS-143 must edit, so the decision cannot be missed at the keyboard; the same handoff is on the DS-143 ticket.

## Scope boundary with DS-143 (concurrent)

DS-144 owns the `AE_DRY_RUN` guard and the skill-symlink branches. DS-143 owns `managed_content`. The `managed_content` heredoc span is **byte-identical to `origin/main`** across both commits here - sha256 `96f143c5a7fd4662619dacb1c2acb033136929c40bf791e31fbd0d9e4d41fd84`, 2331 bytes, all `PYEOF` terminators at column 0 (an indented terminator is a parse error that would brick `install.sh` for every consumer, including `bootstrap.sh`).

## Test plan

- `bash .claude/tests/install-converge.test.sh` - **31 passed, 0 failed** (baseline 29). No new `install.sh` invocation beyond case (e2)'s one.
- `bash -n` and `zsh -n` clean on `install.sh`; `bash -n` clean on the test file.
- Case (e): existing CLAUDE.md left byte-identical under `--dry-run`, plus a dry-run-intent output anchor.
- Case (e2): fresh machine, no CLAUDE.md created, warning fires, anchored to the CLAUDE.md phase actually being reached.
- Case (a): positive control - a real install still writes a complete managed block, and the warning stays silent when the link succeeds. This is what catches over-gating.
- **Mutation-verified, reproduced independently by review:** reverting the gate reddens 4 assertions; disabling the write reddens case (a); removing the summary emission reddens the exact-count assertion (`30 passed, 1 failed`). Pre-fix `install.sh` against the final test file reddens all 6 new assertions. No new assertion is vacuous.
- `rc == 0` assertions were considered and **dropped**: a scrubbed-PATH pre-check (`env PATH=/usr/bin:/bin`) returns rc=1 from a missing python `yaml` module in the adapter-build phase, which runs even under `--dry-run`. Adopting them would have made a CI-wired suite flaky repo-wide.

Closes DS-144.
