### PR TITLE
DS-142: drop stale deck count from marp toolchain description

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-engineering-slides-build",
   "private": true,
-  "description": "Pinned Marp toolchain for scripts/build-slides.sh - upgrading marp is an intentional same-PR action (bump these, regenerate lock, rebuild all 15 .html).",
+  "description": "Pinned Marp toolchain for scripts/build-slides.sh - upgrading marp is an intentional same-PR action (bump these, regenerate lock, rebuild every deck's .html).",
   "dependencies": {
     "@marp-team/marp-cli": "4.4.0",
     "@marp-team/marp-core": "4.3.0",


### PR DESCRIPTION
## Summary
- `scripts/package.json` claimed "rebuild all 15 .html" while the live deck count is 18 (`ls docs/slides/*-slides.md | wc -l`).
- Replaced the hardcoded count with a count-free formulation rather than 15 -> 18, so it cannot go stale again. No CI gate checks this string.
- Same fix shape already applied to `docs/slides/AGENTS.md`.

Out of scope, deliberately: `CHANGELOG.md:582` also says "15 Marp decks", but that is an accurate historical record of PR #185 at merge time. `scripts/package-lock.json` does not mirror the description field (verified).

Refs DS-142

## North Star alignment
- **Works for everyone (universality):** removing the hardcoded count makes the string correct for any checkout at any deck count, rather than correct only at one moment for one repo state.
- **Intent debt:** a build-toolchain description that misstates the artifact set is exactly the class of stale assertion that misleads the next person touching `scripts/build-slides.sh`.
- No behavior, no gate, no adapter surface changes.

## Test plan
- [x] `git diff --stat`: 1 file, 1 insertion, 1 deletion
- [x] `scripts/package.json` still parses as valid JSON
- [x] No em dashes introduced in the diff
- [x] DCO: author email equals `Signed-off-by` email (checked with lowercase `%ae`)
- [ ] CI green on all required checks
