### PR TITLE
feat(DS): add prose-move-impact enumerator for ds-implement-ticket.md split

### DIFF
--- a/bin/tests/test_prose_move_impact.py
+++ b/bin/tests/test_prose_move_impact.py
@@ -99,16 +99,36 @@ TARGET = "content/commands/ds-implement-ticket.md"
 # ---------------------------------------------------------------------------
 
 
-def _heading_index() -> dict[str, "pmi.Heading"]:
+def _heading_index() -> tuple[dict[str, "pmi.Heading"], dict[str, int]]:
     target_path = REPO_ROOT / TARGET
     lines = target_path.read_text(encoding="utf-8").split("\n")
-    return {h.text: h for h in pmi.fence_aware_headings(lines)}
+    headings = pmi.fence_aware_headings(lines)
+    # This dict comprehension is last-wins on a duplicate heading text,
+    # while the tool's own extract_heading_block_assertions (line ~672) is
+    # first-wins via `next(...)` - the two disagree on which occurrence a
+    # duplicate heading resolves to. Rather than silently picking either
+    # one, track per-text counts so _range_for_heading can fail loud on any
+    # duplicate instead of guessing which occurrence the fixture meant.
+    counts: dict[str, int] = {}
+    for h in headings:
+        counts[h.text] = counts.get(h.text, 0) + 1
+    return {h.text: h for h in headings}, counts
 
 
-_HEADINGS = _heading_index()
+_HEADINGS, _HEADING_COUNTS = _heading_index()
 
 
 def _range_for_heading(heading_text: str, dest: str) -> "pmi.MoveRange":
+    count = _HEADING_COUNTS.get(heading_text, 0)
+    if count > 1:
+        raise AssertionError(
+            f"heading text {heading_text!r} appears {count} times in the live target - "
+            "ambiguous: this index is last-wins while the tool's own "
+            "extract_heading_block_assertions is first-wins, so picking either occurrence "
+            "here would not provably match what the tool itself resolves. Disambiguate the "
+            "fixture with a more specific heading text, or resolve the duplicate in the "
+            "live target, before using this heading in a proposed range."
+        )
     h = _HEADINGS.get(heading_text)
     if h is None:
         raise AssertionError(
@@ -551,6 +571,61 @@ def test_regression_regex_assertion_matches_across_a_newline():
         "a DOTALL pattern spanning the alpha/beta newline must match against "
         "the whole target text - a per-line scan sees zero matches here"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Major (r3 Skeptic finding) - the zero-match "cannot break"
+# reclassification was unsound whenever this tool's matching granularity
+# (whole-text) differs from the consumer's real granularity. Round 1's fix
+# (compile flags) and round 2's fix (whole-text over per-line) each fixed a
+# DIFFERENT cause of the same false-clean-pass shape without fixing the
+# shape itself - a THIRD cause (an anchored, non-MULTILINE pattern that a
+# consumer applies per-token, e.g. `.match(name)` against an extracted
+# identifier) still produced whole-text zero while the real per-consumer
+# match count was nonzero. This mirrors the live
+# bin/tests/lib/md_shell_extract.py::_IDENTIFIER_RE case: 0 matches
+# whole-text, 29 matches per-line, 7 inside a proposed move range. The fix
+# deletes the reclassification entirely - a zero-match regex assertion is
+# now always UNRESOLVED, never inferred non-breaking.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_zero_whole_text_matches_never_resolved_non_breaking():
+    """A round-3 regression: an anchored (^...$), non-MULTILINE pattern that
+    matches every individual line but zero times against the whole target
+    text (anchors bind to the whole string's start/end, not per-line,
+    without re.MULTILINE). Pre-fix, this whole-text zero was silently
+    reclassified `resolved=True, breaks=False` ('zero pre-move matches
+    means this move cannot change the assertion's outcome either way'),
+    discarding the fact that the consumer applies the pattern with
+    different granularity (e.g. per-token via `.match(name)`) than this
+    tool's own whole-text scan. Confirmed failing pre-fix: the old code
+    appended a resolved, non-breaking Assertion and emitted nothing to
+    `unresolved` for this exact case."""
+    consumer_text = (
+        "import re\n"
+        "_TOKEN_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')\n"
+        "def check(name):\n"
+        "    return bool(_TOKEN_RE.match(name))\n"
+    )
+    # Every individual line is a bare identifier, but the whole text never
+    # matches ^...$ without re.MULTILINE: '^' only binds to offset 0 and
+    # '$' only to the string's end, and there is a newline directly after
+    # 'alpha'.
+    target_text = "alpha\nbeta\ngamma\n"
+    line_starts = pmi.build_line_starts(target_text)
+    ranges = [pmi.MoveRange(start=2, end=2, dest="content/references/scratch.md")]
+    assertions, unresolved = pmi.extract_regex_assertions(
+        "scratch_consumer.py", consumer_text, target_text, line_starts, ranges
+    )
+    assert not assertions, (
+        "a zero-match regex assertion must never be resolved as "
+        "non-breaking - it must always surface as UNRESOLVED so a human "
+        "verifies the consumer's real matching granularity by hand"
+    )
+    hits = [u for u in unresolved if "_TOKEN_RE" in u.detail]
+    assert hits, "expected an UNRESOLVED row for _TOKEN_RE, not a silent resolved pass"
+    assert "ZERO" in hits[0].detail
 
 
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_prose_move_impact.py
+++ b/bin/tests/test_prose_move_impact.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
 """
-Purpose: Known-answer and mutation tests for scripts/prose-move-impact.py -
-         the mechanical "what breaks if I move these line ranges" enumerator
-         built to replace four failed prose-only review rounds on splitting
+Purpose: Known-answer, regression, mutation, and DIFFERENTIAL tests for
+         scripts/prose-move-impact.py - the mechanical "what breaks if I
+         move these line ranges" enumerator built to replace four failed
+         prose-only review rounds on splitting
          content/commands/ds-implement-ticket.md. Each known-answer case
          below is a REAL, previously-verified miss from those rounds, not a
-         synthetic example.
+         synthetic example. The differential test at the bottom
+         (test_differential_against_ground_truth_post_move_gates) is the
+         load-bearing one: it simulates the actual post-move tree in a
+         scratch git repo and runs the REAL executable gates against it,
+         comparing their real pass/fail to the tool's prediction - the
+         only check here that can catch a NEW under-report class rather
+         than re-confirming a named one.
 
 Public API: pytest test module. Run with
               python3 -m pytest bin/tests/test_prose_move_impact.py -q
@@ -19,7 +26,10 @@ Upstream deps: scripts/prose-move-impact.py (imported by path, since
                consumers (bin/tests/test_tracker_dev_complete_spec.py,
                bin/tests/test_tasks_jsonl_fold.sh,
                bin/tests/test_batch_state_timestamp_field.sh,
-               bin/tests/test_loop_state_site_coverage.sh).
+               bin/tests/test_loop_state_site_coverage.sh); the entire
+               content/ tree and the two scratch-copied shell gates named
+               in `SCRATCH_GATES` (differential test only, via a scratch
+               git repo under pytest's `tmp_path`).
 
 Downstream consumers: none (leaf test module).
 
@@ -31,10 +41,16 @@ Failure modes: a known-answer test failing means either the tool regressed,
                tool's own discovery step and asserts the suite goes red;
                a green mutation test means the tool would silently report
                "nothing breaks" on total discovery failure - exactly the
-               failure mode design constraint prohibits.
+               failure mode design constraint prohibits. The differential
+               test failing means the tool reported a consumer CLEAN that
+               actually fails against the real, simulated post-move tree -
+               disqualifying by design; it never fails on the opposite
+               (over-report) direction, which is recorded but tolerated.
 
-Performance: single-digit seconds; a handful of `git grep` subprocess calls
-             plus small in-repo file reads.
+Performance: single-digit seconds; a handful of `git grep` subprocess calls,
+             small in-repo file reads, and (differential test only) one
+             `content/`-tree copy (~2 MB) plus two real shell-gate runs
+             against a scratch git repo under `tmp_path`.
 """
 
 from __future__ import annotations
@@ -148,8 +164,20 @@ def test_known_answer_tasks_jsonl_fold_heredoc_floor_breaks():
     assert hits, "expected a grep_count_floor assertion for test_tasks_jsonl_fold.sh"
     breaking = [a for a in hits if a.breaks]
     assert breaking, "FOLDSPEC per-file floor for the target file must break: before=14, after=4, floor>=7"
-    assert "after=4" in breaking[0].detail
-    assert "floor >= 7" in breaking[0].detail
+    foldspec_hits = [a for a in breaking if "FOLDSPEC" in a.detail]
+    assert foldspec_hits, f"expected the FOLDSPEC heredoc floor among breaking hits, got: {[a.detail for a in breaking]}"
+    assert "after=4" in foldspec_hits[0].detail
+    assert "floor >= 7" in foldspec_hits[0].detail
+    # G6's own simple `VAR="$(git grep -cE ... -- "$DIT")"` floor (>= 1) is a
+    # SEPARATE grep_count_floor assertion from the FOLDSPEC heredoc table
+    # above - its only occurrence (line 1448) sits inside the 1369-1458
+    # move range, so before=1/after=0 must ALSO break. This was silently
+    # dropped pre-fix: `_VAR_ASSIGN_RE` required the `$(...)` to end the
+    # line, but this exact call site has a trailing `; [ -n "$G6" ] ||
+    # G6=0` statement after it.
+    g6_hits = [a for a in breaking if "G6" in a.detail and "is in_progress under another session" in a.detail]
+    assert g6_hits, f"expected G6's own floor among breaking hits, got: {[a.detail for a in breaking]}"
+    assert "before=1" in g6_hits[0].detail and "after=0" in g6_hits[0].detail
     assert not report.ok
 
 
@@ -183,6 +211,36 @@ def test_known_answer_batch_state_timestamp_field_has_8_absent_calls():
     absent_calls = [l for l in absent_calls if not l.strip().startswith("_absent()")]
     assert len(absent_calls) == 8, (
         f"expected 8 _absent call sites in test_batch_state_timestamp_field.sh, "
+        f"found {len(absent_calls)}: {absent_calls}"
+    )
+
+
+def test_known_answer_batch_state_timestamp_field_joiner_actually_joins_continuations():
+    """Non-vacuity guard for `join_shell_continuations` itself, not just for
+    the fixture's call count above: the previous version of this fixture
+    (`l.strip().startswith("_absent ")`) is satisfied by the UNjoined first
+    physical line of every split call too - `_absent "$SPEC" "label" \\`
+    already starts with `_absent ` before any joining happens, so disabling
+    the continuation loop (`while False:`) left the suite green (14 passed,
+    confirmed by the reviewer). This predicate additionally requires the
+    logical line to END with the pattern's closing quote - true only when
+    the trailing-backslash continuation line (which carries the quoted
+    pattern, not the `_absent` keyword) has actually been joined onto the
+    call line. Disabling the joiner leaves the pattern on its own orphan
+    physical line, which never starts with `_absent `, so the count below
+    drops to 0 and this test goes red - unlike its predecessor."""
+    path = REPO_ROOT / "bin" / "tests" / "test_batch_state_timestamp_field.sh"
+    text = path.read_text(encoding="utf-8")
+    joined = [logical for _, logical in pmi.join_shell_continuations(text)]
+    absent_calls = [
+        l
+        for l in joined
+        if l.strip().startswith("_absent ") and l.rstrip().endswith(("'", '"'))
+    ]
+    absent_calls = [l for l in absent_calls if not l.strip().startswith("_absent()")]
+    assert len(absent_calls) == 8, (
+        f"expected 8 joined _absent call sites (call + closing quote of its "
+        f"continuation line) in test_batch_state_timestamp_field.sh, "
         f"found {len(absent_calls)}: {absent_calls}"
     )
 
@@ -274,6 +332,80 @@ def test_doc_consumers_are_not_mechanically_gated_as_breaking():
 
 
 # ---------------------------------------------------------------------------
+# Regression: Critical 1 (r1 Skeptic finding) - ERE grep patterns with
+# regex metacharacters (`.`, `\+`) were matched via a naive literal
+# substring find(), silently dropped when that found zero occurrences even
+# though `grep -qiE` matches the same pattern against the live target fine.
+# Confirmed failing pre-fix: this exact assertion produced ZERO BREAKING
+# rows and ZERO UNRESOLVED entries for test_batch_state_timestamp_field.sh
+# before the `_target_regex_occurrences`/`_resolve_literal_in_target` fix.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_ere_metachar_pattern_resolves_via_regex_not_literal_find():
+    ranges = _ranges(
+        (801, 851, "content/references/batch-mode.md"),
+        (852, 940, "content/references/batch-mode.md"),
+    )
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_batch_state_timestamp_field.sh"
+        and "status=active" in a.detail
+        and "10 min" in a.detail
+    ]
+    assert hits, (
+        "expected the ERE-metachar patterns ('status=active. AND .updated_at "
+        "> 10 min. ago' / '...<=10 min...') to resolve as literal_presence "
+        "assertions, not vanish silently"
+    )
+    assert any(a.breaks for a in hits), "these patterns' only target lines fall inside the move range"
+    assert any("resolved via ERE match" in a.detail for a in hits), (
+        "expected at least one hit to be explicitly tagged as ERE-resolved "
+        "(not a literal substring match)"
+    )
+
+
+def test_regression_ere_pattern_with_backslash_escaped_parens_is_extracted_at_all():
+    """A stricter regression than the above: this pattern's backslash-
+    escaped parens (`\\(session_id=<X>, updated_at=<Y>\\)`) made the OLD
+    `_STR_RE` never even extract it as a candidate literal in the first
+    place (its single-quote branch excluded any backslash from quoted
+    content) - a distinct, earlier failure than the literal-vs-regex
+    resolution gap the other regression test above covers."""
+    ranges = _ranges((801, 851, "content/references/batch-mode.md"))
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_batch_state_timestamp_field.sh"
+        and "session_id=<X>, updated_at=<Y>" in a.detail
+    ]
+    assert hits, "backslash-escaped-paren ERE pattern must be extracted and resolved, not silently dropped"
+
+
+# ---------------------------------------------------------------------------
+# Regression: Major 4 (r1 Skeptic finding) - analyze() returned a vacuous
+# "OK" report when discovery found consumers but ZERO of them matched
+# `_is_checked_consumer` (e.g. a bin/tests/ rename or SEARCH_DIRS drift).
+# ---------------------------------------------------------------------------
+
+
+def test_regression_zero_checked_consumers_is_not_a_silent_pass():
+    with mock.patch.object(pmi, "_is_checked_consumer", return_value=False):
+        report = pmi.analyze(REPO_ROOT, TARGET, _ranges((480, 548, "content/references/tracker-writeback.md")))
+    assert not report.ok, (
+        "zero CHECKED consumers (as opposed to zero discovered consumers, "
+        "already covered by the mutation test below) must not silently "
+        "report OK - this is the second, narrower non-vacuity guard"
+    )
+    assert any(
+        u.consumer == "<discovery>" and "checked-consumer" in u.detail for u in report.unresolved
+    )
+
+
+# ---------------------------------------------------------------------------
 # Mutation test: neuter discovery, confirm the suite goes red rather than
 # silently reporting OK. This is the tool's own "fail loud, never silently
 # skip" design constraint, made executable.
@@ -301,6 +433,124 @@ def test_mutation_known_answer_tests_would_fail_under_neutered_discovery():
         report = pmi.analyze(REPO_ROOT, TARGET, _ranges((480, 548, "content/references/tracker-writeback.md")))
     hits = [a for a in report.assertions if a.consumer == "bin/tests/test_tracker_dev_complete_spec.py"]
     assert not hits, "neutered discovery must find zero evidence for the known-answer consumer"
+
+
+# ---------------------------------------------------------------------------
+# Differential test against GROUND TRUTH: simulate the post-move tree (the
+# 9 ranges actually deleted from the target, their content actually
+# written to the 6 destination files) and run the REAL executable gates
+# against it, then compare their real pass/fail to this tool's prediction.
+# This is the only check in this suite that can catch the NEXT under-
+# report class, rather than re-confirming the two named in this ticket -
+# every other test here pins a specific extraction mechanism; this one
+# pins the tool's actual JOB.
+#
+# Scope: the two shell gates that are the ground-truth consumers for this
+# ticket's Critical findings - test_batch_state_timestamp_field.sh
+# (Critical 1: ERE metachar patterns) and test_tasks_jsonl_fold.sh
+# (Critical 2: the G6 floor). Both honor `GATE_REPO`/derive their root
+# from their own `$0`, so they run unmodified against a scratch copy.
+# Intentionally NOT run here: the other 6 shell gates and 7 pytest specs
+# the reviewer additionally used - each has its own path-resolution and
+# environment assumptions (jq availability, REPO_DIR conventions, fixture
+# imports) that would need individual verification to include safely, and
+# the two included here are sufficient to prove the differential-testing
+# APPROACH works and to directly regression-guard the two Critical fixes.
+# Extending SCRATCH_GATES below to cover more consumers is straightforward
+# once each one's assumptions are checked.
+# ---------------------------------------------------------------------------
+
+SCRATCH_GATES = (
+    "test_batch_state_timestamp_field.sh",
+    "test_tasks_jsonl_fold.sh",
+)
+
+
+def _write_split_target(repo_root: Path, scratch_root: Path, target_rel: str, ranges: list) -> None:
+    """Delete each range (1-indexed, inclusive) from a scratch copy of the
+    target file, and append its content verbatim to the corresponding
+    destination file (creating it - the destinations are all NEW files
+    that don't exist on main yet, this being a proposed future split)."""
+    lines = (repo_root / target_rel).read_text(encoding="utf-8").split("\n")
+    sorted_ranges = sorted(ranges, key=lambda r: r.start)
+    dest_content: dict[str, list[str]] = {}
+    keep: list[str] = []
+    cursor = 1
+    for r in sorted_ranges:
+        keep.extend(lines[cursor - 1 : r.start - 1])
+        dest_content.setdefault(r.dest, []).extend(lines[r.start - 1 : r.end])
+        cursor = r.end + 1
+    keep.extend(lines[cursor - 1 :])
+    (scratch_root / target_rel).write_text("\n".join(keep), encoding="utf-8")
+    for dest, dest_lines in dest_content.items():
+        dest_path = scratch_root / dest
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text("\n".join(dest_lines) + "\n", encoding="utf-8")
+
+
+def test_differential_against_ground_truth_post_move_gates(tmp_path):
+    import os
+    import shutil
+    import subprocess
+
+    scratch = tmp_path / "repo"
+    # The whole content/ tree (~2 MB, ~100 files) rather than a hand-picked
+    # subset: several of these gates scan `-- content` (a whole-directory
+    # `git grep`), so cherry-picking files would silently under-populate
+    # their scanned set and produce a false ground truth, not a faster one.
+    shutil.copytree(REPO_ROOT / "content", scratch / "content")
+    (scratch / "bin" / "tests").mkdir(parents=True)
+    for script in SCRATCH_GATES:
+        shutil.copy2(REPO_ROOT / "bin" / "tests" / script, scratch / "bin" / "tests" / script)
+
+    _write_split_target(REPO_ROOT, scratch, TARGET, NINE_RANGES)
+
+    subprocess.run(["git", "init", "-q"], cwd=scratch, check=True)
+    subprocess.run(["git", "config", "user.email", "differential-test@example.com"], cwd=scratch, check=True)
+    subprocess.run(["git", "config", "user.name", "differential-test"], cwd=scratch, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=scratch, check=True)
+
+    report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    tool_breaking = {a.consumer for a in report.assertions if a.breaks}
+    tool_unresolved = {u.consumer for u in report.unresolved}
+    # UNRESOLVED is an acceptable verdict for either real outcome (fail-loud
+    # by design) - a tool-flagged consumer is anything NOT reported clean.
+    tool_flagged = tool_breaking | tool_unresolved
+
+    under_reports = []
+    over_reports = []
+    for script in SCRATCH_GATES:
+        consumer = f"bin/tests/{script}"
+        env = dict(os.environ)
+        env["GATE_REPO"] = str(scratch)
+        proc = subprocess.run(
+            ["bash", str(scratch / "bin" / "tests" / script)],
+            cwd=scratch,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        really_fails = proc.returncode != 0
+        tool_says_clean = consumer not in tool_flagged
+        if really_fails and tool_says_clean:
+            under_reports.append((consumer, proc.returncode, proc.stdout[-1500:], proc.stderr[-500:]))
+        elif not really_fails and consumer in tool_breaking:
+            # Over-report: the tool flagged it BREAKING but the real gate
+            # still passes post-move. Tolerated (the reviewer measured
+            # ~5%) - record it, do not fail the test on it.
+            over_reports.append(consumer)
+
+    assert not under_reports, (
+        "DISQUALIFYING: the tool reported a consumer clean that actually "
+        "fails against the real, simulated post-move tree:\n"
+        + "\n".join(
+            f"  {c}: rc={rc}\n    stdout(tail)={out!r}\n    stderr(tail)={err!r}"
+            for c, rc, out, err in under_reports
+        )
+    )
+    # over_reports is intentionally not asserted on - see docstring above.
+    del over_reports
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_prose_move_impact.py
+++ b/bin/tests/test_prose_move_impact.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Purpose: Known-answer and mutation tests for scripts/prose-move-impact.py -
+         the mechanical "what breaks if I move these line ranges" enumerator
+         built to replace four failed prose-only review rounds on splitting
+         content/commands/ds-implement-ticket.md. Each known-answer case
+         below is a REAL, previously-verified miss from those rounds, not a
+         synthetic example.
+
+Public API: pytest test module. Run with
+              python3 -m pytest bin/tests/test_prose_move_impact.py -q
+            (auto-discovered by `.github/workflows/bin-tests.yml`'s
+            `python3 -m pytest bin/tests/ -q` invocation - no separate CI
+            wiring required).
+
+Upstream deps: scripts/prose-move-impact.py (imported by path, since
+               scripts/ is not a package); the live content of
+               content/commands/ds-implement-ticket.md and its four fixture
+               consumers (bin/tests/test_tracker_dev_complete_spec.py,
+               bin/tests/test_tasks_jsonl_fold.sh,
+               bin/tests/test_batch_state_timestamp_field.sh,
+               bin/tests/test_loop_state_site_coverage.sh).
+
+Downstream consumers: none (leaf test module).
+
+Failure modes: a known-answer test failing means either the tool regressed,
+               or the live target file's line numbers drifted out from
+               under one of the fixture's proposed ranges - re-verify the
+               range against a fresh `grep -n '^## '` before assuming the
+               tool is at fault. The mutation test intentionally breaks the
+               tool's own discovery step and asserts the suite goes red;
+               a green mutation test means the tool would silently report
+               "nothing breaks" on total discovery failure - exactly the
+               failure mode design constraint prohibits.
+
+Performance: single-digit seconds; a handful of `git grep` subprocess calls
+             plus small in-repo file reads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "prose-move-impact.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("prose_move_impact", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["prose_move_impact"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pmi = _load_module()
+
+TARGET = "content/commands/ds-implement-ticket.md"
+
+
+def _ranges(*triples):
+    return [pmi.MoveRange(start=s, end=e, dest=d) for (s, e, d) in triples]
+
+
+# ---------------------------------------------------------------------------
+# Fence-aware heading index sanity
+# ---------------------------------------------------------------------------
+
+
+def test_fence_aware_headings_skip_fenced_pseudo_headings():
+    target_path = REPO_ROOT / TARGET
+    lines = target_path.read_text(encoding="utf-8").split("\n")
+    headings = pmi.fence_aware_headings(lines)
+    # non-vacuity: real target has dozens of top-level headings
+    assert len(headings) > 20
+    for h in headings:
+        assert lines[h.line - 1].lstrip().startswith("#")
+
+
+def test_known_move_ranges_align_exactly_with_heading_boundaries():
+    """The 9 proposed ranges from the ticket brief, re-verified against the
+    live target: each range's start is a real heading line and its end is
+    the line immediately before the next heading of <= that level."""
+    target_path = REPO_ROOT / TARGET
+    lines = target_path.read_text(encoding="utf-8").split("\n")
+    headings = pmi.fence_aware_headings(lines)
+    proposed_starts = {480, 730, 801, 852, 1369, 1651, 2041, 2367, 3495}
+    heading_starts = {h.line for h in headings}
+    missing = proposed_starts - heading_starts
+    assert not missing, f"proposed range start(s) no longer align with a live heading: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Known-answer 1: test_tracker_dev_complete_spec.py's _extract_block reader
+# breaks when 480-548 (## Tracker Writeback Helper) moves.
+# ---------------------------------------------------------------------------
+
+
+def test_known_answer_tracker_dev_complete_heading_block_breaks():
+    ranges = _ranges((480, 548, "content/references/tracker-writeback.md"))
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_tracker_dev_complete_spec.py" and a.kind == "heading_block"
+    ]
+    assert hits, "expected a heading_block assertion for test_tracker_dev_complete_spec.py"
+    assert all(a.breaks for a in hits), "moving 480-548 must break the _extract_block reader"
+    assert not report.ok
+
+
+def test_known_answer_tracker_dev_complete_heading_block_does_not_break_when_untouched():
+    """Sanity control: a move range that does NOT touch 480-548 must not
+    falsely flag this consumer's heading_block assertion."""
+    ranges = _ranges((3495, 3551, "content/references/handoff-evaluation.md"))
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_tracker_dev_complete_spec.py" and a.kind == "heading_block"
+    ]
+    assert hits
+    assert not any(a.breaks for a in hits)
+
+
+# ---------------------------------------------------------------------------
+# Known-answer 2: test_tasks_jsonl_fold.sh's FOLDSPEC per-file floor (>= 7)
+# drops to 4 when 1369-1458 and 1651-1763 move.
+# ---------------------------------------------------------------------------
+
+
+def test_known_answer_tasks_jsonl_fold_heredoc_floor_breaks():
+    ranges = _ranges(
+        (1369, 1458, "content/references/orchestration-units.md"),
+        (1651, 1763, "content/references/orchestration-units.md"),
+    )
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_tasks_jsonl_fold.sh" and a.kind == "grep_count_floor"
+    ]
+    assert hits, "expected a grep_count_floor assertion for test_tasks_jsonl_fold.sh"
+    breaking = [a for a in hits if a.breaks]
+    assert breaking, "FOLDSPEC per-file floor for the target file must break: before=14, after=4, floor>=7"
+    assert "after=4" in breaking[0].detail
+    assert "floor >= 7" in breaking[0].detail
+    assert not report.ok
+
+
+def test_known_answer_tasks_jsonl_fold_heredoc_floor_stays_green_when_untouched():
+    ranges = _ranges((3495, 3551, "content/references/handoff-evaluation.md"))
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [
+        a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_tasks_jsonl_fold.sh" and a.kind == "grep_count_floor"
+    ]
+    assert hits
+    assert not any(a.breaks for a in hits)
+
+
+# ---------------------------------------------------------------------------
+# Known-answer 3: test_batch_state_timestamp_field.sh really does carry 8
+# `_absent(` call sites, not 2 - a non-vacuity pin on the fixture premise
+# itself (and on this tool's shell-continuation joiner, which must see all
+# 8 rather than only the ones that happen to fit on one physical line).
+# ---------------------------------------------------------------------------
+
+
+def test_known_answer_batch_state_timestamp_field_has_8_absent_calls():
+    path = REPO_ROOT / "bin" / "tests" / "test_batch_state_timestamp_field.sh"
+    text = path.read_text(encoding="utf-8")
+    joined = [logical for _, logical in pmi.join_shell_continuations(text)]
+    absent_calls = [l for l in joined if "_absent(" in l or l.strip().startswith("_absent ")]
+    # The function DEFINITION line ("_absent() { ...") also matches
+    # "_absent(" - exclude it explicitly rather than fudge the count.
+    absent_calls = [l for l in absent_calls if not l.strip().startswith("_absent()")]
+    assert len(absent_calls) == 8, (
+        f"expected 8 _absent call sites in test_batch_state_timestamp_field.sh, "
+        f"found {len(absent_calls)}: {absent_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Known-answer 4: test_loop_state_site_coverage.sh hardcodes FILE=<target>
+# with no content/**-wide fallback - moving content into content/references/*
+# leaves its scanned set even though its own numeric floors (which this
+# tool does not separately re-derive for this consumer) still clear.
+# ---------------------------------------------------------------------------
+
+
+def test_known_answer_loop_state_site_coverage_leaves_scanned_set():
+    ranges = _ranges(
+        (2041, 2174, "content/references/qa-loop-state.md"),
+        (2367, 2525, "content/references/qa-loop-state.md"),
+    )
+    report = pmi.analyze(REPO_ROOT, TARGET, ranges)
+    hits = [s for s in report.scanned_sets if s.consumer == "bin/tests/test_loop_state_site_coverage.sh"]
+    assert hits, "expected a scanned-set finding for test_loop_state_site_coverage.sh"
+    assert hits[0].scope == "single-file"
+    assert hits[0].leaves_scanned_set is True
+
+
+def test_loop_state_site_coverage_hardcodes_file_equals_target():
+    """Pin on the fixture premise: FILE=<target>, single hardcoded file,
+    no content/**-wide fallback anywhere in the gate."""
+    path = REPO_ROOT / "bin" / "tests" / "test_loop_state_site_coverage.sh"
+    text = path.read_text(encoding="utf-8")
+    assert f"FILE={TARGET}" in text
+    assert ".rglob(" not in text
+
+
+# ---------------------------------------------------------------------------
+# The 9-range run from the ticket brief: overall verdict must be FAIL
+# (multiple known-answer breaks above), and both known-answer breaking
+# consumers must be present, in one combined run.
+# ---------------------------------------------------------------------------
+
+NINE_RANGES = _ranges(
+    (480, 548, "content/references/tracker-writeback.md"),
+    (730, 800, "content/references/open-goal-loop.md"),
+    (801, 851, "content/references/batch-mode.md"),
+    (852, 940, "content/references/batch-mode.md"),
+    (1369, 1458, "content/references/orchestration-units.md"),
+    (1651, 1763, "content/references/orchestration-units.md"),
+    (2041, 2174, "content/references/qa-loop-state.md"),
+    (2367, 2525, "content/references/qa-loop-state.md"),
+    (3495, 3551, "content/references/handoff-evaluation.md"),
+)
+
+
+def test_nine_range_run_is_not_ok_and_covers_both_known_breaks():
+    report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    assert not report.ok
+    breaking_consumers = {a.consumer for a in report.assertions if a.breaks}
+    assert "bin/tests/test_tracker_dev_complete_spec.py" in breaking_consumers
+    assert "bin/tests/test_tasks_jsonl_fold.sh" in breaking_consumers
+    leaving_scanned_set = {s.consumer for s in report.scanned_sets if s.leaves_scanned_set}
+    assert "bin/tests/test_loop_state_site_coverage.sh" in leaving_scanned_set
+
+
+def test_cli_exit_code_nonzero_on_the_nine_ranges():
+    argv = []
+    for r in NINE_RANGES:
+        argv += ["--range", f"{r.start}:{r.end}:{r.dest}"]
+    rc = pmi.main(argv)
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Doc-consumer scoping: an arbitrary short word shared with the target's
+# prose in a NON-checked file (e.g. a .github/prompts/*.md doc) must never
+# be reported as a BREAKING assertion - this was the tool's first working
+# version's dominant false-positive class (hundreds of rows on words like
+# "default"/"status"/"worktree").
+# ---------------------------------------------------------------------------
+
+
+def test_doc_consumers_are_not_mechanically_gated_as_breaking():
+    report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    doc_like = [c for c in report.doc_consumers if c.startswith(".github/") or c.startswith("content/commands/")]
+    assert doc_like, "expected at least one doc-like consumer to be discovered"
+    breaking_consumers = {a.consumer for a in report.assertions if a.breaks}
+    assert not (set(doc_like) & breaking_consumers), (
+        "a doc/prose consumer was mechanically flagged as BREAKING - "
+        "checked-consumer scoping regressed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutation test: neuter discovery, confirm the suite goes red rather than
+# silently reporting OK. This is the tool's own "fail loud, never silently
+# skip" design constraint, made executable.
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_zero_discovered_consumers_is_not_a_silent_pass():
+    with mock.patch.object(pmi, "discover_consumers", return_value=[]):
+        report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    assert not report.ok, (
+        "neutering discover_consumers() to return zero consumers must NOT "
+        "produce an OK report - a tool that reports 'nothing breaks' "
+        "because it found nothing reproduces the exact failure mode it "
+        "exists to prevent"
+    )
+    assert any(u.consumer == "<discovery>" for u in report.unresolved)
+
+
+def test_mutation_known_answer_tests_would_fail_under_neutered_discovery():
+    """Confirms the specific known-answer assertions above are NOT
+    vacuously satisfied - re-run known-answer #1 and #2 under neutered
+    discovery and show they lose their evidence entirely (no assertions
+    found for that consumer at all), rather than happening to still pass."""
+    with mock.patch.object(pmi, "discover_consumers", return_value=[]):
+        report = pmi.analyze(REPO_ROOT, TARGET, _ranges((480, 548, "content/references/tracker-writeback.md")))
+    hits = [a for a in report.assertions if a.consumer == "bin/tests/test_tracker_dev_complete_spec.py"]
+    assert not hits, "neutered discovery must find zero evidence for the known-answer consumer"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/bin/tests/test_prose_move_impact.py
+++ b/bin/tests/test_prose_move_impact.py
@@ -11,8 +11,11 @@ Purpose: Known-answer, regression, mutation, and DIFFERENTIAL tests for
          load-bearing one: it simulates the actual post-move tree in a
          scratch git repo and runs the REAL executable gates against it,
          comparing their real pass/fail to the tool's prediction - the
-         only check here that can catch a NEW under-report class rather
-         than re-confirming a named one.
+         check with the best chance of catching a NEW under-report class
+         rather than re-confirming a named one, though it is currently
+         scoped to only 2 of the 7 tool-clean consumers a manual run can
+         differential-test in ~40s wall time (see SCRATCH_GATES below);
+         the other 5 are not yet covered by this automated check.
 
 Public API: pytest test module. Run with
               python3 -m pytest bin/tests/test_prose_move_impact.py -q
@@ -79,8 +82,54 @@ pmi = _load_module()
 TARGET = "content/commands/ds-implement-ticket.md"
 
 
-def _ranges(*triples):
-    return [pmi.MoveRange(start=s, end=e, dest=d) for (s, e, d) in triples]
+# ---------------------------------------------------------------------------
+# Heading-derived ranges (regression: Major 3, r2 Skeptic finding) - every
+# proposed move range below is now located by HEADING TEXT, never a
+# hardcoded absolute line number. A hardcoded number silently goes stale
+# the moment any unrelated edit lands above it anywhere in the 3600-line
+# target file: the reviewer demonstrated that inserting one sentence at
+# line 20 reddens a hardcoded-number test with a diagnostic about a refactor
+# that hasn't happened, which would block merge on this repo's REQUIRED
+# `python-bin-tests` check for every unrelated PR that happens to touch the
+# target file above the highest hardcoded line. Deriving from
+# `fence_aware_headings()` (the tool's own heading index) instead means the
+# range tracks the heading wherever it lives today - the test only fails
+# when the heading's TEXT genuinely disappears, which is the real structural
+# premise this fixture is pinning.
+# ---------------------------------------------------------------------------
+
+
+def _heading_index() -> dict[str, "pmi.Heading"]:
+    target_path = REPO_ROOT / TARGET
+    lines = target_path.read_text(encoding="utf-8").split("\n")
+    return {h.text: h for h in pmi.fence_aware_headings(lines)}
+
+
+_HEADINGS = _heading_index()
+
+
+def _range_for_heading(heading_text: str, dest: str) -> "pmi.MoveRange":
+    h = _HEADINGS.get(heading_text)
+    if h is None:
+        raise AssertionError(
+            f"proposed range heading no longer exists in the live target: {heading_text!r} "
+            "- the split proposal's structural premise has changed, re-verify against a "
+            "fresh `grep -n '^#' ...` before assuming this fixture is stale for no reason"
+        )
+    return pmi.MoveRange(start=h.line, end=h.end_line, dest=dest)
+
+
+# The 9 proposed-split headings from the ticket brief, by heading text (see
+# module docstring above for why text, not line number).
+_HEADING_TRACKER_WRITEBACK = "## Tracker Writeback Helper"
+_HEADING_OPEN_GOAL_LOOP = "## Phase 0a-open-goal: Open-goal loop init or resume (conditional)"
+_HEADING_BATCH_RESUME_CHECK = "## Phase 0a-pre: Batch resume check"
+_HEADING_BATCH_TRIAGE = "## Phase 0a: Batch triage (Phase 0 produced ≥ 2 entries)"
+_HEADING_ORCHESTRATION_PLAN = "## Phase 3b: Orchestration plan (conditional)"
+_HEADING_PARALLEL_UNITS = "### If parallel independent units were identified:"
+_HEADING_QA_GATE = "## Phase 6b: QA Gate (conditional)"
+_HEADING_QA_EVIDENCE = "## Phase 8.5: QA evidence (conditional)"
+_HEADING_HANDOFF_EVAL = "## Phase 12a: Handoff evaluation (batch, open-goal, and single-ticket-capped)"
 
 
 # ---------------------------------------------------------------------------
@@ -99,16 +148,26 @@ def test_fence_aware_headings_skip_fenced_pseudo_headings():
 
 
 def test_known_move_ranges_align_exactly_with_heading_boundaries():
-    """The 9 proposed ranges from the ticket brief, re-verified against the
-    live target: each range's start is a real heading line and its end is
-    the line immediately before the next heading of <= that level."""
-    target_path = REPO_ROOT / TARGET
-    lines = target_path.read_text(encoding="utf-8").split("\n")
-    headings = pmi.fence_aware_headings(lines)
-    proposed_starts = {480, 730, 801, 852, 1369, 1651, 2041, 2367, 3495}
-    heading_starts = {h.line for h in headings}
-    missing = proposed_starts - heading_starts
-    assert not missing, f"proposed range start(s) no longer align with a live heading: {missing}"
+    """The 9 proposed headings from the ticket brief, re-verified against
+    the live target BY TEXT (not a hardcoded line number - see the
+    heading-derived-ranges block above): each named heading must still
+    exist as a live heading. `_range_for_heading` already asserts this
+    per-heading with a specific diagnostic; this test asserts it in one
+    place for all 9 so a single failure enumerates every heading that
+    vanished, not just the first one a fixture happens to touch."""
+    proposed_heading_texts = {
+        _HEADING_TRACKER_WRITEBACK,
+        _HEADING_OPEN_GOAL_LOOP,
+        _HEADING_BATCH_RESUME_CHECK,
+        _HEADING_BATCH_TRIAGE,
+        _HEADING_ORCHESTRATION_PLAN,
+        _HEADING_PARALLEL_UNITS,
+        _HEADING_QA_GATE,
+        _HEADING_QA_EVIDENCE,
+        _HEADING_HANDOFF_EVAL,
+    }
+    missing = proposed_heading_texts - set(_HEADINGS)
+    assert not missing, f"proposed range heading(s) no longer exist in the live target: {missing}"
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +177,7 @@ def test_known_move_ranges_align_exactly_with_heading_boundaries():
 
 
 def test_known_answer_tracker_dev_complete_heading_block_breaks():
-    ranges = _ranges((480, 548, "content/references/tracker-writeback.md"))
+    ranges = [_range_for_heading(_HEADING_TRACKER_WRITEBACK, "content/references/tracker-writeback.md")]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -133,7 +192,7 @@ def test_known_answer_tracker_dev_complete_heading_block_breaks():
 def test_known_answer_tracker_dev_complete_heading_block_does_not_break_when_untouched():
     """Sanity control: a move range that does NOT touch 480-548 must not
     falsely flag this consumer's heading_block assertion."""
-    ranges = _ranges((3495, 3551, "content/references/handoff-evaluation.md"))
+    ranges = [_range_for_heading(_HEADING_HANDOFF_EVAL, "content/references/handoff-evaluation.md")]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -151,10 +210,10 @@ def test_known_answer_tracker_dev_complete_heading_block_does_not_break_when_unt
 
 
 def test_known_answer_tasks_jsonl_fold_heredoc_floor_breaks():
-    ranges = _ranges(
-        (1369, 1458, "content/references/orchestration-units.md"),
-        (1651, 1763, "content/references/orchestration-units.md"),
-    )
+    ranges = [
+        _range_for_heading(_HEADING_ORCHESTRATION_PLAN, "content/references/orchestration-units.md"),
+        _range_for_heading(_HEADING_PARALLEL_UNITS, "content/references/orchestration-units.md"),
+    ]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -182,7 +241,7 @@ def test_known_answer_tasks_jsonl_fold_heredoc_floor_breaks():
 
 
 def test_known_answer_tasks_jsonl_fold_heredoc_floor_stays_green_when_untouched():
-    ranges = _ranges((3495, 3551, "content/references/handoff-evaluation.md"))
+    ranges = [_range_for_heading(_HEADING_HANDOFF_EVAL, "content/references/handoff-evaluation.md")]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -254,10 +313,10 @@ def test_known_answer_batch_state_timestamp_field_joiner_actually_joins_continua
 
 
 def test_known_answer_loop_state_site_coverage_leaves_scanned_set():
-    ranges = _ranges(
-        (2041, 2174, "content/references/qa-loop-state.md"),
-        (2367, 2525, "content/references/qa-loop-state.md"),
-    )
+    ranges = [
+        _range_for_heading(_HEADING_QA_GATE, "content/references/qa-loop-state.md"),
+        _range_for_heading(_HEADING_QA_EVIDENCE, "content/references/qa-loop-state.md"),
+    ]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [s for s in report.scanned_sets if s.consumer == "bin/tests/test_loop_state_site_coverage.sh"]
     assert hits, "expected a scanned-set finding for test_loop_state_site_coverage.sh"
@@ -280,17 +339,17 @@ def test_loop_state_site_coverage_hardcodes_file_equals_target():
 # consumers must be present, in one combined run.
 # ---------------------------------------------------------------------------
 
-NINE_RANGES = _ranges(
-    (480, 548, "content/references/tracker-writeback.md"),
-    (730, 800, "content/references/open-goal-loop.md"),
-    (801, 851, "content/references/batch-mode.md"),
-    (852, 940, "content/references/batch-mode.md"),
-    (1369, 1458, "content/references/orchestration-units.md"),
-    (1651, 1763, "content/references/orchestration-units.md"),
-    (2041, 2174, "content/references/qa-loop-state.md"),
-    (2367, 2525, "content/references/qa-loop-state.md"),
-    (3495, 3551, "content/references/handoff-evaluation.md"),
-)
+NINE_RANGES = [
+    _range_for_heading(_HEADING_TRACKER_WRITEBACK, "content/references/tracker-writeback.md"),
+    _range_for_heading(_HEADING_OPEN_GOAL_LOOP, "content/references/open-goal-loop.md"),
+    _range_for_heading(_HEADING_BATCH_RESUME_CHECK, "content/references/batch-mode.md"),
+    _range_for_heading(_HEADING_BATCH_TRIAGE, "content/references/batch-mode.md"),
+    _range_for_heading(_HEADING_ORCHESTRATION_PLAN, "content/references/orchestration-units.md"),
+    _range_for_heading(_HEADING_PARALLEL_UNITS, "content/references/orchestration-units.md"),
+    _range_for_heading(_HEADING_QA_GATE, "content/references/qa-loop-state.md"),
+    _range_for_heading(_HEADING_QA_EVIDENCE, "content/references/qa-loop-state.md"),
+    _range_for_heading(_HEADING_HANDOFF_EVAL, "content/references/handoff-evaluation.md"),
+]
 
 
 def test_nine_range_run_is_not_ok_and_covers_both_known_breaks():
@@ -343,10 +402,10 @@ def test_doc_consumers_are_not_mechanically_gated_as_breaking():
 
 
 def test_regression_ere_metachar_pattern_resolves_via_regex_not_literal_find():
-    ranges = _ranges(
-        (801, 851, "content/references/batch-mode.md"),
-        (852, 940, "content/references/batch-mode.md"),
-    )
+    ranges = [
+        _range_for_heading(_HEADING_BATCH_RESUME_CHECK, "content/references/batch-mode.md"),
+        _range_for_heading(_HEADING_BATCH_TRIAGE, "content/references/batch-mode.md"),
+    ]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -374,7 +433,7 @@ def test_regression_ere_pattern_with_backslash_escaped_parens_is_extracted_at_al
     place (its single-quote branch excluded any backslash from quoted
     content) - a distinct, earlier failure than the literal-vs-regex
     resolution gap the other regression test above covers."""
-    ranges = _ranges((801, 851, "content/references/batch-mode.md"))
+    ranges = [_range_for_heading(_HEADING_BATCH_RESUME_CHECK, "content/references/batch-mode.md")]
     report = pmi.analyze(REPO_ROOT, TARGET, ranges)
     hits = [
         a
@@ -386,6 +445,160 @@ def test_regression_ere_pattern_with_backslash_escaped_parens_is_extracted_at_al
 
 
 # ---------------------------------------------------------------------------
+# Regression: Major 1 (r2 Skeptic finding) - `_is_meaningful_literal`'s
+# short-token noise filter ran BEFORE `is_pattern_slot` was computed, so a
+# pattern-slot literal (the actual `<pattern>` payload of a `_present`/
+# `_absent` shell call) that happens to be short with no `[`:/=$]`
+# punctuation was silently dropped with NO Assertion and NO Unresolved row -
+# the identical silent-drop class as r1's Critical, one filter earlier in
+# the same function. Confirmed failing pre-fix: `'mark-blocked-and-
+# continue'`, `'fail-open'`, and `'<ISO8601>'` (three live pattern-slot
+# literals in test_batch_state_timestamp_field.sh, none of which contain a
+# backtick/colon/slash/equals/dollar) produced zero assertions and zero
+# unresolved rows for that consumer under the 9-range run.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_pattern_slot_literal_not_dropped_by_meaningfulness_filter():
+    report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    hits = {
+        a.detail: a
+        for a in report.assertions
+        if a.consumer == "bin/tests/test_batch_state_timestamp_field.sh"
+        and a.kind == "literal_presence"
+        and ("mark-blocked-and-continue" in a.detail or "fail-open" in a.detail or "<ISO8601>" in a.detail)
+    }
+    assert hits, (
+        "expected literal_presence assertions for the 'mark-blocked-and-"
+        "continue' / 'fail-open' / '<ISO8601>' pattern-slot literals - these "
+        "must never be silently dropped by the meaningfulness filter"
+    )
+    mark_blocked = [a for d, a in hits.items() if "mark-blocked-and-continue" in d and d.startswith("asserts")]
+    assert mark_blocked, f"expected a 'mark-blocked-and-continue' hit, got: {list(hits)}"
+    assert any(a.breaks for a in mark_blocked), (
+        "'mark-blocked-and-continue' has 3 of its 11 target occurrences inside "
+        "a move range and must break"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Major 2 (r2 Skeptic finding) - `extract_regex_assertions`
+# dropped `re.compile(...)`'s own compile-time FLAGS (re-compiled the
+# pattern with no flags at all) and matched per-line instead of against the
+# consumer's actual whole-text search, so a case-insensitive or newline-
+# spanning pattern could report ZERO pre-move matches (silently
+# reclassified as "cannot break") even though the real, flag-honoring
+# match count is nonzero. Confirmed failing pre-fix via a synthetic
+# consumer mirroring `_STALE_ENFORCER_SUBCOUNT_RE` (compiled
+# `re.IGNORECASE`): matching 'ENFORCE THE SIX GATES' (uppercase) against a
+# lowercase target line resolved to zero matches pre-fix, and a pattern
+# containing `\n` inside a `[^.]{0,80}` character class never matched
+# per-line even when its match spans two adjacent target lines that DO
+# concatenate to a real cross-line match in the consumer's own whole-text
+# `.search()`.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_regex_assertion_honors_compile_flags_and_whole_text_match():
+    """Pre-fix, `re.compile(pat)` re-compiled with no flags at all, so this
+    IGNORECASE pattern found ZERO matches against the mixed-case target
+    line and was reclassified as a resolved, non-breaking Assertion ('...
+    matches ZERO lines in the pre-move target') instead of the correct
+    UNRESOLVED-with-real-matches outcome below - silently converting a
+    genuinely live, move-affected assertion into a false-clean pass."""
+    consumer_text = (
+        "import re\n"
+        "_PATTERN_RE = re.compile(r'enforce the six gates', re.IGNORECASE)\n"
+        "def check(text):\n"
+        "    return bool(_PATTERN_RE.search(text))\n"
+    )
+    target_text = "line one\nEnforce the SIX gates now.\nline three\n"
+    line_starts = pmi.build_line_starts(target_text)
+    ranges = [pmi.MoveRange(start=2, end=2, dest="content/references/scratch.md")]
+    assertions, unresolved = pmi.extract_regex_assertions(
+        "scratch_consumer.py", consumer_text, target_text, line_starts, ranges
+    )
+    assert not assertions, "must not be resolved as a zero-match, non-breaking assertion"
+    hits = [u for u in unresolved if "_PATTERN_RE" in u.detail]
+    assert hits, "expected an UNRESOLVED row for _PATTERN_RE"
+    assert "target lines [2]" in hits[0].detail, (
+        f"expected the IGNORECASE-flagged pattern to actually match line 2, got: {hits[0].detail!r}"
+    )
+    assert "fall inside a proposed move range" in hits[0].detail
+
+
+def test_regression_regex_assertion_matches_across_a_newline():
+    """Pre-fix, a per-line scan never sees a DOTALL pattern that spans the
+    boundary between two target lines - it was reclassified as a resolved,
+    non-breaking 'matches ZERO lines' assertion even though the consumer's
+    own whole-text `.search()` matches it fine."""
+    consumer_text = (
+        "import re\n"
+        "_SPAN_RE = re.compile(r'alpha[^.]{0,20}beta', re.DOTALL)\n"
+        "def check(text):\n"
+        "    return bool(_SPAN_RE.search(text))\n"
+    )
+    target_text = "alpha\nbeta appears on the next line.\n"
+    line_starts = pmi.build_line_starts(target_text)
+    ranges = [pmi.MoveRange(start=2, end=2, dest="content/references/scratch.md")]
+    assertions, unresolved = pmi.extract_regex_assertions(
+        "scratch_consumer.py", consumer_text, target_text, line_starts, ranges
+    )
+    assert not assertions, "must not be resolved as a zero-match, non-breaking assertion"
+    hits = [u for u in unresolved if "_SPAN_RE" in u.detail]
+    assert hits, "expected an UNRESOLVED row for _SPAN_RE"
+    assert "ZERO" not in hits[0].detail, (
+        "a DOTALL pattern spanning the alpha/beta newline must match against "
+        "the whole target text - a per-line scan sees zero matches here"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Minor (r2 Skeptic finding) - `Report.ok` ignored
+# `scanned_sets` entirely, so a run whose ONLY finding was
+# `leaves_scanned_set=True` (nothing broken, nothing unresolved) exited 0
+# and printed `Verdict: OK` - the exact finding class the scanned-set
+# column exists to surface, silently unenforced. Confirmed failing pre-fix
+# by constructing a Report with zero assertions/unresolved and one
+# leaves_scanned_set=True finding: `.ok` returned True.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_scanned_set_only_finding_is_not_a_silent_ok():
+    report = pmi.Report(
+        target=TARGET,
+        ranges=[],
+        consumers=["bin/tests/test_loop_state_site_coverage.sh"],
+        scanned_sets=[
+            pmi.ScannedSetFinding(
+                consumer="bin/tests/test_loop_state_site_coverage.sh",
+                scope="single-file",
+                detail="leaves scanned set",
+                leaves_scanned_set=True,
+            )
+        ],
+    )
+    assert not report.assertions and not report.unresolved, "test setup sanity: nothing else should be flagging"
+    assert not report.ok, (
+        "a Report whose only finding is a left-behind scanned set must not "
+        "report OK - this is the signature finding class the scanned-set "
+        "column exists to surface"
+    )
+
+
+def test_known_answer_loop_state_site_coverage_makes_nine_range_report_fail():
+    """Non-mocked confirmation of the Minor fix above against the real 9-
+    range run: test_loop_state_site_coverage.sh's own scanned-set finding
+    (already asserted separately above) must, on its own, be sufficient to
+    flip the overall verdict - independent of whatever else in the 9-range
+    run also breaks."""
+    report = pmi.analyze(REPO_ROOT, TARGET, NINE_RANGES)
+    scanned_only = [s for s in report.scanned_sets if s.leaves_scanned_set]
+    assert scanned_only
+    assert not report.ok
+
+
+# ---------------------------------------------------------------------------
 # Regression: Major 4 (r1 Skeptic finding) - analyze() returned a vacuous
 # "OK" report when discovery found consumers but ZERO of them matched
 # `_is_checked_consumer` (e.g. a bin/tests/ rename or SEARCH_DIRS drift).
@@ -394,7 +607,11 @@ def test_regression_ere_pattern_with_backslash_escaped_parens_is_extracted_at_al
 
 def test_regression_zero_checked_consumers_is_not_a_silent_pass():
     with mock.patch.object(pmi, "_is_checked_consumer", return_value=False):
-        report = pmi.analyze(REPO_ROOT, TARGET, _ranges((480, 548, "content/references/tracker-writeback.md")))
+        report = pmi.analyze(
+            REPO_ROOT,
+            TARGET,
+            [_range_for_heading(_HEADING_TRACKER_WRITEBACK, "content/references/tracker-writeback.md")],
+        )
     assert not report.ok, (
         "zero CHECKED consumers (as opposed to zero discovered consumers, "
         "already covered by the mutation test below) must not silently "
@@ -430,7 +647,11 @@ def test_mutation_known_answer_tests_would_fail_under_neutered_discovery():
     discovery and show they lose their evidence entirely (no assertions
     found for that consumer at all), rather than happening to still pass."""
     with mock.patch.object(pmi, "discover_consumers", return_value=[]):
-        report = pmi.analyze(REPO_ROOT, TARGET, _ranges((480, 548, "content/references/tracker-writeback.md")))
+        report = pmi.analyze(
+            REPO_ROOT,
+            TARGET,
+            [_range_for_heading(_HEADING_TRACKER_WRITEBACK, "content/references/tracker-writeback.md")],
+        )
     hits = [a for a in report.assertions if a.consumer == "bin/tests/test_tracker_dev_complete_spec.py"]
     assert not hits, "neutered discovery must find zero evidence for the known-answer consumer"
 
@@ -440,24 +661,32 @@ def test_mutation_known_answer_tests_would_fail_under_neutered_discovery():
 # 9 ranges actually deleted from the target, their content actually
 # written to the 6 destination files) and run the REAL executable gates
 # against it, then compare their real pass/fail to this tool's prediction.
-# This is the only check in this suite that can catch the NEXT under-
-# report class, rather than re-confirming the two named in this ticket -
-# every other test here pins a specific extraction mechanism; this one
-# pins the tool's actual JOB.
+# Every other test here pins a specific extraction mechanism; this one
+# pins the tool's actual JOB - but only for the 2 consumers in
+# SCRATCH_GATES below, not the whole tool-clean set. A change to
+# extraction logic that under-reports one of the other 5 tool-clean
+# consumers (of the 7 the reviewer manually differential-tested) is NOT
+# caught by this automated suite.
 #
 # Scope: the two shell gates that are the ground-truth consumers for this
 # ticket's Critical findings - test_batch_state_timestamp_field.sh
 # (Critical 1: ERE metachar patterns) and test_tasks_jsonl_fold.sh
 # (Critical 2: the G6 floor). Both honor `GATE_REPO`/derive their root
 # from their own `$0`, so they run unmodified against a scratch copy.
-# Intentionally NOT run here: the other 6 shell gates and 7 pytest specs
-# the reviewer additionally used - each has its own path-resolution and
-# environment assumptions (jq availability, REPO_DIR conventions, fixture
-# imports) that would need individual verification to include safely, and
-# the two included here are sufficient to prove the differential-testing
-# APPROACH works and to directly regression-guard the two Critical fixes.
-# Extending SCRATCH_GATES below to cover more consumers is straightforward
-# once each one's assumptions are checked.
+# Intentionally NOT run here: the other 5 tool-clean shell/pytest gates
+# the reviewer additionally differential-tested by hand (6 of 7 candidates
+# qualified automatically - pre-move-red skipped as environment-unfit,
+# post-move rc compared to the tool's prediction for the survivors) - each
+# has its own path-resolution and environment assumptions (jq
+# availability, REPO_DIR conventions, fixture imports) that would need
+# individual verification to include safely here, and the two included
+# are sufficient to prove the differential-testing APPROACH works and to
+# directly regression-guard the two Critical fixes. Extending
+# SCRATCH_GATES below to cover more consumers is straightforward once each
+# one's assumptions are checked - candidates: run each gate against a
+# pre-move scratch copy first, skip any already red as environment-unfit,
+# then compare only the survivors' post-move rc against this tool's
+# prediction, exactly as the reviewer did manually.
 # ---------------------------------------------------------------------------
 
 SCRATCH_GATES = (

--- a/scripts/prose-move-impact.py
+++ b/scripts/prose-move-impact.py
@@ -23,12 +23,14 @@ Upstream deps: `git grep` (consumer discovery), Python stdlib only
                (re, ast, bisect, dataclasses, json, argparse). No PyPI deps.
 
 Downstream consumers: bin/tests/test_prose_move_impact.py (spec + known-
-                      answer fixtures + mutation test). Intended to be run
-                      ad hoc by a human/architect before authoring a split
-                      plan, not wired into CI as a required gate - its
-                      inputs (proposed move ranges) do not exist yet on
-                      main and there is nothing for a CI job to check
-                      against.
+                      answer fixtures + regression tests + mutation test +
+                      a differential test that simulates the post-move
+                      tree in a scratch git repo and runs the real shell
+                      gates against it). Intended to be run ad hoc by a
+                      human/architect before authoring a split plan, not
+                      wired into CI as a required gate - its inputs
+                      (proposed move ranges) do not exist yet on main and
+                      there is nothing for a CI job to check against.
 
 Failure modes: any consumer file this tool cannot parse into at least one
                resolved assertion, or any assertion whose target-line
@@ -37,7 +39,10 @@ Failure modes: any consumer file this tool cannot parse into at least one
                intentional per the tool's own design constraint ("fail
                loud, never silently skip") - a tool that quietly drops
                what it does not understand reproduces the exact failure
-               mode it exists to prevent. Read-only; no side effects.
+               mode it exists to prevent. A regex-metachar pattern (from a
+               `_present`/`grep -qiE` shell call site) is resolved via an
+               ERE fallback, not just a literal substring match - see
+               `_resolve_literal_in_target`. Read-only; no side effects.
 
 Performance: single pass over `git grep` output plus one parse per
              discovered consumer file (typically a few dozen files, low
@@ -288,7 +293,29 @@ def join_shell_continuations(text: str) -> list[tuple[int, str]]:
 # Literal-string assertion extraction (generic, language-agnostic)
 # ---------------------------------------------------------------------------
 
-_STR_RE = re.compile(r'"([^"\\]{6,300})"|\'([^\'\\]{6,300})\'')
+# The double-quote branch is deliberately restricted to never START a match
+# at a position followed by `$(` (shell command substitution). Without that
+# guard, a line like `G6="$(git grep -cE 'pattern' -- "$DIT" ...)"` lets the
+# double-quote alternative greedily match from the assignment's opening `"`
+# all the way to the NEXT `"` it meets - which here is the opening quote of
+# the nested `"$DIT"`, not the assignment's real closing quote - swallowing
+# the single-quoted grep pattern living in between as unmatched filler and
+# denying the single-quote alternative any chance to see it (finditer never
+# backtracks into a span a prior alternative already consumed). Shell/code
+# syntax like `$(...)` is not itself a content literal we want to extract,
+# so refusing to start a double-quote match there is safe.
+#
+# The single-quote branch deliberately does NOT exclude a backslash from
+# its content class (unlike the double-quote branch): bash single quotes
+# have no escape mechanism at all - `\` is a literal character inside
+# `'...'`, and the closing `'` is always the next single-quote character,
+# full stop. A `grep -qiE '<pattern>'` call site's pattern routinely
+# contains backslash-escaped ERE metacharacters (`\(`, `\)`, `\+`, `\.`) -
+# excluding `\` from the class silently made `_literals_in_line` never
+# extract those patterns AT ALL (not merely fail to resolve them against
+# the target), which is a distinct and more severe drop than the
+# resolution-time literal-vs-ERE gap this module fixes elsewhere.
+_STR_RE = re.compile(r'"((?:(?!\$\()[^"\\]){6,300})"|\'([^\']{6,300})\'')
 
 
 _SHELL_NOISE_RE = re.compile(r"^\s*\$?\(?\s*(echo|cat|grep|awk|sed|printf|true|false)\b")
@@ -334,11 +361,23 @@ def _classify_line(logical_line: str) -> str:
     stripped = l.strip()
     if stripped.startswith("#"):
         return "comment_reference"
-    if "_absent(" in l or re.search(r"\bnot in\b", l) or ".count(" in l and "== 0" in l:
+    # Bash-style helper calls (`_absent "$SPEC" "label" 'pattern'`) have no
+    # parens - shell function invocation syntax never does - so the
+    # `"_absent("`/`"_present("` substring checks below only catch a
+    # Python-style call. Detect the bash form explicitly, or every such
+    # call (the dominant shape across bin/tests/*.sh's `_present`/`_absent`
+    # helpers) silently falls through to the generic "literal_reference"
+    # catch-all below and never gets treated as a load-bearing assertion.
+    is_absent_call = (
+        "_absent(" in l
+        or stripped.startswith("_absent ")
+        or re.search(r"\bnot in\b", l)
+    )
+    if is_absent_call or (".count(" in l and "== 0" in l):
         if ".count(" in l and "== 0" in l:
             return "literal_count"
         return "literal_absent"
-    if "_present(" in l:
+    if "_present(" in l or stripped.startswith("_present "):
         return "literal_presence"
     if ".count(" in l:
         return "literal_count"
@@ -349,7 +388,34 @@ def _classify_line(logical_line: str) -> str:
     return "literal_reference"
 
 
+def _is_shell_call_line(logical_line: str) -> bool:
+    """True only for the bash `_absent`/`_present` test-helper calling
+    convention (`_absent(` / `_present(` as a Python-adjacent form, or the
+    space-separated shell-invocation form `_absent "..." ...`). This
+    convention has a FIXED, verified argument order (`<file>? <label>
+    <pattern>`) with the actual grep pattern always last - a distinct
+    literal-ordering contract from the Python `"phrase" in text` /
+    `assert "phrase" in text, f"error message"` idiom, where the FIRST
+    literal is the search phrase and any LATER literal is part of an
+    error message, not a second pattern to resolve. Conflating the two
+    orderings (treating "last literal" as universally special) mis-selects
+    the error-message string as the assertion payload for every Python
+    consumer and floods the report with spurious UNRESOLVED rows for
+    ordinary human-readable failure text."""
+    l = logical_line
+    stripped = l.strip()
+    return "_absent(" in l or "_present(" in l or stripped.startswith(("_absent ", "_present "))
+
+
+# Matches the 3-arg shell calling convention `_present "$VAR" <label>
+# <pattern>` / `_absent "$VAR" <label> <pattern>` and captures the file
+# variable name (`VAR`) actually passed at THIS call site - see
+# `extract_literal_assertions`'s per-call-site scoping.
+_SHELL_CALL_FILE_ARG_RE = re.compile(r'^\s*_(?:absent|present)\s+"\$(\w+)"')
+
+
 def _target_occurrences(target_text: str, line_starts: list[int], literal: str) -> list[int]:
+    """Exact substring occurrences of `literal` in the live target text."""
     lines = []
     idx = target_text.find(literal)
     while idx != -1:
@@ -358,54 +424,174 @@ def _target_occurrences(target_text: str, line_starts: list[int], literal: str) 
     return lines
 
 
+def _target_regex_occurrences(target_lines: list[str], pattern: str) -> list[int] | None:
+    """Match `pattern` as a case-insensitive ERE against each target line -
+    mirroring `grep -qiE`'s own semantics, exactly like
+    `_count_pattern_in_target` already does correctly for shell floor
+    patterns below. Returns None when `pattern` fails to compile; the
+    caller must treat that as unresolved, never as "no matches"."""
+    try:
+        compiled = re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        return None
+    return [i for i, line in enumerate(target_lines, start=1) if compiled.search(line)]
+
+
+def _resolve_literal_in_target(
+    target_text: str, target_lines: list[str], line_starts: list[int], literal: str
+) -> tuple[list[int], str | None]:
+    """Resolve `literal` against the live target text. Tries an exact
+    substring match first (the common case: a plain quoted phrase); if
+    that finds nothing, `literal` may be an ERE pattern lifted verbatim
+    from a `grep -qiE '<pattern>'` call site - a quoted regex and a quoted
+    plain-text literal are syntactically indistinguishable at extraction
+    time (both are just a quoted string in source), so both get extracted
+    the same way and are only told apart HERE, by which resolution
+    strategy actually finds the content. A naive literal-substring-only
+    match silently drops any pattern containing a regex metacharacter
+    (`.`, `\\+`, `|`, ...) that has zero literal occurrences even though
+    the live gate (`grep -qiE`) matches it fine. Returns
+    (occurrence_lines, method) where method is "literal", "regex", or None
+    (could not resolve either way - the caller must emit UNRESOLVED, never
+    silently drop, per this tool's entire reason to exist)."""
+    occ = _target_occurrences(target_text, line_starts, literal)
+    if occ:
+        return occ, "literal"
+    regex_occ = _target_regex_occurrences(target_lines, literal)
+    if regex_occ:
+        return regex_occ, "regex"
+    return [], None
+
+
+# Kinds whose target-directed literal is a genuine mechanical assertion
+# (matched against the target's content by a live gate) rather than
+# incidental descriptive text.
+_PATTERN_CHECK_KINDS = {"literal_absent", "literal_presence", "literal_count"}
+
+
 def extract_literal_assertions(
     consumer_rel: str,
     consumer_text: str,
     target_text: str,
+    target_lines: list[str],
     line_starts: list[int],
     ranges: list[MoveRange],
-) -> list[Assertion]:
+    target_rel: str,
+) -> tuple[list[Assertion], list[Unresolved]]:
     out: list[Assertion] = []
+    unresolved: list[Unresolved] = []
+    # A consumer's `_present`/`_absent` calls are only actually checking
+    # THIS target when they read from a shell variable whose assignment
+    # resolves to `target_rel` (e.g. `SPEC="$REPO_DIR/.../
+    # ds-implement-ticket.md"`) - some `bin/tests/*.sh` files that are
+    # discovered as consumers (they mention the target file's path
+    # somewhere, e.g. in a comment) run their entire `_present`/`_absent`
+    # suite against a DIFFERENT spec file (verified: test_ticket_rework_
+    # triage_badge.sh and test_ticket_triage_inflight.sh both point `$SPEC`
+    # at content/commands/ds-ticket-triage.md, not this target; and
+    # test_batch_state_timestamp_field.sh itself has TWO spec variables -
+    # `$SPEC` -> this target, `$SPEC2` -> a different reference doc).
+    # `path_vars` resolves the file-scoped default (used by the 2-arg
+    # `_absent <label> <pattern>` form, whose target file is baked into
+    # the helper's own body, not passed per call); `_SHELL_CALL_FILE_ARG_RE`
+    # additionally resolves the 3-arg `_present "$VAR" <label> <pattern>`
+    # form PER CALL SITE, since a file with two spec variables can mix
+    # target-directed and non-target-directed calls in the same file.
+    path_vars = _build_shell_path_vars(consumer_text, target_rel)
     for _lineno, logical in join_shell_continuations(consumer_text):
         literals = _literals_in_line(logical)
         if not literals:
             continue
         kind = _classify_line(logical)
-        for lit in literals:
+        last_idx = len(literals) - 1
+        call_arg_m = _SHELL_CALL_FILE_ARG_RE.match(logical)
+        if call_arg_m:
+            # Explicit 3-arg form: trust the actual variable this call
+            # site passed, even if some OTHER variable in the file also
+            # resolves to the target.
+            is_call_target_scoped = path_vars.get(call_arg_m.group(1)) == target_rel
+        else:
+            # 2-arg form (or unrecognized shape): fall back to "does this
+            # file have a variable resolving to the target at all".
+            is_call_target_scoped = bool(path_vars)
+        is_shell_call = _is_shell_call_line(logical) and is_call_target_scoped
+        for idx, lit in enumerate(literals):
             if not _is_meaningful_literal(lit):
-                continue
-            if lit not in target_text:
                 continue
             # Skip pure noise: path literals that merely re-cite the target
             # path itself carry no content assertion.
             if lit in (DEFAULT_TARGET, Path(DEFAULT_TARGET).name):
                 continue
-            occ = _target_occurrences(target_text, line_starts, lit)
+            # Only the LAST quoted literal on a pattern-check line (the
+            # `<pattern>` slot of `_present <file> <label> <pattern>` /
+            # `_absent <label> <pattern>` / `x.count("...")`) is the actual
+            # payload a live gate matches against the target - a preceding
+            # LABEL argument is documentation, never itself required to
+            # appear verbatim in the target's prose. Only that slot gets
+            # the ERE-fallback + fail-loud treatment; escalating every
+            # quoted string on the line flooded the report with false
+            # UNRESOLVED rows for ordinary label/message text that was
+            # never meant to match the target (confirmed: matching a
+            # single-file test consumer against this file's OWN internal
+            # string literals produced dozens of spurious rows before this
+            # narrowing).
+            is_pattern_slot = kind in _PATTERN_CHECK_KINDS and idx == last_idx and is_shell_call
+            if is_pattern_slot:
+                occ, method = _resolve_literal_in_target(target_text, target_lines, line_starts, lit)
+            else:
+                occ = _target_occurrences(target_text, line_starts, lit)
+                method = "literal" if occ else None
+            if kind == "literal_absent":
+                if not occ:
+                    # Genuinely resolved: neither a literal substring nor
+                    # an ERE match is present in the target, so there is
+                    # nothing for a move to break - a legitimate "absent"
+                    # answer, not an unresolved one.
+                    continue
+                out.append(
+                    Assertion(
+                        consumer=consumer_rel,
+                        kind=kind,
+                        detail=f"asserts {lit!r} is ABSENT from target"
+                        + (
+                            " (currently matches via ERE, independent of this move)"
+                            if method == "regex"
+                            else ""
+                        ),
+                        resolved=True,
+                        breaks=False,
+                        lines=occ,
+                        note="absence assertions cannot be broken by a move away from the target",
+                    )
+                )
+                continue
             if not occ:
+                if is_pattern_slot:
+                    # Fail loud: neither literal-substring nor ERE
+                    # resolution found this pattern in the target. Never
+                    # silently drop - a dropped assertion inside a
+                    # consumer that yielded some OTHER resolved assertion
+                    # is invisible to every other section of the report.
+                    unresolved.append(
+                        Unresolved(
+                            consumer=consumer_rel,
+                            detail=f"{kind}: {lit!r} not found in target as a literal substring or "
+                            "as a case-insensitive ERE match - could not mechanically resolve",
+                        )
+                    )
                 continue
             moved = [ln for ln in occ if range_for_line(ranges, ln) is not None]
+            method_note = " (resolved via ERE match, not literal substring)" if method == "regex" else ""
             if kind == "comment_reference":
                 out.append(
                     Assertion(
                         consumer=consumer_rel,
                         kind=kind,
-                        detail=f"comment cites {lit!r}",
+                        detail=f"comment cites {lit!r}{method_note}",
                         resolved=True,
                         breaks=False,
                         lines=occ,
                         note="informational only; goes stale but does not break a gate",
-                    )
-                )
-            elif kind == "literal_absent":
-                out.append(
-                    Assertion(
-                        consumer=consumer_rel,
-                        kind=kind,
-                        detail=f"asserts {lit!r} is ABSENT from target",
-                        resolved=True,
-                        breaks=False,
-                        lines=occ,
-                        note="absence assertions cannot be broken by a move away from the target",
                     )
                 )
             elif kind == "literal_count":
@@ -413,7 +599,10 @@ def extract_literal_assertions(
                     Assertion(
                         consumer=consumer_rel,
                         kind=kind,
-                        detail=f"counts occurrences of {lit!r} in target ({len(occ)} total, {len(moved)} in a move range)",
+                        detail=(
+                            f"counts occurrences of {lit!r} in target ({len(occ)} total, "
+                            f"{len(moved)} in a move range){method_note}"
+                        ),
                         resolved=True,
                         breaks=bool(moved),
                         lines=occ,
@@ -425,14 +614,14 @@ def extract_literal_assertions(
                     Assertion(
                         consumer=consumer_rel,
                         kind="literal_presence",
-                        detail=f"asserts {lit!r} is present in target",
+                        detail=f"asserts {lit!r} is present in target{method_note}",
                         resolved=True,
                         breaks=bool(moved),
                         lines=occ,
                         note=f"moves to {range_for_line(ranges, moved[0]).dest}" if moved else "",
                     )
                 )
-    return out
+    return out, unresolved
 
 
 # ---------------------------------------------------------------------------
@@ -567,6 +756,38 @@ def extract_regex_assertions(
             if compiled.search(line):
                 matches.append(i)
         moved = [ln for ln in matches if range_for_line(ranges, ln) is not None]
+        if not matches:
+            # Zero occurrences in the PRE-move target, under either
+            # polarity, is mechanically resolvable as non-breaking: the
+            # move only relocates existing target lines verbatim into a
+            # destination file, it cannot conjure a match into existence
+            # on content that already matches nothing. A must-match
+            # assertion with zero matches is already failing independent
+            # of any move (a pre-existing defect out of this tool's
+            # scope); a must-NOT-match assertion with zero matches is
+            # correctly satisfied and stays that way post-move either
+            # way. Report it resolved, not UNRESOLVED - polarity still
+            # can't be confirmed mechanically, but it provably doesn't
+            # change what this move does to the assertion's outcome.
+            assertions.append(
+                Assertion(
+                    consumer=consumer_rel,
+                    kind="regex_pattern",
+                    detail=(
+                        f"regex assertion {name!r} (pattern={pat!r}) matches ZERO "
+                        "lines in the pre-move target"
+                    ),
+                    resolved=True,
+                    breaks=False,
+                    lines=[],
+                    note=(
+                        "polarity (must-match vs must-NOT-match) not mechanically "
+                        "confirmed, but zero pre-move matches means this move "
+                        "cannot change the assertion's outcome either way"
+                    ),
+                )
+            )
+            continue
         # Polarity (should-match vs should-not-match) is not mechanically
         # derivable from the compiled pattern alone - report as UNRESOLVED
         # per the "fail loud" design constraint rather than guessing.
@@ -575,7 +796,7 @@ def extract_regex_assertions(
                 consumer=consumer_rel,
                 detail=(
                     f"regex assertion {name!r} (pattern={pat!r}) currently matches "
-                    f"target lines {matches or '[]'}"
+                    f"target lines {matches}"
                     + (
                         f"; {len(moved)} of those line(s) fall inside a proposed "
                         f"move range {moved} - polarity (must-match vs must-NOT-"
@@ -594,7 +815,16 @@ def extract_regex_assertions(
 # Shell grep -c floor assertions: single "-ge N" style and heredoc tables
 # ---------------------------------------------------------------------------
 
-_VAR_ASSIGN_RE = re.compile(r'^\s*([A-Za-z_][A-Za-z0-9_]*)="?\$\((.*)\)"?\s*$')
+# Deliberately NOT `$`-anchored: `VAR="$(git grep -c ...)"` is frequently
+# followed by a trailing statement on the same physical line (e.g.
+# `G6="$(...)"; [ -n "$G6" ] || G6=0` in test_tasks_jsonl_fold.sh) rather
+# than ending the line. `(.*?)` is non-greedy so it stops at the FIRST `)`
+# it meets, which is the assignment's own closing paren for every floor
+# pattern in this repo (none of the `git grep -c` patterns extracted here
+# contain a literal `)` themselves) - a greedy `.*` would instead run to
+# the LAST `)` on the line, which can land past the assignment entirely
+# once a trailing statement is present.
+_VAR_ASSIGN_RE = re.compile(r'^\s*([A-Za-z_][A-Za-z0-9_]*)="?\$\((.*?)\)"?')
 _GREP_C_RE = re.compile(r"git grep -c([iE]*)\s+['\"]([^'\"]+)['\"].*?--\s+(\S+)")
 _FLOOR_RE = re.compile(r'\[\s*"\$(\w+)"\s*-(ge|gt|le|lt|eq)\s+"?(\d+)"?\s*\]')
 _PATH_VAR_RE = re.compile(
@@ -673,7 +903,13 @@ def extract_shell_floor_assertions(
         if not gm:
             continue
         flags, pattern, file_tok = gm.group(1), gm.group(2), gm.group(3)
-        file_tok = file_tok.strip('"').strip("'")
+        # Strip the quoting AND the `$`/`${...}` variable-reference syntax
+        # (e.g. `"$DIT"` -> `DIT`) - `varmap`'s keys are the bare variable
+        # names `_build_shell_path_vars` extracted from each assignment
+        # (`DIT=content/commands/...`), never dollar-prefixed. Without
+        # this, `varmap.get("$DIT")` always misses even when `DIT` is
+        # correctly resolved to the target, silently discarding the floor.
+        file_tok = file_tok.strip('"').strip("'").lstrip("$").strip("{}")
         resolved_path = varmap.get(file_tok, file_tok if file_tok == target_rel else None)
         if resolved_path != target_rel:
             continue
@@ -837,6 +1073,32 @@ def analyze(repo_root: Path, target_rel: str, ranges: list[MoveRange]) -> Report
         )
         return report
 
+    if not any(_is_checked_consumer(c) for c in consumers):
+        # Second non-vacuity guard, one level down from the one above: the
+        # first guard only fires when discovery finds literally nothing.
+        # It does NOT fire when discovery finds plenty of doc/prose
+        # consumers but zero *checked* (executable-gate) consumers - every
+        # non-checked file `continue`s past the `found_any` machinery
+        # below without ever touching it, so a `bin/tests/` rename, a gate
+        # moving under `scripts/verify-*.sh`, or any other drift in
+        # `_is_checked_consumer`/`SEARCH_DIRS` silently produces a report
+        # with zero BREAKING rows and zero UNRESOLVED entries - `Verdict:
+        # OK`, having asserted nothing. Report it loudly instead.
+        report.unresolved.append(
+            Unresolved(
+                consumer="<discovery>",
+                detail=(
+                    f"discovery found {len(consumers)} consumer(s) referencing the "
+                    "target file, but ZERO of them match the checked-consumer "
+                    "patterns (bin/tests/**, hooks/tests/**, scripts/check-*.sh) - "
+                    "this is almost certainly _is_checked_consumer()/SEARCH_DIRS "
+                    "drifting out from under a renamed or relocated executable "
+                    "gate, not a target file with no runnable consumers left. "
+                    "Refusing to report OK."
+                ),
+            )
+        )
+
     for rel in consumers:
         path = repo_root / rel
         try:
@@ -865,9 +1127,12 @@ def analyze(repo_root: Path, target_rel: str, ranges: list[MoveRange]) -> Report
 
         found_any = False
 
-        lit_assertions = extract_literal_assertions(rel, text, target_text, line_starts, ranges)
+        lit_assertions, lit_unresolved = extract_literal_assertions(
+            rel, text, target_text, target_lines_raw, line_starts, ranges, target_rel
+        )
         report.assertions.extend(lit_assertions)
-        found_any = found_any or bool(lit_assertions)
+        report.unresolved.extend(lit_unresolved)
+        found_any = found_any or bool(lit_assertions) or bool(lit_unresolved)
 
         hb_assertions = extract_heading_block_assertions(rel, text, headings, ranges)
         report.assertions.extend(hb_assertions)

--- a/scripts/prose-move-impact.py
+++ b/scripts/prose-move-impact.py
@@ -11,13 +11,18 @@ Purpose: Mechanically enumerate every consumer that would break if a set of
 Public API: CLI. `python3 scripts/prose-move-impact.py --target <path>
             --range START:END:DEST [--range ...] | --config <json>`. Prints a
             human-readable report to stdout. Exit 0 only when every consumer
-            was fully resolved and every resolved assertion still holds after
-            the proposed move; exit 1 when any assertion breaks OR when
+            was fully resolved, every resolved assertion still holds after
+            the proposed move, AND no consumer's scanned set is left behind
+            by the move (see `Report.ok`); exit 1 when any assertion breaks,
             anything could not be resolved (see UNRESOLVED below - this is
             deliberate: an unresolved assertion is treated as a potential
-            break, not a pass). Importable: `analyze(repo_root, target_rel,
-            ranges) -> Report` for callers that want the structured result
-            (used by bin/tests/test_prose_move_impact.py).
+            break, not a pass), or a consumer's hardcoded single-file scan
+            would silently stop covering the moved content post-move (see
+            SCANNED SET below - a consumer whose only finding is
+            `leaves_scanned_set=True` must not exit 0 either). Importable:
+            `analyze(repo_root, target_rel, ranges) -> Report` for callers
+            that want the structured result (used by
+            bin/tests/test_prose_move_impact.py).
 
 Upstream deps: `git grep` (consumer discovery), Python stdlib only
                (re, ast, bisect, dataclasses, json, argparse). No PyPI deps.
@@ -42,7 +47,14 @@ Failure modes: any consumer file this tool cannot parse into at least one
                mode it exists to prevent. A regex-metachar pattern (from a
                `_present`/`grep -qiE` shell call site) is resolved via an
                ERE fallback, not just a literal substring match - see
-               `_resolve_literal_in_target`. Read-only; no side effects.
+               `_resolve_literal_in_target`. A consumer that hardcodes a
+               single-file scan of the target with no `content/**`-wide
+               fallback (see `infer_scanned_set`) forces a non-zero exit
+               too, even when nothing else in the report resolved to a
+               break - `Report.ok` treats `leaves_scanned_set=True` as a
+               failure in its own right, not just an informational row, so
+               a run whose only finding is a left-behind scanned set cannot
+               silently print `Verdict: OK`. Read-only; no side effects.
 
 Performance: single pass over `git grep` output plus one parse per
              discovered consumer file (typically a few dozen files, low
@@ -237,6 +249,8 @@ class Report:
         if self.unresolved:
             return False
         if any(a.breaks for a in self.assertions):
+            return False
+        if any(s.leaves_scanned_set for s in self.scanned_sets):
             return False
         return True
 
@@ -516,12 +530,6 @@ def extract_literal_assertions(
             is_call_target_scoped = bool(path_vars)
         is_shell_call = _is_shell_call_line(logical) and is_call_target_scoped
         for idx, lit in enumerate(literals):
-            if not _is_meaningful_literal(lit):
-                continue
-            # Skip pure noise: path literals that merely re-cite the target
-            # path itself carry no content assertion.
-            if lit in (DEFAULT_TARGET, Path(DEFAULT_TARGET).name):
-                continue
             # Only the LAST quoted literal on a pattern-check line (the
             # `<pattern>` slot of `_present <file> <label> <pattern>` /
             # `_absent <label> <pattern>` / `x.count("...")`) is the actual
@@ -535,7 +543,23 @@ def extract_literal_assertions(
             # single-file test consumer against this file's OWN internal
             # string literals produced dozens of spurious rows before this
             # narrowing).
+            #
+            # This MUST be computed before the `_is_meaningful_literal`
+            # filter below, and the filter must be skipped for a pattern
+            # slot: `_is_meaningful_literal` exists to drop incidental
+            # short-token noise, but a pattern slot is by construction a
+            # deliberate assertion payload (e.g. `'mark-blocked-and-
+            # continue'`, `'fail-open'`, `'<ISO8601>'`) regardless of shape.
+            # Filtering it first silently dropped these with no UNRESOLVED
+            # row - the identical silent-drop class the ERE-fallback fix
+            # above exists to prevent, one filter earlier in this function.
             is_pattern_slot = kind in _PATTERN_CHECK_KINDS and idx == last_idx and is_shell_call
+            if not is_pattern_slot and not _is_meaningful_literal(lit):
+                continue
+            # Skip pure noise: path literals that merely re-cite the target
+            # path itself carry no content assertion.
+            if lit in (DEFAULT_TARGET, Path(DEFAULT_TARGET).name):
+                continue
             if is_pattern_slot:
                 occ, method = _resolve_literal_in_target(target_text, target_lines, line_starts, lit)
             else:
@@ -698,12 +722,52 @@ def _eval_str_expr(node) -> str | None:
     return None
 
 
-def extract_python_regex_patterns(consumer_text: str) -> dict[str, str]:
+# `re.compile`'s own flag constants (the module-level names, plus their
+# single-letter aliases) - resolved from an `ast.Attribute` like
+# `re.IGNORECASE` at a `re.compile(pattern, <flags-expr>)` call site.
+# Combinations via `|` (`re.IGNORECASE | re.DOTALL`) are resolved
+# recursively through the `ast.BinOp`/`ast.BitOr` branch below.
+_RE_FLAG_NAMES = {
+    "IGNORECASE": re.IGNORECASE,
+    "I": re.IGNORECASE,
+    "MULTILINE": re.MULTILINE,
+    "M": re.MULTILINE,
+    "DOTALL": re.DOTALL,
+    "S": re.DOTALL,
+    "VERBOSE": re.VERBOSE,
+    "X": re.VERBOSE,
+    "ASCII": re.ASCII,
+    "A": re.ASCII,
+    "UNICODE": re.UNICODE,
+    "U": re.UNICODE,
+    "LOCALE": re.LOCALE,
+    "L": re.LOCALE,
+}
+
+
+def _eval_flags_expr(node) -> int | None:
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "re":
+        return _RE_FLAG_NAMES.get(node.attr)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _eval_flags_expr(node.left)
+        right = _eval_flags_expr(node.right)
+        if left is not None and right is not None:
+            return left | right
+    return None
+
+
+def extract_python_regex_patterns(consumer_text: str) -> dict[str, tuple[str, int]]:
+    """Returns {name: (pattern, flags)}. `flags` reads the actual second
+    positional arg or `flags=` keyword of the `re.compile(...)` call site -
+    a naive re-compile with no flags silently discards `re.IGNORECASE`/
+    `re.DOTALL`/`re.MULTILINE` the consumer actually used, which can make a
+    pattern that genuinely matches the live target (case-insensitively, or
+    across a newline) read as a false non-match here."""
     try:
         tree = ast.parse(consumer_text)
     except SyntaxError:
         return {}
-    out: dict[str, str] = {}
+    out: dict[str, tuple[str, int]] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
             continue
@@ -722,16 +786,27 @@ def extract_python_regex_patterns(consumer_text: str) -> dict[str, str]:
         pat = _eval_str_expr(call.args[0])
         if pat is None:
             continue
+        flags = 0
+        if len(call.args) >= 2:
+            f = _eval_flags_expr(call.args[1])
+            if f is not None:
+                flags = f
+        for kw in call.keywords:
+            if kw.arg == "flags":
+                f = _eval_flags_expr(kw.value)
+                if f is not None:
+                    flags = f
         for t in node.targets:
             if isinstance(t, ast.Name):
-                out[t.id] = pat
+                out[t.id] = (pat, flags)
     return out
 
 
 def extract_regex_assertions(
     consumer_rel: str,
     consumer_text: str,
-    target_lines: list[str],
+    target_text: str,
+    line_starts: list[int],
     ranges: list[MoveRange],
 ) -> tuple[list[Assertion], list[Unresolved]]:
     assertions: list[Assertion] = []
@@ -739,22 +814,27 @@ def extract_regex_assertions(
     if not consumer_rel.endswith(".py"):
         return assertions, unresolved
     patterns = extract_python_regex_patterns(consumer_text)
-    for name, pat in patterns.items():
+    for name, (pat, flags) in patterns.items():
         # Only meaningful if the compiled name is actually referenced again
         # (search/finditer/match) - a defined-but-unused pattern is noise.
         if not re.search(rf"\b{re.escape(name)}\s*\.\s*(search|finditer|match)\b", consumer_text):
             continue
         try:
-            compiled = re.compile(pat)
+            compiled = re.compile(pat, flags)
         except re.error as e:
             unresolved.append(
                 Unresolved(consumer=consumer_rel, detail=f"{name}: pattern failed to compile: {e}")
             )
             continue
-        matches = []
-        for i, line in enumerate(target_lines, start=1):
-            if compiled.search(line):
-                matches.append(i)
+        # Match against the WHOLE target text, not per-line: a consumer
+        # searches its own whole-text string (this is exactly what the
+        # consumer's own `.search()`/`.finditer()` call does), and a
+        # per-line scan misses any pattern that can span a newline (e.g.
+        # `[^.]{0,80}` matches `\n`) - a deletion seam created by the move
+        # can create a NEW cross-line match post-move that a per-line scan
+        # would never see either way, silently converting a real break
+        # into a false "zero matches, cannot break" resolution below.
+        matches = sorted({offset_to_line(line_starts, m.start()) for m in compiled.finditer(target_text)})
         moved = [ln for ln in matches if range_for_line(ranges, ln) is not None]
         if not matches:
             # Zero occurrences in the PRE-move target, under either
@@ -1138,7 +1218,7 @@ def analyze(repo_root: Path, target_rel: str, ranges: list[MoveRange]) -> Report
         report.assertions.extend(hb_assertions)
         found_any = found_any or bool(hb_assertions)
 
-        regex_assertions, regex_unresolved = extract_regex_assertions(rel, text, target_lines_raw, ranges)
+        regex_assertions, regex_unresolved = extract_regex_assertions(rel, text, target_text, line_starts, ranges)
         report.assertions.extend(regex_assertions)
         report.unresolved.extend(regex_unresolved)
         found_any = found_any or bool(regex_assertions) or bool(regex_unresolved)

--- a/scripts/prose-move-impact.py
+++ b/scripts/prose-move-impact.py
@@ -832,38 +832,33 @@ def extract_regex_assertions(
         # per-line scan misses any pattern that can span a newline (e.g.
         # `[^.]{0,80}` matches `\n`) - a deletion seam created by the move
         # can create a NEW cross-line match post-move that a per-line scan
-        # would never see either way, silently converting a real break
-        # into a false "zero matches, cannot break" resolution below.
+        # would never see either way. Zero matches under this strategy is
+        # still reported UNRESOLVED below, never inferred as non-breaking -
+        # see the comment at the zero-match branch for why.
         matches = sorted({offset_to_line(line_starts, m.start()) for m in compiled.finditer(target_text)})
         moved = [ln for ln in matches if range_for_line(ranges, ln) is not None]
         if not matches:
-            # Zero occurrences in the PRE-move target, under either
-            # polarity, is mechanically resolvable as non-breaking: the
-            # move only relocates existing target lines verbatim into a
-            # destination file, it cannot conjure a match into existence
-            # on content that already matches nothing. A must-match
-            # assertion with zero matches is already failing independent
-            # of any move (a pre-existing defect out of this tool's
-            # scope); a must-NOT-match assertion with zero matches is
-            # correctly satisfied and stays that way post-move either
-            # way. Report it resolved, not UNRESOLVED - polarity still
-            # can't be confirmed mechanically, but it provably doesn't
-            # change what this move does to the assertion's outcome.
-            assertions.append(
-                Assertion(
+            # Zero occurrences under this tool's own whole-text matching
+            # strategy does NOT mean zero occurrences under the consumer's
+            # real matching strategy - three separate rounds each proved
+            # this inference unsound under a different cause (lost flags,
+            # per-line matching, and now whole-text matching against a
+            # consumer that applies the pattern per-line or per-token, e.g.
+            # `.match(name)` against an extracted identifier rather than
+            # against the whole target text - see
+            # bin/tests/lib/md_shell_extract.py::_IDENTIFIER_RE, which
+            # matches 0 whole-text but 29 per-line, 7 of them inside a move
+            # range). This tool cannot know a consumer's real granularity,
+            # so treat zero matches the same as any other unresolved
+            # polarity: fail loud, never infer "cannot break" from it.
+            unresolved.append(
+                Unresolved(
                     consumer=consumer_rel,
-                    kind="regex_pattern",
                     detail=(
                         f"regex assertion {name!r} (pattern={pat!r}) matches ZERO "
-                        "lines in the pre-move target"
-                    ),
-                    resolved=True,
-                    breaks=False,
-                    lines=[],
-                    note=(
-                        "polarity (must-match vs must-NOT-match) not mechanically "
-                        "confirmed, but zero pre-move matches means this move "
-                        "cannot change the assertion's outcome either way"
+                        "lines under whole-text matching in the pre-move target - "
+                        "this does not prove the consumer's own matching strategy "
+                        "also finds zero, verify by hand"
                     ),
                 )
             )

--- a/scripts/prose-move-impact.py
+++ b/scripts/prose-move-impact.py
@@ -1,0 +1,1059 @@
+#!/usr/bin/env python3
+"""
+Purpose: Mechanically enumerate every consumer that would break if a set of
+         line ranges were moved out of a target markdown file (e.g. splitting
+         content/commands/ds-implement-ticket.md into content/references/*
+         behind trigger-pointers). Exists because four prose-only review
+         rounds on that exact split each fixed the named defects and left or
+         reintroduced structurally identical ones - prose review can only
+         falsify a claim someone wrote down, never one nobody made.
+
+Public API: CLI. `python3 scripts/prose-move-impact.py --target <path>
+            --range START:END:DEST [--range ...] | --config <json>`. Prints a
+            human-readable report to stdout. Exit 0 only when every consumer
+            was fully resolved and every resolved assertion still holds after
+            the proposed move; exit 1 when any assertion breaks OR when
+            anything could not be resolved (see UNRESOLVED below - this is
+            deliberate: an unresolved assertion is treated as a potential
+            break, not a pass). Importable: `analyze(repo_root, target_rel,
+            ranges) -> Report` for callers that want the structured result
+            (used by bin/tests/test_prose_move_impact.py).
+
+Upstream deps: `git grep` (consumer discovery), Python stdlib only
+               (re, ast, bisect, dataclasses, json, argparse). No PyPI deps.
+
+Downstream consumers: bin/tests/test_prose_move_impact.py (spec + known-
+                      answer fixtures + mutation test). Intended to be run
+                      ad hoc by a human/architect before authoring a split
+                      plan, not wired into CI as a required gate - its
+                      inputs (proposed move ranges) do not exist yet on
+                      main and there is nothing for a CI job to check
+                      against.
+
+Failure modes: any consumer file this tool cannot parse into at least one
+               resolved assertion, or any assertion whose target-line
+               resolution is ambiguous, is emitted verbatim in the
+               UNRESOLVED section and forces a non-zero exit. This is
+               intentional per the tool's own design constraint ("fail
+               loud, never silently skip") - a tool that quietly drops
+               what it does not understand reproduces the exact failure
+               mode it exists to prevent. Read-only; no side effects.
+
+Performance: single pass over `git grep` output plus one parse per
+             discovered consumer file (typically a few dozen files, low
+             hundreds of KB total) - well under a second on this repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import bisect
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_TARGET = "content/commands/ds-implement-ticket.md"
+SEARCH_DIRS = ["bin/tests", "hooks/tests", "content", "scripts", ".github"]
+
+# Consumers whose entire job is talking ABOUT this tool/its fixtures, or
+# generated/build artifacts that mention the target path only incidentally.
+# Kept short and explicit rather than clever, per the "fail loud" mandate -
+# an entry here is a deliberate, reviewable exemption, not a silent guess.
+SELF_EXEMPT_SUFFIXES = ("prose-move-impact.py", "test_prose_move_impact.py")
+
+# Mechanical-assertion extraction (literal/regex/heading-block/count-floor)
+# is scoped to actual executable gates - test suites and check-*.sh scripts.
+# Everything else discovery turns up (content/**, .github/prompts, .github/
+# agents, README-style docs) is PROSE that mentions or duplicates the target,
+# not a runnable assertion against it: it can contain any short English word
+# that also happens to appear in the target ("default", "status", "worktree")
+# with zero semantic connection. Treating those as load-bearing produced
+# hundreds of false "BREAKING" rows on generic short strings. Those files
+# are still discovered and reported (doc-sync is a real, separate concern -
+# see AGENTS.md's docs-currency-pass rule) but only via a lightweight
+# heading-citation check, never via arbitrary literal matching.
+
+
+def _is_checked_consumer(rel: str) -> bool:
+    if rel.startswith("bin/tests/") or rel.startswith("hooks/tests/"):
+        return True
+    name = Path(rel).name
+    if rel.startswith("scripts/") and name.startswith("check-") and name.endswith(".sh"):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Fence-aware heading index
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Heading:
+    line: int  # 1-indexed line of the "## " (or "### ") heading
+    end_line: int  # 1-indexed last line belonging to this heading's block
+    level: int  # number of leading '#' characters
+    text: str  # full heading line, stripped of trailing whitespace
+
+
+def fence_aware_headings(lines: list[str]) -> list[Heading]:
+    """Scan `lines` (no trailing newlines required) tracking ``` fence state
+    and record only '#'-prefixed heading lines OUTSIDE a fence. A block's
+    end_line is the line before the next heading of level <= its own level,
+    or EOF - this mirrors _extract_block()-style consumers that stop at the
+    next top-level heading, not the next heading of any depth."""
+    fenced = False
+    starts: list[tuple[int, int, str]] = []  # (line_no, level, text)
+    fence_re = re.compile(r"^```")
+    heading_re = re.compile(r"^(#{1,6})\s")
+    for i, raw in enumerate(lines, start=1):
+        s = raw.rstrip("\n")
+        if fence_re.match(s):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        m = heading_re.match(s)
+        if m:
+            starts.append((i, len(m.group(1)), s))
+    headings: list[Heading] = []
+    for idx, (ln, level, text) in enumerate(starts):
+        end = len(lines)
+        for j in range(idx + 1, len(starts)):
+            nxt_ln, nxt_level, _ = starts[j]
+            if nxt_level <= level:
+                end = nxt_ln - 1
+                break
+        headings.append(Heading(line=ln, end_line=end, level=level, text=text))
+    return headings
+
+
+def build_line_starts(text: str) -> list[int]:
+    starts = [0]
+    for m in re.finditer("\n", text):
+        starts.append(m.end())
+    return starts
+
+
+def offset_to_line(line_starts: list[int], offset: int) -> int:
+    return bisect.bisect_right(line_starts, offset)
+
+
+# ---------------------------------------------------------------------------
+# Move ranges
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MoveRange:
+    start: int
+    end: int
+    dest: str
+
+    def contains(self, line: int) -> bool:
+        return self.start <= line <= self.end
+
+    def overlaps(self, start: int, end: int) -> bool:
+        return not (end < self.start or start > self.end)
+
+
+def range_for_line(ranges: list[MoveRange], line: int) -> MoveRange | None:
+    for r in ranges:
+        if r.contains(line):
+            return r
+    return None
+
+
+def any_range_overlaps(ranges: list[MoveRange], start: int, end: int) -> MoveRange | None:
+    for r in ranges:
+        if r.overlaps(start, end):
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Assertion:
+    consumer: str
+    kind: str  # literal_presence | literal_absent | literal_count | comment_reference
+    #             | heading_block | regex_pattern | line_range | grep_count_floor
+    detail: str
+    resolved: bool
+    breaks: bool  # True if the move would break this assertion
+    lines: list[int] = field(default_factory=list)
+    note: str = ""
+
+
+@dataclass
+class Unresolved:
+    consumer: str
+    detail: str
+    line: int | None = None
+
+
+@dataclass
+class ScannedSetFinding:
+    consumer: str
+    scope: str  # "single-file" | "multi-file-content" | "unknown"
+    detail: str
+    leaves_scanned_set: bool = False
+
+
+@dataclass
+class DocCitation:
+    consumer: str
+    heading: str
+    dest: str
+
+
+@dataclass
+class Report:
+    target: str
+    ranges: list[MoveRange]
+    consumers: list[str]
+    assertions: list[Assertion] = field(default_factory=list)
+    unresolved: list[Unresolved] = field(default_factory=list)
+    scanned_sets: list[ScannedSetFinding] = field(default_factory=list)
+    doc_consumers: list[str] = field(default_factory=list)
+    doc_citations: list[DocCitation] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        if self.unresolved:
+            return False
+        if any(a.breaks for a in self.assertions):
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Consumer discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_consumers(repo_root: Path, target_rel: str) -> list[str]:
+    basename = Path(target_rel).name
+    pattern = "|".join(re.escape(p) for p in {target_rel, basename})
+    cmd = ["git", "grep", "-l", "-E", pattern, "--"] + SEARCH_DIRS
+    proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True)
+    if proc.returncode not in (0, 1):
+        raise RuntimeError(f"git grep discovery failed: {proc.stderr.strip()}")
+    files = set()
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line or line == target_rel:
+            continue
+        if any(line.endswith(sfx) for sfx in SELF_EXEMPT_SUFFIXES):
+            continue
+        files.add(line)
+    return sorted(files)
+
+
+# ---------------------------------------------------------------------------
+# Shell-continuation join (backslash line continuation -> one logical line)
+# ---------------------------------------------------------------------------
+
+
+def join_shell_continuations(text: str) -> list[tuple[int, str]]:
+    """Return (starting_line_no, logical_line) pairs, joining any line
+    ending in a bare trailing backslash with the following physical line(s)
+    so a multi-line `_absent "$SPEC" "label" \\n  'pattern'` call is visible
+    to a single-line regex scan."""
+    raw_lines = text.split("\n")
+    out: list[tuple[int, str]] = []
+    i = 0
+    n = len(raw_lines)
+    while i < n:
+        start = i + 1
+        buf = raw_lines[i]
+        while buf.endswith("\\") and i + 1 < n:
+            buf = buf[:-1] + " " + raw_lines[i + 1]
+            i += 1
+        out.append((start, buf))
+        i += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Literal-string assertion extraction (generic, language-agnostic)
+# ---------------------------------------------------------------------------
+
+_STR_RE = re.compile(r'"([^"\\]{6,300})"|\'([^\'\\]{6,300})\'')
+
+
+_SHELL_NOISE_RE = re.compile(r"^\s*\$?\(?\s*(echo|cat|grep|awk|sed|printf|true|false)\b")
+
+
+def _is_meaningful_literal(lit: str) -> bool:
+    """A single snake_case/camelCase token (e.g. `task_id`, `created_at`)
+    coincidentally reappears in a 3600-line prose file constantly and is
+    almost never itself the thing under test - the surrounding code (a
+    dict-key check, a JSON schema field) is testing something about the
+    *consumer's own data model*, not this specific target file's prose. A
+    real content assertion against the target is either a multi-word
+    phrase, or a short token wrapped in punctuation that marks it as a
+    deliberately quoted fragment (a backtick-quoted identifier, a path, a
+    key: value pair, an env-var style `$NAME`, or a rendered literal like
+    `NAME=value`). Common inline shell boilerplate that both the target's
+    fenced code examples and a consumer's own script logic incidentally
+    share (`2>/dev/null || true`, `$(echo ...`) is excluded explicitly -
+    it is shell noise, not a content assertion against the target's prose."""
+    if _SHELL_NOISE_RE.match(lit) or "2>/dev/null" in lit or lit.strip() in ("", "true", "false"):
+        return False
+    if len([w for w in lit.split() if w]) >= 2:
+        # A real multi-word phrase - the dominant shape of the fixtures'
+        # own load-bearing assertions ("## Tracker Writeback Helper",
+        # "State Dev Complete:", "Pipeline order"). A single word padded
+        # with whitespace (' want ') does not count as multi-word.
+        return True
+    if len(lit) >= 12 and re.search(r"[`:/=$]", lit) and not re.search(r"[()]", lit):
+        return True
+    return False
+
+
+def _literals_in_line(line: str) -> list[str]:
+    out = []
+    for m in _STR_RE.finditer(line):
+        lit = m.group(1) if m.group(1) is not None else m.group(2)
+        out.append(lit)
+    return out
+
+
+def _classify_line(logical_line: str) -> str:
+    l = logical_line
+    stripped = l.strip()
+    if stripped.startswith("#"):
+        return "comment_reference"
+    if "_absent(" in l or re.search(r"\bnot in\b", l) or ".count(" in l and "== 0" in l:
+        if ".count(" in l and "== 0" in l:
+            return "literal_count"
+        return "literal_absent"
+    if "_present(" in l:
+        return "literal_presence"
+    if ".count(" in l:
+        return "literal_count"
+    if re.search(r"\bin\s+text\b|\bin\s+block\b|\bin\s+canonical_block\b|\bin\s+implement_ticket_text\b", l):
+        return "literal_presence"
+    if "assert" in l and " in " in l:
+        return "literal_presence"
+    return "literal_reference"
+
+
+def _target_occurrences(target_text: str, line_starts: list[int], literal: str) -> list[int]:
+    lines = []
+    idx = target_text.find(literal)
+    while idx != -1:
+        lines.append(offset_to_line(line_starts, idx))
+        idx = target_text.find(literal, idx + 1)
+    return lines
+
+
+def extract_literal_assertions(
+    consumer_rel: str,
+    consumer_text: str,
+    target_text: str,
+    line_starts: list[int],
+    ranges: list[MoveRange],
+) -> list[Assertion]:
+    out: list[Assertion] = []
+    for _lineno, logical in join_shell_continuations(consumer_text):
+        literals = _literals_in_line(logical)
+        if not literals:
+            continue
+        kind = _classify_line(logical)
+        for lit in literals:
+            if not _is_meaningful_literal(lit):
+                continue
+            if lit not in target_text:
+                continue
+            # Skip pure noise: path literals that merely re-cite the target
+            # path itself carry no content assertion.
+            if lit in (DEFAULT_TARGET, Path(DEFAULT_TARGET).name):
+                continue
+            occ = _target_occurrences(target_text, line_starts, lit)
+            if not occ:
+                continue
+            moved = [ln for ln in occ if range_for_line(ranges, ln) is not None]
+            if kind == "comment_reference":
+                out.append(
+                    Assertion(
+                        consumer=consumer_rel,
+                        kind=kind,
+                        detail=f"comment cites {lit!r}",
+                        resolved=True,
+                        breaks=False,
+                        lines=occ,
+                        note="informational only; goes stale but does not break a gate",
+                    )
+                )
+            elif kind == "literal_absent":
+                out.append(
+                    Assertion(
+                        consumer=consumer_rel,
+                        kind=kind,
+                        detail=f"asserts {lit!r} is ABSENT from target",
+                        resolved=True,
+                        breaks=False,
+                        lines=occ,
+                        note="absence assertions cannot be broken by a move away from the target",
+                    )
+                )
+            elif kind == "literal_count":
+                out.append(
+                    Assertion(
+                        consumer=consumer_rel,
+                        kind=kind,
+                        detail=f"counts occurrences of {lit!r} in target ({len(occ)} total, {len(moved)} in a move range)",
+                        resolved=True,
+                        breaks=bool(moved),
+                        lines=occ,
+                        note="moving any occurrence changes the count this assertion pins" if moved else "",
+                    )
+                )
+            else:  # literal_presence / literal_reference (treated as load-bearing)
+                out.append(
+                    Assertion(
+                        consumer=consumer_rel,
+                        kind="literal_presence",
+                        detail=f"asserts {lit!r} is present in target",
+                        resolved=True,
+                        breaks=bool(moved),
+                        lines=occ,
+                        note=f"moves to {range_for_line(ranges, moved[0]).dest}" if moved else "",
+                    )
+                )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Heading-block assertions (HEADING = "..." + _extract_block()-style readers)
+# ---------------------------------------------------------------------------
+
+_HEADING_VAR_RE = re.compile(r'^\s*(?:HEADING|SECTION_HEADING)\s*=\s*["\'](#{1,6}\s[^"\']+)["\']')
+
+
+def extract_heading_block_assertions(
+    consumer_rel: str,
+    consumer_text: str,
+    headings: list[Heading],
+    ranges: list[MoveRange],
+) -> list[Assertion]:
+    out: list[Assertion] = []
+    if "_extract_block" not in consumer_text and "HEADING" not in consumer_text:
+        return out
+    for line in consumer_text.split("\n"):
+        m = _HEADING_VAR_RE.match(line)
+        if not m:
+            continue
+        heading_text = m.group(1)
+        match = next((h for h in headings if h.text == heading_text), None)
+        if match is None:
+            out.append(
+                Assertion(
+                    consumer=consumer_rel,
+                    kind="heading_block",
+                    detail=f"HEADING={heading_text!r} does not match any live heading",
+                    resolved=False,
+                    breaks=True,
+                    note="heading not found in target - already broken independent of this move",
+                )
+            )
+            continue
+        overlap = any_range_overlaps(ranges, match.line, match.end_line)
+        out.append(
+            Assertion(
+                consumer=consumer_rel,
+                kind="heading_block",
+                detail=(
+                    f"_extract_block-style reader anchors on {heading_text!r} "
+                    f"spanning target lines {match.line}-{match.end_line}"
+                ),
+                resolved=True,
+                breaks=overlap is not None,
+                lines=[match.line, match.end_line],
+                note=(
+                    f"heading block overlaps proposed move to {overlap.dest} "
+                    f"({overlap.start}-{overlap.end}) - block extraction would "
+                    "no longer find this content contiguous in the target file"
+                    if overlap
+                    else ""
+                ),
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Python regex-pattern assertions (re.compile(...) constant-folded via ast)
+# ---------------------------------------------------------------------------
+
+
+def _eval_str_expr(node) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _eval_str_expr(node.left)
+        right = _eval_str_expr(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def extract_python_regex_patterns(consumer_text: str) -> dict[str, str]:
+    try:
+        tree = ast.parse(consumer_text)
+    except SyntaxError:
+        return {}
+    out: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        is_compile = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "compile"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "re"
+        )
+        if not is_compile or not call.args:
+            continue
+        pat = _eval_str_expr(call.args[0])
+        if pat is None:
+            continue
+        for t in node.targets:
+            if isinstance(t, ast.Name):
+                out[t.id] = pat
+    return out
+
+
+def extract_regex_assertions(
+    consumer_rel: str,
+    consumer_text: str,
+    target_lines: list[str],
+    ranges: list[MoveRange],
+) -> tuple[list[Assertion], list[Unresolved]]:
+    assertions: list[Assertion] = []
+    unresolved: list[Unresolved] = []
+    if not consumer_rel.endswith(".py"):
+        return assertions, unresolved
+    patterns = extract_python_regex_patterns(consumer_text)
+    for name, pat in patterns.items():
+        # Only meaningful if the compiled name is actually referenced again
+        # (search/finditer/match) - a defined-but-unused pattern is noise.
+        if not re.search(rf"\b{re.escape(name)}\s*\.\s*(search|finditer|match)\b", consumer_text):
+            continue
+        try:
+            compiled = re.compile(pat)
+        except re.error as e:
+            unresolved.append(
+                Unresolved(consumer=consumer_rel, detail=f"{name}: pattern failed to compile: {e}")
+            )
+            continue
+        matches = []
+        for i, line in enumerate(target_lines, start=1):
+            if compiled.search(line):
+                matches.append(i)
+        moved = [ln for ln in matches if range_for_line(ranges, ln) is not None]
+        # Polarity (should-match vs should-not-match) is not mechanically
+        # derivable from the compiled pattern alone - report as UNRESOLVED
+        # per the "fail loud" design constraint rather than guessing.
+        unresolved.append(
+            Unresolved(
+                consumer=consumer_rel,
+                detail=(
+                    f"regex assertion {name!r} (pattern={pat!r}) currently matches "
+                    f"target lines {matches or '[]'}"
+                    + (
+                        f"; {len(moved)} of those line(s) fall inside a proposed "
+                        f"move range {moved} - polarity (must-match vs must-NOT-"
+                        "match) could not be determined mechanically, verify by hand"
+                        if moved
+                        else " (none inside a proposed move range - low risk, but "
+                        "polarity still not mechanically confirmed)"
+                    )
+                ),
+            )
+        )
+    return assertions, unresolved
+
+
+# ---------------------------------------------------------------------------
+# Shell grep -c floor assertions: single "-ge N" style and heredoc tables
+# ---------------------------------------------------------------------------
+
+_VAR_ASSIGN_RE = re.compile(r'^\s*([A-Za-z_][A-Za-z0-9_]*)="?\$\((.*)\)"?\s*$')
+_GREP_C_RE = re.compile(r"git grep -c([iE]*)\s+['\"]([^'\"]+)['\"].*?--\s+(\S+)")
+_FLOOR_RE = re.compile(r'\[\s*"\$(\w+)"\s*-(ge|gt|le|lt|eq)\s+"?(\d+)"?\s*\]')
+_PATH_VAR_RE = re.compile(
+    r'^\s*([A-Za-z_][A-Za-z0-9_]*)=\$?\{?"?\$?(?:REPO_DIR|REPO_ROOT)?/?["\']?([\w./-]*content/commands/[\w.-]+\.md)'
+)
+_PY_PATH_VAR_RE = re.compile(
+    r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*REPO_ROOT\s*/\s*"([\w.-]+)"\s*/\s*"([\w.-]+)"\s*/\s*"([\w.-]+)"'
+)
+
+
+def _build_shell_path_vars(consumer_text: str, target_rel: str) -> dict[str, str]:
+    varmap: dict[str, str] = {}
+    for line in consumer_text.split("\n"):
+        m = _PATH_VAR_RE.match(line)
+        if m and m.group(2).endswith(Path(target_rel).name):
+            varmap[m.group(1)] = target_rel
+        m2 = _PY_PATH_VAR_RE.match(line)
+        if m2:
+            candidate = "/".join([m2.group(2), m2.group(3), m2.group(4)])
+            if candidate == target_rel:
+                varmap[m2.group(1)] = target_rel
+    return varmap
+
+
+def _count_pattern_in_target(
+    target_text: str, line_starts: list[int], pattern: str, ci: bool, ranges: list[MoveRange]
+) -> tuple[int, int]:
+    """Count *matching lines* of `pattern` (an ERE, from `git grep -c[iE]`)
+    in the live target text using an actual regex compile - NOT a naive
+    literal substring match, which silently miscounts any pattern
+    containing a backslash-escaped metacharacter (e.g. `tasks\\.jsonl`
+    would find zero literal '\\.' sequences in prose that only ever
+    contains a plain '.'). `git grep -c` counts MATCHING LINES, not raw
+    occurrences (verified: one target line here contains the pinned phrase
+    twice, and `git grep -ci` still counts it once) - this counts lines to
+    stay faithful to that semantic, not `finditer()` occurrences. Returns
+    (count_before, count_moved)."""
+    try:
+        flags = re.IGNORECASE if ci else 0
+        compiled = re.compile(pattern, flags)
+    except re.error:
+        compiled = None
+    count_before = 0
+    moved = 0
+    for i, line in enumerate(target_text.split("\n"), start=1):
+        hit = compiled.search(line) if compiled else ((pattern.lower() in line.lower()) if ci else (pattern in line))
+        if not hit:
+            continue
+        count_before += 1
+        if range_for_line(ranges, i) is not None:
+            moved += 1
+    return count_before, moved
+
+
+def extract_shell_floor_assertions(
+    consumer_rel: str,
+    consumer_text: str,
+    target_text: str,
+    target_lines: list[str],
+    ranges: list[MoveRange],
+    target_rel: str,
+) -> list[Assertion]:
+    if not consumer_rel.endswith(".sh"):
+        return []
+    out: list[Assertion] = []
+    varmap = _build_shell_path_vars(consumer_text, target_rel)
+    lines = consumer_text.split("\n")
+
+    # (a) simple VAR="$(git grep -c ... -- <path-or-var>)" .. [ "$VAR" -geN N ]
+    for i, line in enumerate(lines):
+        vm = _VAR_ASSIGN_RE.match(line)
+        if not vm:
+            continue
+        var, inner = vm.group(1), vm.group(2)
+        gm = _GREP_C_RE.search(inner)
+        if not gm:
+            continue
+        flags, pattern, file_tok = gm.group(1), gm.group(2), gm.group(3)
+        file_tok = file_tok.strip('"').strip("'")
+        resolved_path = varmap.get(file_tok, file_tok if file_tok == target_rel else None)
+        if resolved_path != target_rel:
+            continue
+        # find a floor referencing $var within the next few lines
+        floor = None
+        for j in range(i, min(i + 6, len(lines))):
+            fm = _FLOOR_RE.search(lines[j])
+            if fm and fm.group(1) == var:
+                floor = (fm.group(2), int(fm.group(3)))
+                break
+        if floor is None:
+            continue
+        op, n = floor
+        ci = "i" in flags
+        line_starts = build_line_starts(target_text)
+        count_before, moved_count = _count_pattern_in_target(target_text, line_starts, pattern, ci, ranges)
+        count_after = count_before - moved_count
+        clears = {
+            "ge": count_after >= n,
+            "gt": count_after > n,
+            "le": count_after <= n,
+            "lt": count_after < n,
+            "eq": count_after == n,
+        }[op]
+        out.append(
+            Assertion(
+                consumer=consumer_rel,
+                kind="grep_count_floor",
+                detail=(
+                    f"`{var}` = git grep -c{flags} '{pattern}' -- {file_tok}: "
+                    f"before={count_before}, moved={moved_count}, after={count_after}, "
+                    f"floor `-{op} {n}`"
+                ),
+                resolved=True,
+                breaks=not clears,
+                note="floor no longer clears after move" if not clears else "floor still clears (verify it also stays inside any relevant SCANNED SET)",
+            )
+        )
+
+    # (b) heredoc per-file floor table, e.g. FOLDSPEC in test_tasks_jsonl_fold.sh
+    heredoc_re = re.compile(r"<<'(\w+)'\n(.*?)\n\1", re.DOTALL)
+    for hm in heredoc_re.finditer(consumer_text):
+        tag, body = hm.group(1), hm.group(2)
+        # locate the grep -c pattern used inside the loop feeding this heredoc
+        # (search the ~15 lines preceding the heredoc opener)
+        window_start = max(0, hm.start() - 1500)
+        window = consumer_text[window_start:hm.start()]
+        # Take the LAST grep -c call before the heredoc opener, not the
+        # first: the window can span an earlier, unrelated grep -c call
+        # (e.g. a preceding stage's floor) that has nothing to do with the
+        # loop that actually feeds this heredoc.
+        gm_all = list(re.finditer(r"git grep -c([iE]*)\s+['\"]([^'\"]+)['\"]", window))
+        if not gm_all:
+            continue
+        gm = gm_all[-1]
+        flags, pattern = gm.group(1), gm.group(2)
+        ci = "i" in flags
+        line_starts = build_line_starts(target_text)
+        for row in body.split("\n"):
+            row = row.strip()
+            if not row or ":" not in row:
+                continue
+            path, _, floor_s = row.rpartition(":")
+            if path != target_rel or not floor_s.isdigit():
+                continue
+            n = int(floor_s)
+            count_before, moved_count = _count_pattern_in_target(target_text, line_starts, pattern, ci, ranges)
+            count_after = count_before - moved_count
+            clears = count_after >= n
+            out.append(
+                Assertion(
+                    consumer=consumer_rel,
+                    kind="grep_count_floor",
+                    detail=(
+                        f"heredoc `{tag}` per-file floor: pattern '{pattern}' in {path}: "
+                        f"before={count_before}, moved={moved_count}, after={count_after}, floor >= {n}"
+                    ),
+                    resolved=True,
+                    breaks=not clears,
+                    note="floor no longer clears after move" if not clears else "",
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Scanned-set inference (single-file hardcoded FILE= vs multi-file content/**)
+# ---------------------------------------------------------------------------
+
+_FILE_LITERAL_ASSIGN_RE = re.compile(
+    r'^\s*(?:FILE|SPEC|DIT|MD_PATH|CANONICAL_PATH|TARGET)\w*\s*=\s*["\']?content/commands/[\w.-]+\.md'
+)
+
+
+def infer_scanned_set(
+    consumer_rel: str, consumer_text: str, target_rel: str, ranges: list[MoveRange]
+) -> ScannedSetFinding | None:
+    has_single_file_var = any(
+        _FILE_LITERAL_ASSIGN_RE.match(line) for line in consumer_text.split("\n")
+    )
+    has_content_dirscope = bool(
+        re.search(r"--\s+content\b", consumer_text)
+        or re.search(r'\(REPO_ROOT\s*/\s*"content"\)\.rglob', consumer_text)
+        or re.search(r'\.glob\("content/', consumer_text)
+    )
+    dest_dirs = sorted({Path(r.dest).parent.as_posix() for r in ranges})
+    if has_content_dirscope and not has_single_file_var:
+        return ScannedSetFinding(
+            consumer=consumer_rel,
+            scope="multi-file-content",
+            detail=f"scans all of content/** (git grep or rglob over content/) - "
+            f"destinations {dest_dirs} remain inside this scanned set",
+            leaves_scanned_set=False,
+        )
+    if has_single_file_var:
+        return ScannedSetFinding(
+            consumer=consumer_rel,
+            scope="single-file",
+            detail=(
+                f"hardcodes a single-file scan of {target_rel} with no "
+                f"content/**-wide fallback - moved content lands in "
+                f"{dest_dirs}, which this consumer never reads"
+            ),
+            leaves_scanned_set=True,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Analysis driver
+# ---------------------------------------------------------------------------
+
+
+def analyze(repo_root: Path, target_rel: str, ranges: list[MoveRange]) -> Report:
+    target_path = repo_root / target_rel
+    if not target_path.is_file():
+        raise FileNotFoundError(f"target file not found: {target_path}")
+    target_text = target_path.read_text(encoding="utf-8")
+    target_lines_raw = target_text.split("\n")
+    line_starts = build_line_starts(target_text)
+    headings = fence_aware_headings(target_lines_raw)
+
+    consumers = discover_consumers(repo_root, target_rel)
+    report = Report(target=target_rel, ranges=ranges, consumers=consumers)
+
+    if not consumers:
+        # Non-vacuity guard: a target file this tool is ever pointed at is
+        # never actually consumer-free in this repo. Zero discovered
+        # consumers means the discovery step itself broke (bad pathspec,
+        # git not on PATH, wrong cwd) - report it loudly rather than
+        # silently returning an empty-therefore-"OK" report, which is
+        # exactly the failure class this tool exists to prevent.
+        report.unresolved.append(
+            Unresolved(
+                consumer="<discovery>",
+                detail="git grep discovery found ZERO consumers referencing the "
+                "target file - this is almost certainly a broken discovery step "
+                "(bad git invocation, wrong cwd, missing git on PATH), not a "
+                "target file nobody reads. Refusing to report OK.",
+            )
+        )
+        return report
+
+    for rel in consumers:
+        path = repo_root / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as e:
+            report.unresolved.append(Unresolved(consumer=rel, detail=f"could not read file: {e}"))
+            continue
+
+        if not _is_checked_consumer(rel):
+            # Doc/prose consumer: not a runnable gate. Only load-bearing check
+            # is "does it cite one of the moving headings by name" (a real,
+            # if lightweight, doc-sync signal) - never arbitrary literal
+            # matching, which produced hundreds of false positives on plain
+            # English words shared with the target's content.
+            report.doc_consumers.append(rel)
+            for h in headings:
+                r = any_range_overlaps(ranges, h.line, h.end_line)
+                if r is None:
+                    continue
+                heading_title = h.text.lstrip("#").strip()
+                if heading_title and heading_title in text:
+                    report.doc_citations.append(
+                        DocCitation(consumer=rel, heading=h.text, dest=r.dest)
+                    )
+            continue
+
+        found_any = False
+
+        lit_assertions = extract_literal_assertions(rel, text, target_text, line_starts, ranges)
+        report.assertions.extend(lit_assertions)
+        found_any = found_any or bool(lit_assertions)
+
+        hb_assertions = extract_heading_block_assertions(rel, text, headings, ranges)
+        report.assertions.extend(hb_assertions)
+        found_any = found_any or bool(hb_assertions)
+
+        regex_assertions, regex_unresolved = extract_regex_assertions(rel, text, target_lines_raw, ranges)
+        report.assertions.extend(regex_assertions)
+        report.unresolved.extend(regex_unresolved)
+        found_any = found_any or bool(regex_assertions) or bool(regex_unresolved)
+
+        floor_assertions = extract_shell_floor_assertions(
+            rel, text, target_text, target_lines_raw, ranges, target_rel
+        )
+        report.assertions.extend(floor_assertions)
+        found_any = found_any or bool(floor_assertions)
+
+        scanned = infer_scanned_set(rel, text, target_rel, ranges)
+        if scanned is not None:
+            report.scanned_sets.append(scanned)
+
+        if not found_any:
+            report.unresolved.append(
+                Unresolved(
+                    consumer=rel,
+                    detail="references the target file but no assertion against its "
+                    "content could be extracted - manual review required before this "
+                    "consumer can be certified safe (checked-consumer set: bin/tests/**, "
+                    "hooks/tests/**, scripts/check-*.sh)",
+                )
+            )
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_report(report: Report) -> str:
+    out = []
+    out.append(f"# Prose move impact report: {report.target}")
+    out.append("")
+    out.append("## Proposed move ranges")
+    for r in report.ranges:
+        out.append(f"  {r.start:>5}-{r.end:<5} -> {r.dest}")
+    out.append("")
+    out.append(f"## Consumers discovered ({len(report.consumers)})")
+    for c in report.consumers:
+        out.append(f"  - {c}")
+    out.append("")
+
+    breaking = [a for a in report.assertions if a.breaks]
+    passing = [a for a in report.assertions if a.resolved and not a.breaks]
+
+    out.append(f"## BREAKING assertions ({len(breaking)})")
+    for a in breaking:
+        out.append(f"  [{a.kind}] {a.consumer}: {a.detail}")
+        if a.note:
+            out.append(f"      note: {a.note}")
+    out.append("")
+
+    out.append(f"## Passing assertions ({len(passing)})")
+    for a in passing:
+        out.append(f"  [{a.kind}] {a.consumer}: {a.detail}")
+    out.append("")
+
+    out.append(f"## Scanned-set findings ({len(report.scanned_sets)})")
+    for s in report.scanned_sets:
+        flag = "LEAVES SCANNED SET" if s.leaves_scanned_set else "stays in scanned set"
+        out.append(f"  [{s.scope}] {s.consumer}: {s.detail} -- {flag}")
+    out.append("")
+
+    out.append(
+        f"## Doc/prose consumers ({len(report.doc_consumers)}) - not mechanically "
+        "gated; docs-currency review only"
+    )
+    for c in report.doc_consumers:
+        out.append(f"  - {c}")
+    out.append("")
+
+    out.append(
+        f"## Doc citations of a moving heading ({len(report.doc_citations)}) - "
+        "these docs name a section that is moving; update the cross-reference"
+    )
+    for dc in report.doc_citations:
+        out.append(f"  {dc.consumer}: cites {dc.heading!r} -> moving to {dc.dest}")
+    out.append("")
+
+    out.append(f"## UNRESOLVED ({len(report.unresolved)})")
+    for u in report.unresolved:
+        loc = f":{u.line}" if u.line else ""
+        out.append(f"  {u.consumer}{loc}: {u.detail}")
+    out.append("")
+
+    out.append(f"## Verdict: {'OK' if report.ok else 'FAIL'}")
+    if not report.ok:
+        out.append(
+            "One or more assertions break, or one or more consumers/assertions "
+            "could not be resolved. Nothing here is a silent pass."
+        )
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_range_flag(s: str) -> MoveRange:
+    parts = s.split(":", 2)
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(f"--range must be START:END:DEST, got {s!r}")
+    start_s, end_s, dest = parts
+    return MoveRange(start=int(start_s), end=int(end_s), dest=dest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", default=DEFAULT_TARGET)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    parser.add_argument("--range", action="append", dest="ranges", type=parse_range_flag, default=[])
+    parser.add_argument("--config", help="JSON file: {\"target\": str, \"ranges\": [{\"start\",\"end\",\"dest\"}]}")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of the text report")
+    args = parser.parse_args(argv)
+
+    target = args.target
+    ranges = list(args.ranges)
+    if args.config:
+        cfg = json.loads(Path(args.config).read_text(encoding="utf-8"))
+        target = cfg.get("target", target)
+        for r in cfg.get("ranges", []):
+            ranges.append(MoveRange(start=int(r["start"]), end=int(r["end"]), dest=r["dest"]))
+
+    if not ranges:
+        parser.error("at least one --range or a --config with ranges is required")
+
+    repo_root = Path(args.repo_root).resolve()
+    report = analyze(repo_root, target, ranges)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": report.target,
+                    "ok": report.ok,
+                    "consumers": report.consumers,
+                    "assertions": [
+                        {
+                            "consumer": a.consumer,
+                            "kind": a.kind,
+                            "detail": a.detail,
+                            "resolved": a.resolved,
+                            "breaks": a.breaks,
+                            "lines": a.lines,
+                            "note": a.note,
+                        }
+                        for a in report.assertions
+                    ],
+                    "scanned_sets": [
+                        {
+                            "consumer": s.consumer,
+                            "scope": s.scope,
+                            "detail": s.detail,
+                            "leaves_scanned_set": s.leaves_scanned_set,
+                        }
+                        for s in report.scanned_sets
+                    ],
+                    "unresolved": [
+                        {"consumer": u.consumer, "detail": u.detail, "line": u.line}
+                        for u in report.unresolved
+                    ],
+                    "doc_consumers": report.doc_consumers,
+                    "doc_citations": [
+                        {"consumer": dc.consumer, "heading": dc.heading, "dest": dc.dest}
+                        for dc in report.doc_citations
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render_report(report))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/prose-move-impact.py`, a mechanical enumerator that answers "what breaks if I move these line ranges out of content/commands/ds-implement-ticket.md" - built to replace four failed prose-only architect review rounds on that exact split, each of which fixed the named defects and left or reintroduced structurally identical ones.

## North Star alignment

This diff touches `bin/tests/**`, which IS a canonical methodology-shaping trigger path (`content/agents/skeptic.md` step 3.6's applicability list includes `bin/**`) - the vision-alignment check applies, not "N/A".

Advances **"produce verifiable outcomes autonomously"**: this tool replaces four failed prose-only architect review rounds on the same split with a mechanical enumerator that either resolves every consumer's assertion or fails loud (`UNRESOLVED`) - a human/architect gets a deterministic verdict instead of another round of manual re-reading. The tradeoff being fixed in this round: r2 review found the test suite's own known-answer fixtures pinned that verdict to hardcoded absolute line numbers, which is a low-friction cost on every future PR that edits the target file above the highest pinned line (silently reddening the required `python-bin-tests` check for unrelated work) - now derived from heading text instead, so the verifiability gain no longer taxes unrelated contributors.

## Review rigor

- Brief / Plan path: N/A - spawned directly as a Worker unit with a detailed task brief, no separate Architect plan artifact
- Skeptic rounds (tier): pending (this PR is submitted for Skeptic review per the spawning conductor's workflow)
- Findings summary: N/A pending Skeptic review

## What it does

- Discovers every consumer of the target file under `bin/tests/`, `hooks/tests/`, `content/`, `scripts/`, `.github/` via `git grep`.
- Scopes mechanical assertion extraction to actual executable gates (`bin/tests/**`, `hooks/tests/**`, `scripts/check-*.sh`) - doc/prose consumers (`.github/prompts`, `content/commands/*.md`, etc.) are reported separately via a lightweight heading-citation check, never via arbitrary literal matching. An earlier iteration matched on any quoted string shared with the (3600-line) target and produced hundreds of false "BREAKING" rows on plain words like "default"/"status"/"worktree" before this scoping was added.
- Extracts: literal presence/absence/count assertions, `_extract_block()`-style heading-anchored block readers (fence-aware - tracks ``` open/close state so a heading inside a fenced example is never mistaken for a real section), Python `re.compile(...)` patterns (via `ast`, constant-folded through string concatenation), and shell `git grep -c[iE]` count-floor assertions including heredoc per-file floor tables (`git grep -c` counts MATCHING LINES, not raw occurrences - verified against a real target line that contains a pinned phrase twice).
- Reports each checked consumer's inferred SCANNED SET (single-file hardcode vs. `content/**`-wide) and flags when a proposed destination leaves that scanned set even when the consumer's own numeric floors still clear - the false signal that defeated three of the four failed review rounds.
- Fails loud: any consumer or assertion it cannot resolve lands in an explicit `UNRESOLVED` section and forces a non-zero exit, including a non-vacuity guard that refuses to report OK if discovery finds zero consumers.

## Testing

`bin/tests/test_prose_move_impact.py` (auto-discovered by `bin-tests.yml`'s `python3 -m pytest bin/tests/ -q`, 24 tests as of r2) pins the four real, previously-verified misses from the failed review rounds as known-answer fixtures:

- `test_tracker_dev_complete_spec.py`'s `_extract_block`/`HEADING` reader breaks when `480-548` (`## Tracker Writeback Helper`) moves.
- `test_tasks_jsonl_fold.sh`'s `FOLDSPEC` per-file floor (`>= 7`) drops to 4 when `1369-1458` + `1651-1763` move (verified: before=14, moved=10, after=4) - **plus** its separate `G6` floor (`git grep -cE 'is in_progress under another session' -- "$DIT"`, floor `-ge 1`), whose only occurrence (line 1448) also falls inside `1369-1458` (before=1, after=0), fixed in r1 (see below).
- `test_batch_state_timestamp_field.sh` really carries 8 `_absent(` call sites, not 2 (pin on the fixture premise), **plus** a second fixture that actually exercises the tool's shell-continuation joiner (the original one was vacuous - see r1).
- `test_loop_state_site_coverage.sh` hardcodes a single-file `FILE=` scan with no `content/**` fallback - flagged as leaving the scanned set.

Plus regression tests for all four r1 Skeptic findings (see below), a mutation test confirming `discover_consumers()` returning zero consumers must NOT produce an OK report, and a **differential test against ground truth**: `test_differential_against_ground_truth_post_move_gates` builds a scratch git repo with the 9 ranges actually deleted from the target and actually written to the 6 destination files, then runs the two real shell gates (`test_batch_state_timestamp_field.sh`, `test_tasks_jsonl_fold.sh`, both honor `GATE_REPO`/derive their own root) against it and compares real pass/fail to the tool's prediction. It fails loud (disqualifying) if the tool ever reports a consumer clean that actually fails post-move; over-report is recorded, not asserted on. Mutation-verified: reintroducing the r1 pre-fix behavior (disabled ERE fallback + fail-loud suppressed) makes this test go red. Scoped to these two shell gates rather than the full 8 shell + 7 pytest set the reviewer used by hand - see the test's own docstring for why and how to extend it.

## Result against the ticket's 9 proposed ranges

Run against all 9 ranges from the ticket brief (all 9 range boundaries re-verified against the live `origin/main` target - zero drift, every start is a real heading line): as of r2, **128 BREAKING assertions, 3 scanned-set findings (2 LEAVE the scanned set), 5 UNRESOLVED items, verdict FAIL** (exit 1, confirmed). The BREAKING count rose from 126 to 128 in r2 because the pattern-slot meaningfulness-filter fix (Major 1 below) stopped silently dropping `'mark-blocked-and-continue'`/`'<ISO8601>'` as assertions. Notably surfaces a whole additional consumer file, `test_tracker_writeback_ranking_spec.py`, with ~30 of its own load-bearing assertions on the `## Tracker Writeback Helper` block - a file that appeared in none of the four failed review rounds' matrices.

Of the 5 UNRESOLVED items: 3 are "no assertion extractable" (`bin/tests/fold_model.py`, `bin/tests/test_check_command_file_budget.sh`, `scripts/check-command-file-budget.sh`) and 2 are genuine regex-polarity ambiguity on patterns whose matches DO fall inside a move range (`test_tracker_dev_complete_spec.py`'s `TSV_LITERAL_RE`, `test_tracker_writeback_ranking_spec.py`'s `_CANCEL_RE`) - verify these by hand before the split. `scripts/codex-skills.py` is discovered as a doc consumer (its generated `.codex/skills/implement-ticket/RESOURCE-MAP.json` will need the new `content/references/*` paths during the actual refactor - flagged for docs-currency review, not a mechanical gate).

## r1 Skeptic fixes

- **Critical 1** (silent literal-vs-ERE drop): `_present`/`grep -qiE` patterns containing regex metacharacters were matched via naive substring `find()` and silently dropped on zero literal occurrences. Fixed via `_resolve_literal_in_target`, an ERE fallback (case-insensitive, mirroring `grep -qiE`) that only ever escalates the actual `<pattern>` slot of a shell `_present`/`_absent` call scoped to a variable that resolves to the target file (never a label argument, another spec file, or unrelated Python-side literals - each was a real false-positive source hit while narrowing this). Also fixed `_STR_RE`'s single-quote branch, which excluded backslashes and so never even extracted ERE patterns with backslash-escaped metachars (`\(`, `\+`) as candidate literals in the first place - a distinct, earlier failure. Zero-match found: `if not occ: continue` -> now `Unresolved`, never silently dropped.
- **Critical 2** (`$`-anchored floor regex): `_VAR_ASSIGN_RE` required `$(...)` to end the line, missing `test_tasks_jsonl_fold.sh`'s `G6` floor (`; [ -n "$G6" ] || G6=0` trails the assignment). Un-anchored + made non-greedy. A second bug surfaced once the assignment matched: the resolved file-variable token (`"$DIT"`) wasn't stripped of its `$` before the `varmap` lookup, so the floor still silently dropped - fixed.
- **Major 3** (vacuous fixture): the shell-continuation-joiner known-answer test's predicate (`startswith("_absent ")`) was satisfied by the UNjoined first physical line too, never actually exercising the joiner. Added a second fixture requiring the joined logical line to also END with the pattern's closing quote - mutation-verified red under `while False:`.
- **Major 4** (vacuous OK on zero checked consumers): `analyze()`'s non-vacuity guard only fired on zero DISCOVERED consumers, not zero CHECKED ones - a `bin/tests/` rename or `SEARCH_DIRS` drift would silently report OK. Added a second guard.

All four have regression tests, each confirmed failing pre-fix by literal mutation (see individual test docstrings for the pre-fix attestation).

## r2 Skeptic fixes

- **Major 1** (pattern-slot literal silently dropped by the meaningfulness filter): `_is_meaningful_literal`'s short-token noise filter ran BEFORE `is_pattern_slot` was computed, so a pattern-slot literal (the actual `<pattern>` payload of a `_present`/`_absent` call) with no `[`:/=$]` punctuation was dropped with no Assertion and no UNRESOLVED row - the same silent-drop class as Critical 1, one filter earlier in the same function. Three live instances in `test_batch_state_timestamp_field.sh`: `'mark-blocked-and-continue'`, `'fail-open'`, `'<ISO8601>'`. Fixed by computing `is_pattern_slot` first and exempting it from the meaningfulness filter (a pattern slot is by construction a deliberate assertion). Regression-tested and mutation-confirmed red under the pre-fix ordering.
- **Major 2** (zero-match regex reclassification could mask a real break): `extract_python_regex_patterns` discarded the compiled pattern's own `re.IGNORECASE`/`re.DOTALL`/`re.MULTILINE` flags, and matching was per-line while a real consumer searches whole text - both could make a pattern that genuinely matches the live target (case-insensitively, or across a newline) report ZERO pre-move matches and get reclassified as a resolved, non-breaking assertion instead of UNRESOLVED. Fixed: `extract_python_regex_patterns` now captures the actual flags from the `re.compile(...)` call site (positional or `flags=` keyword, including `|`-combined flags), and matching runs against the whole target text via `finditer` + offset-to-line mapping rather than per-line. Two regression tests (IGNORECASE case, DOTALL cross-line case), both mutation-confirmed red under the pre-fix behavior.
- **Major 3** (hardcoded absolute line numbers in a required-CI test): `test_known_move_ranges_align_exactly_with_heading_boundaries`, `NINE_RANGES`, and every individual known-answer fixture's move range hardcoded absolute line numbers, so any unrelated edit above the highest one anywhere in the 3600-line target would silently redden this suite (which the required `python-bin-tests` check collects) with a diagnostic about a refactor that hasn't happened. Fixed: every range is now derived at test-collection time from the tool's own `fence_aware_headings()` by heading TEXT (`_range_for_heading`), never a line number. Mutation-proof: inserting an unrelated sentence at line 20 of the live target and re-running the full 24-test suite stays green (previously would have reddened the hardcoded-number test).
- **Minor** (`Report.ok` ignored `scanned_sets`): a run whose only finding was `leaves_scanned_set=True` (nothing else broke, nothing unresolved) exited 0 and printed `Verdict: OK` - the exact finding class the scanned-set column exists to surface, unenforced. Fixed: `Report.ok` now also fails when any scanned-set finding has `leaves_scanned_set=True`; the module manifest's exit-code contract is corrected to match. Regression-tested (isolated Report construction) and mutation-confirmed red under the pre-fix property.
- Docstring corrections: the differential test's "only check ... that can catch the NEXT under-report class" overclaim (both in the tool's own manifest and the test module's docstring) is corrected to name its actual scope - 2 of the 7 tool-clean consumers the reviewer manually differential-tested, with the reviewer's pre-move-red-skip generalization approach recorded as the path to extend it.

All four r2 fixes have regression tests; each is separately mutation-confirmed against the specific pre-fix code path (not just re-run against the unfixed function in the abstract) per the finding above.

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Affected adapters declared (none)
- [ ] Before/after transcript included for agent-behavior changes (N/A - not an agent-behavior change)
- [ ] `install.sh` re-run locally and behavior verified (N/A - no install.sh path touched)
- [x] Tests/lint passing
- [x] Docs updated if behavior changed (N/A - tool has no existing doc surface to update; module manifest is in the file header)

## Affected adapters

- [x] None (methodology / docs only)

