### PR TITLE
feat(DS-154): add bin/ds-learning-shard, in-flight per-session learning capture

### DIFF
--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,6 +1,6 @@
 # bin/
 
-Sixteen CLI entry points (13 Python, 1 Bash, 2 Node) that the dinostack
+Seventeen CLI entry points (14 Python, 1 Bash, 2 Node) that the dinostack
 methodology exposes as PATH-wired commands. Each binary ships with a
 module-manifest docstring (Purpose / Public API / Upstream deps / Downstream
 consumers / Failure modes / Performance) that is the authoritative description
@@ -24,6 +24,7 @@ sunset (external cron jobs and shell aliases reference it).
 | `ds-feedback` | Python | Manage the home-dir feedback store (`~/.agentic/feedback.jsonl`) - append/list/mark operator and agent friction items. |
 | `ds-help` | Python | Print the static slash-command reference to stdout. Zero file I/O; never fails. |
 | `ds-identity` | Python | Manage per-developer identity files used by the Stop hook for session telemetry attribution. |
+| `ds-learning-shard` | Python | Manage the home-dir per-session learning shard store (`~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl`) - `append` one in-flight learning (capped at 5 per session, soft-fail), `rollup` the not-yet-folded raw entries idempotently, `list` for diagnostics. Performs no classification. |
 | `ds-memory` | Python | Query `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md`; return compact Markdown summaries. |
 | `ds-migrate` | Python | Apply additive project scaffolding migrations (`check` / `apply` / `diff` subcommands). |
 | `ds-parse-subagent-usage` | Python | Parse a Claude Code subagent transcript JSONL and emit `{tokens, model, wall_seconds}` for `spawn_complete` events. |

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -24,7 +24,7 @@ sunset (external cron jobs and shell aliases reference it).
 | `ds-feedback` | Python | Manage the home-dir feedback store (`~/.agentic/feedback.jsonl`) - append/list/mark operator and agent friction items. |
 | `ds-help` | Python | Print the static slash-command reference to stdout. Zero file I/O; never fails. |
 | `ds-identity` | Python | Manage per-developer identity files used by the Stop hook for session telemetry attribution. |
-| `ds-learning-shard` | Python | Manage the home-dir per-session learning shard store (`~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl`) - `append` one in-flight learning (capped at 5 per session, soft-fail), `rollup` the not-yet-folded raw entries idempotently, `list` for diagnostics. Performs no classification. |
+| `ds-learning-shard` | Python | Manage the home-dir per-session learning shard store (`~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl`) - `append` one in-flight learning (capped at 5 per session, soft-fail), `rollup` the not-yet-folded raw entries idempotently, `list` for diagnostics. Performs no classification. `--repo` accepts any path inside the repo - a linked worktree and its primary checkout resolve to one `<repo-key>`, via `git rev-parse --git-common-dir`. |
 | `ds-memory` | Python | Query `.agentic/events.jsonl`, `MEMORY.md`, and `.agentic/context.md`; return compact Markdown summaries. |
 | `ds-migrate` | Python | Apply additive project scaffolding migrations (`check` / `apply` / `diff` subcommands). |
 | `ds-parse-subagent-usage` | Python | Parse a Claude Code subagent transcript JSONL and emit `{tokens, model, wall_seconds}` for `spawn_complete` events. |

--- a/bin/_lib.py
+++ b/bin/_lib.py
@@ -30,6 +30,7 @@ Upstream deps: Python 3 stdlib only (contextlib, fcntl, os, time, pathlib).
 
 Downstream consumers: bin/ds-config (atomic_write), bin/ds-defer (both
                       helpers), bin/ds-feedback (both helpers),
+                      bin/ds-learning-shard (both helpers),
                       bin/ds-migrate (atomic_write), bin/ds-tracker
                       (atomic_write). bin/ds-identity does NOT use this
                       module - it ships its own _atomic_write_identity and

--- a/bin/agentic-learning-shard
+++ b/bin/agentic-learning-shard
@@ -1,0 +1,1 @@
+ds-learning-shard

--- a/bin/ds-learning-shard
+++ b/bin/ds-learning-shard
@@ -34,6 +34,24 @@ Data model:
   ~/.agentic/learnings-shards/<repo-key>/.rolled-up.json     - rollup bookkeeping.
   ~/.agentic/learnings-shards/<repo-key>/.lock               - per-repo exclusive lock.
 
+  .rolled-up.json shape:
+    {"updated_ts": "<utc>", "shards": {"<shard file name>":
+       {"rolled_ids": ["<entry id>", ...], "rolled_ts": "<utc>"}}}
+
+  Bookkeeping is keyed on the SET of entry ids already rolled up, never on a
+  count or a position. `_read_shard` skips malformed lines by contract, so any
+  count is a positional index into PARSED rows: the moment an already-rolled
+  line stops parsing, every later row shifts down one and an un-rolled entry
+  falls behind the index permanently. A count also has a mirror image in the
+  other direction (bookkeeping claiming more rows than the shard now holds).
+  A set membership test has neither: malformed lines, shrinkage, reordering
+  and duplicates are all non-events, because `id` is a CLI-owned uuid4 the
+  caller can never supply.
+
+  The id set is bounded by construction: on every write it is intersected with
+  the ids the shard actually holds right now, and a shard is capped at 5
+  entries, so a shard's `rolled_ids` can never exceed the cap.
+
   Entry fields:
     id           (CLI-owned) uuid4, assigned on append.
     ts           (CLI-owned) UTC ISO8601, assigned on append.
@@ -96,10 +114,15 @@ Failure modes:
   append: over-cap append is a soft-fail no-op (stderr + exit 0). description over
     500 chars is truncated, not rejected.
   rollup: absent store, absent repo dir, and absent shard file all emit "[]" and exit
-    0 - not errors. Idempotent: entries already marked rolled-up are never re-emitted,
-    so a second rollup over the same shard set emits "[]" and changes nothing. A
-    corrupt .rolled-up.json is treated as empty bookkeeping (entries may be re-emitted
-    once) rather than as a hard failure.
+    0 - not errors. Idempotent: entries whose id is already recorded are never
+    re-emitted, so a second rollup over the same shard set emits "[]" and changes
+    nothing. A corrupt .rolled-up.json, or a shard record in any shape other than
+    the id-keyed one above (including the pre-DS-154 count shape), is treated as
+    UNKNOWN bookkeeping and its entries are re-emitted once, rather than as a hard
+    failure. Re-emission is the safe direction: a duplicate is recoverable
+    conductor-side, a lost learning is not. A parsed row with no CLI-owned string
+    `id` cannot be tracked, so it is emitted and never recorded - it will be
+    emitted again by the next rollup. The CLI never writes such a row.
   list: absent store emits "[]" and exits 0. Malformed JSONL lines are skipped.
 
   Locking: append, rollup and list take the same per-repo-key exclusive lock for
@@ -299,6 +322,10 @@ def _ensure_lock_bootstrap(repo: str) -> Path:
     store_root().mkdir(mode=0o700, parents=True, exist_ok=True)
     lock.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     lock.touch(exist_ok=True)
+    # touch() honours the ambient umask (0o644 observed), while every other
+    # artefact in the store is deliberately 0o700/0o600. Unreachable inside a
+    # 0o700 parent, but consistency here is free.
+    os.chmod(lock, 0o600)
     return lock
 
 
@@ -353,6 +380,24 @@ def _read_rollup_state(repo: str) -> dict:
     return shards if isinstance(shards, dict) else {}
 
 
+def _rolled_ids(entry: object) -> set[str] | None:
+    """Ids already rolled up for one shard, or None when the record is unknown.
+
+    None means "this record cannot be trusted against these rows" - a corrupt
+    record, or the pre-DS-154 count shape ({"rolled_count": N}), or anything
+    else that is not an id list. The caller re-emits on None. That is the safe
+    direction by design: a duplicate entry is recoverable conductor-side, a
+    silently dropped learning is not, and this store exists precisely so a
+    learning is never lost.
+    """
+    if not isinstance(entry, dict):
+        return None
+    ids = entry.get("rolled_ids")
+    if not isinstance(ids, list):
+        return None
+    return {item for item in ids if isinstance(item, str)}
+
+
 def _write_rollup_state(repo: str, shards: dict) -> None:
     path = repo_dir(repo) / ROLLUP_STATE_NAME
     payload = {
@@ -376,8 +421,10 @@ _ARRAY_EMITTED = False
 def _emit_array(rows: list[dict]) -> None:
     """Emit the stdout JSON array for rollup/list and flush it immediately."""
     global _ARRAY_EMITTED
-    _ARRAY_EMITTED = True
+    # Set AFTER print(), not before: the flag's whole job is to answer "did an
+    # array reach stdout?", and setting it first claims yes before anything has.
     print(json.dumps(rows, indent=2))
+    _ARRAY_EMITTED = True
     sys.stdout.flush()
 
 
@@ -440,20 +487,41 @@ def cmd_rollup(args: argparse.Namespace) -> int:
         emitted: list[dict] = []
         for path in _shard_files(args.repo, args.session_key):
             rows = _read_shard(path)
-            entry = state.get(path.name)
-            already = 0
-            if isinstance(entry, dict) and isinstance(entry.get("rolled_count"), int):
-                already = max(0, entry["rolled_count"])
-            if already > len(rows):
-                # Bookkeeping claims more entries than the shard now holds, so
-                # it cannot be trusted against these rows. Self-heal by
-                # re-emitting rather than stranding every entry forever.
-                already = 0
-            fresh = rows[already:]
+            # None (unknown/legacy record) degrades to "nothing rolled up yet",
+            # so the shard's entries are re-emitted rather than stranded.
+            rolled = _rolled_ids(state.get(path.name))
+            if rolled is None:
+                rolled = set()
+
+            fresh: list[dict] = []
+            present: set[str] = set()   # ids the shard holds RIGHT NOW
+            newly: set[str] = set()     # ids emitted by THIS pass
+            for row in rows:
+                row_id = row.get("id")
+                if not isinstance(row_id, str):
+                    # No CLI-owned id, so it cannot be tracked. Emit it - loss
+                    # is the one direction that is not recoverable - and never
+                    # record it. The CLI never writes such a row.
+                    fresh.append(row)
+                    continue
+                present.add(row_id)
+                if row_id in rolled or row_id in newly:
+                    # Already rolled up, or a duplicate row within this same
+                    # pass. Membership has no ordering and no mirror image.
+                    continue
+                newly.add(row_id)
+                fresh.append(row)
+
             if not fresh:
                 continue
             emitted.extend(fresh)
-            state[path.name] = {"rolled_count": len(rows), "rolled_ts": _now()}
+            # Intersecting with `present` bounds the set: it can never hold
+            # more ids than the shard itself, and the shard is capped at
+            # ENTRY_CAP_PER_SHARD entries.
+            state[path.name] = {
+                "rolled_ids": sorted((rolled & present) | newly),
+                "rolled_ts": _now(),
+            }
 
         # Emit-then-mark, both INSIDE the lock and with an explicit flush.
         # Marking first (or printing after release, where stdout is block
@@ -532,6 +600,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str]) -> int:
+    # Per-invocation state. One process per invocation in practice, but a stale
+    # True here would suppress the soft-fail "[]" of a LATER call and mask a
+    # real failure from any in-process caller (a test, chiefly).
+    global _ARRAY_EMITTED
+    _ARRAY_EMITTED = False
+
     args = build_parser().parse_args(argv[1:])
     try:
         return args.func(args)

--- a/bin/ds-learning-shard
+++ b/bin/ds-learning-shard
@@ -20,6 +20,15 @@ Public API:
   ds-learning-shard list   --repo <path> [--session-key <key>]
   ds-learning-shard --help
 
+  --repo takes ANY path inside the repo: the primary checkout root, a linked
+  worktree root, or a subdirectory of either. All three resolve to ONE repo-key
+  (see "repo-key" under Data model), so an isolation-worktree engineer's appends
+  are visible to a conductor rolling up from the primary checkout. Callers do not
+  need to normalise the path themselves.
+
+  rollup and list emit a JSON array to stdout and exit 0 on EVERY path,
+  soft-fails included. append emits a human-readable status line, never JSON.
+
 Data model:
   ~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl - one JSON object per line.
   ~/.agentic/learnings-shards/<repo-key>/.rolled-up.json     - rollup bookkeeping.
@@ -39,10 +48,23 @@ Data model:
 
   IMPORTANT: id and ts are CLI-owned. A caller can never set them.
 
-  repo-key: "<sanitized-basename>-<first 12 hex of sha256(resolved absolute repo path)>".
+  repo-key: "<sanitized-basename>-<first 12 hex of sha256(canonical repo path)>".
   The path hash is what makes the key collision-resistant: two different checkouts
   with the SAME directory basename get different keys. A bare basename must never
   be used as the key.
+
+  --repo caller contract: pass ANY path inside the repo - the primary checkout
+  root, a linked worktree root, or a subdirectory of either. The canonical path is
+  derived from `git rev-parse --git-common-dir`, which returns the PRIMARY
+  repository's .git directory even when called from inside a linked worktree, so a
+  worktree and its primary checkout resolve to ONE key. That is the whole point:
+  an isolation-worktree engineer appends with --repo <worktree> and the conductor
+  rolls up with --repo <primary>, and both reach the same shard directory.
+  Fallbacks, in order: a bare repo (common dir IS the root, not "<root>/.git")
+  uses that root; a path that is not a git repository, or any git failure at all
+  (git absent, unsupported flag, non-zero exit, timeout), degrades to hashing the
+  caller's own resolved absolute path. Degrading never raises - the soft-fail
+  contract applies here too.
 
   Cap: 5 entries per (repo-key, session-key) shard. The 6th and later appends in a
   session are a soft-fail no-op - "cap reached, entry dropped" on stderr, exit 0.
@@ -51,9 +73,12 @@ Data model:
   Classification: this CLI performs ZERO judgment. `rollup` emits the raw entries
   verbatim; deciding what is worth keeping is conductor-side and out of scope here.
 
-Upstream deps: Python 3 stdlib only (argparse, hashlib, json, os, re, sys, uuid,
-               datetime, pathlib). Shared helpers: bin/_lib
-               (acquire_exclusive_lock, atomic_write).
+Upstream deps: Python 3 stdlib only (argparse, hashlib, importlib.machinery,
+               importlib.util, json, os, re, subprocess, sys, uuid, datetime,
+               pathlib). Shared helpers: bin/_lib (acquire_exclusive_lock,
+               atomic_write). External: `git` is invoked read-only for repo-key
+               canonicalisation and is OPTIONAL - its absence degrades the key,
+               never the exit code.
 
 Downstream consumers: none yet - DS-154 Unit A ships the CLI only. Later units wire
                       it into the agent and command layers.
@@ -63,6 +88,11 @@ Failure modes:
   error prints ONE line to stderr and exits 0. That includes lock timeouts, I/O
   failures, and malformed bookkeeping. Argparse usage errors are the one exception
   (exit 2), since a malformed invocation is a caller bug, not a runtime condition.
+  The soft-fail handler ALSO emits "[]" on stdout for the stdout-producing
+  subcommands (rollup, list), so "exit 0" and "parseable JSON array on stdout"
+  hold together on every path a consumer can reach. Empty stdout with exit 0
+  would crash any consumer doing json.loads(stdout) with no signal to expect it.
+  append produces no stdout array and is unaffected.
   append: over-cap append is a soft-fail no-op (stderr + exit 0). description over
     500 chars is truncated, not rejected.
   rollup: absent store, absent repo dir, and absent shard file all emit "[]" and exit
@@ -88,6 +118,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -125,6 +156,18 @@ ENTRY_CAP_PER_SHARD = 5
 ROLLUP_STATE_NAME = ".rolled-up.json"
 LOCK_NAME = ".lock"
 
+# Subcommands whose documented contract is "a JSON array on stdout, exit 0".
+# The soft-fail handler must still honour that, or a consumer's json.loads()
+# crashes on empty stdout while the exit code claims success.
+STDOUT_ARRAY_COMMANDS = ("rollup", "list")
+
+GIT_TIMEOUT_SECONDS = 5.0
+
+REPO_HELP = (
+    "Any path inside the repo - primary checkout, linked worktree, or a "
+    "subdirectory of either. All resolve to one shard directory."
+)
+
 _SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
 
 
@@ -138,19 +181,82 @@ def _sanitize(text: str) -> str:
     return _SAFE_CHARS.sub("_", text)
 
 
+def _git_common_dir(resolved: str) -> Path | None:
+    """Absolute path of the repo's COMMON .git dir, or None if unavailable.
+
+    Called from inside a linked worktree, `git rev-parse --git-common-dir`
+    reports the PRIMARY repository's .git directory, not the worktree's own
+    .git file - that is exactly the identity we want the repo-key to be built
+    on. `--path-format=absolute` needs git >= 2.31, so an older git falls back
+    to the plain form and the (possibly relative) answer is joined onto the
+    caller's path. Every failure mode returns None so the caller can degrade.
+    """
+    attempts = (
+        ["--path-format=absolute", "--git-common-dir"],
+        ["--git-common-dir"],
+    )
+    for extra in attempts:
+        try:
+            proc = subprocess.run(
+                ["git", "-C", resolved, "rev-parse", *extra],
+                capture_output=True,
+                text=True,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            # git absent, not executable, or timed out - degrade, never raise.
+            return None
+        if proc.returncode != 0:
+            continue
+        out = proc.stdout.strip()
+        if not out:
+            continue
+        path = Path(out)
+        if not path.is_absolute():
+            path = Path(resolved) / path
+        return path
+    return None
+
+
+def canonical_repo_path(repo: str) -> str:
+    """Collapse any path inside a repo onto ONE canonical absolute path.
+
+    A linked worktree and its primary checkout MUST canonicalise to the same
+    string: an isolation-worktree engineer appends with --repo <worktree> while
+    the conductor rolls up with --repo <primary>, and a divergent key silently
+    loses the learning - the precise failure this store exists to eliminate.
+
+    Non-bare repo: the common dir is "<root>/.git", so the root is its parent.
+    Bare repo: the common dir IS the root. Not a repo, or any git failure at
+    all: the caller's own resolved absolute path, i.e. the pre-canonicalisation
+    behaviour, which keeps two same-basename non-repo paths distinct.
+    """
+    resolved = str(Path(repo).expanduser().resolve())
+    common = _git_common_dir(resolved)
+    if common is None:
+        return resolved
+    root = common.parent if common.name == ".git" else common
+    try:
+        return str(root.resolve())
+    except OSError:
+        return resolved
+
+
 def repo_key(repo: str) -> str:
     """Build a filesystem-safe, collision-resistant key for a repo path.
 
-    Format: "<sanitized-basename>-<sha256(resolved abs path)[:12]>".
+    Format: "<sanitized-basename>-<sha256(canonical repo path)[:12]>".
 
-    The hash is over the RESOLVED ABSOLUTE path, so two different checkouts that
-    share a directory basename get different keys. A bare basename (the only
-    precedent in this repo, bin/ds-identity's local `project_slug = cwd.name`) is
-    deliberately not used - it collides across paths.
+    The hash is over the CANONICAL ABSOLUTE path (see canonical_repo_path), so
+    two different checkouts that share a directory basename get different keys
+    while a worktree and its primary checkout get the SAME key. A bare basename
+    (the only precedent in this repo, bin/ds-identity's local
+    `project_slug = cwd.name`) is deliberately not used - it collides across
+    paths.
     """
-    resolved = str(Path(repo).expanduser().resolve())
-    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:12]
-    base = _sanitize(Path(resolved).name) or "repo"
+    canonical = canonical_repo_path(repo)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    base = _sanitize(Path(canonical).name) or "repo"
     return f"{base[:40]}-{digest}"
 
 
@@ -187,20 +293,31 @@ def _ensure_lock_bootstrap(repo: str) -> Path:
     already exist - mirrors bin/ds-feedback's bootstrap.
     """
     lock = _lock_path(repo)
+    # mkdir(mode=...) applies the mode to the LEAF only, so create the store
+    # root explicitly - otherwise ~/.agentic/learnings-shards gets the ambient
+    # umask while only the per-repo dir is 0o700. Defence in depth.
+    store_root().mkdir(mode=0o700, parents=True, exist_ok=True)
     lock.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     lock.touch(exist_ok=True)
     return lock
 
 
-def _read_shard(path: Path) -> list[dict]:
-    """Parse one shard file. Absent file returns []; malformed lines are skipped."""
+def _read_shard_lines(path: Path) -> list[str]:
+    """Raw non-blank lines of a shard file, verbatim. Absent file returns [].
+
+    The cap counts PHYSICAL lines, not parsed rows: counting only parsable rows
+    lets one corrupt line push a shard past the cap forever.
+    """
     if not path.is_file():
         return []
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _read_shard(path: Path) -> list[dict]:
+    """Parse one shard file. Absent file returns []; malformed lines are skipped."""
     rows: list[dict] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for line in _read_shard_lines(path):
         line = line.strip()
-        if not line:
-            continue
         try:
             parsed = json.loads(line)
         except json.JSONDecodeError:
@@ -249,12 +366,27 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# Set once a JSON array has reached stdout, so the soft-fail handler emits its
+# fallback "[]" only when nothing was emitted. Without this, a failure AFTER a
+# successful emit would append a second array and stdout would stop being
+# parseable - the very defect the fallback exists to prevent.
+_ARRAY_EMITTED = False
+
+
+def _emit_array(rows: list[dict]) -> None:
+    """Emit the stdout JSON array for rollup/list and flush it immediately."""
+    global _ARRAY_EMITTED
+    _ARRAY_EMITTED = True
+    print(json.dumps(rows, indent=2))
+    sys.stdout.flush()
+
+
 def cmd_append(args: argparse.Namespace) -> int:
     lock = _ensure_lock_bootstrap(args.repo)
     path = shard_path(args.repo, args.session_key)
 
     with acquire_exclusive_lock(lock):
-        existing = _read_shard(path)
+        existing = _read_shard_lines(path)
         if len(existing) >= ENTRY_CAP_PER_SHARD:
             # Soft-fail: the agent must never have to count, and must never be
             # blocked. Dropping the entry is the intended behaviour, not an error.
@@ -282,9 +414,14 @@ def cmd_append(args: argparse.Namespace) -> int:
             "description": description,
             "resolution": args.resolution,
         }
-        with open(path, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
-        os.chmod(path, 0o600)
+        # Rewrite the whole shard atomically rather than open(path, "a"): a
+        # crash mid-append leaves a newline-less partial line, and the NEXT
+        # append concatenates onto it, making both entries permanently
+        # unparseable while still reporting success. Existing lines are carried
+        # over verbatim (malformed ones included - this is not a repair pass),
+        # and the shard is capped at 5 entries so rewriting it stays cheap.
+        line = json.dumps(record, separators=(",", ":"))
+        atomic_write(path, "\n".join([*existing, line]) + "\n", mode=0o600)
 
     print(f"{PROG}: appended 1 entry ({len(existing) + 1}/{ENTRY_CAP_PER_SHARD}).")
     return 0
@@ -294,7 +431,7 @@ def cmd_rollup(args: argparse.Namespace) -> int:
     root = store_root()
     if not root.is_dir() or not repo_dir(args.repo).is_dir():
         # Absent store is not an error.
-        print("[]")
+        _emit_array([])
         return 0
 
     lock = _ensure_lock_bootstrap(args.repo)
@@ -307,23 +444,35 @@ def cmd_rollup(args: argparse.Namespace) -> int:
             already = 0
             if isinstance(entry, dict) and isinstance(entry.get("rolled_count"), int):
                 already = max(0, entry["rolled_count"])
+            if already > len(rows):
+                # Bookkeeping claims more entries than the shard now holds, so
+                # it cannot be trusted against these rows. Self-heal by
+                # re-emitting rather than stranding every entry forever.
+                already = 0
             fresh = rows[already:]
             if not fresh:
                 continue
             emitted.extend(fresh)
             state[path.name] = {"rolled_count": len(rows), "rolled_ts": _now()}
 
+        # Emit-then-mark, both INSIDE the lock and with an explicit flush.
+        # Marking first (or printing after release, where stdout is block
+        # buffered and only flushes at exit) lets a kill in the window mark
+        # entries rolled-up that were never emitted - unrecoverable without
+        # hand-editing .rolled-up.json. This order fails the other way: a kill
+        # after the flush re-emits on the next rollup, which is a duplicate,
+        # not a loss.
+        # Raw entries, verbatim. No judgment, no classification - conductor-side.
+        _emit_array(emitted)
+
         if emitted:
             _write_rollup_state(args.repo, state)
-
-    # Raw entries, verbatim. No judgment, no classification - that is conductor-side.
-    print(json.dumps(emitted, indent=2))
     return 0
 
 
 def cmd_list(args: argparse.Namespace) -> int:
     if not store_root().is_dir() or not repo_dir(args.repo).is_dir():
-        print("[]")
+        _emit_array([])
         return 0
 
     lock = _ensure_lock_bootstrap(args.repo)
@@ -332,7 +481,7 @@ def cmd_list(args: argparse.Namespace) -> int:
         for path in _shard_files(args.repo, args.session_key):
             rows.extend(_read_shard(path))
 
-    print(json.dumps(rows, indent=2))
+    _emit_array(rows)
     return 0
 
 
@@ -347,7 +496,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="cmd", required=True)
 
     p_append = sub.add_parser("append", help="Append one learning entry to this session's shard")
-    p_append.add_argument("--repo", required=True, help="Repo path the learning belongs to")
+    p_append.add_argument("--repo", required=True, help=REPO_HELP)
     p_append.add_argument(
         "--session-key",
         required=True,
@@ -370,12 +519,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_rollup = sub.add_parser(
         "rollup", help="Emit not-yet-rolled-up entries as a JSON array and mark them"
     )
-    p_rollup.add_argument("--repo", required=True, help="Repo path to roll up")
+    p_rollup.add_argument("--repo", required=True, help=REPO_HELP)
     p_rollup.add_argument("--session-key", default=None, help="Limit to one session's shard")
     p_rollup.set_defaults(func=cmd_rollup)
 
     p_list = sub.add_parser("list", help="List shard entries as a JSON array (diagnostic)")
-    p_list.add_argument("--repo", required=True, help="Repo path to list")
+    p_list.add_argument("--repo", required=True, help=REPO_HELP)
     p_list.add_argument("--session-key", default=None, help="Limit to one session's shard")
     p_list.set_defaults(func=cmd_list)
 
@@ -388,6 +537,12 @@ def main(argv: list[str]) -> int:
         return args.func(args)
     except Exception as exc:  # noqa: BLE001 - soft-fail: never block the caller
         print(f"{PROG}: soft-fail: {type(exc).__name__}: {exc}", file=sys.stderr)
+        # rollup and list promise "a JSON array on stdout, exit 0". Silence plus
+        # exit 0 crashes any consumer doing json.loads(stdout) and gives it no
+        # signal to expect that. Emit the empty array unless one already went
+        # out (a second array would be just as unparseable).
+        if getattr(args, "cmd", None) in STDOUT_ARRAY_COMMANDS and not _ARRAY_EMITTED:
+            print("[]")
         return 0
 
 

--- a/bin/ds-learning-shard
+++ b/bin/ds-learning-shard
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Purpose: CLI for the per-session learning shard store
+         (~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl), which lets a
+         write-capable subagent (chiefly `engineer`) record a learning the moment it
+         hits one, in-flight and harness-agnostic, instead of relying on an operator
+         remembering to run /ds-wrap at end of session. A conductor-side rollup later
+         folds the raw entries into .agentic/learnings.md / MEMORY.md.
+
+         The store is deliberately in the HOME directory, OUTSIDE any repo: an
+         isolation-worktree engineer's .agentic/ is worktree-local and is deleted
+         before the PR opens, so a shard written in-repo is gone before anything can
+         read it.
+
+Public API:
+  ds-learning-shard append --repo <path> --session-key <key> --agent-id <id>
+                          --role <role> --event-type {workaround,dead-end,gotcha,decision}
+                          --domain-tag <tag> --description <text> [--resolution <text>]
+  ds-learning-shard rollup --repo <path> [--session-key <key>]
+  ds-learning-shard list   --repo <path> [--session-key <key>]
+  ds-learning-shard --help
+
+Data model:
+  ~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl - one JSON object per line.
+  ~/.agentic/learnings-shards/<repo-key>/.rolled-up.json     - rollup bookkeeping.
+  ~/.agentic/learnings-shards/<repo-key>/.lock               - per-repo exclusive lock.
+
+  Entry fields:
+    id           (CLI-owned) uuid4, assigned on append.
+    ts           (CLI-owned) UTC ISO8601, assigned on append.
+    session_key  caller-supplied, opaque. Never read from the environment and never
+                 generated here - the caller owns session identity.
+    agent_id     caller-supplied.
+    role         caller-supplied.
+    event_type   caller-supplied; one of workaround | dead-end | gotcha | decision.
+    domain_tag   caller-supplied.
+    description  caller-supplied; TRUNCATED to 500 chars (never rejected).
+    resolution   caller-supplied, optional; null when omitted.
+
+  IMPORTANT: id and ts are CLI-owned. A caller can never set them.
+
+  repo-key: "<sanitized-basename>-<first 12 hex of sha256(resolved absolute repo path)>".
+  The path hash is what makes the key collision-resistant: two different checkouts
+  with the SAME directory basename get different keys. A bare basename must never
+  be used as the key.
+
+  Cap: 5 entries per (repo-key, session-key) shard. The 6th and later appends in a
+  session are a soft-fail no-op - "cap reached, entry dropped" on stderr, exit 0.
+  The agent must never have to count, and must never be blocked.
+
+  Classification: this CLI performs ZERO judgment. `rollup` emits the raw entries
+  verbatim; deciding what is worth keeping is conductor-side and out of scope here.
+
+Upstream deps: Python 3 stdlib only (argparse, hashlib, json, os, re, sys, uuid,
+               datetime, pathlib). Shared helpers: bin/_lib
+               (acquire_exclusive_lock, atomic_write).
+
+Downstream consumers: none yet - DS-154 Unit A ships the CLI only. Later units wire
+                      it into the agent and command layers.
+
+Failure modes:
+  Soft-fail throughout: this CLI must never block a caller's task. Any unexpected
+  error prints ONE line to stderr and exits 0. That includes lock timeouts, I/O
+  failures, and malformed bookkeeping. Argparse usage errors are the one exception
+  (exit 2), since a malformed invocation is a caller bug, not a runtime condition.
+  append: over-cap append is a soft-fail no-op (stderr + exit 0). description over
+    500 chars is truncated, not rejected.
+  rollup: absent store, absent repo dir, and absent shard file all emit "[]" and exit
+    0 - not errors. Idempotent: entries already marked rolled-up are never re-emitted,
+    so a second rollup over the same shard set emits "[]" and changes nothing. A
+    corrupt .rolled-up.json is treated as empty bookkeeping (entries may be re-emitted
+    once) rather than as a hard failure.
+  list: absent store emits "[]" and exits 0. Malformed JSONL lines are skipped.
+
+  Locking: append, rollup and list take the same per-repo-key exclusive lock for
+  their full read/modify/write critical section. acquire_exclusive_lock (bin/_lib)
+  opens the lock file in 'r' mode and requires it to already exist, so every
+  subcommand mkdir -p's the parent and touch()es the lock file first.
+
+Performance: Standard. Single small append or single-directory scan; no indexing.
+  Shards are capped at 5 entries each, so files stay tiny.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers from bin/_lib (same directory; bin/ is on sys.path at runtime).
+# .resolve() follows a PATH symlink (e.g. ~/.local/bin/ds-learning-shard ->
+# repo bin/ds-learning-shard, as created by install.sh) back to the real
+# bin/ directory so _lib.py is found on a bare `ds-learning-shard` invocation.
+import sys as _sys
+import importlib.util as _ilu
+import importlib.machinery as _ilm
+
+_LIB_PATH = Path(__file__).resolve().parent / "_lib.py"
+if "_lib" in _sys.modules:
+    _lib_mod = _sys.modules["_lib"]
+else:
+    _loader = _ilm.SourceFileLoader("_lib", str(_LIB_PATH))
+    _spec = _ilu.spec_from_loader("_lib", _loader)
+    _lib_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+    _loader.exec_module(_lib_mod)
+    _sys.modules["_lib"] = _lib_mod
+    del _loader, _spec
+acquire_exclusive_lock = _lib_mod.acquire_exclusive_lock
+atomic_write = _lib_mod.atomic_write
+del _sys, _ilu, _ilm, _lib_mod
+
+PROG = "ds-learning-shard"
+
+EVENT_TYPES = ("workaround", "dead-end", "gotcha", "decision")
+
+DESCRIPTION_MAX_CHARS = 500
+ENTRY_CAP_PER_SHARD = 5
+
+ROLLUP_STATE_NAME = ".rolled-up.json"
+LOCK_NAME = ".lock"
+
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def store_root() -> Path:
+    """Root of the shard store. Resolved at call time so $HOME is honoured."""
+    return Path(os.path.expanduser("~/.agentic/learnings-shards"))
+
+
+def _sanitize(text: str) -> str:
+    """Replace anything outside [A-Za-z0-9._-] with '_'."""
+    return _SAFE_CHARS.sub("_", text)
+
+
+def repo_key(repo: str) -> str:
+    """Build a filesystem-safe, collision-resistant key for a repo path.
+
+    Format: "<sanitized-basename>-<sha256(resolved abs path)[:12]>".
+
+    The hash is over the RESOLVED ABSOLUTE path, so two different checkouts that
+    share a directory basename get different keys. A bare basename (the only
+    precedent in this repo, bin/ds-identity's local `project_slug = cwd.name`) is
+    deliberately not used - it collides across paths.
+    """
+    resolved = str(Path(repo).expanduser().resolve())
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:12]
+    base = _sanitize(Path(resolved).name) or "repo"
+    return f"{base[:40]}-{digest}"
+
+
+def session_stem(session_key: str) -> str:
+    """Deterministic filesystem-safe stem for an opaque caller-supplied session key.
+
+    A key that is already safe and short is used verbatim (readable shard names in
+    the common case). Anything else is sanitized, truncated, and suffixed with a
+    hash of the RAW key so two distinct keys can never share one shard file.
+    """
+    safe = _sanitize(session_key)
+    if safe == session_key and 0 < len(session_key) <= 64:
+        return session_key
+    digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()[:12]
+    return f"{safe[:48]}-{digest}"
+
+
+def repo_dir(repo: str) -> Path:
+    return store_root() / repo_key(repo)
+
+
+def shard_path(repo: str, session_key: str) -> Path:
+    return repo_dir(repo) / f"{session_stem(session_key)}.jsonl"
+
+
+def _lock_path(repo: str) -> Path:
+    return repo_dir(repo) / LOCK_NAME
+
+
+def _ensure_lock_bootstrap(repo: str) -> Path:
+    """mkdir -p the repo shard dir and touch its lock file.
+
+    acquire_exclusive_lock opens the lock file in 'r' mode and requires it to
+    already exist - mirrors bin/ds-feedback's bootstrap.
+    """
+    lock = _lock_path(repo)
+    lock.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    lock.touch(exist_ok=True)
+    return lock
+
+
+def _read_shard(path: Path) -> list[dict]:
+    """Parse one shard file. Absent file returns []; malformed lines are skipped."""
+    if not path.is_file():
+        return []
+    rows: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            rows.append(parsed)
+    return rows
+
+
+def _shard_files(repo: str, session_key: str | None) -> list[Path]:
+    """Shard files for a repo, or just the one session's shard when given."""
+    directory = repo_dir(repo)
+    if session_key is not None:
+        one = shard_path(repo, session_key)
+        return [one] if one.is_file() else []
+    if not directory.is_dir():
+        return []
+    return sorted(p for p in directory.glob("*.jsonl") if p.is_file())
+
+
+def _read_rollup_state(repo: str) -> dict:
+    """Read .rolled-up.json. Absent or corrupt is treated as empty bookkeeping."""
+    path = repo_dir(repo) / ROLLUP_STATE_NAME
+    if not path.is_file():
+        return {}
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    shards = parsed.get("shards")
+    return shards if isinstance(shards, dict) else {}
+
+
+def _write_rollup_state(repo: str, shards: dict) -> None:
+    path = repo_dir(repo) / ROLLUP_STATE_NAME
+    payload = {
+        "updated_ts": _now(),
+        "shards": shards,
+    }
+    atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n", mode=0o600)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    lock = _ensure_lock_bootstrap(args.repo)
+    path = shard_path(args.repo, args.session_key)
+
+    with acquire_exclusive_lock(lock):
+        existing = _read_shard(path)
+        if len(existing) >= ENTRY_CAP_PER_SHARD:
+            # Soft-fail: the agent must never have to count, and must never be
+            # blocked. Dropping the entry is the intended behaviour, not an error.
+            print(
+                f"{PROG}: cap reached, entry dropped "
+                f"({ENTRY_CAP_PER_SHARD} per session)",
+                file=sys.stderr,
+            )
+            return 0
+
+        description = args.description
+        if len(description) > DESCRIPTION_MAX_CHARS:
+            description = description[:DESCRIPTION_MAX_CHARS]
+
+        record = {
+            # CLI-owned - never trusted from the caller.
+            "id": str(uuid.uuid4()),
+            "ts": _now(),
+            # Caller-supplied.
+            "session_key": args.session_key,
+            "agent_id": args.agent_id,
+            "role": args.role,
+            "event_type": args.event_type,
+            "domain_tag": args.domain_tag,
+            "description": description,
+            "resolution": args.resolution,
+        }
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        os.chmod(path, 0o600)
+
+    print(f"{PROG}: appended 1 entry ({len(existing) + 1}/{ENTRY_CAP_PER_SHARD}).")
+    return 0
+
+
+def cmd_rollup(args: argparse.Namespace) -> int:
+    root = store_root()
+    if not root.is_dir() or not repo_dir(args.repo).is_dir():
+        # Absent store is not an error.
+        print("[]")
+        return 0
+
+    lock = _ensure_lock_bootstrap(args.repo)
+    with acquire_exclusive_lock(lock):
+        state = _read_rollup_state(args.repo)
+        emitted: list[dict] = []
+        for path in _shard_files(args.repo, args.session_key):
+            rows = _read_shard(path)
+            entry = state.get(path.name)
+            already = 0
+            if isinstance(entry, dict) and isinstance(entry.get("rolled_count"), int):
+                already = max(0, entry["rolled_count"])
+            fresh = rows[already:]
+            if not fresh:
+                continue
+            emitted.extend(fresh)
+            state[path.name] = {"rolled_count": len(rows), "rolled_ts": _now()}
+
+        if emitted:
+            _write_rollup_state(args.repo, state)
+
+    # Raw entries, verbatim. No judgment, no classification - that is conductor-side.
+    print(json.dumps(emitted, indent=2))
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    if not store_root().is_dir() or not repo_dir(args.repo).is_dir():
+        print("[]")
+        return 0
+
+    lock = _ensure_lock_bootstrap(args.repo)
+    with acquire_exclusive_lock(lock):
+        rows: list[dict] = []
+        for path in _shard_files(args.repo, args.session_key):
+            rows.extend(_read_shard(path))
+
+    print(json.dumps(rows, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog=PROG,
+        description=(
+            "Manage the home-dir per-session learning shard store "
+            "(~/.agentic/learnings-shards/)."
+        ),
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_append = sub.add_parser("append", help="Append one learning entry to this session's shard")
+    p_append.add_argument("--repo", required=True, help="Repo path the learning belongs to")
+    p_append.add_argument(
+        "--session-key",
+        required=True,
+        help="Opaque caller-supplied session key (never read from the environment)",
+    )
+    p_append.add_argument("--agent-id", required=True, help="Agent id that hit the learning")
+    p_append.add_argument("--role", required=True, help="Agent role (e.g. engineer)")
+    p_append.add_argument(
+        "--event-type", required=True, choices=EVENT_TYPES, help="Kind of learning"
+    )
+    p_append.add_argument("--domain-tag", required=True, help="Short domain tag")
+    p_append.add_argument(
+        "--description",
+        required=True,
+        help=f"What happened (truncated to {DESCRIPTION_MAX_CHARS} chars, never rejected)",
+    )
+    p_append.add_argument("--resolution", default=None, help="How it was resolved (optional)")
+    p_append.set_defaults(func=cmd_append)
+
+    p_rollup = sub.add_parser(
+        "rollup", help="Emit not-yet-rolled-up entries as a JSON array and mark them"
+    )
+    p_rollup.add_argument("--repo", required=True, help="Repo path to roll up")
+    p_rollup.add_argument("--session-key", default=None, help="Limit to one session's shard")
+    p_rollup.set_defaults(func=cmd_rollup)
+
+    p_list = sub.add_parser("list", help="List shard entries as a JSON array (diagnostic)")
+    p_list.add_argument("--repo", required=True, help="Repo path to list")
+    p_list.add_argument("--session-key", default=None, help="Limit to one session's shard")
+    p_list.set_defaults(func=cmd_list)
+
+    return p
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv[1:])
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001 - soft-fail: never block the caller
+        print(f"{PROG}: soft-fail: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/tests/test_bin_symlink_resolution.py
+++ b/bin/tests/test_bin_symlink_resolution.py
@@ -58,6 +58,7 @@ CASES = [
     ("agentic-team", ["--help"], 0),
     ("agentic-tracker", ["--help"], 0),
     ("agentic-branch-prune", ["--help"], 0),
+    ("agentic-learning-shard", ["--help"], 0),
 ]
 
 # Completeness backstop: every bin/agentic-* python CLI that carries the

--- a/bin/tests/test_ds_learning_shard.py
+++ b/bin/tests/test_ds_learning_shard.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+Regression tests for bin/ds-learning-shard (DS-154 Unit A).
+
+Coverage:
+  1. append writes a well-formed JSONL line: CLI-owned id/ts present, every
+     caller-supplied field preserved verbatim.
+  2. description over 500 chars is TRUNCATED, not rejected.
+  3. the 5-entry-per-shard cap: the 6th append exits 0, prints to stderr, and
+     adds no line.
+  4. rollup emits entries then marks them; a second rollup emits [] (idempotency).
+  5. rollup against an absent store emits [] and exits 0.
+  6. two --repo paths with the SAME directory basename produce DIFFERENT
+     repo-keys - the regression guard against the bare-basename slug trap.
+  7. symlink invocation through a real os.symlink in a subprocess - the only way
+     to exercise the bin/_lib PATH-symlink resolution bug (in-process import
+     never hits it).
+
+Every subprocess runs under a fake $HOME so the developer's real
+~/.agentic/learnings-shards store is never touched.
+
+Run with: python3 -m pytest bin/tests/test_ds_learning_shard.py -x
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_BIN = Path(__file__).resolve().parent.parent
+CLI = REPO_BIN / "ds-learning-shard"
+
+
+def _load_module():
+    """Load bin/ds-learning-shard as a module (extension-less executable)."""
+    loader = importlib.machinery.SourceFileLoader("ds_learning_shard", str(CLI))
+    spec = importlib.util.spec_from_loader("ds_learning_shard", loader)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    loader.exec_module(module)
+    return module
+
+
+def run(home: Path, *args: str, cli: Path | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(cli or CLI), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def append(home: Path, repo: Path, session: str, **over: str) -> subprocess.CompletedProcess:
+    fields = {
+        "--agent-id": "agent-abc123",
+        "--role": "engineer",
+        "--event-type": "gotcha",
+        "--domain-tag": "git",
+        "--description": "worktree branch leaked into the conductor checkout",
+        "--resolution": "verify git branch --show-current after every spawn",
+    }
+    fields.update(over)
+    argv: list[str] = ["append", "--repo", str(repo), "--session-key", session]
+    for key, value in fields.items():
+        argv += [key, value]
+    return run(home, *argv)
+
+
+def store_dir(home: Path) -> Path:
+    return home / ".agentic" / "learnings-shards"
+
+
+def read_entries(home: Path, repo: Path, session: str) -> list[dict]:
+    proc = run(home, "list", "--repo", str(repo), "--session-key", session)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+@pytest.fixture()
+def env(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "proj" / "DinoStack"
+    repo.mkdir(parents=True)
+    return home, repo
+
+
+# --- 1. well-formed append ------------------------------------------------
+
+
+def test_append_writes_well_formed_line(env):
+    home, repo = env
+    proc = append(home, repo, "sess-1")
+    assert proc.returncode == 0, proc.stderr
+
+    entries = read_entries(home, repo, "sess-1")
+    assert len(entries) == 1
+    row = entries[0]
+
+    # CLI-owned fields present and non-empty.
+    assert row["id"] and len(row["id"]) == 36
+    assert row["ts"].endswith("Z") and row["ts"][4] == "-"
+
+    # Caller-supplied fields preserved verbatim.
+    assert row["session_key"] == "sess-1"
+    assert row["agent_id"] == "agent-abc123"
+    assert row["role"] == "engineer"
+    assert row["event_type"] == "gotcha"
+    assert row["domain_tag"] == "git"
+    assert row["description"] == "worktree branch leaked into the conductor checkout"
+    assert row["resolution"] == "verify git branch --show-current after every spawn"
+
+    # Store lives under HOME, outside the repo.
+    assert store_dir(home).is_dir()
+    assert not (repo / ".agentic").exists()
+
+
+def test_caller_supplied_id_and_ts_are_ignored():
+    """id/ts are CLI-owned; there is no CLI surface to set them."""
+    module = _load_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["append", "--repo", ".", "--session-key", "s", "--id", "x"])
+
+
+def test_resolution_is_optional(env):
+    home, repo = env
+    argv = [
+        "append", "--repo", str(repo), "--session-key", "sess-nores",
+        "--agent-id", "a", "--role", "engineer", "--event-type", "decision",
+        "--domain-tag", "ci", "--description", "chose squash merge",
+    ]
+    proc = run(home, *argv)
+    assert proc.returncode == 0, proc.stderr
+    assert read_entries(home, repo, "sess-nores")[0]["resolution"] is None
+
+
+# --- 2. description truncation -------------------------------------------
+
+
+def test_long_description_is_truncated_not_rejected(env):
+    home, repo = env
+    long_text = "x" * 900
+    proc = append(home, repo, "sess-long", **{"--description": long_text})
+    assert proc.returncode == 0, proc.stderr
+
+    entries = read_entries(home, repo, "sess-long")
+    assert len(entries) == 1, "over-long description must be stored, not rejected"
+    assert len(entries[0]["description"]) == 500
+    assert entries[0]["description"] == "x" * 500
+
+
+def test_description_at_limit_is_untouched(env):
+    home, repo = env
+    exact = "y" * 500
+    append(home, repo, "sess-exact", **{"--description": exact})
+    assert read_entries(home, repo, "sess-exact")[0]["description"] == exact
+
+
+# --- 3. per-shard cap -----------------------------------------------------
+
+
+def test_cap_five_entries_sixth_is_dropped_softly(env):
+    home, repo = env
+    for i in range(5):
+        proc = append(home, repo, "sess-cap", **{"--domain-tag": f"tag{i}"})
+        assert proc.returncode == 0, proc.stderr
+    assert len(read_entries(home, repo, "sess-cap")) == 5
+
+    sixth = append(home, repo, "sess-cap", **{"--domain-tag": "overflow"})
+    assert sixth.returncode == 0, "over-cap append must never block the caller"
+    assert "cap reached, entry dropped" in sixth.stderr
+
+    entries = read_entries(home, repo, "sess-cap")
+    assert len(entries) == 5, "6th append must not add a line"
+    assert all(row["domain_tag"] != "overflow" for row in entries)
+
+
+def test_cap_is_per_session_not_per_repo(env):
+    home, repo = env
+    for i in range(5):
+        append(home, repo, "sess-a", **{"--domain-tag": f"a{i}"})
+    proc = append(home, repo, "sess-b", **{"--domain-tag": "b0"})
+    assert proc.returncode == 0
+    assert "cap reached" not in proc.stderr
+    assert len(read_entries(home, repo, "sess-b")) == 1
+
+
+# --- 4. rollup + idempotency ---------------------------------------------
+
+
+def test_rollup_emits_then_marks_and_is_idempotent(env):
+    home, repo = env
+    append(home, repo, "sess-r1", **{"--domain-tag": "one"})
+    append(home, repo, "sess-r2", **{"--domain-tag": "two"})
+
+    first = run(home, "rollup", "--repo", str(repo))
+    assert first.returncode == 0, first.stderr
+    emitted = json.loads(first.stdout)
+    assert len(emitted) == 2
+    assert {row["domain_tag"] for row in emitted} == {"one", "two"}
+    # Raw entries, verbatim - no classification field added by the CLI.
+    assert set(emitted[0]) == {
+        "id", "ts", "session_key", "agent_id", "role",
+        "event_type", "domain_tag", "description", "resolution",
+    }
+
+    second = run(home, "rollup", "--repo", str(repo))
+    assert second.returncode == 0, second.stderr
+    assert json.loads(second.stdout) == [], "second rollup must emit []"
+
+    # Entries themselves are not deleted; only the bookkeeping advanced.
+    assert len(read_entries(home, repo, "sess-r1")) == 1
+
+
+def test_rollup_session_scoped(env):
+    home, repo = env
+    append(home, repo, "sess-x", **{"--domain-tag": "x"})
+    append(home, repo, "sess-y", **{"--domain-tag": "y"})
+
+    scoped = run(home, "rollup", "--repo", str(repo), "--session-key", "sess-x")
+    emitted = json.loads(scoped.stdout)
+    assert [row["domain_tag"] for row in emitted] == ["x"]
+
+    rest = run(home, "rollup", "--repo", str(repo))
+    assert [row["domain_tag"] for row in json.loads(rest.stdout)] == ["y"]
+
+
+def test_rollup_picks_up_entries_appended_after_a_rollup(env):
+    home, repo = env
+    append(home, repo, "sess-late", **{"--domain-tag": "first"})
+    run(home, "rollup", "--repo", str(repo))
+    append(home, repo, "sess-late", **{"--domain-tag": "second"})
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    emitted = json.loads(proc.stdout)
+    assert [row["domain_tag"] for row in emitted] == ["second"]
+
+
+# --- 5. absent store ------------------------------------------------------
+
+
+def test_rollup_absent_store_emits_empty_array(env):
+    home, repo = env
+    assert not store_dir(home).exists()
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == []
+    assert not store_dir(home).exists(), "rollup must not create the store"
+
+
+def test_list_absent_store_emits_empty_array(env):
+    home, repo = env
+    proc = run(home, "list", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == []
+
+
+def test_rollup_absent_session_shard_emits_empty_array(env):
+    home, repo = env
+    append(home, repo, "sess-present")
+    proc = run(home, "rollup", "--repo", str(repo), "--session-key", "sess-missing")
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == []
+
+
+# --- 6. repo-key collision resistance ------------------------------------
+
+
+def test_same_basename_different_paths_get_different_repo_keys(tmp_path: Path):
+    """Regression guard: a bare directory basename is NOT an acceptable repo key."""
+    module = _load_module()
+    a = tmp_path / "alpha" / "DinoStack"
+    b = tmp_path / "beta" / "DinoStack"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+
+    key_a = module.repo_key(str(a))
+    key_b = module.repo_key(str(b))
+
+    assert a.name == b.name == "DinoStack"
+    assert key_a != key_b, "same-basename repos must not share a shard directory"
+    assert key_a == module.repo_key(str(a)), "repo key must be stable across calls"
+    # Filesystem-safe.
+    assert all(ch.isalnum() or ch in "._-" for ch in key_a)
+
+
+def test_same_basename_repos_write_to_separate_shard_dirs(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    a = tmp_path / "alpha" / "DinoStack"
+    b = tmp_path / "beta" / "DinoStack"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+
+    append(home, a, "sess-1", **{"--domain-tag": "from-alpha"})
+    append(home, b, "sess-1", **{"--domain-tag": "from-beta"})
+
+    dirs = sorted(p.name for p in store_dir(home).iterdir() if p.is_dir())
+    assert len(dirs) == 2, f"expected two distinct shard dirs, got {dirs}"
+    assert [r["domain_tag"] for r in read_entries(home, a, "sess-1")] == ["from-alpha"]
+    assert [r["domain_tag"] for r in read_entries(home, b, "sess-1")] == ["from-beta"]
+
+
+def test_session_key_with_path_separators_is_filesystem_safe(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "proj"
+    repo.mkdir()
+
+    proc = append(home, repo, "../../escape/key")
+    assert proc.returncode == 0, proc.stderr
+    shards = list(store_dir(home).rglob("*.jsonl"))
+    assert len(shards) == 1
+    assert shards[0].parent.parent == store_dir(home), "shard must stay inside the store"
+    assert read_entries(home, repo, "../../escape/key")[0]["session_key"] == "../../escape/key"
+
+
+# --- 7. symlink invocation (mandatory _lib resolution guard) --------------
+
+
+def test_invocation_through_a_path_symlink(tmp_path: Path):
+    """install.sh symlinks bin/ds-* into ~/.local/bin but never _lib.py.
+
+    A bare Path(__file__).parent lookup would resolve to the symlink's dir and
+    raise FileNotFoundError at import time. Only a real symlink + subprocess
+    exercises this; in-process import never does.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "proj"
+    repo.mkdir()
+
+    link_dir = tmp_path / "local-bin"
+    link_dir.mkdir()
+    link = link_dir / "ds-learning-shard"
+    os.symlink(CLI, link)
+    assert link.is_symlink()
+    assert not (link_dir / "_lib.py").exists()
+
+    helped = run(home, "--help", cli=link)
+    assert helped.returncode == 0, helped.stderr
+    assert "FileNotFoundError" not in helped.stderr
+
+    argv = [
+        "append", "--repo", str(repo), "--session-key", "sess-symlink",
+        "--agent-id", "a", "--role", "engineer", "--event-type", "workaround",
+        "--domain-tag", "install", "--description", "via symlink",
+    ]
+    proc = run(home, *argv, cli=link)
+    assert proc.returncode == 0, proc.stderr
+    assert "FileNotFoundError" not in proc.stderr
+    assert read_entries(home, repo, "sess-symlink")[0]["description"] == "via symlink"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/bin/tests/test_ds_learning_shard.py
+++ b/bin/tests/test_ds_learning_shard.py
@@ -15,6 +15,11 @@ Coverage:
   7. symlink invocation through a real os.symlink in a subprocess - the only way
      to exercise the bin/_lib PATH-symlink resolution bug (in-process import
      never hits it).
+  8. rollup and list emit a parseable "[]" on the soft-fail path, not empty
+     stdout with exit 0 (which crashes any consumer doing json.loads(stdout)).
+  9. a linked git worktree and its primary checkout produce the SAME repo-key,
+     so an isolation-worktree engineer's appends are visible to a conductor
+     rolling up from the primary checkout.
 
 Every subprocess runs under a fake $HOME so the developer's real
 ~/.agentic/learnings-shards store is never touched.
@@ -28,6 +33,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -359,6 +365,224 @@ def test_invocation_through_a_path_symlink(tmp_path: Path):
     assert proc.returncode == 0, proc.stderr
     assert "FileNotFoundError" not in proc.stderr
     assert read_entries(home, repo, "sess-symlink")[0]["description"] == "via symlink"
+
+
+# --- 8. soft-fail still emits a parseable JSON array ----------------------
+
+
+def _break_the_lock(home: Path, repo: Path) -> Path:
+    """Force every locked path to raise, without touching the early-exit checks.
+
+    The repo shard dir must still exist (or rollup/list take the documented
+    absent-store branch and never reach the soft-fail handler), so the lock FILE
+    is replaced by a DIRECTORY: Path.touch(exist_ok=True) is satisfied by utime
+    on a directory, and acquire_exclusive_lock's open(..., "r") then raises
+    IsADirectoryError inside the try block main() guards.
+    """
+    module = _load_module()
+    # repo_key does not read HOME, so the in-process value matches the CLI's.
+    lock = store_dir(home) / module.repo_key(str(repo)) / ".lock"
+    assert lock.is_file(), "the append fixture should have created the real lock file"
+    lock.unlink()
+    lock.mkdir()
+    return lock
+
+
+@pytest.mark.parametrize("subcommand", ["rollup", "list"])
+def test_soft_fail_still_emits_empty_json_array(env, subcommand):
+    """Contract: rollup/list emit a JSON array to stdout and exit 0 - ALWAYS.
+
+    Empty stdout with exit 0 crashes json.loads(stdout) and the exit code gives
+    the consumer no reason to expect it.
+    """
+    home, repo = env
+    append(home, repo, "sess-soft")
+    broken = _break_the_lock(home, repo)
+    assert broken.is_dir()
+
+    proc = run(home, subcommand, "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert "soft-fail" in proc.stderr, "the soft-fail path must actually have fired"
+    assert json.loads(proc.stdout) == [], f"{subcommand} stdout must stay parseable"
+
+
+def test_soft_fail_after_a_successful_emit_does_not_append_a_second_array(env):
+    """The fallback must not turn one valid array into two, which is unparseable."""
+    home, repo = env
+    append(home, repo, "sess-two")
+    # An unwritable shard dir lets rollup emit, then fail writing .rolled-up.json.
+    key_dir = next(p for p in store_dir(home).iterdir() if p.is_dir())
+    original = key_dir.stat().st_mode
+    os.chmod(key_dir, 0o500)
+    try:
+        proc = run(home, "rollup", "--repo", str(repo))
+    finally:
+        os.chmod(key_dir, original)
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert len(payload) == 1, "the emitted array must survive the later failure"
+
+
+# --- 9. worktree / primary checkout key convergence -----------------------
+
+
+def _require_git() -> str:
+    """git is optional locally, MANDATORY in CI.
+
+    A silently-skipped assertion is indistinguishable from a passing one in a
+    CI log, so skipping is only allowed off CI.
+    """
+    found = shutil.which("git")
+    if found:
+        return found
+    if os.environ.get("CI"):
+        raise AssertionError("git is required in CI; refusing to skip this assertion")
+    pytest.skip("git not installed")
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    proc = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "-c", "user.email=t@example.com",
+         "-c", "user.name=Test", *args],
+        cwd=str(cwd), capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"git {' '.join(args)} failed: {proc.stderr}"
+    return proc
+
+
+def _make_repo_with_worktree(root: Path) -> tuple[Path, Path]:
+    primary = root / "primary" / "DinoStack"
+    primary.mkdir(parents=True)
+    _git("init", "-q", cwd=primary)
+    _git("commit", "-q", "--allow-empty", "-m", "init", cwd=primary)
+    worktree = primary / ".claude" / "worktrees" / "agent-abc"
+    _git("worktree", "add", "-q", str(worktree), "-b", "wt-abc", cwd=primary)
+    return primary, worktree
+
+
+def test_worktree_and_primary_checkout_share_one_repo_key(tmp_path: Path):
+    """The driving scenario: engineer appends from a worktree, conductor rolls
+    up from the primary checkout. Divergent keys silently lose the learning."""
+    _require_git()
+    module = _load_module()
+    primary, worktree = _make_repo_with_worktree(tmp_path)
+
+    assert worktree.is_dir()
+    assert primary.resolve() != worktree.resolve()
+    assert module.repo_key(str(worktree)) == module.repo_key(str(primary))
+
+
+def test_subdirectory_of_a_checkout_shares_its_repo_key(tmp_path: Path):
+    _require_git()
+    module = _load_module()
+    primary, _ = _make_repo_with_worktree(tmp_path)
+    sub = primary / "bin" / "tests"
+    sub.mkdir(parents=True)
+    assert module.repo_key(str(sub)) == module.repo_key(str(primary))
+
+
+def test_two_git_repos_with_the_same_basename_still_differ(tmp_path: Path):
+    """Canonicalisation must not regress the same-basename collision guard."""
+    _require_git()
+    module = _load_module()
+    keys = []
+    for parent in ("alpha", "beta"):
+        repo = tmp_path / parent / "DinoStack"
+        repo.mkdir(parents=True)
+        _git("init", "-q", cwd=repo)
+        _git("commit", "-q", "--allow-empty", "-m", "init", cwd=repo)
+        keys.append(module.repo_key(str(repo)))
+    assert keys[0] != keys[1]
+
+
+def test_non_git_path_still_yields_a_stable_key(tmp_path: Path):
+    """Documented fallback: hash the caller's own resolved absolute path."""
+    module = _load_module()
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    assert not (plain / ".git").exists()
+
+    key = module.repo_key(str(plain))
+    assert key == module.repo_key(str(plain)), "key must be stable across calls"
+    assert key.startswith("not-a-repo-")
+    assert all(ch.isalnum() or ch in "._-" for ch in key)
+    assert module.canonical_repo_path(str(plain)) == str(plain.resolve())
+
+
+def test_entry_appended_from_a_worktree_is_rolled_up_from_the_primary(tmp_path: Path):
+    """End-to-end proof of Major 2: the learning must not vanish."""
+    _require_git()
+    home = tmp_path / "home"
+    home.mkdir()
+    primary, worktree = _make_repo_with_worktree(tmp_path)
+
+    proc = append(home, worktree, "sess-wt", **{"--domain-tag": "from-worktree"})
+    assert proc.returncode == 0, proc.stderr
+
+    rolled = run(home, "rollup", "--repo", str(primary))
+    assert rolled.returncode == 0, rolled.stderr
+    emitted = json.loads(rolled.stdout)
+    assert [row["domain_tag"] for row in emitted] == ["from-worktree"]
+
+    dirs = [p.name for p in store_dir(home).iterdir() if p.is_dir()]
+    assert len(dirs) == 1, f"worktree and primary must share ONE shard dir, got {dirs}"
+
+
+# --- 10. minor hardening --------------------------------------------------
+
+
+def test_cap_counts_physical_lines_not_parsed_rows(env):
+    """A corrupt line must consume cap budget, or a shard grows without bound."""
+    home, repo = env
+    append(home, repo, "sess-corrupt")
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    with open(shard, "a", encoding="utf-8") as handle:
+        handle.write("{not json\n" * 4)
+
+    proc = append(home, repo, "sess-corrupt", **{"--domain-tag": "overflow"})
+    assert proc.returncode == 0
+    assert "cap reached, entry dropped" in proc.stderr
+    assert len(shard.read_text(encoding="utf-8").splitlines()) == 5
+
+
+def test_append_recovers_from_a_newline_less_partial_line(env):
+    """A crash mid-append must not make the NEXT append concatenate onto it."""
+    home, repo = env
+    append(home, repo, "sess-partial")
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    with open(shard, "a", encoding="utf-8") as handle:
+        handle.write('{"partial": tru')  # no trailing newline
+
+    proc = append(home, repo, "sess-partial", **{"--domain-tag": "after-crash"})
+    assert proc.returncode == 0, proc.stderr
+    lines = shard.read_text(encoding="utf-8").splitlines()
+    assert lines[-1].startswith("{"), "the new entry must be its own line"
+    assert json.loads(lines[-1])["domain_tag"] == "after-crash"
+    assert [r["domain_tag"] for r in read_entries(home, repo, "sess-partial")][-1] == "after-crash"
+
+
+def test_rollup_self_heals_a_stale_rolled_count(env):
+    """rolled_count > len(rows) must not strand every entry forever."""
+    home, repo = env
+    append(home, repo, "sess-stale", **{"--domain-tag": "only"})
+    run(home, "rollup", "--repo", str(repo))
+
+    state_path = next(store_dir(home).rglob(".rolled-up.json"))
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    for name in state["shards"]:
+        state["shards"][name]["rolled_count"] = 99
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert [r["domain_tag"] for r in json.loads(proc.stdout)] == ["only"]
+
+
+def test_store_root_is_not_world_readable(env):
+    home, repo = env
+    append(home, repo, "sess-mode")
+    assert store_dir(home).stat().st_mode & 0o077 == 0
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ds_learning_shard.py
+++ b/bin/tests/test_ds_learning_shard.py
@@ -20,6 +20,13 @@ Coverage:
   9. a linked git worktree and its primary checkout produce the SAME repo-key,
      so an isolation-worktree engineer's appends are visible to a conductor
      rolling up from the primary checkout.
+ 10. rollup bookkeeping is keyed on the CLI-owned uuid4 entry id, never on a
+     count or a position. A positional index into parsed rows loses an
+     un-rolled entry the moment an ALREADY-rolled line stops parsing (every
+     later row shifts down one), and has a mirror image in the other direction
+     as well. The id-set tests cover corruption in both directions, duplicate
+     rows, reordered rows, an unknown/legacy count-shaped state record, and
+     the bound on the id set itself.
 
 Every subprocess runs under a fake $HOME so the developer's real
 ~/.agentic/learnings-shards store is never touched.
@@ -562,8 +569,12 @@ def test_append_recovers_from_a_newline_less_partial_line(env):
     assert [r["domain_tag"] for r in read_entries(home, repo, "sess-partial")][-1] == "after-crash"
 
 
-def test_rollup_self_heals_a_stale_rolled_count(env):
-    """rolled_count > len(rows) must not strand every entry forever."""
+def test_rollup_self_heals_an_untrustworthy_state_record(env):
+    """A shard record in any non-id-keyed shape must re-emit, never strand.
+
+    Re-emission is the safe direction: a duplicate is recoverable
+    conductor-side, a lost learning is not.
+    """
     home, repo = env
     append(home, repo, "sess-stale", **{"--domain-tag": "only"})
     run(home, "rollup", "--repo", str(repo))
@@ -571,12 +582,162 @@ def test_rollup_self_heals_a_stale_rolled_count(env):
     state_path = next(store_dir(home).rglob(".rolled-up.json"))
     state = json.loads(state_path.read_text(encoding="utf-8"))
     for name in state["shards"]:
-        state["shards"][name]["rolled_count"] = 99
+        state["shards"][name] = {"garbage": True}
     state_path.write_text(json.dumps(state), encoding="utf-8")
 
     proc = run(home, "rollup", "--repo", str(repo))
     assert proc.returncode == 0, proc.stderr
     assert [r["domain_tag"] for r in json.loads(proc.stdout)] == ["only"]
+
+
+# --- 11. id-keyed rollup bookkeeping (Major: positional index loses entries) --
+
+
+def _state_path(home: Path) -> Path:
+    return next(store_dir(home).rglob(".rolled-up.json"))
+
+
+def _corrupt_line(shard: Path, index: int) -> None:
+    """Make one physical line of a shard unparseable, in place."""
+    lines = shard.read_text(encoding="utf-8").splitlines()
+    lines[index] = "{not json"
+    shard.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_corrupting_an_already_rolled_line_does_not_lose_a_fresh_entry(env):
+    """The defect a positional rolled_count cannot survive.
+
+    rolled_count is an index into PARSED rows, and _read_shard skips malformed
+    lines by contract. Corrupting an already-rolled line shifts every later row
+    down one, so the row at that index is skipped forever. Keyed on ids there
+    is no index to shift.
+    """
+    home, repo = env
+    for tag in ("e1", "e2", "e3"):
+        append(home, repo, "sess-shift", **{"--domain-tag": tag})
+
+    first = run(home, "rollup", "--repo", str(repo))
+    assert [r["domain_tag"] for r in json.loads(first.stdout)] == ["e1", "e2", "e3"]
+
+    for tag in ("e4", "e5"):
+        append(home, repo, "sess-shift", **{"--domain-tag": tag})
+
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    _corrupt_line(shard, 1)  # already-rolled e2
+
+    second = run(home, "rollup", "--repo", str(repo))
+    assert second.returncode == 0, second.stderr
+    emitted = [r["domain_tag"] for r in json.loads(second.stdout)]
+    assert emitted == ["e4", "e5"], f"e4 must not fall behind an index: {emitted}"
+
+
+def test_malformed_line_that_was_never_rolled_up_does_not_block_later_entries(env):
+    """The mirror direction: a corrupt line among UN-rolled rows."""
+    home, repo = env
+    append(home, repo, "sess-mal", **{"--domain-tag": "a"})
+    append(home, repo, "sess-mal", **{"--domain-tag": "b"})
+    append(home, repo, "sess-mal", **{"--domain-tag": "c"})
+
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    _corrupt_line(shard, 1)  # never-rolled "b"
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert [r["domain_tag"] for r in json.loads(proc.stdout)] == ["a", "c"]
+
+
+def test_duplicate_rows_are_emitted_once(env):
+    """A duplicated physical line shares one id and must not double-emit."""
+    home, repo = env
+    append(home, repo, "sess-dup", **{"--domain-tag": "solo"})
+
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    line = shard.read_text(encoding="utf-8").splitlines()[0]
+    shard.write_text(line + "\n" + line + "\n", encoding="utf-8")
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    emitted = json.loads(proc.stdout)
+    assert [r["domain_tag"] for r in emitted] == ["solo"], "duplicate id emitted twice"
+
+    again = run(home, "rollup", "--repo", str(repo))
+    assert json.loads(again.stdout) == []
+
+
+def test_reordered_rows_are_not_re_emitted(env):
+    """Membership has no ordering; a positional index does."""
+    home, repo = env
+    for tag in ("r1", "r2", "r3"):
+        append(home, repo, "sess-reorder", **{"--domain-tag": tag})
+    run(home, "rollup", "--repo", str(repo))
+
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    lines = shard.read_text(encoding="utf-8").splitlines()
+    shard.write_text("\n".join(reversed(lines)) + "\n", encoding="utf-8")
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == [], "reordering must not re-emit"
+
+
+def test_pre_existing_count_shaped_state_re_emits_rather_than_losing(env):
+    """Nothing is in production, so no migration - but never crash, never lose."""
+    home, repo = env
+    append(home, repo, "sess-legacy", **{"--domain-tag": "kept-1"})
+    append(home, repo, "sess-legacy", **{"--domain-tag": "kept-2"})
+    run(home, "rollup", "--repo", str(repo))
+
+    state_path = _state_path(home)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    # Exactly the pre-DS-154 shape, id list removed.
+    state["shards"] = {
+        name: {"rolled_count": 2, "rolled_ts": "2026-01-01T00:00:00Z"}
+        for name in state["shards"]
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    proc = run(home, "rollup", "--repo", str(repo))
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == "" or "soft-fail" not in proc.stderr, proc.stderr
+    emitted = [r["domain_tag"] for r in json.loads(proc.stdout)]
+    assert emitted == ["kept-1", "kept-2"], f"count-shaped state must not lose: {emitted}"
+
+    # And the rewritten state is id-keyed again, so idempotency resumes.
+    assert json.loads(run(home, "rollup", "--repo", str(repo)).stdout) == []
+
+
+def test_rollup_state_is_id_keyed_and_bounded_by_the_shard(env):
+    """Schema assertion plus the stated bound: never more ids than the shard holds."""
+    home, repo = env
+    for tag in ("b1", "b2"):
+        append(home, repo, "sess-bound", **{"--domain-tag": tag})
+    run(home, "rollup", "--repo", str(repo))
+
+    state = json.loads(_state_path(home).read_text(encoding="utf-8"))
+    (record,) = state["shards"].values()
+    assert "rolled_count" not in record, "positional bookkeeping must be gone"
+    assert isinstance(record["rolled_ids"], list)
+
+    shard = next(store_dir(home).rglob("*.jsonl"))
+    live_ids = {json.loads(line)["id"] for line in shard.read_text(encoding="utf-8").splitlines()}
+    assert set(record["rolled_ids"]) == live_ids
+    assert len(record["rolled_ids"]) <= 5, "bounded by ENTRY_CAP_PER_SHARD"
+
+    # Truncating the shard must shrink the id set, not grow it unboundedly.
+    shard.write_text("", encoding="utf-8")
+    for tag in ("b3",):
+        append(home, repo, "sess-bound", **{"--domain-tag": tag})
+    run(home, "rollup", "--repo", str(repo))
+    state = json.loads(_state_path(home).read_text(encoding="utf-8"))
+    (record,) = state["shards"].values()
+    assert len(record["rolled_ids"]) == 1
+
+
+def test_lock_file_is_not_group_or_world_readable(env):
+    home, repo = env
+    append(home, repo, "sess-lockmode")
+    lock = next(store_dir(home).rglob(".lock"))
+    assert lock.stat().st_mode & 0o077 == 0
 
 
 def test_store_root_is_not_world_readable(env):


### PR DESCRIPTION
Implements Unit A of DS-154: the CLI that lets a write-capable subagent record a learning **the moment it hits one**, instead of relying on an operator remembering to run `/ds-wrap` at the end of a session.

`/ds-wrap` is not touched by this PR and is not going away. The goal is that it stop being *necessary*.

## What this adds

`bin/ds-learning-shard` with three subcommands:

- `append` - one JSON line per learning into `~/.agentic/learnings-shards/<repo-key>/<session-key>.jsonl`. `id` (uuid4) and `ts` are CLI-owned and never trusted from the caller. Capped at 5 entries per shard; the 6th prints to stderr and exits 0.
- `rollup` - emits a JSON array of not-yet-rolled-up entries for a conductor to classify. **Zero judgment in the CLI** - classification stays conductor-side.
- `list` - diagnostic.

Nothing calls it yet. Wiring is Units B through F.

## Two design decisions worth reviewing

**The store is in `$HOME`, not the repo.** An isolation-worktree engineer's `.agentic/` is worktree-local and is deleted at Phase 8, before Phase 9 opens the PR. A shard written in-repo is gone before anything can read it. Same pattern `bin/agentic-feedback` already uses.

**`repo-key` normalizes through `git rev-parse --git-common-dir`,** so a linked worktree, its primary checkout, and any subdirectory resolve to one key. Without this the engineer appends under one key and the conductor rolls up under another, and the learning is silently lost - the exact failure this ticket exists to eliminate. Four fallback paths (git absent, non-zero exit, timeout bounded at 5s, git < 2.31) all degrade to a resolved-path hash rather than failing.

**`session-key` is opaque and caller-supplied.** The CLI never reads or generates it, and touches no harness environment variable. Only Claude Code exposes a session id to the conductor's shell; every other adapter keeps it inside its own hook or plugin process, so reading one would make this Claude-only.

## Review history

Three Skeptic rounds. Round 2's Major was round 1's Minor in mirror image: a positional `rolled_count` index into *parsed* rows, while malformed lines are skipped, so corrupting an already-rolled line shifted the frontier and dropped an un-rolled entry permanently. Fixed structurally rather than with a third one-directional guard - bookkeeping now keys on the CLI-owned uuid4 id set, which has no ordering and therefore no mirror image.

Two Minors accepted and documented rather than fixed: `rollup` exits 120 if a consumer truncates its stdout pipe (unreachable for the documented `json.loads(stdout)` consumer), and a hand-edited row lacking an `id` re-emits on every rollup (unreachable via the CLI, and re-emission is the safe direction - a duplicate is recoverable, a lost learning is not).

## Verification

- Full suite `1149 passed` (1112 on `origin/main`, +36 new tests +1 symlink case).
- Every new assertion mutation-tested with `__pycache__` cleared and `-p no:cacheprovider`; the Skeptic independently re-ran the two that matter and confirmed the CLI byte-identical afterward.
- 20 parallel appends interleaved with 5 rollups: exactly 5 entries, no lost update, no entry both emitted and lost.
- repo-key verified identical across primary, linked worktree, and subdirectory with a real `git worktree add`; distinct for two same-basename repos; `/tmp` and `/private/tmp` collapse.

## North Star alignment

- **Guard operator attention** - capture happens in flight, at the moment the learning occurs, removing the dependency on an operator remembering `/ds-wrap` before a session ends.
- **Works for everyone** - HOME-dir store, caller-supplied opaque session key, no harness environment variable, git optional with a clean degradation path. Nothing here is Claude-specific.
- No pillar regressed; no new operator ceremony.

Doc-sync: triggered (new `bin/` CLI); `bin/AGENTS.md` entry-points table and its count updated in the same branch. No README, CONTRIBUTING, `content/SKILL.md`, or slide asserts a CLI count that this staled.
