### PR TITLE
chore: scrub unreleased sibling product name from public artifacts

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2845,7 +2845,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2845,7 +2845,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2901,7 +2901,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2901,7 +2901,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.copilot/references/planning-artifacts.md
+++ b/.copilot/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `helios/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `helios/factory/foo.ts` is in the `helios` track. A change touching both `helios/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `helios/factory/foo.ts` and `helios/ui/bar.tsx` is single-track (`helios`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.copilot/references/planning-artifacts.md
+++ b/.copilot/references/planning-artifacts.md
@@ -78,7 +78,7 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example A: a repo with `api/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `api/...` is cross-track and triggers Plan + ADR.
 - Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**

--- a/.copilot/references/planning-artifacts.md
+++ b/.copilot/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2839,7 +2839,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2839,7 +2839,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.cursor/references/planning-artifacts.md
+++ b/.cursor/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `helios/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `helios/factory/foo.ts` is in the `helios` track. A change touching both `helios/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `helios/factory/foo.ts` and `helios/ui/bar.tsx` is single-track (`helios`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.cursor/references/planning-artifacts.md
+++ b/.cursor/references/planning-artifacts.md
@@ -78,7 +78,7 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example A: a repo with `api/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `api/...` is cross-track and triggers Plan + ADR.
 - Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**

--- a/.cursor/references/planning-artifacts.md
+++ b/.cursor/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2845,7 +2845,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2845,7 +2845,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.gemini/references/planning-artifacts.md
+++ b/.gemini/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `helios/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `helios/factory/foo.ts` is in the `helios` track. A change touching both `helios/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `helios/factory/foo.ts` and `helios/ui/bar.tsx` is single-track (`helios`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.gemini/references/planning-artifacts.md
+++ b/.gemini/references/planning-artifacts.md
@@ -78,7 +78,7 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example A: a repo with `api/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `api/...` is cross-track and triggers Plan + ADR.
 - Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**

--- a/.gemini/references/planning-artifacts.md
+++ b/.gemini/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2842,7 +2842,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2842,7 +2842,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4295,10 +4295,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `helios/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `helios/factory/foo.ts` is in the `helios` track. A change touching both `helios/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `helios/factory/foo.ts` and `helios/ui/bar.tsx` is single-track (`helios`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.
@@ -16586,7 +16586,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4297,7 +4297,7 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example A: a repo with `api/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `api/...` is cross-track and triggers Plan + ADR.
 - Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
@@ -16586,7 +16586,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4295,10 +4295,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2844,7 +2844,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2844,7 +2844,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2843,7 +2843,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2843,7 +2843,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/bin/tests/test_ds_primary_name_sweep.py
+++ b/bin/tests/test_ds_primary_name_sweep.py
@@ -156,13 +156,19 @@ Public API: python3 -m pytest bin/tests/test_ds_primary_name_sweep.py -q
             Also directly executable: python3 bin/tests/test_ds_primary_name_sweep.py
             Exits 0 on all pass, 1 on any failure (direct-execution mode).
 
-Upstream deps: Python 3 stdlib only (ast, json, os, pathlib). Check (2)
-               parses scripts/codex-skills.py source without executing it.
-               Check (3) requires `.codex/AGENTS.md` and
+Upstream deps: Python 3 stdlib only (ast, json, os, pathlib, subprocess).
+               Check (2) parses scripts/codex-skills.py source without
+               executing it. Check (3) requires `.codex/AGENTS.md` and
                `.codex/skills/dinostack/METHODOLOGY.md` to exist
                (built by `.codex/build.sh`); if absent, that check fails
                loudly rather than skipping, since a repo that ships
                `.codex/**` without these files is itself a defect.
+               `test_no_sibling_product_brand_name_in_tracked_tree` shells
+               out to `git ls-files -z` (the one subprocess call in this
+               module) to enumerate the tracked tree; see that function's
+               own docstring and the preceding section comment for why
+               tracked-files-based scanning was chosen over a filesystem
+               walk.
 
 Downstream consumers: bin-tests CI job (pytest bin/tests/ -q picks up every
                       test_*.py file automatically).
@@ -170,13 +176,15 @@ Downstream consumers: bin-tests CI job (pytest bin/tests/ -q picks up every
 Failure modes: any assertion failure prints/raises and is counted; the
                direct-execution __main__ path exits 1 if any check fails.
 
-Performance: < 2 s wall time (pure filesystem/AST reads, no subprocess).
+Performance: < 2 s wall time (pure filesystem/AST reads plus one
+             `git ls-files` subprocess call).
 """
 
 from __future__ import annotations
 
 import ast
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -402,11 +410,83 @@ def test_content_residue_set_pinned_to_known_exceptions() -> None:
     )
 
 
+# --- Sibling-product brand-name guard (round-2 review, Finding 1) --------
+#
+# A prior commit scrubbed a sibling product's brand name out of this public
+# repo (docs/, content/, and every adapter dir). Nothing pinned that the
+# name stays out, and the residue sweep above is deliberately scoped to
+# content/ only - it would not catch a reintroduction under docs/ (which is
+# hand-authored, not generated from content/) or under an adapter dir such
+# as .hermes/SKILL.md (which aggregates every command and is a documented
+# silent-revert vector - see AGENTS.md "Aggregate generated files revert
+# across PRs"). This closes that gap with a whole-tracked-tree scan.
+
+
+def _tracked_repo_files() -> list[Path]:
+    """Every git-tracked file in the repo, via `git ls-files -z` (NUL
+    separated, so filenames containing spaces or newlines are handled
+    correctly). Deliberately git-tracked-files-based rather than a
+    filesystem walk: `git ls-files` gives the exclusions this guard needs
+    for free, because none of them are ever tracked - `.git/` itself, the
+    gitignored `.agentic/**` runtime tree (except the one carved-out
+    `team.yml`, which cannot contain a brand-name residue), and gitignored
+    `node_modules/` (which is exactly where an unrelated vendored file
+    happens to share the brand name in its filename - see the module-level
+    docstring on that collision). A filesystem walk would instead scan
+    whatever untracked local junk happens to be sitting in the worktree
+    (editor scratch files, an accidentally-materialized node_modules/
+    tree) and would have to hand-exclude all of the above, which is
+    exactly the kind of hand-maintained exclusion list that goes stale.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return [REPO_ROOT / p for p in out.decode("utf-8", errors="ignore").split("\0") if p]
+
+
+# The forbidden brand string is built from character codes rather than
+# written as a string literal on purpose: this test file is itself part of
+# the tracked tree the scan below walks, so a literal occurrence of the
+# brand name in this source file would make the guard trip over its OWN
+# source and fail unconditionally the moment it was added. Do NOT "clean
+# this up" into a plain string literal - that reintroduces exactly the
+# self-triggering bug this comment exists to prevent. (H-e-l-i-o-s)
+_FORBIDDEN_BRAND_TOKEN = "".join(chr(c) for c in (72, 101, 108, 105, 111, 115))
+
+
+def test_no_sibling_product_brand_name_in_tracked_tree() -> None:
+    """Scans every git-tracked file in the repo (not just content/, and not
+    just adapter dirs) for the sibling-product brand name, matched
+    case-insensitively (mirrors the case-insensitive `git grep -a -i`
+    verification this program is expected to satisfy). This repo is public;
+    the sibling product is unreleased and non-open-source and must never be
+    named here."""
+    token_lower = _FORBIDDEN_BRAND_TOKEN.lower()
+    failures = []
+    for path in _tracked_repo_files():
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:  # pragma: no cover - defensive
+            continue
+        if token_lower in text.lower():
+            failures.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not failures, (
+        "sibling-product brand name found in tracked file(s) - this repo is public "
+        "and must never reference the unreleased sibling product by name:\n"
+        + "\n".join(sorted(failures))
+    )
+
+
 EXTRA_TESTS = [
     test_bin_scripts_do_not_self_identify_with_old_names,
     test_codex_literal_rules_replacements_never_contain_old_names,
     test_codex_generated_identity_commands_use_ds_identity,
     test_content_residue_set_pinned_to_known_exceptions,
+    test_no_sibling_product_brand_name_in_tracked_tree,
 ]
 
 

--- a/bin/tests/test_ds_primary_name_sweep.py
+++ b/bin/tests/test_ds_primary_name_sweep.py
@@ -453,8 +453,17 @@ def _tracked_repo_files() -> list[Path]:
 # brand name in this source file would make the guard trip over its OWN
 # source and fail unconditionally the moment it was added. Do NOT "clean
 # this up" into a plain string literal - that reintroduces exactly the
-# self-triggering bug this comment exists to prevent. (H-e-l-i-o-s)
+# self-triggering bug this comment exists to prevent.
 _FORBIDDEN_BRAND_TOKEN = "".join(chr(c) for c in (72, 101, 108, 105, 111, 115))
+
+
+# Floor on the number of files `git ls-files -z` must enumerate before this
+# guard's scan is trusted. The tree currently has ~1163 tracked files; this
+# is set well below that (not a maintenance tripwire) purely to catch the
+# `git ls-files` call itself failing or returning empty - a scan over zero
+# files passes vacuously having checked nothing, per this repo's "green
+# often means the check did not run" lesson.
+MIN_EXPECTED_TRACKED_FILE_COUNT = 500
 
 
 def test_no_sibling_product_brand_name_in_tracked_tree() -> None:
@@ -465,11 +474,21 @@ def test_no_sibling_product_brand_name_in_tracked_tree() -> None:
     the sibling product is unreleased and non-open-source and must never be
     named here."""
     token_lower = _FORBIDDEN_BRAND_TOKEN.lower()
+    tracked_files = _tracked_repo_files()
+    assert len(tracked_files) >= MIN_EXPECTED_TRACKED_FILE_COUNT, (
+        f"`git ls-files -z` enumeration itself failed or returned suspiciously few files "
+        f"({len(tracked_files)} < {MIN_EXPECTED_TRACKED_FILE_COUNT}) - this guard would "
+        "otherwise pass vacuously having scanned nothing"
+    )
+
     failures = []
-    for path in _tracked_repo_files():
+    for path in tracked_files:
         try:
             text = path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:  # pragma: no cover - defensive
+        except IsADirectoryError:
+            # Expected: a small number of tracked entries are symlinks to
+            # directories (their real contents are tracked and scanned
+            # separately via their own paths).
             continue
         if token_lower in text.lower():
             failures.append(str(path.relative_to(REPO_ROOT)))

--- a/bin/tests/test_ds_primary_name_sweep.py
+++ b/bin/tests/test_ds_primary_name_sweep.py
@@ -335,10 +335,6 @@ def test_codex_generated_identity_commands_use_ds_identity() -> None:
 # referenced the old name, so nothing was deferred there. That file
 # therefore no longer appears in this residue set.
 #
-# `agentic-factory` is unrelated to the bin/agentic-* rename program
-# entirely - it is the sibling `agentic-factory/` track name in the
-# parent ai-tools repo, referenced as a worked example in
-# planning-artifacts.md - and is expected to remain indefinitely.
 RESIDUE_TOKEN_PATTERN = re.compile(r"agentic-[a-zA-Z][a-zA-Z0-9-]*")
 # Exact protected token set - NOT a prefix check. A prefix check
 # (`token.startswith("dinostack")`) silently drops any token
@@ -365,20 +361,21 @@ PROTECTED_TOKENS = {
     "agentic-engineering-profile",
     "agentic-engineering-preset",
 }
-EXPECTED_RESIDUE_SET = {
-    ("content/references/planning-artifacts.md", "agentic-factory"),
-}
+EXPECTED_RESIDUE_SET: set[tuple[str, str]] = set()
 
 
 def test_content_residue_set_pinned_to_known_exceptions() -> None:
     """Scans every file under content/** for `agentic-<word>` tokens,
     excludes the protected `dinostack` skill noun and its marker
     extensions, and asserts the remaining (file, token) set is exactly
-    EXPECTED_RESIDUE_SET - no more, no fewer. A third stray old name
-    anywhere under content/** turns this RED; renaming either of the two
-    known exceptions (or removing them) also turns it RED until this set
-    is updated to match, which is the point: the residue set can no
-    longer silently drift out of sync with what the docstring claims."""
+    EXPECTED_RESIDUE_SET - no more, no fewer. The set is currently empty:
+    the sole prior exception (`content/references/planning-artifacts.md`,
+    `agentic-factory`) was a worked-example track name that named an
+    operator's private repo and was neutralized to a generic name. Any
+    stray old name anywhere under content/** turns this RED; adding a new
+    exception requires updating this set to match, which is the point:
+    the residue set can no longer silently drift out of sync with what
+    the docstring claims."""
     assert CONTENT_DIR.is_dir(), f"{CONTENT_DIR} is missing"
 
     found: set[tuple[str, str]] = set()

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2839,7 +2839,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `helios/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2839,7 +2839,7 @@ Soft-fail: if the call errors, log and continue. The PR remaining in draft state
    if [ -f .github/CODEOWNERS ] || [ -f docs/CODEOWNERS ] || [ -f CODEOWNERS ]; then
      echo "CODEOWNERS detected - GitHub will auto-route review requests."
    ```
-   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `webapp/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
+   (Note: this checks repo root and `.github/`/`docs/` subdirectories - the standard GitHub CODEOWNERS locations. Subdirectory CODEOWNERS in monorepo tracks - e.g. `app/.github/CODEOWNERS` - are out of scope for v1; root-level CODEOWNERS is sufficient for the typical project.)
 
 2. **AGENTS.md `## PR Workflow` `Reviewers:` fallback** - if no CODEOWNERS file found AND `PR_WORKFLOW_REVIEWERS` (resolved in Setup) is non-empty:
    ```bash

--- a/content/references/planning-artifacts.md
+++ b/content/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `helios/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `helios/factory/foo.ts` is in the `helios` track. A change touching both `helios/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `helios/factory/foo.ts` and `helios/ui/bar.tsx` is single-track (`helios`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/content/references/planning-artifacts.md
+++ b/content/references/planning-artifacts.md
@@ -78,7 +78,7 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example A: a repo with `api/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `api/...` is cross-track and triggers Plan + ADR.
 - Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**

--- a/content/references/planning-artifacts.md
+++ b/content/references/planning-artifacts.md
@@ -76,10 +76,10 @@ All triggers are mechanical. Operator judgment is not a field. Triggers are eval
 
 **Unit counting rule.** Only units whose own risk classification is Elevated or above count toward the 2-5 / 6+ thresholds. Trivial units in a mixed-risk plan do not count - they are routed per the standard Trivial conductor rule and contribute zero to promotion.
 
-**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
+**"Track" definition (mechanical).** A track is a depth-1 directory under the repo root that contains its own `AGENTS.md` file (per the conventions in `content/rules/conventions.md`). Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks - they are sub-context within their parent track.
 
-- Worked example A: a repo with `agentic-engineering/AGENTS.md`, `webapp/AGENTS.md`, `agentic-factory/AGENTS.md`, `models/AGENTS.md` at depth 1. A unit touching `webapp/factory/foo.ts` is in the `webapp` track. A change touching both `webapp/...` and `agentic-engineering/...` is cross-track and triggers Plan + ADR.
-- Worked example B: a change touching `webapp/factory/foo.ts` and `webapp/ui/bar.tsx` is single-track (`webapp`); the nested `factory/AGENTS.md` does not split the track.
+- Worked example A: a repo with `docs/AGENTS.md`, `app/AGENTS.md`, `worker/AGENTS.md`, `infra/AGENTS.md` at depth 1. A unit touching `app/factory/foo.ts` is in the `app` track. A change touching both `app/...` and `docs/...` is cross-track and triggers Plan + ADR.
+- Worked example B: a change touching `app/factory/foo.ts` and `app/ui/bar.tsx` is single-track (`app`); the nested `factory/AGENTS.md` does not split the track.
 
 **Other notes:**
 - Unit count comes from the orchestration-planner's JSONL output, counted by `unit_slug` entries with risk >= Elevated.

--- a/docs/agentic-engineering-comparison.html
+++ b/docs/agentic-engineering-comparison.html
@@ -1022,7 +1022,7 @@
       <li><span class="src-title">ICM / Model Workspace Protocol</span> <span class="desc">- Jake Van Clief</span></li>
       <li><span class="src-title">GSD / Get Shit Done</span> <span class="desc">- T&Acirc;CHES</span></li>
       <li><span class="src-title">Arize "Alex" runtime context management</span> <span class="desc">- Salian</span></li>
-      <li><span class="src-title">Agentic OS</span> <span class="desc">- Chase, vs Helios, which embeds DinoStack</span></li>
+      <li><span class="src-title">Agentic OS</span> <span class="desc">- Chase, vs a sibling desktop product that embeds DinoStack</span></li>
       <li><span class="src-title">In-context prompting vs orchestration</span> <span class="desc">- University of Melbourne</span></li>
       <li><span class="src-title">120x architect-builder method</span> <span class="desc">- ChatGPT/Claude + Codex/Claude Code (channel 120x-ai)</span></li>
       <li><span class="src-title">lazy</span> <span class="desc">- a runnable local async-development orchestrator (getlazy/ierceg)</span></li>

--- a/docs/agentic-engineering-comparison.html
+++ b/docs/agentic-engineering-comparison.html
@@ -1022,7 +1022,7 @@
       <li><span class="src-title">ICM / Model Workspace Protocol</span> <span class="desc">- Jake Van Clief</span></li>
       <li><span class="src-title">GSD / Get Shit Done</span> <span class="desc">- T&Acirc;CHES</span></li>
       <li><span class="src-title">Arize "Alex" runtime context management</span> <span class="desc">- Salian</span></li>
-      <li><span class="src-title">Agentic OS</span> <span class="desc">- Chase, vs a sibling desktop product that embeds DinoStack</span></li>
+      <li><span class="src-title">Agentic OS</span> <span class="desc">- Chase</span></li>
       <li><span class="src-title">In-context prompting vs orchestration</span> <span class="desc">- University of Melbourne</span></li>
       <li><span class="src-title">120x architect-builder method</span> <span class="desc">- ChatGPT/Claude + Codex/Claude Code (channel 120x-ai)</span></li>
       <li><span class="src-title">lazy</span> <span class="desc">- a runnable local async-development orchestrator (getlazy/ierceg)</span></li>

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -1,8 +1,7 @@
 # DinoStack Product Vision (North Star)
 
 **Status:** Ratified (committed 2026-06-28). This is the operator-owned product-intent layer - the
-lens every review and design decision is measured against. Authored 2026-06-24; synthesized from
-DinoStack's `README.md` and `CLAUDE.md`.
+lens every review and design decision is measured against. Authored 2026-06-24.
 
 ## The problem
 

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -2,8 +2,7 @@
 
 **Status:** Ratified (committed 2026-06-28). This is the operator-owned product-intent layer - the
 lens every review and design decision is measured against. Authored 2026-06-24; synthesized from
-DinoStack's README/CLAUDE.md and the vision of the sibling product this methodology was
-originally extracted from, which DinoStack exists to serve.
+DinoStack's `README.md` and `CLAUDE.md`.
 
 ## The problem
 

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -2,8 +2,8 @@
 
 **Status:** Ratified (committed 2026-06-28). This is the operator-owned product-intent layer - the
 lens every review and design decision is measured against. Authored 2026-06-24; synthesized from
-DinoStack's README/CLAUDE.md and the Helios vision
-(`../helios/docs/overview/vision.md`), which DinoStack exists to serve.
+DinoStack's README/CLAUDE.md and the vision of the sibling product this methodology was
+originally extracted from, which DinoStack exists to serve.
 
 ## The problem
 

--- a/docs/slides/planning-tier-slides.html
+++ b/docs/slides/planning-tier-slides.html
@@ -912,7 +912,7 @@ hr {
 </tbody>
 </table>
 <p><strong>Unit counting rule:</strong> only units whose risk is Elevated or above count. Trivial units contribute zero.</p>
-<p><strong>&quot;Cross-track&quot; (mechanical):</strong> a depth-1 directory under the repo root with its own <code>AGENTS.md</code>. Nested <code>AGENTS.md</code> files (e.g. <code>webapp/factory/AGENTS.md</code>) do not create new tracks.</p>
+<p><strong>&quot;Cross-track&quot; (mechanical):</strong> a depth-1 directory under the repo root with its own <code>AGENTS.md</code>. Nested <code>AGENTS.md</code> files (e.g. <code>app/factory/AGENTS.md</code>) do not create new tracks.</p>
 <div class="callout">
 All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.
 </div>

--- a/docs/slides/planning-tier-slides.html
+++ b/docs/slides/planning-tier-slides.html
@@ -912,7 +912,7 @@ hr {
 </tbody>
 </table>
 <p><strong>Unit counting rule:</strong> only units whose risk is Elevated or above count. Trivial units contribute zero.</p>
-<p><strong>&quot;Cross-track&quot; (mechanical):</strong> a depth-1 directory under the repo root with its own <code>AGENTS.md</code>. Nested <code>AGENTS.md</code> files (e.g. <code>helios/factory/AGENTS.md</code>) do not create new tracks.</p>
+<p><strong>&quot;Cross-track&quot; (mechanical):</strong> a depth-1 directory under the repo root with its own <code>AGENTS.md</code>. Nested <code>AGENTS.md</code> files (e.g. <code>webapp/factory/AGENTS.md</code>) do not create new tracks.</p>
 <div class="callout">
 All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.
 </div>

--- a/docs/slides/planning-tier-slides.md
+++ b/docs/slides/planning-tier-slides.md
@@ -296,7 +296,7 @@ Interactive path is preferred for features still being framed. Mechanical path i
 
 **Unit counting rule:** only units whose risk is Elevated or above count. Trivial units contribute zero.
 
-**"Cross-track" (mechanical):** a depth-1 directory under the repo root with its own `AGENTS.md`. Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks.
+**"Cross-track" (mechanical):** a depth-1 directory under the repo root with its own `AGENTS.md`. Nested `AGENTS.md` files (e.g. `app/factory/AGENTS.md`) do not create new tracks.
 
 <div class="callout">
 All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.

--- a/docs/slides/planning-tier-slides.md
+++ b/docs/slides/planning-tier-slides.md
@@ -296,7 +296,7 @@ Interactive path is preferred for features still being framed. Mechanical path i
 
 **Unit counting rule:** only units whose risk is Elevated or above count. Trivial units contribute zero.
 
-**"Cross-track" (mechanical):** a depth-1 directory under the repo root with its own `AGENTS.md`. Nested `AGENTS.md` files (e.g. `helios/factory/AGENTS.md`) do not create new tracks.
+**"Cross-track" (mechanical):** a depth-1 directory under the repo root with its own `AGENTS.md`. Nested `AGENTS.md` files (e.g. `webapp/factory/AGENTS.md`) do not create new tracks.
 
 <div class="callout">
 All triggers are mechanical. Operator judgment is not a field. Evaluate after orchestration-planner returns.


### PR DESCRIPTION
Removes an unreleased, non-open-source sibling product's brand name from every shipped artifact in this public repo, and adds an automated guard so it cannot come back.

## What changed

**Name removal (4 commits).** The name appeared in 17 tracked files: methodology source (`content/references/planning-artifacts.md`, `content/commands/ds-implement-ticket.md`), public docs (`docs/overview/vision.md`, `docs/agentic-engineering-comparison.html`, `docs/slides/planning-tier-slides.md`), and the 11 adapter dirs plus `.github/**` extras that regenerate from `content/`. All uses were illustrative, so each was replaced with a neutral placeholder that preserves the sentence's meaning rather than deleted.

**Identifying residue removed too.** Three follow-ups after review:
- Deleted an oblique clause in `docs/agentic-engineering-comparison.html` ("a sibling desktop product that embeds DinoStack") - "desktop" was identifying residue, and the clause was informationally empty in a Sources list where every other entry names a real public source.
- Deleted a false provenance claim in `docs/overview/vision.md`. It cited `CLAUDE.md`, a 22-byte `@`-import stub pointing at a `MEMORY.md` that is untracked here (DS-129), so a reader following it from a fresh clone finds nothing. Deleted rather than narrowed, per the repo's standing lesson.
- Neutralized the whole monorepo worked example, not just the one name. It previously published three real internal track names alongside one placeholder, which read as an obvious redaction. Now `api`/`app`/`worker`/`infra`, unified across both source files and every restatement.

**New guard.** `test_no_sibling_product_brand_name_in_tracked_tree` in `bin/tests/test_ds_primary_name_sweep.py` scans every `git ls-files` blob, case-insensitively and binary-inclusive. The existing residue sweep was scoped to `content/` only, which left the hand-maintained `docs/` surface unguarded - `docs/slides/*.md` is hand-authored, not generated, which is exactly why the first commit's manual sweep missed it there. The search token is built via `chr()` codes so the test file does not itself become a residue hit; there is an inline comment explaining why it must not be simplified back to a literal.

## Verification

- Whole-tree sweep at the tip returns zero hits for the literal (binary-inclusive) and zero for a loose separator-tolerant pattern. The final review went further and collapsed all 1163 tracked blobs to letters-only, defeating any separator or line-break evasion: still zero. Commit messages checked separately, since `git grep` does not cover them.
- The guard was mutation-tested independently by the reviewer, not just by the author: 7 injections across `docs/`, adapter dirs, root files, and `content/`, in mixed/lower/upper case - RED on all 7, GREEN after each restore. The empty-enumeration path was forced and now fails rather than passing vacuously.
- `bin/tests/`: 1113 passed. Hooks JS suite: 0 failed. Adapter drift clean over the verbatim `adapter-sync.yml` pathspec after `build-all.sh`. Budget gates, methodology-drift, codex-skill-sync, symlink-relative, slides byte-identity: all pass. Zero em dashes added.

Four review rounds; every round's findings resolved and re-verified. Full history: the same defect class relocated twice (a paraphrase, then a differently-false replacement claim, then a hyphenated spelling inside the guard's own comment), which is why the sweeps above are deliberately broader than a literal grep.

## Known limitation

The name remains recoverable from git history - 12 earlier commits contain it. The operator has explicitly decided to accept that residual exposure rather than rewrite public history, which would break every existing clone and fork. This PR cleans the current tree only.

## North Star alignment

Advances **works for everyone (universality)**. Shipped methodology content and public docs no longer carry one operator's private product identity, workspace layout, or internal track names. A teammate or external adopter reading `content/references/planning-artifacts.md` now sees a generic monorepo example rather than someone else's org chart. The new guard makes that property enforced rather than aspirational.

No pillar regressed. `docs/overview/vision.md` is operator-owned under the product-intent layer and is normally never agent-written; this edit was directly and explicitly instructed by the operator, which is the attestation for that change.
