### PR TITLE
fix(precommit): point hook symlink at the common repo, not the worktree

### DIFF
--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -59,6 +59,24 @@
 #     asserts the main checkout's hook still resolves AND executes -
 #     confirmed to fail against the pre-fix source (see git history/PR for
 #     the baseline failure output this test was written to catch).
+#   - Major 1 (dangling-at-install for bare/separate-gitdir/submodule
+#     worktrees): Test 8 exercises a bare repo + `git worktree add`, where
+#     dirname(--git-common-dir) has no hooks/pre-commit of its own.
+#     resolve_hook_src falls back to the worktree's own hooks/pre-commit
+#     rather than emitting a target dangling from install time. Test 8 ALSO
+#     asserts the KNOWN, undisclosed-no-longer residual: this fallback
+#     target is still inside the worktree, so removing the worktree leaves
+#     the hook dangling anyway (see the library's Failure-modes "KNOWN
+#     RESIDUAL" bullet) - not a regression, not fixed by this PR, disclosed
+#     rather than silently left unverified.
+#   - Major 2 (uninstall orphaning a legacy-targeted hook): Test 9.
+#   - Minor 1 (install_precommit_hook's `[[ ! -f "$hook_src" ]]` guard was
+#     reachable but had zero coverage): Test 10 - an ordinary repo with no
+#     hooks/pre-commit file at all, the only shape that exercises
+#     resolve_hook_src's unchecked fallback branches.
+#   - Minor 3 (legacy_hook_src used the raw, non-canonicalized repo_dir):
+#     Test 11 - install with a trailing-slash spelling, uninstall with the
+#     canonical spelling of the same directory.
 #   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
@@ -537,6 +555,25 @@ else
   _fail "Test 8 (Major 1 regression): installed hook failed to execute for a bare-repo worktree. rc=$BARE_HOOK_RUN_RC output=$BARE_HOOK_RUN_OUTPUT"
 fi
 
+# Test 8 (Minor 2, known-residual disclosure): unlike Test 6's ordinary
+# linked worktree, this bare-repo layout has no better source than the
+# worktree's OWN hooks/pre-commit (see the manifest's "KNOWN RESIDUAL"
+# Failure-modes bullet) - resolve_hook_src cannot point at anything outside
+# the worktree here because nothing outside it exists. Removing the
+# worktree therefore leaves the installed symlink DANGLING. This is NOT a
+# regression (identical on origin/main) and NOT something this PR fixes -
+# asserting the known-bad outcome directly documents the residual instead
+# of leaving it silently unverified (Test 6, by contrast, asserts the
+# GOOD outcome because an ordinary linked worktree DOES have a better
+# source: the main checkout's own hooks/pre-commit).
+git -C "$BARE_REPO" worktree remove -f "$BARE_WT" >/dev/null 2>&1
+
+if [[ ! -e "$BARE_HOOK_DST" ]]; then
+  _pass "Test 8 (Minor 2, known residual documented): bare-repo worktree hook is DANGLING after worktree removal, as disclosed in the manifest's Failure modes section (not a regression, no better source exists)"
+else
+  _fail "Test 8 (Minor 2 regression): expected the KNOWN residual (dangling hook after bare-repo worktree removal) but the hook still resolves at $BARE_HOOK_DST - either the residual was silently fixed (update the manifest disclosure) or the fixture broke"
+fi
+
 # ============================================================
 # Test 9: Major-2 regression - uninstall recognises a hook installed by the
 #         legacy (pre-this-PR) unconditional "<repo_dir>/hooks/pre-commit"
@@ -605,6 +642,126 @@ if [[ -L "$FOREIGN2_HOOK_DST" ]] && [[ "$(readlink "$FOREIGN2_HOOK_DST")" == "$F
   _pass "Test 9 (Major 2, no over-match): a symlink pointing at neither the resolved nor legacy target is left untouched"
 else
   _fail "Test 9 (Major 2 regression, over-match): the widened uninstall check removed or altered a genuinely foreign hook. Output: $FOREIGN2_OUT"
+fi
+
+# ============================================================
+# Test 10: Minor 1 - install_precommit_hook's own defense-in-depth guard
+#          ("resolved pre-commit hook source does not exist" - the guard
+#          that follows resolve_hook_src's call in install_precommit_hook)
+#          is independently exercised, not merely reachable in theory.
+#          resolve_hook_src's FALLBACK branches are unchecked (see the
+#          manifest's corrected Public-API wording for resolve_hook_src),
+#          so an ordinary (non-worktree) git repo with NO hooks/pre-commit
+#          file at all is the only way to make resolve_hook_src return a
+#          source path that genuinely does not exist, and this guard is
+#          the only thing standing between that and installing a dangling
+#          symlink.
+# ============================================================
+
+NO_HOOK_REPO="$TMP_ROOT/no-hook-repo"
+mkdir -p "$NO_HOOK_REPO"
+git init -q "$NO_HOOK_REPO"
+git -C "$NO_HOOK_REPO" config user.email test@test.com
+git -C "$NO_HOOK_REPO" config user.name test
+
+if [[ ! -f "$NO_HOOK_REPO/hooks/pre-commit" ]]; then
+  _pass "Test 10 setup: no-hook-repo fixture genuinely has no hooks/pre-commit file"
+else
+  _fail "Test 10 setup: unexpectedly found hooks/pre-commit (fixture setup bug)"
+fi
+
+NO_HOOK_SRC="$(resolve_hook_src "$NO_HOOK_REPO")"
+if [[ "$NO_HOOK_SRC" == "$NO_HOOK_REPO/hooks/pre-commit" ]] && [[ ! -f "$NO_HOOK_SRC" ]]; then
+  _pass "Test 10: resolve_hook_src returns the unchecked fallback path, and it genuinely does not exist (confirms the install-side guard is reachable, not dead code)"
+else
+  _fail "Test 10: resolve_hook_src returned an unexpected source for the no-hook fixture: $NO_HOOK_SRC"
+fi
+
+NO_HOOK_OUT="$(install_precommit_hook "$NO_HOOK_REPO" 2>&1)"
+NO_HOOK_RC=$?
+
+if [[ $NO_HOOK_RC -eq 0 ]]; then
+  _pass "Test 10 (Minor 1): install_precommit_hook exits 0 when the resolved source does not exist"
+else
+  _fail "Test 10 (Minor 1): install_precommit_hook exited $NO_HOOK_RC instead of 0. Output: $NO_HOOK_OUT"
+fi
+
+if echo "$NO_HOOK_OUT" | grep -qi "resolved pre-commit hook source does not exist"; then
+  _pass "Test 10 (Minor 1): prints the defense-in-depth skip message"
+else
+  _fail "Test 10 (Minor 1 regression): expected the defense-in-depth skip message. Output: $NO_HOOK_OUT"
+fi
+
+NO_HOOK_REAL_HOOKS_DIR="$(git -C "$NO_HOOK_REPO" rev-parse --git-path hooks)"
+case "$NO_HOOK_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) NO_HOOK_REAL_HOOKS_DIR="$NO_HOOK_REPO/$NO_HOOK_REAL_HOOKS_DIR" ;;
+esac
+NO_HOOK_DST="$NO_HOOK_REAL_HOOKS_DIR/pre-commit"
+
+if [[ ! -e "$NO_HOOK_DST" ]]; then
+  _pass "Test 10 (Minor 1): no dangling symlink was created at $NO_HOOK_DST despite a missing source"
+else
+  _fail "Test 10 (Minor 1 regression): a symlink/file was created at $NO_HOOK_DST despite the resolved source not existing. Output: $NO_HOOK_OUT"
+fi
+
+# ============================================================
+# Test 11: Minor 3 - resolve_hook_src's fallback and
+#          uninstall_precommit_hook's legacy_hook_src must agree on a
+#          canonical spelling of repo_dir, not the raw caller-supplied
+#          string. Installs from a bare-repo + worktree fixture (Test 8's
+#          layout, where the fallback IS the installed target) using a
+#          repo_dir spelled with a trailing slash, then uninstalls using
+#          the canonical (no-trailing-slash) spelling of the SAME
+#          directory. Pre-fix, the installed symlink target embeds the
+#          trailing-slash spelling while uninstall recomputes both
+#          candidates from the canonical spelling - neither matches, and
+#          the hook is orphaned ("not ours, skipping"). Post-fix, both
+#          calls canonicalize repo_dir first, so they agree regardless of
+#          which spelling either caller used.
+# ============================================================
+
+CANON_SRC_REPO="$TMP_ROOT/canon-src-repo"
+_make_fixture_repo "$CANON_SRC_REPO"
+
+CANON_BARE_REPO="$TMP_ROOT/canon-bare-repo.git"
+git clone -q --bare "$CANON_SRC_REPO" "$CANON_BARE_REPO" >/dev/null 2>&1
+
+CANON_WT="$TMP_ROOT/canon-wt-branch"
+git -C "$CANON_BARE_REPO" worktree add -q "$CANON_WT" -b canon-wt-test-branch >/dev/null 2>&1
+
+# Install using a NON-canonical (trailing-slash) spelling of the worktree.
+CANON_INSTALL_OUT="$(install_precommit_hook "$CANON_WT/" 2>&1)"
+CANON_INSTALL_RC=$?
+
+if [[ $CANON_INSTALL_RC -eq 0 ]]; then
+  _pass "Test 11 (Minor 3) setup: install_precommit_hook exits 0 for the trailing-slash spelling"
+else
+  _fail "Test 11 (Minor 3) setup: install_precommit_hook exited $CANON_INSTALL_RC. Output: $CANON_INSTALL_OUT"
+fi
+
+CANON_HOOK_DST="$CANON_BARE_REPO/hooks/pre-commit"
+if [[ -e "$CANON_HOOK_DST" ]]; then
+  _pass "Test 11 (Minor 3) setup: hook installed at $CANON_HOOK_DST via the trailing-slash spelling"
+else
+  _fail "Test 11 (Minor 3) setup: expected a hook at $CANON_HOOK_DST after install. Output: $CANON_INSTALL_OUT"
+fi
+
+# Uninstall using the CANONICAL (no trailing slash) spelling of the SAME
+# directory - this is the cross-spelling mismatch Minor 3 exercises.
+CANON_UNINSTALL_OUT="$(uninstall_precommit_hook "$CANON_WT" 2>&1)"
+CANON_UNINSTALL_RC=$?
+
+if [[ $CANON_UNINSTALL_RC -eq 0 ]]; then
+  _pass "Test 11 (Minor 3): uninstall_precommit_hook exits 0 across the spelling mismatch"
+else
+  _fail "Test 11 (Minor 3): uninstall_precommit_hook exited $CANON_UNINSTALL_RC. Output: $CANON_UNINSTALL_OUT"
+fi
+
+if [[ ! -e "$CANON_HOOK_DST" ]]; then
+  _pass "Test 11 (Minor 3 fixed): hook installed via a trailing-slash repo_dir is correctly removed by uninstall using the canonical spelling"
+else
+  _fail "Test 11 (Minor 3 regression): hook installed via a trailing-slash repo_dir was left ORPHANED by uninstall using the canonical spelling - legacy_hook_src is not canonicalized consistently with the installed target. Output: $CANON_UNINSTALL_OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -25,7 +25,12 @@
 # Failure modes: any assertion failure prints the failing assertion and exits 1.
 #                All fixtures live under a temporary directory; the real repo
 #                and its .git/hooks are never touched (verified by this test
-#                itself via a before/after checksum of the real hook).
+#                itself via a before/after checksum AND a before/after
+#                `readlink` of the real hook's own symlink target - the
+#                checksum alone is insufficient because `shasum` follows a
+#                symlink and hashes its resolved content, so it cannot
+#                detect a re-point at a byte-identical hooks/pre-commit in
+#                a different checkout; see Test 7).
 #
 # Performance: < 2 s wall time (pure git + shell, no network).
 #
@@ -83,6 +88,17 @@ REAL_HOOK_PATH_FOR_CHECKSUM="$REAL_HOOKS_DIR_FOR_CHECKSUM/pre-commit"
 REAL_HOOK_CHECKSUM_BEFORE=""
 if [[ -n "$REAL_HOOKS_DIR_FOR_CHECKSUM" ]] && [[ -e "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
   REAL_HOOK_CHECKSUM_BEFORE="$(shasum -a 256 "$REAL_HOOK_PATH_FOR_CHECKSUM" 2>/dev/null | awk '{print $1}')"
+fi
+# `shasum` FOLLOWS a symlink and hashes its resolved content, so a checksum
+# alone cannot detect a re-point of the real hook symlink at a
+# byte-identical hooks/pre-commit in a DIFFERENT checkout - precisely this
+# PR's bug shape (a dangling/mis-targeted symlink that still happens to
+# resolve to identical bytes today). Capture the symlink's own TARGET via
+# `readlink` as well, so Test 7 below can assert the link itself, not just
+# its resolved content, is unchanged.
+REAL_HOOK_TARGET_BEFORE=""
+if [[ -L "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
+  REAL_HOOK_TARGET_BEFORE="$(readlink "$REAL_HOOK_PATH_FOR_CHECKSUM")"
 fi
 
 # shellcheck source=scripts/lib/precommit.sh
@@ -414,7 +430,25 @@ fi
 # Test 7: real checkout's actual .git/hooks/pre-commit is never touched by
 #         this test file. All fixtures above use isolated temp repos; this
 #         asserts that invariant directly rather than trusting it.
+#
+#         Verified via TWO independent before/after checks, not one:
+#         a `shasum` of the resolved content, AND a `readlink` of the
+#         symlink's own target. `shasum` follows a symlink and hashes what
+#         it resolves to, so it alone is BLIND to a re-point of the link at
+#         a different, byte-identical hooks/pre-commit (e.g. another
+#         checkout's copy of the same file) - exactly this PR's bug shape.
+#         The `readlink` check catches that a `shasum`-only test would miss.
 # ============================================================
+
+REAL_HOOK_TARGET_AFTER=""
+if [[ -L "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
+  REAL_HOOK_TARGET_AFTER="$(readlink "$REAL_HOOK_PATH_FOR_CHECKSUM")"
+fi
+if [[ "$REAL_HOOK_TARGET_AFTER" == "$REAL_HOOK_TARGET_BEFORE" ]]; then
+  _pass "Test 7: real checkout's .git/hooks/pre-commit symlink target unchanged by this test run (${REAL_HOOK_TARGET_AFTER:-<not a symlink>})"
+else
+  _fail "Test 7: real checkout's .git/hooks/pre-commit symlink target CHANGED - before=$REAL_HOOK_TARGET_BEFORE after=$REAL_HOOK_TARGET_AFTER"
+fi
 
 if [[ -n "$REAL_HOOKS_DIR_FOR_CHECKSUM" ]] && [[ -e "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
   REAL_HOOK_CHECKSUM_AFTER="$(shasum -a 256 "$REAL_HOOK_PATH_FOR_CHECKSUM" 2>/dev/null | awk '{print $1}')"
@@ -429,6 +463,148 @@ else
   else
     _fail "Test 7: real checkout's .git/hooks/pre-commit existed before this run (checksum $REAL_HOOK_CHECKSUM_BEFORE) but is missing after"
   fi
+fi
+
+# ============================================================
+# Test 8: bare repo + `git worktree add` - Major-1 regression (dangling
+#         symlink at install time). dirname(--git-common-dir) for this
+#         layout is the bare repo's PARENT directory, which has no
+#         "hooks/pre-commit" of its own - resolve_hook_src must detect that
+#         the candidate file does not exist and fall back to the worktree's
+#         own "hooks/pre-commit" (which DOES exist, checked out from the
+#         same tracked history) rather than emit a target that is dangling
+#         from the moment it is installed.
+# ============================================================
+
+BARE_SRC_REPO="$TMP_ROOT/bare-src-repo"
+_make_fixture_repo "$BARE_SRC_REPO"
+
+BARE_REPO="$TMP_ROOT/bare-repo.git"
+git clone -q --bare "$BARE_SRC_REPO" "$BARE_REPO" >/dev/null 2>&1
+
+BARE_WT="$TMP_ROOT/bare-wt-branch"
+git -C "$BARE_REPO" worktree add -q "$BARE_WT" -b bare-wt-test-branch >/dev/null 2>&1
+
+if [[ -f "$BARE_WT/hooks/pre-commit" ]]; then
+  _pass "Test 8 setup: bare-repo worktree fixture has a real hooks/pre-commit checked out"
+else
+  _fail "Test 8 setup: bare-repo worktree fixture missing hooks/pre-commit at $BARE_WT/hooks/pre-commit (fixture setup bug)"
+fi
+
+BARE_COMMON_DIR="$(git -C "$BARE_WT" rev-parse --path-format=absolute --git-common-dir)"
+BARE_COMMON_DIR_PARENT="$(dirname "$BARE_COMMON_DIR")"
+if [[ ! -f "$BARE_COMMON_DIR_PARENT/hooks/pre-commit" ]]; then
+  _pass "Test 8 setup: dirname(--git-common-dir) ($BARE_COMMON_DIR_PARENT) has no hooks/pre-commit of its own - this is the layout Major 1 exercises"
+else
+  _fail "Test 8 setup: unexpectedly found hooks/pre-commit under dirname(--git-common-dir) - fixture does not exercise the bug"
+fi
+
+BARE_HOOK_SRC="$(resolve_hook_src "$BARE_WT")"
+
+if [[ -f "$BARE_HOOK_SRC" ]]; then
+  _pass "Test 8 (Major 1): resolve_hook_src for a bare-repo worktree returns a source file that actually EXISTS ($BARE_HOOK_SRC)"
+else
+  _fail "Test 8 (Major 1 regression): resolve_hook_src for a bare-repo worktree returned a NONEXISTENT source: $BARE_HOOK_SRC - this is the dangling-at-install bug"
+fi
+
+if [[ "$BARE_HOOK_SRC" == "$BARE_WT/hooks/pre-commit" ]]; then
+  _pass "Test 8: bare-repo worktree falls back to the worktree's own hooks/pre-commit (the only one that exists in this layout)"
+else
+  _fail "Test 8: bare-repo worktree resolved to an unexpected source: $BARE_HOOK_SRC"
+fi
+
+BARE_OUT="$(install_precommit_hook "$BARE_WT" 2>&1)"
+BARE_RC=$?
+
+if [[ $BARE_RC -eq 0 ]]; then
+  _pass "Test 8: install_precommit_hook exits 0 for a bare-repo worktree"
+else
+  _fail "Test 8: install_precommit_hook exited $BARE_RC for a bare-repo worktree. Output: $BARE_OUT"
+fi
+
+BARE_HOOK_DST="$BARE_REPO/hooks/pre-commit"
+if [[ -e "$BARE_HOOK_DST" ]] && [[ -x "$BARE_HOOK_DST" ]]; then
+  _pass "Test 8 (Major 1): installed hook resolves and is executable, not dangling ($BARE_HOOK_DST)"
+else
+  _fail "Test 8 (Major 1 regression): installed hook is dangling or missing at $BARE_HOOK_DST. Output: $BARE_OUT"
+fi
+
+BARE_HOOK_RUN_OUTPUT="$("$BARE_HOOK_DST" 2>&1)"
+BARE_HOOK_RUN_RC=$?
+if [[ $BARE_HOOK_RUN_RC -eq 0 ]] && [[ "$BARE_HOOK_RUN_OUTPUT" == "fixture pre-commit" ]]; then
+  _pass "Test 8 (Major 1): installed hook actually EXECUTES for a bare-repo worktree (output: $BARE_HOOK_RUN_OUTPUT)"
+else
+  _fail "Test 8 (Major 1 regression): installed hook failed to execute for a bare-repo worktree. rc=$BARE_HOOK_RUN_RC output=$BARE_HOOK_RUN_OUTPUT"
+fi
+
+# ============================================================
+# Test 9: Major-2 regression - uninstall recognises a hook installed by the
+#         legacy (pre-this-PR) unconditional "<repo_dir>/hooks/pre-commit"
+#         target, AND a foreign hook pointing at neither target is still
+#         left alone (the widened check must not over-match).
+# ============================================================
+
+LEGACY_WT_MAIN="$TMP_ROOT/legacy-wt-main-repo"
+_make_fixture_repo "$LEGACY_WT_MAIN"
+
+LEGACY_WT_BRANCH="$TMP_ROOT/legacy-wt-branch"
+git -C "$LEGACY_WT_MAIN" worktree add -q "$LEGACY_WT_BRANCH" -b legacy-wt-test-branch >/dev/null 2>&1
+
+LEGACY_REAL_HOOKS_DIR="$(git -C "$LEGACY_WT_BRANCH" rev-parse --git-path hooks)"
+case "$LEGACY_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) LEGACY_REAL_HOOKS_DIR="$LEGACY_WT_BRANCH/$LEGACY_REAL_HOOKS_DIR" ;;
+esac
+LEGACY_HOOK_DST="$LEGACY_REAL_HOOKS_DIR/pre-commit"
+
+# Simulate a hook installed by the OLD (pre-this-PR) code: unconditionally
+# targeting "<repo_dir>/hooks/pre-commit" inside the worktree itself, not
+# the new worktree-aware resolved target.
+mkdir -p "$LEGACY_REAL_HOOKS_DIR"
+ln -s "$LEGACY_WT_BRANCH/hooks/pre-commit" "$LEGACY_HOOK_DST"
+
+LEGACY_OUT="$(uninstall_precommit_hook "$LEGACY_WT_BRANCH" 2>&1)"
+LEGACY_RC=$?
+
+if [[ $LEGACY_RC -eq 0 ]]; then
+  _pass "Test 9 (Major 2): uninstall_precommit_hook exits 0 for a legacy-targeted hook"
+else
+  _fail "Test 9 (Major 2): uninstall_precommit_hook exited $LEGACY_RC. Output: $LEGACY_OUT"
+fi
+
+if [[ ! -e "$LEGACY_HOOK_DST" ]]; then
+  _pass "Test 9 (Major 2): legacy-targeted (pre-this-PR) hook is removed by uninstall"
+else
+  _fail "Test 9 (Major 2 regression): legacy-targeted hook still present at $LEGACY_HOOK_DST after uninstall - orphaned, will dangle once the worktree is removed. Output: $LEGACY_OUT"
+fi
+
+# Foreign-hook guard: a symlink pointing at neither the resolved target nor
+# the legacy target must still be left alone by the widened check.
+FOREIGN2_WT_MAIN="$TMP_ROOT/foreign2-wt-main-repo"
+_make_fixture_repo "$FOREIGN2_WT_MAIN"
+
+FOREIGN2_WT_BRANCH="$TMP_ROOT/foreign2-wt-branch"
+git -C "$FOREIGN2_WT_MAIN" worktree add -q "$FOREIGN2_WT_BRANCH" -b foreign2-wt-test-branch >/dev/null 2>&1
+
+FOREIGN2_REAL_HOOKS_DIR="$(git -C "$FOREIGN2_WT_BRANCH" rev-parse --git-path hooks)"
+case "$FOREIGN2_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) FOREIGN2_REAL_HOOKS_DIR="$FOREIGN2_WT_BRANCH/$FOREIGN2_REAL_HOOKS_DIR" ;;
+esac
+FOREIGN2_HOOK_DST="$FOREIGN2_REAL_HOOKS_DIR/pre-commit"
+
+# Points at a completely unrelated path - neither the resolved worktree
+# target nor "<repo_dir>/hooks/pre-commit" for THIS repo_dir.
+FOREIGN2_UNRELATED_TARGET="$TMP_ROOT/some-other-project/hooks/pre-commit"
+mkdir -p "$FOREIGN2_REAL_HOOKS_DIR"
+ln -s "$FOREIGN2_UNRELATED_TARGET" "$FOREIGN2_HOOK_DST"
+
+FOREIGN2_OUT="$(uninstall_precommit_hook "$FOREIGN2_WT_BRANCH" 2>&1)"
+
+if [[ -L "$FOREIGN2_HOOK_DST" ]] && [[ "$(readlink "$FOREIGN2_HOOK_DST")" == "$FOREIGN2_UNRELATED_TARGET" ]]; then
+  _pass "Test 9 (Major 2, no over-match): a symlink pointing at neither the resolved nor legacy target is left untouched"
+else
+  _fail "Test 9 (Major 2 regression, over-match): the widened uninstall check removed or altered a genuinely foreign hook. Output: $FOREIGN2_OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -6,7 +6,13 @@
 #          a git worktree - there ".git" is a FILE (a gitdir pointer), not a
 #          directory, so a plain `ln -s`/`rm` against
 #          "$REPO_DIR/.git/hooks/..." fails or silently no-ops (DS-58, both
-#          the install side and the symmetric uninstall side).
+#          the install side and the symmetric uninstall side). Also covers
+#          the follow-up fix: the symlink SOURCE must be the common repo's
+#          own "hooks/pre-commit", not the worktree's - a worktree's working
+#          tree is ephemeral, and pointing the shared hook at a path inside
+#          it leaves a dangling symlink once that worktree is removed (git
+#          silently treats a dangling hook symlink as "no hook", not an
+#          error - the commit-time regression that motivated this addendum).
 #
 # Public API: ./bin/tests/test_precommit_worktree.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -14,11 +20,12 @@
 # Upstream deps: bash, git, mktemp.
 #
 # Downstream consumers: developer running locally before commit; can be
-#                       wired into CI.
+#                       wired into CI (.github/workflows/bin-tests.yml).
 #
 # Failure modes: any assertion failure prints the failing assertion and exits 1.
 #                All fixtures live under a temporary directory; the real repo
-#                and its .git/hooks are never touched.
+#                and its .git/hooks are never touched (verified by this test
+#                itself via a before/after checksum of the real hook).
 #
 # Performance: < 2 s wall time (pure git + shell, no network).
 #
@@ -35,7 +42,19 @@
 #     the hook installed. uninstall_precommit_hook shares the same
 #     resolve_git_hooks_dir resolution and removes the AE-owned hook from
 #     the real (shared, main-repo) hooks dir; a foreign hook is preserved.
-#   This test re-creates worktree fixtures for both sides to prevent
+#   - post-DS-58 dangling-symlink regression (worktree-hijack): the hooks
+#     DIRECTORY resolution (DS-58) was correct, but install_precommit_hook
+#     still symlinked "<repo_dir>/hooks/pre-commit" as the TARGET - inside
+#     the worktree itself. Once that worktree was removed, the shared
+#     .git/hooks/pre-commit symlink dangled and git silently ran no hook at
+#     all (no error - commits just stopped being checked). Fixed via
+#     resolve_hook_src, which points the symlink at the COMMON repo's own
+#     hooks/pre-commit when repo_dir is a linked worktree. Test 6 below
+#     creates a REAL linked worktree, installs from it, removes it, and
+#     asserts the main checkout's hook still resolves AND executes -
+#     confirmed to fail against the pre-fix source (see git history/PR for
+#     the baseline failure output this test was written to catch).
+#   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
 set -uo pipefail
@@ -46,6 +65,24 @@ LIB="$REPO_DIR/scripts/lib/precommit.sh"
 if [[ ! -f "$LIB" ]]; then
   echo "FAIL: $LIB not found" >&2
   exit 1
+fi
+
+# Checksum the REAL checkout's actual hook before running anything, so Test 7
+# (below) can assert this test file never touched it. All fixtures in this
+# file operate on isolated temp repos under $TMP_ROOT - never on $REPO_DIR.
+# Resolved via `git rev-parse --git-path hooks` (not a hardcoded
+# "$REPO_DIR/.git/hooks") so this also works correctly when the test itself
+# is being run from a linked worktree, where ".git" is a file, not a dir.
+REAL_HOOKS_DIR_FOR_CHECKSUM="$(git -C "$REPO_DIR" rev-parse --git-path hooks 2>/dev/null)"
+case "$REAL_HOOKS_DIR_FOR_CHECKSUM" in
+  /*) : ;;
+  "") : ;;
+  *) REAL_HOOKS_DIR_FOR_CHECKSUM="$REPO_DIR/$REAL_HOOKS_DIR_FOR_CHECKSUM" ;;
+esac
+REAL_HOOK_PATH_FOR_CHECKSUM="$REAL_HOOKS_DIR_FOR_CHECKSUM/pre-commit"
+REAL_HOOK_CHECKSUM_BEFORE=""
+if [[ -n "$REAL_HOOKS_DIR_FOR_CHECKSUM" ]] && [[ -e "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
+  REAL_HOOK_CHECKSUM_BEFORE="$(shasum -a 256 "$REAL_HOOK_PATH_FOR_CHECKSUM" 2>/dev/null | awk '{print $1}')"
 fi
 
 # shellcheck source=scripts/lib/precommit.sh
@@ -74,6 +111,12 @@ _ae_is_ours() {
 AE_DRY_RUN=false
 
 TMP_ROOT="$(mktemp -d)"
+# Resolve to the physical path (macOS /tmp -> /private/tmp symlink) so that
+# string-equality comparisons against paths git resolves via
+# `rev-parse --path-format=absolute` (which follows symlinks) agree with the
+# path this script builds by string concatenation - otherwise the two are
+# semantically the same location but never string-equal.
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
 _cleanup() {
   [[ -n "${TMP_ROOT:-}" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
 }
@@ -174,10 +217,23 @@ else
   _fail "worktree case: real hooks dir resolved to unexpected path: $REAL_HOOKS_DIR"
 fi
 
-if [[ -L "$WT_HOOK_DST" ]] && [[ "$(readlink "$WT_HOOK_DST")" == "$WT_BRANCH/hooks/pre-commit" ]]; then
-  _pass "worktree case: pre-commit symlink installed at real hooks dir ($WT_HOOK_DST)"
+# The symlink TARGET must be the common (main) repo's own hooks/pre-commit,
+# NOT the worktree's - the worktree's working tree is ephemeral and a
+# target inside it dangles once the worktree is removed (the bug this test
+# file's Test 6 exercises end-to-end).
+if [[ -L "$WT_HOOK_DST" ]] && [[ "$(readlink "$WT_HOOK_DST")" == "$WT_MAIN/hooks/pre-commit" ]]; then
+  _pass "worktree case: pre-commit symlink installed at real hooks dir, targeting the MAIN repo's hooks/pre-commit ($WT_HOOK_DST)"
 else
-  _fail "worktree case: pre-commit symlink not found/correct at $WT_HOOK_DST. Output: $OUT"
+  _fail "worktree case: pre-commit symlink not found/correct (expected target $WT_MAIN/hooks/pre-commit) at $WT_HOOK_DST. Output: $OUT"
+fi
+
+# A second install run from the same worktree must be a no-op (the resolved
+# source already matches) rather than rewriting the symlink.
+OUT2="$(install_precommit_hook "$WT_BRANCH" 2>&1)"
+if echo "$OUT2" | grep -qi "already linked"; then
+  _pass "worktree case: re-running install_precommit_hook from the worktree is a no-op"
+else
+  _fail "worktree case: expected 'already linked' no-op on re-install. Output: $OUT2"
 fi
 
 # ============================================================
@@ -201,8 +257,8 @@ case "$UNINSTALL_REAL_HOOKS_DIR" in
 esac
 UNINSTALL_HOOK_DST="$UNINSTALL_REAL_HOOKS_DIR/pre-commit"
 
-if [[ -L "$UNINSTALL_HOOK_DST" ]] && [[ "$(readlink "$UNINSTALL_HOOK_DST")" == "$UNINSTALL_WT_BRANCH/hooks/pre-commit" ]]; then
-  _pass "uninstall setup: pre-commit hook installed at real hooks dir before uninstall test"
+if [[ -L "$UNINSTALL_HOOK_DST" ]] && [[ "$(readlink "$UNINSTALL_HOOK_DST")" == "$UNINSTALL_WT_MAIN/hooks/pre-commit" ]]; then
+  _pass "uninstall setup: pre-commit hook installed at real hooks dir before uninstall test, targeting the MAIN repo"
 else
   _fail "uninstall setup: pre-commit hook not installed at $UNINSTALL_HOOK_DST as expected"
 fi
@@ -302,6 +358,77 @@ if echo "$OUT" | grep -qi "skipping pre-commit hook removal"; then
   _pass "non-repo case: uninstall prints a non-fatal skip warning"
 else
   _fail "non-repo case: uninstall expected a non-fatal skip warning. Output: $OUT"
+fi
+
+# ============================================================
+# Test 6: post-DS-58 worktree-hijack regression - a REAL linked worktree is
+#         created, install_precommit_hook runs from it, the worktree is then
+#         REMOVED, and the main checkout's shared hook must still resolve
+#         AND execute. A plain `test -e` on a dangling symlink is FALSE (it
+#         does not follow to a missing target), so this alone is enough to
+#         catch the bug - but this test goes further and actually invokes
+#         the hook to prove it runs, not just that the path resolves.
+# ============================================================
+
+HIJACK_MAIN="$TMP_ROOT/hijack-main-repo"
+_make_fixture_repo "$HIJACK_MAIN"
+
+HIJACK_WT="$TMP_ROOT/hijack-wt-branch"
+git -C "$HIJACK_MAIN" worktree add -q "$HIJACK_WT" -b hijack-wt-test-branch >/dev/null 2>&1
+
+install_precommit_hook "$HIJACK_WT" >/dev/null 2>&1
+
+MAIN_HOOK_DST="$HIJACK_MAIN/.git/hooks/pre-commit"
+
+if [[ -L "$MAIN_HOOK_DST" ]]; then
+  _pass "Test 6 setup: main repo's .git/hooks/pre-commit is a symlink after install-from-worktree"
+else
+  _fail "Test 6 setup: main repo's .git/hooks/pre-commit is not a symlink at $MAIN_HOOK_DST"
+fi
+
+# Remove the worktree - this is the moment the pre-fix bug fires: if the
+# symlink target was inside $HIJACK_WT, it now dangles.
+git -C "$HIJACK_MAIN" worktree remove -f "$HIJACK_WT" >/dev/null 2>&1
+
+if [[ -e "$MAIN_HOOK_DST" ]]; then
+  _pass "Test 6: main repo's pre-commit symlink still resolves (test -e true) after the worktree was removed"
+else
+  _fail "Test 6 (worktree-hijack regression): main repo's pre-commit symlink is DANGLING after worktree removal - test -e is false at $MAIN_HOOK_DST"
+fi
+
+if [[ -x "$MAIN_HOOK_DST" ]]; then
+  _pass "Test 6: main repo's pre-commit symlink still resolves to an executable (test -x true)"
+else
+  _fail "Test 6 (worktree-hijack regression): main repo's pre-commit symlink does not resolve to an executable at $MAIN_HOOK_DST"
+fi
+
+HOOK_RUN_OUTPUT="$("$MAIN_HOOK_DST" 2>&1)"
+HOOK_RUN_RC=$?
+if [[ $HOOK_RUN_RC -eq 0 ]] && [[ "$HOOK_RUN_OUTPUT" == "fixture pre-commit" ]]; then
+  _pass "Test 6: main repo's pre-commit hook actually EXECUTES after the worktree was removed (output: $HOOK_RUN_OUTPUT)"
+else
+  _fail "Test 6 (worktree-hijack regression): main repo's pre-commit hook failed to execute after worktree removal. rc=$HOOK_RUN_RC output=$HOOK_RUN_OUTPUT"
+fi
+
+# ============================================================
+# Test 7: real checkout's actual .git/hooks/pre-commit is never touched by
+#         this test file. All fixtures above use isolated temp repos; this
+#         asserts that invariant directly rather than trusting it.
+# ============================================================
+
+if [[ -n "$REAL_HOOKS_DIR_FOR_CHECKSUM" ]] && [[ -e "$REAL_HOOK_PATH_FOR_CHECKSUM" ]]; then
+  REAL_HOOK_CHECKSUM_AFTER="$(shasum -a 256 "$REAL_HOOK_PATH_FOR_CHECKSUM" 2>/dev/null | awk '{print $1}')"
+  if [[ "$REAL_HOOK_CHECKSUM_AFTER" == "$REAL_HOOK_CHECKSUM_BEFORE" ]]; then
+    _pass "Test 7: real checkout's .git/hooks/pre-commit checksum unchanged by this test run ($REAL_HOOK_CHECKSUM_AFTER)"
+  else
+    _fail "Test 7: real checkout's .git/hooks/pre-commit checksum CHANGED - before=$REAL_HOOK_CHECKSUM_BEFORE after=$REAL_HOOK_CHECKSUM_AFTER"
+  fi
+else
+  if [[ -z "$REAL_HOOK_CHECKSUM_BEFORE" ]]; then
+    _pass "Test 7: real checkout's .git/hooks/pre-commit did not exist before or after this test run"
+  else
+    _fail "Test 7: real checkout's .git/hooks/pre-commit existed before this run (checksum $REAL_HOOK_CHECKSUM_BEFORE) but is missing after"
+  fi
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -69,7 +69,8 @@
 #     the hook dangling anyway (see the library's Failure-modes "KNOWN
 #     RESIDUAL" bullet) - not a regression, not fixed by this PR, disclosed
 #     rather than silently left unverified.
-#   - Major 2 (uninstall orphaning a legacy-targeted hook): Test 9.
+#   - Major 2 (uninstall orphaning a legacy-targeted hook): Test 9 (canonical
+#     fixture path only - see Test 12 for the non-canonical variant).
 #   - Minor 1 (install_precommit_hook's `[[ ! -f "$hook_src" ]]` guard was
 #     reachable but had zero coverage): Test 10 - an ordinary repo with no
 #     hooks/pre-commit file at all, the only shape that exercises
@@ -77,6 +78,10 @@
 #   - Minor 3 (legacy_hook_src used the raw, non-canonicalized repo_dir):
 #     Test 11 - install with a trailing-slash spelling, uninstall with the
 #     canonical spelling of the same directory.
+#   - Major 1 (round 3: legacy candidate regressed against a symlinked-
+#     parent, non-canonical repo_dir spelling - the cross-version boundary
+#     where pre-this-PR code always used the raw spelling but the legacy
+#     candidate had become canonical-only): Test 12.
 #   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
@@ -568,10 +573,10 @@ fi
 # source: the main checkout's own hooks/pre-commit).
 git -C "$BARE_REPO" worktree remove -f "$BARE_WT" >/dev/null 2>&1
 
-if [[ ! -e "$BARE_HOOK_DST" ]]; then
+if [[ -L "$BARE_HOOK_DST" ]] && [[ ! -e "$BARE_HOOK_DST" ]]; then
   _pass "Test 8 (Minor 2, known residual documented): bare-repo worktree hook is DANGLING after worktree removal, as disclosed in the manifest's Failure modes section (not a regression, no better source exists)"
 else
-  _fail "Test 8 (Minor 2 regression): expected the KNOWN residual (dangling hook after bare-repo worktree removal) but the hook still resolves at $BARE_HOOK_DST - either the residual was silently fixed (update the manifest disclosure) or the fixture broke"
+  _fail "Test 8 (Minor 2 regression): expected the KNOWN residual (a DANGLING symlink, i.e. -L true and -e false) but got -L=$([[ -L "$BARE_HOOK_DST" ]] && echo true || echo false) -e=$([[ -e "$BARE_HOOK_DST" ]] && echo true || echo false) at $BARE_HOOK_DST - either the residual was silently fixed (update the manifest disclosure), the fixture broke, or the symlink was never created (plain absence, not dangling)"
 fi
 
 # ============================================================
@@ -699,10 +704,10 @@ case "$NO_HOOK_REAL_HOOKS_DIR" in
 esac
 NO_HOOK_DST="$NO_HOOK_REAL_HOOKS_DIR/pre-commit"
 
-if [[ ! -e "$NO_HOOK_DST" ]]; then
+if [[ ! -L "$NO_HOOK_DST" ]] && [[ ! -e "$NO_HOOK_DST" ]]; then
   _pass "Test 10 (Minor 1): no dangling symlink was created at $NO_HOOK_DST despite a missing source"
 else
-  _fail "Test 10 (Minor 1 regression): a symlink/file was created at $NO_HOOK_DST despite the resolved source not existing. Output: $NO_HOOK_OUT"
+  _fail "Test 10 (Minor 1 regression): a symlink/file was created at $NO_HOOK_DST despite the resolved source not existing (-L=$([[ -L "$NO_HOOK_DST" ]] && echo true || echo false) -e=$([[ -e "$NO_HOOK_DST" ]] && echo true || echo false)). Output: $NO_HOOK_OUT"
 fi
 
 # ============================================================
@@ -762,6 +767,61 @@ if [[ ! -e "$CANON_HOOK_DST" ]]; then
   _pass "Test 11 (Minor 3 fixed): hook installed via a trailing-slash repo_dir is correctly removed by uninstall using the canonical spelling"
 else
   _fail "Test 11 (Minor 3 regression): hook installed via a trailing-slash repo_dir was left ORPHANED by uninstall using the canonical spelling - legacy_hook_src is not canonicalized consistently with the installed target. Output: $CANON_UNINSTALL_OUT"
+fi
+
+# ============================================================
+# Test 12: Major 1 - uninstall's legacy candidate must match a hook
+#          installed under a NON-CANONICAL repo_dir spelling (reached
+#          through a symlinked PARENT directory), not just the canonical
+#          spelling. Pre-this-fix, legacy_hook_src was built AFTER repo_dir
+#          had already been overwritten with its canonicalized form, so
+#          the raw spelling was lost entirely by the time the legacy
+#          candidate string was assembled - a legacy hook installed under
+#          the raw spelling (exactly what pre-this-PR, non-canonicalizing
+#          code would have done) then matched neither the resolved target
+#          nor the legacy candidate, and was orphaned.
+# ============================================================
+
+MAJOR1_REAL_PARENT="$TMP_ROOT/major1-real-parent"
+mkdir -p "$MAJOR1_REAL_PARENT"
+MAJOR1_REPO="$MAJOR1_REAL_PARENT/repo"
+_make_fixture_repo "$MAJOR1_REPO"
+
+MAJOR1_SYMLINK_PARENT="$TMP_ROOT/major1-symlinked-parent"
+ln -s "$MAJOR1_REAL_PARENT" "$MAJOR1_SYMLINK_PARENT"
+
+# Non-canonical spelling of the SAME repo, reached through the symlinked
+# parent directory.
+MAJOR1_RAW_REPO_DIR="$MAJOR1_SYMLINK_PARENT/repo"
+
+if [[ "$MAJOR1_RAW_REPO_DIR" != "$MAJOR1_REPO" ]]; then
+  _pass "Test 12 setup: raw (symlinked-parent) and canonical repo_dir spellings genuinely differ as strings"
+else
+  _fail "Test 12 setup: raw and canonical spellings are string-identical - fixture does not exercise the bug"
+fi
+
+MAJOR1_HOOKS_DIR="$MAJOR1_REPO/.git/hooks"
+mkdir -p "$MAJOR1_HOOKS_DIR"
+MAJOR1_HOOK_DST="$MAJOR1_HOOKS_DIR/pre-commit"
+
+# Simulate a hook installed by legacy (pre-this-PR, non-canonicalizing)
+# code: the symlink target is built directly from the RAW spelling passed
+# in, with no canonicalization step at all.
+ln -s "$MAJOR1_RAW_REPO_DIR/hooks/pre-commit" "$MAJOR1_HOOK_DST"
+
+MAJOR1_OUT="$(uninstall_precommit_hook "$MAJOR1_RAW_REPO_DIR" 2>&1)"
+MAJOR1_RC=$?
+
+if [[ $MAJOR1_RC -eq 0 ]]; then
+  _pass "Test 12 (Major 1): uninstall_precommit_hook exits 0 for a legacy hook installed under a non-canonical spelling"
+else
+  _fail "Test 12 (Major 1): uninstall_precommit_hook exited $MAJOR1_RC. Output: $MAJOR1_OUT"
+fi
+
+if [[ ! -e "$MAJOR1_HOOK_DST" ]]; then
+  _pass "Test 12 (Major 1 fixed): legacy hook installed under a non-canonical (symlinked-parent) spelling is removed by uninstall"
+else
+  _fail "Test 12 (Major 1 regression): legacy hook installed under a non-canonical spelling was left ORPHANED by uninstall - the legacy candidate must match both the raw and the canonical repo_dir spellings. Output: $MAJOR1_OUT"
 fi
 
 # ---- Results ----

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -40,8 +40,15 @@
 #     the FILE existing (`[[ -f ]]`), not merely the directory - on any
 #     resolution failure (not a git repo, git missing, common-dir has no
 #     parent, candidate file does not exist, etc) falls back to
-#     "<repo_dir>/hooks/pre-commit" unchanged - never errors, and never
-#     returns a target known not to exist.
+#     "<repo_dir>/hooks/pre-commit" - but that fallback itself is NOT
+#     existence-gated (it is echoed unconditionally on every fallback
+#     branch), so resolve_hook_src CAN still return a path that does not
+#     exist, e.g. an ordinary (non-worktree) repo_dir with no
+#     hooks/pre-commit file at all. Only the worktree-linked candidate is
+#     existence-checked. install_precommit_hook's own `[[ -f "$hook_src" ]]`
+#     guard is therefore load-bearing, not redundant belt-and-braces - do
+#     not remove it on the assumption this function already guarantees an
+#     existing source.
 #
 #   install_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir and the symlink
@@ -103,12 +110,45 @@
 #     never propagates a failure to the caller.
 #   - Resolved hooks dir does not yet exist (fresh worktree/repo): created
 #     via mkdir -p before the symlink is written (install only).
+#   - KNOWN RESIDUAL (not a regression - identical on origin/main): a bare
+#     repo + `git worktree add`, `git init --separate-git-dir` + worktree,
+#     and a submodule + worktree all fall back to the worktree's OWN
+#     "hooks/pre-commit" (resolve_hook_src has no better source in these
+#     three layouts - `git worktree list --porcelain` returns the gitdir,
+#     not a working tree, in all three). That fallback target is still
+#     INSIDE the worktree, so the installed symlink dangles the moment that
+#     worktree is removed, same failure mode this module exists to prevent,
+#     just not reachable from an ordinary linked worktree. Test 8 in
+#     bin/tests/test_precommit_worktree.sh asserts this known-dangling
+#     outcome directly rather than leaving it undocumented.
 #   - Safe to source under set -euo pipefail; no top-level side effects
 #     beyond the function definitions.
 #
 # Performance: up to three `git rev-parse` calls per invocation (one in
 # resolve_git_hooks_dir, two in resolve_hook_src).
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# _precommit_canonical_repo_dir <repo_dir>
+#   Internal helper (not part of the public API). Echoes the physical,
+#   symlink-resolved, trailing-slash-free form of <repo_dir> via
+#   `(cd <repo_dir> && pwd -P)`, or <repo_dir> unchanged if that cd fails
+#   (non-existent dir - callers already tolerate an unresolvable repo_dir
+#   downstream). resolve_hook_src's worktree-linked candidate is already
+#   canonical (derived from `git rev-parse --path-format=absolute
+#   --git-common-dir`), but its FALLBACK path and
+#   uninstall_precommit_hook's legacy_hook_src are both built by string
+#   concatenation on the raw repo_dir argument - two callers passing
+#   different (but equivalent) spellings of the same directory (a trailing
+#   slash, or a path through a symlinked parent) would otherwise produce
+#   two different fallback/legacy strings for the same real hook, breaking
+#   the exact-match comparisons in install/uninstall. Canonicalizing once,
+#   consistently, closes that gap.
+# ---------------------------------------------------------------------------
+_precommit_canonical_repo_dir() {
+  local d="$1"
+  (cd "$d" 2>/dev/null && pwd -P) || echo "$d"
+}
 
 # ---------------------------------------------------------------------------
 # resolve_git_hooks_dir <repo_dir>
@@ -139,6 +179,7 @@ resolve_git_hooks_dir() {
 # ---------------------------------------------------------------------------
 resolve_hook_src() {
   local repo_dir="$1"
+  repo_dir="$(_precommit_canonical_repo_dir "$repo_dir")"
   local fallback="$repo_dir/hooks/pre-commit"
 
   local git_dir common_dir
@@ -174,7 +215,7 @@ resolve_hook_src() {
   common_worktree="$(dirname "$common_dir")"
   candidate="$common_worktree/hooks/pre-commit"
   if [[ -z "$common_worktree" || ! -f "$candidate" ]]; then
-    echo "  ! could not resolve a real hooks/pre-commit under the common worktree ($common_worktree) - falling back to $fallback (non-fatal)" >&2
+    echo "  ! could not resolve a real hooks/pre-commit under the common worktree ($common_worktree) - falling back to $fallback (non-fatal, but this hook WILL stop working once this worktree is removed - see Failure modes above)" >&2
     echo "$fallback"
     return 0
   fi
@@ -188,6 +229,7 @@ resolve_hook_src() {
 # ---------------------------------------------------------------------------
 install_precommit_hook() {
   local repo_dir="$1"
+  repo_dir="$(_precommit_canonical_repo_dir "$repo_dir")"
   local hook_src
   hook_src="$(resolve_hook_src "$repo_dir")"
 
@@ -197,9 +239,12 @@ install_precommit_hook() {
     return 0
   fi
 
-  # Defense in depth: resolve_hook_src is expected to only ever return an
-  # existing file (it falls back rather than emit a dangling target), but
-  # never create a link whose source is missing regardless of how it got
+  # This guard is LOAD-BEARING, not redundant belt-and-braces: only
+  # resolve_hook_src's worktree-linked candidate is existence-gated - its
+  # fallback ("$repo_dir/hooks/pre-commit") is echoed unconditionally on
+  # every fallback branch and can itself be a path that does not exist
+  # (e.g. an ordinary repo_dir with no hooks/pre-commit file at all).
+  # Never create a link whose source is missing regardless of how it got
   # here - a dangling symlink is silently treated by git as "no hook",
   # exactly the failure mode this module exists to prevent.
   if [[ ! -f "$hook_src" ]]; then
@@ -248,6 +293,7 @@ install_precommit_hook() {
 # ---------------------------------------------------------------------------
 uninstall_precommit_hook() {
   local repo_dir="$1"
+  repo_dir="$(_precommit_canonical_repo_dir "$repo_dir")"
   local hook_src
   hook_src="$(resolve_hook_src "$repo_dir")"
 

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -17,29 +17,53 @@
 #     and echoes nothing on resolution failure (not a git repo, git
 #     missing, etc).
 #
+#   resolve_hook_src <repo_dir>
+#     Echoes the symlink TARGET path for the hooks/pre-commit source file -
+#     "<repo_dir>/hooks/pre-commit" for an ordinary checkout (byte-for-byte
+#     identical to the original DS-58 behavior), but the COMMON repo's
+#     "<main worktree>/hooks/pre-commit" when <repo_dir> is a linked
+#     worktree. This matters because the hooks DIRECTORY (resolved by
+#     resolve_git_hooks_dir, per DS-58) is shared across every worktree of a
+#     repo, but a worktree's own working tree is ephemeral - pointing the
+#     shared hook at a path inside it leaves a dangling symlink (which git
+#     silently treats as "no hook", not an error) once that worktree is
+#     removed. Detects "linked worktree" by comparing
+#     `git rev-parse --path-format=absolute --git-dir` against
+#     `--git-common-dir`: equal means an ordinary (or bare main) checkout,
+#     different means a linked worktree, in which case the target becomes
+#     "$(dirname <git-common-dir>)/hooks/pre-commit". On any resolution
+#     failure (not a git repo, git missing, common-dir has no parent, etc)
+#     falls back to "<repo_dir>/hooks/pre-commit" unchanged - never errors.
+#
 #   install_precommit_hook <repo_dir>
-#     Resolves the real hooks dir via resolve_git_hooks_dir, mkdir -p's it
-#     if needed, and symlinks hooks/pre-commit into it. Honours the
-#     caller's $AE_DRY_RUN ("true"/"false") and reuses the caller's
-#     _ae_is_ours function (must already be defined in the sourcing script)
-#     to detect and re-point stale symlinks from another methodology
-#     checkout. If hooks-dir resolution fails for any reason, prints a
-#     non-fatal warning and returns 0 - never aborts the caller.
+#     Resolves the real hooks dir via resolve_git_hooks_dir and the symlink
+#     source via resolve_hook_src, mkdir -p's the hooks dir if needed, and
+#     symlinks the resolved source into it. Honours the caller's
+#     $AE_DRY_RUN ("true"/"false") and reuses the caller's _ae_is_ours
+#     function (must already be defined in the sourcing script) to detect
+#     and re-point stale symlinks from another methodology checkout. An
+#     existing symlink that already matches the resolved source (including
+#     an already-correctly-repointed worktree install) is left untouched
+#     (reported as "already linked", not rewritten). If hooks-dir
+#     resolution fails for any reason, prints a non-fatal warning and
+#     returns 0 - never aborts the caller.
 #
 #   uninstall_precommit_hook <repo_dir>
-#     Resolves the real hooks dir via resolve_git_hooks_dir and removes the
-#     pre-commit symlink there iff it is a symlink pointing exactly at
-#     "<repo_dir>/hooks/pre-commit" (the same ownership check the original
-#     per-adapter uninstall blocks used - never deletes a foreign hook, a
-#     real file, or a symlink pointing elsewhere). If hooks-dir resolution
-#     fails for any reason, prints a non-fatal warning and returns 0 -
-#     never aborts the caller.
+#     Resolves the real hooks dir via resolve_git_hooks_dir and the expected
+#     symlink target via resolve_hook_src (the same resolution
+#     install_precommit_hook used, so a worktree-repointed symlink is
+#     recognised as ours), and removes the pre-commit symlink there iff it
+#     is a symlink pointing exactly at that resolved target (the same
+#     ownership check the original per-adapter uninstall blocks used -
+#     never deletes a foreign hook, a real file, or a symlink pointing
+#     elsewhere). If hooks-dir resolution fails for any reason, prints a
+#     non-fatal warning and returns 0 - never aborts the caller.
 #
 # Upstream dependencies:
-#   git (rev-parse --git-path), the caller's $REPO_DIR/hooks/pre-commit
-#   source file, the caller's $AE_DRY_RUN variable (install only), the
-#   caller's _ae_is_ours function (install only; duplicated per-adapter
-#   helper).
+#   git (rev-parse --git-path / --git-dir / --git-common-dir), the caller's
+#   $REPO_DIR/hooks/pre-commit source file, the caller's $AE_DRY_RUN
+#   variable (install only), the caller's _ae_is_ours function (install
+#   only; duplicated per-adapter helper).
 #
 # Downstream consumers:
 #   .claude/install.sh, .cursor/install.sh, .opencode/install.sh,
@@ -50,12 +74,17 @@
 #   - `git rev-parse --git-path hooks` fails (not a git repo, git missing):
 #     resolve_git_hooks_dir returns 1; both install_precommit_hook and
 #     uninstall_precommit_hook print a non-fatal warning and return 0.
+#   - `git rev-parse --git-dir`/`--git-common-dir` fails, or the common
+#     dir's parent can't be determined: resolve_hook_src falls back to
+#     "<repo_dir>/hooks/pre-commit" (today's pre-worktree-fix behavior) -
+#     never propagates a failure to the caller.
 #   - Resolved hooks dir does not yet exist (fresh worktree/repo): created
 #     via mkdir -p before the symlink is written (install only).
 #   - Safe to source under set -euo pipefail; no top-level side effects
 #     beyond the function definitions.
 #
-# Performance: one `git rev-parse` call per invocation.
+# Performance: up to three `git rev-parse` calls per invocation (one in
+# resolve_git_hooks_dir, two in resolve_hook_src).
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -82,12 +111,51 @@ resolve_git_hooks_dir() {
 }
 
 # ---------------------------------------------------------------------------
+# resolve_hook_src <repo_dir>
+#   See "Public API" above.
+# ---------------------------------------------------------------------------
+resolve_hook_src() {
+  local repo_dir="$1"
+  local fallback="$repo_dir/hooks/pre-commit"
+
+  local git_dir common_dir
+  if ! git_dir="$(git -C "$repo_dir" rev-parse --path-format=absolute --git-dir 2>/dev/null)" || [[ -z "$git_dir" ]]; then
+    echo "$fallback"
+    return 0
+  fi
+  if ! common_dir="$(git -C "$repo_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || [[ -z "$common_dir" ]]; then
+    echo "$fallback"
+    return 0
+  fi
+
+  if [[ "$git_dir" == "$common_dir" ]]; then
+    # Ordinary checkout (or the main worktree of a repo that also has
+    # linked worktrees) - unchanged from the original DS-58 behavior.
+    echo "$fallback"
+    return 0
+  fi
+
+  # Linked worktree: git-dir and git-common-dir diverge. The common repo's
+  # own working tree is the parent of the common .git dir - use ITS
+  # hooks/pre-commit as the symlink target so it outlives this worktree.
+  local common_worktree
+  common_worktree="$(dirname "$common_dir")"
+  if [[ -z "$common_worktree" || ! -d "$common_worktree" ]]; then
+    echo "$fallback"
+    return 0
+  fi
+
+  echo "$common_worktree/hooks/pre-commit"
+}
+
+# ---------------------------------------------------------------------------
 # install_precommit_hook <repo_dir>
 #   See "Public API" above.
 # ---------------------------------------------------------------------------
 install_precommit_hook() {
   local repo_dir="$1"
-  local hook_src="$repo_dir/hooks/pre-commit"
+  local hook_src
+  hook_src="$(resolve_hook_src "$repo_dir")"
 
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then
@@ -136,7 +204,8 @@ install_precommit_hook() {
 # ---------------------------------------------------------------------------
 uninstall_precommit_hook() {
   local repo_dir="$1"
-  local hook_src="$repo_dir/hooks/pre-commit"
+  local hook_src
+  hook_src="$(resolve_hook_src "$repo_dir")"
 
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -22,18 +22,26 @@
 #     "<repo_dir>/hooks/pre-commit" for an ordinary checkout (byte-for-byte
 #     identical to the original DS-58 behavior), but the COMMON repo's
 #     "<main worktree>/hooks/pre-commit" when <repo_dir> is a linked
-#     worktree. This matters because the hooks DIRECTORY (resolved by
-#     resolve_git_hooks_dir, per DS-58) is shared across every worktree of a
-#     repo, but a worktree's own working tree is ephemeral - pointing the
-#     shared hook at a path inside it leaves a dangling symlink (which git
-#     silently treats as "no hook", not an error) once that worktree is
-#     removed. Detects "linked worktree" by comparing
-#     `git rev-parse --path-format=absolute --git-dir` against
-#     `--git-common-dir`: equal means an ordinary (or bare main) checkout,
-#     different means a linked worktree, in which case the target becomes
-#     "$(dirname <git-common-dir>)/hooks/pre-commit". On any resolution
-#     failure (not a git repo, git missing, common-dir has no parent, etc)
-#     falls back to "<repo_dir>/hooks/pre-commit" unchanged - never errors.
+#     worktree AND that file actually exists there. This matters because
+#     the hooks DIRECTORY (resolved by resolve_git_hooks_dir, per DS-58) is
+#     shared across every worktree of a repo, but a worktree's own working
+#     tree is ephemeral - pointing the shared hook at a path inside it
+#     leaves a dangling symlink (which git silently treats as "no hook",
+#     not an error) once that worktree is removed. Detects "linked
+#     worktree" by comparing `git rev-parse --path-format=absolute
+#     --git-dir` against `--git-common-dir`: equal means an ordinary (or
+#     bare main) checkout, different means a linked worktree, in which case
+#     the candidate target becomes "$(dirname <git-common-dir>)/hooks/pre-commit".
+#     dirname(<git-common-dir>) is the common repo's own working tree ONLY
+#     for an ordinary linked worktree - it is NOT for a bare repo +
+#     `git worktree add`, `git init --separate-git-dir` + worktree, or a
+#     submodule + worktree, where it resolves to some other directory with
+#     no "hooks/pre-commit" of its own. The candidate is therefore gated on
+#     the FILE existing (`[[ -f ]]`), not merely the directory - on any
+#     resolution failure (not a git repo, git missing, common-dir has no
+#     parent, candidate file does not exist, etc) falls back to
+#     "<repo_dir>/hooks/pre-commit" unchanged - never errors, and never
+#     returns a target known not to exist.
 #
 #   install_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir and the symlink
@@ -53,17 +61,32 @@
 #     symlink target via resolve_hook_src (the same resolution
 #     install_precommit_hook used, so a worktree-repointed symlink is
 #     recognised as ours), and removes the pre-commit symlink there iff it
-#     is a symlink pointing exactly at that resolved target (the same
-#     ownership check the original per-adapter uninstall blocks used -
-#     never deletes a foreign hook, a real file, or a symlink pointing
-#     elsewhere). If hooks-dir resolution fails for any reason, prints a
-#     non-fatal warning and returns 0 - never aborts the caller.
+#     is a symlink pointing exactly at that resolved target OR at the
+#     legacy unconditional "<repo_dir>/hooks/pre-commit" target that
+#     pre-this-PR code (or this code from an ordinary, non-worktree
+#     repo_dir) would have installed (the same ownership check the
+#     original per-adapter uninstall blocks used, widened by exactly one
+#     additional exact-match candidate - never deletes a foreign hook, a
+#     real file, or a symlink pointing anywhere else). If hooks-dir
+#     resolution fails for any reason, prints a non-fatal warning and
+#     returns 0 - never aborts the caller.
 #
 # Upstream dependencies:
-#   git (rev-parse --git-path / --git-dir / --git-common-dir), the caller's
-#   $REPO_DIR/hooks/pre-commit source file, the caller's $AE_DRY_RUN
-#   variable (install only), the caller's _ae_is_ours function (install
-#   only; duplicated per-adapter helper).
+#   git (rev-parse --git-path / --git-dir / --git-common-dir), the COMMON
+#   repo's hooks/pre-commit source file (the caller's own
+#   $REPO_DIR/hooks/pre-commit for an ordinary checkout, but a different
+#   worktree's ancestor repo when $REPO_DIR is a linked worktree - see
+#   resolve_hook_src above), the caller's $AE_DRY_RUN variable (install
+#   only), the caller's _ae_is_ours function (install only; duplicated
+#   per-adapter helper).
+#
+# NOTE: bin/ds-doctor:783 independently hardcodes the same
+#   "<repo_dir>/hooks/pre-commit is the expected symlink target" invariant
+#   (`expected_src = doc.repo_dir / "hooks" / "pre-commit"`) with no shared
+#   source between the two - harmless today only because ds-doctor's own
+#   repo_dir/.git/hooks hardcode already fails first from a worktree, so
+#   the two never actually disagree in a live run. If resolve_hook_src's
+#   resolution logic changes again, check bin/ds-doctor for drift too.
 #
 # Downstream consumers:
 #   .claude/install.sh, .cursor/install.sh, .opencode/install.sh,
@@ -135,17 +158,28 @@ resolve_hook_src() {
     return 0
   fi
 
-  # Linked worktree: git-dir and git-common-dir diverge. The common repo's
-  # own working tree is the parent of the common .git dir - use ITS
-  # hooks/pre-commit as the symlink target so it outlives this worktree.
-  local common_worktree
+  # Linked worktree: git-dir and git-common-dir diverge. In an ordinary
+  # linked worktree, the common repo's own working tree is the parent of
+  # the common .git dir. That assumption does NOT hold for a bare repo +
+  # `git worktree add`, `git init --separate-git-dir` + worktree, or a
+  # submodule + worktree - in all three, dirname(common_dir) is some other
+  # directory (the bare repo's parent, the separate-gitdir's parent, or
+  # `.git/modules/...`) that has no "hooks/pre-commit" of its own. Gate on
+  # the SOURCE FILE actually existing there, not merely on the directory
+  # existing (the directory always exists in those unsupported layouts,
+  # which is what let this fall through undetected before) - if it does
+  # not, degrade to the pre-fix fallback rather than emit a target that is
+  # dangling from the moment it is installed.
+  local common_worktree candidate
   common_worktree="$(dirname "$common_dir")"
-  if [[ -z "$common_worktree" || ! -d "$common_worktree" ]]; then
+  candidate="$common_worktree/hooks/pre-commit"
+  if [[ -z "$common_worktree" || ! -f "$candidate" ]]; then
+    echo "  ! could not resolve a real hooks/pre-commit under the common worktree ($common_worktree) - falling back to $fallback (non-fatal)" >&2
     echo "$fallback"
     return 0
   fi
 
-  echo "$common_worktree/hooks/pre-commit"
+  echo "$candidate"
 }
 
 # ---------------------------------------------------------------------------
@@ -160,6 +194,16 @@ install_precommit_hook() {
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then
     echo "  ! could not resolve git hooks directory - skipping pre-commit hook install (non-fatal)"
+    return 0
+  fi
+
+  # Defense in depth: resolve_hook_src is expected to only ever return an
+  # existing file (it falls back rather than emit a dangling target), but
+  # never create a link whose source is missing regardless of how it got
+  # here - a dangling symlink is silently treated by git as "no hook",
+  # exactly the failure mode this module exists to prevent.
+  if [[ ! -f "$hook_src" ]]; then
+    echo "  ! resolved pre-commit hook source does not exist: $hook_src - skipping pre-commit hook install (non-fatal)"
     return 0
   fi
 
@@ -207,6 +251,23 @@ uninstall_precommit_hook() {
   local hook_src
   hook_src="$(resolve_hook_src "$repo_dir")"
 
+  # Legacy target: the pre-DS-58-worktree-fix (and pre-this-PR) symlink
+  # target, "<repo_dir>/hooks/pre-commit" unconditionally, with no
+  # worktree-awareness. install_precommit_hook heals a link pointing here
+  # via _ae_is_ours, but uninstall previously had no equivalent - a hook
+  # installed by the old code (or by this new code from an ordinary,
+  # non-worktree repo_dir, where hook_src already equals this value) was
+  # left orphaned by an uninstall that only recognised the new resolved
+  # target. Accepting this SECOND exact target widens what uninstall will
+  # remove to exactly: "the current resolved target" OR "the legacy
+  # unconditional <repo_dir>/hooks/pre-commit target" - both still require
+  # an EXACT match (per the existing `[[ "$current_target" == ... ]]`
+  # ownership check), so a foreign hook pointing anywhere else, including a
+  # different methodology checkout's hooks/pre-commit, is still left
+  # untouched. It does NOT match a link pointing at some other project's
+  # own hooks/pre-commit that happens to share a basename but not a path.
+  local legacy_hook_src="$repo_dir/hooks/pre-commit"
+
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then
     echo "  ! could not resolve git hooks directory - skipping pre-commit hook removal (non-fatal)"
@@ -218,7 +279,7 @@ uninstall_precommit_hook() {
   if [[ -L "$hook_dst" ]]; then
     local current_target
     current_target="$(readlink "$hook_dst")"
-    if [[ "$current_target" == "$hook_src" ]]; then
+    if [[ "$current_target" == "$hook_src" || "$current_target" == "$legacy_hook_src" ]]; then
       rm "$hook_dst"
       echo "  - pre-commit hook removed"
     else

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -71,12 +71,17 @@
 #     is a symlink pointing exactly at that resolved target OR at the
 #     legacy unconditional "<repo_dir>/hooks/pre-commit" target that
 #     pre-this-PR code (or this code from an ordinary, non-worktree
-#     repo_dir) would have installed (the same ownership check the
-#     original per-adapter uninstall blocks used, widened by exactly one
-#     additional exact-match candidate - never deletes a foreign hook, a
-#     real file, or a symlink pointing anywhere else). If hooks-dir
-#     resolution fails for any reason, prints a non-fatal warning and
-#     returns 0 - never aborts the caller.
+#     repo_dir) would have installed - checked against BOTH the RAW
+#     repo_dir spelling as passed to this function and its canonicalized
+#     (symlink-resolved) form, since the two can differ when repo_dir is
+#     reached through a symlinked parent, and the legacy target may have
+#     been installed under either spelling depending on which code wrote
+#     it (the same ownership check the original per-adapter uninstall
+#     blocks used, widened by exactly two additional exact-match
+#     candidates - never deletes a foreign hook, a real file, or a symlink
+#     pointing anywhere else). If hooks-dir resolution fails for any
+#     reason, prints a non-fatal warning and returns 0 - never aborts the
+#     caller.
 #
 # Upstream dependencies:
 #   git (rev-parse --git-path / --git-dir / --git-common-dir), the COMMON
@@ -144,9 +149,25 @@
 #   two different fallback/legacy strings for the same real hook, breaking
 #   the exact-match comparisons in install/uninstall. Canonicalizing once,
 #   consistently, closes that gap.
+#
+#   KNOWN EDGE CASE (guarded): an empty <repo_dir> ("") is rejected before
+#   the `cd` - `cd ""` succeeds in both bash and zsh and silently retargets
+#   to the caller's CURRENT directory, which would make this function
+#   fail-open (returning the invoker's cwd, not an error indicator) for a
+#   function whose whole job is deriving where symlinks get written/read.
+#   Not reachable from any of the six current consumers (all set REPO_DIR
+#   unconditionally before calling in), but the raw `cd "$d"` behavior
+#   without this guard would silently swap a caller bug (empty repo_dir)
+#   for a directory-confusion bug instead of surfacing it - echoes the
+#   empty string back unchanged so callers see the same "unresolved"
+#   signal they'd get from any other invalid repo_dir.
 # ---------------------------------------------------------------------------
 _precommit_canonical_repo_dir() {
   local d="$1"
+  if [[ -z "$d" ]]; then
+    echo "$d"
+    return 0
+  fi
   (cd "$d" 2>/dev/null && pwd -P) || echo "$d"
 }
 
@@ -292,27 +313,40 @@ install_precommit_hook() {
 #   See "Public API" above.
 # ---------------------------------------------------------------------------
 uninstall_precommit_hook() {
-  local repo_dir="$1"
-  repo_dir="$(_precommit_canonical_repo_dir "$repo_dir")"
+  local raw_repo_dir="$1"
+  local repo_dir
+  repo_dir="$(_precommit_canonical_repo_dir "$raw_repo_dir")"
   local hook_src
   hook_src="$(resolve_hook_src "$repo_dir")"
 
   # Legacy target: the pre-DS-58-worktree-fix (and pre-this-PR) symlink
   # target, "<repo_dir>/hooks/pre-commit" unconditionally, with no
-  # worktree-awareness. install_precommit_hook heals a link pointing here
-  # via _ae_is_ours, but uninstall previously had no equivalent - a hook
-  # installed by the old code (or by this new code from an ordinary,
-  # non-worktree repo_dir, where hook_src already equals this value) was
-  # left orphaned by an uninstall that only recognised the new resolved
-  # target. Accepting this SECOND exact target widens what uninstall will
-  # remove to exactly: "the current resolved target" OR "the legacy
-  # unconditional <repo_dir>/hooks/pre-commit target" - both still require
-  # an EXACT match (per the existing `[[ "$current_target" == ... ]]`
-  # ownership check), so a foreign hook pointing anywhere else, including a
-  # different methodology checkout's hooks/pre-commit, is still left
-  # untouched. It does NOT match a link pointing at some other project's
-  # own hooks/pre-commit that happens to share a basename but not a path.
-  local legacy_hook_src="$repo_dir/hooks/pre-commit"
+  # worktree-awareness and no canonicalization. install_precommit_hook
+  # heals a link pointing here via _ae_is_ours, but uninstall previously
+  # had no equivalent - a hook installed by the old code (or by this new
+  # code from an ordinary, non-worktree repo_dir, where hook_src already
+  # equals this value) was left orphaned by an uninstall that only
+  # recognised the new resolved target. Two exact-match candidates are
+  # built here, not one: the RAW spelling of repo_dir as originally passed
+  # in (pre-this-PR code, and pre-canonicalization callers, built the
+  # symlink target from this uncanonicalized string) and the CANONICAL
+  # spelling (this PR's install path always symlinks against the
+  # canonicalized form). When repo_dir is reached through a symlinked
+  # parent, those two strings differ, and a hook installed under the raw
+  # spelling would otherwise silently escape both the resolved-target
+  # check and a canonical-only legacy check - re-orphaning it across the
+  # cross-version boundary this widening exists to close. Accepting these
+  # candidates widens what uninstall will remove to exactly: "the current
+  # resolved target" OR "the legacy target built from the raw repo_dir
+  # spelling" OR "the legacy target built from the canonical repo_dir
+  # spelling" - all three still require an EXACT match (per the existing
+  # `[[ "$current_target" == ... ]]` ownership check), so a foreign hook
+  # pointing anywhere else, including a different methodology checkout's
+  # hooks/pre-commit, is still left untouched. It does NOT match a link
+  # pointing at some other project's own hooks/pre-commit that happens to
+  # share a basename but not a path.
+  local legacy_hook_src_raw="$raw_repo_dir/hooks/pre-commit"
+  local legacy_hook_src_canonical="$repo_dir/hooks/pre-commit"
 
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then
@@ -325,7 +359,7 @@ uninstall_precommit_hook() {
   if [[ -L "$hook_dst" ]]; then
     local current_target
     current_target="$(readlink "$hook_dst")"
-    if [[ "$current_target" == "$hook_src" || "$current_target" == "$legacy_hook_src" ]]; then
+    if [[ "$current_target" == "$hook_src" || "$current_target" == "$legacy_hook_src_raw" || "$current_target" == "$legacy_hook_src_canonical" ]]; then
       rm "$hook_dst"
       echo "  - pre-commit hook removed"
     else


### PR DESCRIPTION
`install_precommit_hook` resolved the *hooks directory* correctly for a linked worktree but symlinked `<repo_dir>/hooks/pre-commit` into it. Run from a worktree, that repointed the main checkout's `.git/hooks/pre-commit` at a path about to be deleted - and **git silently does not run a dangling hook**, so commits kept succeeding with no pre-commit checks and no error.

Observed dangling four separate times in one session on a live checkout.

## Fix

Adds `resolve_hook_src <repo_dir>`: compares `git rev-parse --path-format=absolute --git-dir` against `--git-common-dir`.

- **Equal** (ordinary checkout) - target stays `<repo_dir>/hooks/pre-commit`, byte-for-byte as today.
- **Different** (linked worktree) - target becomes `$(dirname <git-common-dir>)/hooks/pre-commit`, the common repo's own hooks file, which outlives any worktree.
- Any resolution failure falls back to today's behavior, preserving the never-abort-the-caller contract.

The hooks-*directory* resolution is untouched - that was DS-58's fix and it is correct.

`uninstall_precommit_hook` calls the same resolver. Its ownership check only removes a symlink pointing at exactly the install-side target, so leaving it on the old path would have silently stopped uninstall from working. The file's manifest header calls out that install and uninstall are symmetric; DS-58 had to fix both sides for the same reason.

## Verification

Pre-fix red against `origin/main`'s `scripts/lib/precommit.sh` (`e23ca35d`), test file held at the fixed version: **20 passed, 5 failed**. The failures are the bug itself - Test 2/3 show the symlink pointing at the ephemeral worktree rather than the main repo, and Test 6 shows it dangling after `git worktree remove`: `test -e` false, `test -x` false, and the hook fails to execute (rc=127). Restoring the fix: **25 passed, 0 failed**.

New coverage in `bin/tests/test_precommit_worktree.sh`:
- **Test 6** - creates a real linked worktree, installs from it, removes the worktree, then asserts the main checkout's hook still resolves **and still executes**. `test -L` alone would pass against the bug, because a dangling symlink is still a symlink.
- **Test 7** - SHA-256 of the real checkout's own hook before and after, proving the test never escapes into the live repo.
- Tests 2/3 corrected to expect the common repo's `hooks/pre-commit` as the target.
- A re-install no-op check.

Real-hook checksum `90924a28…854482` verified identical before and after every run, three times across the session.

## Gates

- `pytest bin/tests/`: 1150 passed
- 37 `bin/tests/test_*.sh`: all pass
- hooks JS: 47/47 including `test-wrap-acquire-lock.js` 80/80 and `test-wrap-release-lock.js` 33/33
- Both shells: `bash` 25/0, `zsh` 25/0 (checked deliberately - `status` and `path` are read-only in zsh and have caused real bugs here; neither appears in the changed code)
- Em-dash check on the diff: empty

`test_precommit_worktree.sh` already existed at a path the `bin-sh-tests` glob discovers, so no workflow edit. `scripts/lib/precommit.sh` is referenced by no adapter `build.sh`, so no adapter rebuild.

Doc-sync: predicate not triggered. The manifest header in `scripts/lib/precommit.sh` documents `resolve_hook_src`, the install/uninstall symmetry, and the failure modes.

## Related

Complementary to `fix/precommit-guard-adoption`, which stops five `bin/tests/*.sh` files from mutating the real hook at all. This PR makes the target durable when the hook is repointed legitimately; that one stops tests from repointing it in the first place. Neither subsumes the other.

## North Star alignment

**Works for everyone (universality):** the ordinary non-worktree install is byte-for-byte unchanged, so no existing setup shifts. The worktree case derives its candidate from git (`--git-dir` vs `--git-common-dir`) rather than from a hardcoded path - but `dirname(--git-common-dir)` **is** still an assumed layout, and it does not hold for bare repos, `--separate-git-dir`, or submodule worktrees. The fix gates that assumption on the candidate file actually existing rather than eliminating it: those three layouts fall back to today's behavior with a warning. That residual is documented in the module's Failure-modes section and asserted by Test 8, not left implicit.

**Enforcement floors preserved:** this restores an enforcement floor rather than relaxing one - a silently-skipped pre-commit hook is a gate that has stopped running without telling anyone. The never-abort-the-caller soft-fail contract is retained, and the new test asserts execution rather than existence so the floor cannot regress into a link that merely looks present.
