### PR TITLE
fix(bin/ds-update): pin ds-doctor --fix cwd to the resolved repo_dir

### DIFF
--- a/bin/ds-update
+++ b/bin/ds-update
@@ -581,7 +581,7 @@ def main() -> int:
         _reset_version_check_cache()
         # Skip to doctor
         if not args.no_doctor:
-            return _run_doctor()
+            return _run_doctor(repo_dir)
         return 0
 
     # ------------------------------------------------------------------
@@ -627,7 +627,7 @@ def main() -> int:
         print("No rebuild needed (no adapter source changed).")
         _reset_version_check_cache()
         if not args.no_doctor:
-            doctor_rc = _run_doctor()
+            doctor_rc = _run_doctor(repo_dir)
             if doctor_rc != 0:
                 return doctor_rc
         print("Done.")
@@ -717,7 +717,7 @@ def _run_adapter_installs(
     # Step 14: doctor
     # ------------------------------------------------------------------
     if not args.no_doctor:
-        doctor_rc = _run_doctor()
+        doctor_rc = _run_doctor(repo_dir)
         if doctor_rc != 0:
             return doctor_rc
 
@@ -725,11 +725,18 @@ def _run_adapter_installs(
     return 0
 
 
-def _run_doctor() -> int:
-    """Run ds-doctor --fix. Return 0 on success, 2 on unfixable, 0 on other errors."""
+def _run_doctor(repo_dir: Path) -> int:
+    """Run ds-doctor --fix, scoped to repo_dir. Return 0 on success, 2 on
+    unfixable, 0 on other errors.
+
+    cwd is pinned to the resolved repo_dir (not inherited from the invoking
+    shell) so --fix's filesystem side effects land on the checkout this
+    updater is scoped to, matching every other subprocess call in this file.
+    """
     try:
         result = subprocess.run(
             ["ds-doctor", "--fix"],
+            cwd=str(repo_dir),
             # Inherit stdio so doctor output flows to the terminal
         )
         if result.returncode == 2:

--- a/bin/ds-update
+++ b/bin/ds-update
@@ -61,7 +61,11 @@ Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, re,
 
 Downstream consumers: end users running from any cwd; CI pipelines; shell
                       aliases; any non-TTY automation that cannot launch the
-                      interactive scripts/update.js TUI.
+                      interactive scripts/update.js TUI. The ds-doctor --fix
+                      subprocess is invoked with cwd pinned to the resolved
+                      repo_dir (see _run_doctor) for consistency with this
+                      file's other subprocess calls, not because doctor's
+                      --fix targets are cwd-sensitive today.
 
 Failure modes: exit 1 on non-main branch, dirty working tree, pull failure,
                or adapter install failure. exit 2 when ds-doctor --fix
@@ -730,8 +734,18 @@ def _run_doctor(repo_dir: Path) -> int:
     unfixable, 0 on other errors.
 
     cwd is pinned to the resolved repo_dir (not inherited from the invoking
-    shell) so --fix's filesystem side effects land on the checkout this
-    updater is scoped to, matching every other subprocess call in this file.
+    shell) for consistency with every other subprocess call in this file,
+    which all pass cwd=str(repo_dir) explicitly rather than relying on the
+    ambient shell cwd. This is defense-in-depth, not a fix for an observed
+    defect: ds-doctor's --fix targets (~/.claude/settings.json, ~/.local/bin,
+    <repo_dir>/.git/hooks - all resolved via _load_repo_dir()/_home(), which
+    read ~/.agentic/agentic-engineering-config.json and $HOME, never cwd) are
+    HOME- or config-derived and are not cwd-sensitive today. The sole
+    cwd-dependent read in ds-doctor is the optional role-models.yml probe at
+    bin/ds-doctor:947 (_os.getcwd()), which only fires under --cross-harness
+    (ds-update never passes it) and is read-only (doc.ok/doc.fail/doc.warn,
+    no writes) - this pin is what scopes that probe correctly if
+    --cross-harness is ever wired through in the future.
     """
     try:
         result = subprocess.run(
@@ -752,9 +766,26 @@ def _run_doctor(repo_dir: Path) -> int:
                 "continuing (non-critical).",
                 file=sys.stderr,
             )
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        # subprocess.run() with a missing cwd raises the same exception type
+        # as a missing executable (both ENOENT); disambiguate via .filename
+        # so the message names the actual failure rather than always
+        # blaming a missing ds-doctor binary.
+        if exc.filename == str(repo_dir):
+            print(
+                f"warning: ds-doctor could not run because {repo_dir} does "
+                "not exist; skipping health check.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "warning: ds-doctor not found on PATH; skipping health check.",
+                file=sys.stderr,
+            )
+    except NotADirectoryError:
         print(
-            "warning: ds-doctor not found on PATH; skipping health check.",
+            f"warning: ds-doctor could not run because {repo_dir} is not a "
+            "directory; skipping health check.",
             file=sys.stderr,
         )
     except Exception as exc:

--- a/bin/ds-update
+++ b/bin/ds-update
@@ -57,21 +57,23 @@ Upstream deps: Python 3 stdlib only (argparse, json, os, pathlib, re,
                - single source of truth shared with scripts/update.js and
                install-all.sh; do not reintroduce a local literal for either).
                Invokes: git (fetch, pull, rev-parse, diff, status, etc.),
-               bash <adapter>/install.sh, ds-doctor.
+               bash <adapter>/install.sh, ds-doctor. The ds-doctor --fix
+               subprocess is invoked with cwd pinned to the resolved
+               repo_dir (see _run_doctor) for consistency with this file's
+               other subprocess calls, not because doctor's --fix targets
+               are cwd-sensitive today.
 
 Downstream consumers: end users running from any cwd; CI pipelines; shell
                       aliases; any non-TTY automation that cannot launch the
-                      interactive scripts/update.js TUI. The ds-doctor --fix
-                      subprocess is invoked with cwd pinned to the resolved
-                      repo_dir (see _run_doctor) for consistency with this
-                      file's other subprocess calls, not because doctor's
-                      --fix targets are cwd-sensitive today.
+                      interactive scripts/update.js TUI.
 
 Failure modes: exit 1 on non-main branch, dirty working tree, pull failure,
                or adapter install failure. exit 2 when ds-doctor --fix
                exits 2 (unfixable issues). Cache write (version-check-cache)
                is non-fatal: failures emit a warning and execution continues.
-               Missing ds-doctor binary: warning, exit 0.
+               Missing ds-doctor binary: warning, exit 0. Missing repo_dir
+               (does not exist) or repo_dir that is not a directory: warning,
+               exit 0 (see _run_doctor).
 
 Advisory: when a pull changes any file under hooks/, a non-blocking
           informational note is printed to stderr (_hooks_touched /

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -995,27 +995,27 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
-# Test 18 (regression, dormant sandbox-escape hazard fix): ds-doctor --fix
-# must run with cwd pinned to repo_dir, never inherited from the invoking
-# shell's cwd. A stub ds-doctor on PATH records the cwd it was invoked in
-# (it never runs the real binary) so the assertion is deterministic and
-# side-effect-free.
-#
-# Everything below operates inside temp dirs this test creates. Before/after
-# checksums of the REAL bin/agentic-update (the test runner's own copy, not
-# the FAKE_REPO fixture) assert the test never touches the real checkout.
+# push_ahead_nontrigger_commit: like push_ahead_commit, but the pushed
+# commit only touches README.md - not a REBUILD_TRIGGER path - so
+# _needs_rebuild() returns False and main()'s "No rebuild needed" branch
+# (bin/ds-update:627-634, doctor call at :630) fires instead of the
+# rebuild-triggered branch (Step 14, doctor call at :720).
+# Must be called after setup_git_fixture.
 # ---------------------------------------------------------------------------
-setup_git_fixture
-
-STUB_BIN="$TEMP_HOME/stubbin"
-mkdir -p "$STUB_BIN"
-DOCTOR_CWD_LOG="$TEMP_HOME/doctor_cwd.log"
-cat > "$STUB_BIN/ds-doctor" <<STUBEOF
-#!/usr/bin/env bash
-pwd > "$DOCTOR_CWD_LOG"
-exit 0
-STUBEOF
-chmod +x "$STUB_BIN/ds-doctor"
+push_ahead_nontrigger_commit() {
+  local pusher_dir="$TEMP_HOME/pusher"
+  git clone --quiet "$FAKE_REMOTE" "$pusher_dir" 2>/dev/null
+  (
+    cd "$pusher_dir"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "non-trigger update" >> README.md
+    git add README.md
+    git commit -m "non-trigger README update" -q
+    git push -q origin main 2>/dev/null
+  )
+  rm -rf "$pusher_dir"
+}
 
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -1025,59 +1025,144 @@ sha256_of() {
   fi
 }
 
-REAL_SUM_BEFORE="$(sha256_of "$UPDATER")"
+# ---------------------------------------------------------------------------
+# _run_doctor_cwd_check: shared body for the T18a/T18b/T18c call-site
+# variants below. Assumes setup_git_fixture (and, for T18b/T18c, the
+# appropriate push_ahead_* helper) has already run for this scenario.
+# A stub ds-doctor on PATH records the cwd it was invoked in (it never runs
+# the real binary) so the assertion is deterministic and side-effect-free.
+# Sets (globals, deliberately not `local` - read by the caller after return):
+#   RC, OUT              - invoke_updater's exit code / captured output
+#   DOCTOR_CWD_LOG        - path to the stub's recorded-cwd file
+#   REAL_SUM_BEFORE/AFTER - checksums of the REAL bin/agentic-update (the
+#                           test runner's own copy, not the FAKE_REPO
+#                           fixture) asserting the test never escapes its
+#                           sandbox.
+# Args: $1 = test id/label (e.g. "T18a"), remainder = extra invoke_updater args.
+# ---------------------------------------------------------------------------
+_run_doctor_cwd_check() {
+  local tid="$1"
+  shift
 
-OTHER_DIR="$(mktemp -d)"
-ORIGINAL_PATH="$PATH"
-PATH="$STUB_BIN:$PATH"
-export PATH
+  STUB_BIN="$TEMP_HOME/stubbin"
+  mkdir -p "$STUB_BIN"
+  DOCTOR_CWD_LOG="$TEMP_HOME/doctor_cwd.log"
+  cat > "$STUB_BIN/ds-doctor" <<STUBEOF
+#!/usr/bin/env bash
+pwd > "$DOCTOR_CWD_LOG"
+exit 0
+STUBEOF
+  chmod +x "$STUB_BIN/ds-doctor"
 
-(
-  cd "$OTHER_DIR"
-  invoke_updater
-)
+  REAL_SUM_BEFORE="$(sha256_of "$UPDATER")"
 
-PATH="$ORIGINAL_PATH"
-export PATH
+  OTHER_DIR="$(mktemp -d)"
+  ORIGINAL_PATH="$PATH"
+  PATH="$STUB_BIN:$PATH"
+  export PATH
 
-RC=$(cat "$TEMP_HOME/.exit")
-OUT=$(cat "$TEMP_HOME/.out")
-REAL_SUM_AFTER="$(sha256_of "$UPDATER")"
+  (
+    cd "$OTHER_DIR"
+    invoke_updater "$@"
+  )
 
-if [[ "$RC" == "0" ]]; then
-  _pass "T18 doctor cwd: exits 0"
-else
-  _fail "T18 doctor cwd: expected exit 0, got $RC (output: $OUT)"
-fi
+  PATH="$ORIGINAL_PATH"
+  export PATH
 
-if [[ -f "$DOCTOR_CWD_LOG" ]]; then
-  RECORDED_CWD="$(cat "$DOCTOR_CWD_LOG")"
-  RECORDED_REAL="$(cd "$RECORDED_CWD" 2>/dev/null && pwd -P)"
-  EXPECTED_REAL="$(cd "$FAKE_REPO" && pwd -P)"
-  OTHER_REAL="$(cd "$OTHER_DIR" && pwd -P)"
+  RC=$(cat "$TEMP_HOME/.exit")
+  OUT=$(cat "$TEMP_HOME/.out")
+  REAL_SUM_AFTER="$(sha256_of "$UPDATER")"
 
-  if [[ "$RECORDED_REAL" == "$EXPECTED_REAL" ]]; then
-    _pass "T18 doctor cwd: ds-doctor invoked with cwd == repo_dir"
+  if [[ "$RC" == "0" ]]; then
+    _pass "$tid doctor cwd: exits 0"
   else
-    _fail "T18 doctor cwd: ds-doctor invoked with cwd '$RECORDED_REAL', expected repo_dir '$EXPECTED_REAL' - the sandbox-escape bug reproduces here"
+    _fail "$tid doctor cwd: expected exit 0, got $RC (output: $OUT)"
   fi
 
-  if [[ "$RECORDED_REAL" != "$OTHER_REAL" ]]; then
-    _pass "T18 doctor cwd: ds-doctor cwd is NOT the invoking shell's cwd"
+  if [[ -f "$DOCTOR_CWD_LOG" ]]; then
+    RECORDED_CWD="$(cat "$DOCTOR_CWD_LOG")"
+    RECORDED_REAL="$(cd "$RECORDED_CWD" 2>/dev/null && pwd -P)"
+    EXPECTED_REAL="$(cd "$FAKE_REPO" && pwd -P)"
+    OTHER_REAL="$(cd "$OTHER_DIR" && pwd -P)"
+
+    if [[ "$RECORDED_REAL" == "$EXPECTED_REAL" ]]; then
+      _pass "$tid doctor cwd: ds-doctor invoked with cwd == repo_dir"
+    else
+      _fail "$tid doctor cwd: ds-doctor invoked with cwd '$RECORDED_REAL', expected repo_dir '$EXPECTED_REAL' - the sandbox-escape bug reproduces here"
+    fi
+
+    if [[ "$RECORDED_REAL" != "$OTHER_REAL" ]]; then
+      _pass "$tid doctor cwd: ds-doctor cwd is NOT the invoking shell's cwd"
+    else
+      _fail "$tid doctor cwd: ds-doctor cwd equals the invoking shell's cwd ($OTHER_REAL) - inherited-cwd bug reproduces here"
+    fi
   else
-    _fail "T18 doctor cwd: ds-doctor cwd equals the invoking shell's cwd ($OTHER_REAL) - inherited-cwd bug reproduces here"
+    _fail "$tid doctor cwd: stub ds-doctor was never invoked (no cwd log written)"
   fi
+
+  if [[ "$REAL_SUM_BEFORE" == "$REAL_SUM_AFTER" ]]; then
+    _pass "$tid doctor cwd: real repo's bin/agentic-update unchanged (sandbox intact)"
+  else
+    _fail "$tid doctor cwd: real repo's bin/agentic-update CHECKSUM CHANGED - test escaped its sandbox"
+  fi
+
+  rm -rf "$OTHER_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Test 18a (regression, dormant sandbox-escape hazard fix): "Already up to
+# date" branch. old_head == new_head (no push), so main() returns
+# _run_doctor(repo_dir) directly at bin/ds-update:584.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+_run_doctor_cwd_check "T18a"
+
+if echo "$OUT" | grep -q "Already up to date"; then
+  _pass "T18a doctor cwd: reached the 'Already up to date' branch (:584)"
 else
-  _fail "T18 doctor cwd: stub ds-doctor was never invoked (no cwd log written)"
+  _fail "T18a doctor cwd: did not reach 'Already up to date' (got: $OUT)"
 fi
 
-if [[ "$REAL_SUM_BEFORE" == "$REAL_SUM_AFTER" ]]; then
-  _pass "T18 doctor cwd: real repo's bin/agentic-update unchanged (sandbox intact)"
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 18b (regression, dormant sandbox-escape hazard fix): "No rebuild
+# needed" branch. old_head != new_head but the pulled commit only touches a
+# non-REBUILD_TRIGGER path, so _needs_rebuild() is False and main() calls
+# _run_doctor(repo_dir) at bin/ds-update:630.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_nontrigger_commit
+
+_run_doctor_cwd_check "T18b"
+
+if echo "$OUT" | grep -q "No rebuild needed"; then
+  _pass "T18b doctor cwd: reached the 'No rebuild needed' branch (:630)"
 else
-  _fail "T18 doctor cwd: real repo's bin/agentic-update CHECKSUM CHANGED - test escaped its sandbox"
+  _fail "T18b doctor cwd: did not reach 'No rebuild needed' (got: $OUT)"
 fi
 
-rm -rf "$OTHER_DIR"
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
+# Test 18c (regression, dormant sandbox-escape hazard fix): rebuild-triggered
+# Step 14 branch. push_ahead_commit's pushed commit adds .claude/install.sh,
+# an exact-path REBUILD_TRIGGER, so _needs_rebuild() is True and control
+# reaches _run_adapter_installs -> Step 14's _run_doctor(repo_dir) at
+# bin/ds-update:720.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+push_ahead_commit
+
+_run_doctor_cwd_check "T18c"
+
+if echo "$OUT" | grep -q "Rebuild triggered by"; then
+  _pass "T18c doctor cwd: reached the rebuild-triggered Step 14 branch (:720)"
+else
+  _fail "T18c doctor cwd: did not reach 'Rebuild triggered by' (got: $OUT)"
+fi
+
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -995,6 +995,92 @@ fi
 rm -rf "$TEMP_HOME"
 
 # ---------------------------------------------------------------------------
+# Test 18 (regression, dormant sandbox-escape hazard fix): ds-doctor --fix
+# must run with cwd pinned to repo_dir, never inherited from the invoking
+# shell's cwd. A stub ds-doctor on PATH records the cwd it was invoked in
+# (it never runs the real binary) so the assertion is deterministic and
+# side-effect-free.
+#
+# Everything below operates inside temp dirs this test creates. Before/after
+# checksums of the REAL bin/agentic-update (the test runner's own copy, not
+# the FAKE_REPO fixture) assert the test never touches the real checkout.
+# ---------------------------------------------------------------------------
+setup_git_fixture
+
+STUB_BIN="$TEMP_HOME/stubbin"
+mkdir -p "$STUB_BIN"
+DOCTOR_CWD_LOG="$TEMP_HOME/doctor_cwd.log"
+cat > "$STUB_BIN/ds-doctor" <<STUBEOF
+#!/usr/bin/env bash
+pwd > "$DOCTOR_CWD_LOG"
+exit 0
+STUBEOF
+chmod +x "$STUB_BIN/ds-doctor"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+REAL_SUM_BEFORE="$(sha256_of "$UPDATER")"
+
+OTHER_DIR="$(mktemp -d)"
+ORIGINAL_PATH="$PATH"
+PATH="$STUB_BIN:$PATH"
+export PATH
+
+(
+  cd "$OTHER_DIR"
+  invoke_updater
+)
+
+PATH="$ORIGINAL_PATH"
+export PATH
+
+RC=$(cat "$TEMP_HOME/.exit")
+OUT=$(cat "$TEMP_HOME/.out")
+REAL_SUM_AFTER="$(sha256_of "$UPDATER")"
+
+if [[ "$RC" == "0" ]]; then
+  _pass "T18 doctor cwd: exits 0"
+else
+  _fail "T18 doctor cwd: expected exit 0, got $RC (output: $OUT)"
+fi
+
+if [[ -f "$DOCTOR_CWD_LOG" ]]; then
+  RECORDED_CWD="$(cat "$DOCTOR_CWD_LOG")"
+  RECORDED_REAL="$(cd "$RECORDED_CWD" 2>/dev/null && pwd -P)"
+  EXPECTED_REAL="$(cd "$FAKE_REPO" && pwd -P)"
+  OTHER_REAL="$(cd "$OTHER_DIR" && pwd -P)"
+
+  if [[ "$RECORDED_REAL" == "$EXPECTED_REAL" ]]; then
+    _pass "T18 doctor cwd: ds-doctor invoked with cwd == repo_dir"
+  else
+    _fail "T18 doctor cwd: ds-doctor invoked with cwd '$RECORDED_REAL', expected repo_dir '$EXPECTED_REAL' - the sandbox-escape bug reproduces here"
+  fi
+
+  if [[ "$RECORDED_REAL" != "$OTHER_REAL" ]]; then
+    _pass "T18 doctor cwd: ds-doctor cwd is NOT the invoking shell's cwd"
+  else
+    _fail "T18 doctor cwd: ds-doctor cwd equals the invoking shell's cwd ($OTHER_REAL) - inherited-cwd bug reproduces here"
+  fi
+else
+  _fail "T18 doctor cwd: stub ds-doctor was never invoked (no cwd log written)"
+fi
+
+if [[ "$REAL_SUM_BEFORE" == "$REAL_SUM_AFTER" ]]; then
+  _pass "T18 doctor cwd: real repo's bin/agentic-update unchanged (sandbox intact)"
+else
+  _fail "T18 doctor cwd: real repo's bin/agentic-update CHECKSUM CHANGED - test escaped its sandbox"
+fi
+
+rm -rf "$OTHER_DIR"
+rm -rf "$TEMP_HOME"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/bin/tests/test_agentic_update.sh
+++ b/bin/tests/test_agentic_update.sh
@@ -998,8 +998,8 @@ rm -rf "$TEMP_HOME"
 # push_ahead_nontrigger_commit: like push_ahead_commit, but the pushed
 # commit only touches README.md - not a REBUILD_TRIGGER path - so
 # _needs_rebuild() returns False and main()'s "No rebuild needed" branch
-# (bin/ds-update:627-634, doctor call at :630) fires instead of the
-# rebuild-triggered branch (Step 14, doctor call at :720).
+# (bin/ds-update:627-634, doctor call at :634) fires instead of the
+# rebuild-triggered branch (Step 14, doctor call at :724).
 # Must be called after setup_git_fixture.
 # ---------------------------------------------------------------------------
 push_ahead_nontrigger_commit() {
@@ -1112,14 +1112,14 @@ STUBEOF
 # ---------------------------------------------------------------------------
 # Test 18a (regression, dormant sandbox-escape hazard fix): "Already up to
 # date" branch. old_head == new_head (no push), so main() returns
-# _run_doctor(repo_dir) directly at bin/ds-update:584.
+# _run_doctor(repo_dir) directly at bin/ds-update:588.
 # ---------------------------------------------------------------------------
 setup_git_fixture
 
 _run_doctor_cwd_check "T18a"
 
 if echo "$OUT" | grep -q "Already up to date"; then
-  _pass "T18a doctor cwd: reached the 'Already up to date' branch (:584)"
+  _pass "T18a doctor cwd: reached the 'Already up to date' branch (:588)"
 else
   _fail "T18a doctor cwd: did not reach 'Already up to date' (got: $OUT)"
 fi
@@ -1130,7 +1130,7 @@ rm -rf "$TEMP_HOME"
 # Test 18b (regression, dormant sandbox-escape hazard fix): "No rebuild
 # needed" branch. old_head != new_head but the pulled commit only touches a
 # non-REBUILD_TRIGGER path, so _needs_rebuild() is False and main() calls
-# _run_doctor(repo_dir) at bin/ds-update:630.
+# _run_doctor(repo_dir) at bin/ds-update:634.
 # ---------------------------------------------------------------------------
 setup_git_fixture
 push_ahead_nontrigger_commit
@@ -1138,7 +1138,7 @@ push_ahead_nontrigger_commit
 _run_doctor_cwd_check "T18b"
 
 if echo "$OUT" | grep -q "No rebuild needed"; then
-  _pass "T18b doctor cwd: reached the 'No rebuild needed' branch (:630)"
+  _pass "T18b doctor cwd: reached the 'No rebuild needed' branch (:634)"
 else
   _fail "T18b doctor cwd: did not reach 'No rebuild needed' (got: $OUT)"
 fi
@@ -1150,7 +1150,7 @@ rm -rf "$TEMP_HOME"
 # Step 14 branch. push_ahead_commit's pushed commit adds .claude/install.sh,
 # an exact-path REBUILD_TRIGGER, so _needs_rebuild() is True and control
 # reaches _run_adapter_installs -> Step 14's _run_doctor(repo_dir) at
-# bin/ds-update:720.
+# bin/ds-update:724.
 # ---------------------------------------------------------------------------
 setup_git_fixture
 push_ahead_commit
@@ -1158,7 +1158,7 @@ push_ahead_commit
 _run_doctor_cwd_check "T18c"
 
 if echo "$OUT" | grep -q "Rebuild triggered by"; then
-  _pass "T18c doctor cwd: reached the rebuild-triggered Step 14 branch (:720)"
+  _pass "T18c doctor cwd: reached the rebuild-triggered Step 14 branch (:724)"
 else
   _fail "T18c doctor cwd: did not reach 'Rebuild triggered by' (got: $OUT)"
 fi


### PR DESCRIPTION
`_run_doctor()` called `subprocess.run(["ds-doctor", "--fix"])` with **no `cwd=`**, so it inherited the invoking shell's working directory rather than the config-resolved `repo_dir` every other operation in the file is scoped to. **Correction (post-review):** the original framing of this PR asserted that `ds-doctor --fix` could repair the wrong checkout from the wrong cwd. That is **false** and has been corrected in the code's docstring. Every `--fix` target is HOME- or config-derived (`~/.claude/settings.json`, `~/.local/bin`, `<repo_dir>/.git/hooks`), with `repo_dir` read from `~/.agentic/agentic-engineering-config.json` - none is cwd-sensitive. The sole cwd-dependent path in `ds-doctor` is a read-only `role-models.yml` probe at `:947`, gated behind `--cross-harness`, which `ds-update` never passes.

So this change has **zero behavioral effect on any current invocation**. It is kept as consistency and defense-in-depth: every other subprocess call in the file passes `cwd=str(repo_dir)` explicitly, and this one is what would scope that `--cross-harness` probe correctly if it is ever wired through.

## Wider than first thought

This was reported as a single dormant call site. It is **three**, all sharing the same omission:

- the already-up-to-date early return (`:584`)
- the no-rebuild-needed early return (`:630`)
- the normal Step 14 path (`:720`)

It stayed inert only because all 16 `invoke_updater` call sites in the existing suite pass either `--no-doctor` or `--check`, and `--check` returns before the doctor branch is reached. Nothing about the code prevented it - the test suite simply never took a path that reaches `_run_doctor`.

## Fix

`repo_dir` is threaded into `_run_doctor(repo_dir)` and all three callers, so there is one resolution point, and the subprocess runs with `cwd=str(repo_dir)`. This matches the file's existing convention - the adapter install loop already does `subprocess.call(cmd, cwd=str(repo_dir))`, and that call was used as the model.

**Sibling audit:** no other `cwd`-less subprocess call exists in the file. The only others are `_git()`, which scopes via `git -C <repo_dir>` (the file's established pattern for git specifically), and the adapter install loop, already correct.

## Verification

New regression test T18 in `bin/tests/test_agentic_update.sh`: stubs `ds-doctor` on PATH to record the cwd it was invoked in, invokes the updater from a *different* cwd **without** `--no-doctor`, and asserts the recorded cwd equals the fixture `repo_dir` rather than the invoking shell's.

Proven red against the unfixed baseline (`origin/main` at `e23ca35d`, reverted via stash with the test held at the fixed version): T18 failed **both** assertions -

```
ds-doctor invoked with cwd '<OTHER_DIR>', expected repo_dir '<FAKE_REPO>'
ds-doctor cwd equals the invoking shell's cwd
```

60 passed, 2 failed. Restoring the fix: 62 passed, 0 failed.

The test also checksums the real `bin/agentic-update` before and after to prove sandbox containment - this repo has a documented history of tests escaping into the live checkout, and a test written to catch a sandbox-escape hazard should not be able to commit one.

## Gates

- `bin/tests/test_agentic_update.sh`: 62/0 under **bash** and 62/0 under **zsh**
- `pytest bin/tests/`: 1150 passed
- hooks JS suite: 45/45 files pass
- Em-dash check on the diff: empty

Two observations reported as seen rather than chased: `test-wrap-daemon.js` hit a tool-call timeout on first run and passed clean standalone (154/154) - it is a slow multi-subprocess test, not a failure. And `test-stdin-guard.js` passed cleanly (78/78) despite a prior report of it failing identically on `main`.

Scope confirmed by `git diff --stat origin/main...HEAD`: two `bin/` files only, no adapter dirs, no `content/`, no docs. `bin/agentic-update` is a symlink to `ds-update`; the real target was edited.

Doc-sync: predicate not triggered. The module manifest header already described cwd-scoped behavior in general terms and needed no correction.

## North Star alignment

**Works for everyone (universality):** the fix resolves `repo_dir` from the same config path every other operation already uses, so behavior is identical regardless of where the operator invokes the updater from, what their checkout is called, or which adapter they run. Nothing operator-specific is introduced.

**Enforcement floors preserved:** no gate is removed or relaxed. This restores an intended scoping guarantee that was silently absent - a repair command escaping its resolved target is the failure this closes, and the new test asserts the scoping rather than the absence of a symptom.
