### PR TITLE
fix(bin/tests): guard the real pre-commit hook across five unguarded install.sh callers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,14 @@ __pycache__/
 # masking a real future bin/ds-* tool: no shipped tool name ends in that
 # suffix, so this pattern can only ever match the test's own residue.
 bin/ds-*-test-fixture
+
+# SIGKILL residue backstop for
+# bin/tests/test_precommit_hook_guard_adoption.sh's truncated-copy fixtures
+# (.tmp-precommit-guard-verify-{prefix,postfix}-<pid>.sh). These MUST live
+# directly in bin/tests/ (not under mktemp -d) because the truncated copy's
+# own REPO_DIR resolution is `$(dirname "$0")/../..`, which assumes exactly
+# that location - see the comment above PREFIX_COPY/POSTFIX_COPY in that
+# file. The EXIT/INT/TERM trap already removes them on every catchable
+# signal; this only covers the uncatchable SIGKILL case so a stray copy
+# never gets swept into a `git add -A`.
+bin/tests/.tmp-precommit-guard-verify-*.sh

--- a/bin/tests/lib/precommit-hook-guard.sh
+++ b/bin/tests/lib/precommit-hook-guard.sh
@@ -43,7 +43,19 @@
 #   .claude/install.sh or .cursor/install.sh / .opencode/install.sh against
 #   the live checkout with only $HOME faked); bin/tests/test_local_bin_ds_prefix_install.sh
 #   (Test 2 invokes a real .claude/install.sh against the live checkout with
-#   only $HOME faked).
+#   only $HOME faked); bin/tests/test_install_profiles.sh,
+#   bin/tests/test_hooks_snapshot_no_live_rewire.sh,
+#   bin/tests/test_install_stop_cadence.sh, and
+#   bin/tests/test_install_profile_config_dir.sh (each invokes a real
+#   .claude/install.sh, in some cases other adapters' install.sh too,
+#   against the live checkout with only $HOME faked - adopted 75225f67);
+#   bin/tests/test_precommit_hook_guard_adoption.sh (the regression verifier
+#   for that adoption - guards its OWN access to the real hook slot
+#   independent of any guard state the truncated reproductions under test
+#   remember). bin/tests/test_precommit_hook_guard_static.sh statically
+#   asserts the guard-save-before-first-install-call invariant across all
+#   five adopting files above but does not source this library or invoke
+#   either function - it is not itself a downstream consumer.
 #
 # Failure modes: if `git rev-parse --git-path hooks` fails to resolve (not
 #   a git repo, git missing), save/restore are no-ops - there is nothing to

--- a/bin/tests/test_hooks_snapshot_migration.sh
+++ b/bin/tests/test_hooks_snapshot_migration.sh
@@ -21,25 +21,26 @@
 #                install.sh/uninstall.sh still builds/runs against the REAL
 #                checkout (like bin/tests/test_kimi_install_symlink.sh) -
 #                only $HOME is sandboxed, and these real-tree effects are
-#                NOT limited to the .claude uninstall.sh call: EVERY
-#                install.sh run in this file (.claude, .gemini, .codex,
-#                .kimi - each invoked twice, first run and idempotent
-#                second run) calls install_precommit_hook (writes
-#                <repo>/.git/hooks/pre-commit) and runs .claude/build.sh +
-#                .cursor/build.sh (regenerates adapter build artifacts in
-#                the live tree) - same three effects documented in
-#                bin/tests/test_local_bin_ds_prefix_install.sh; empirically
-#                idempotent, but none of these runs are read-only. On top
-#                of that, the .claude section's uninstall.sh run (below)
+#                NOT limited to the .claude uninstall.sh call: the .claude
+#                install.sh runs in this file (first run and idempotent
+#                second run) call install_precommit_hook (writes
+#                <repo>/.git/hooks/pre-commit) and every install.sh run
+#                also runs .claude/build.sh + .cursor/build.sh (regenerates
+#                adapter build artifacts in the live tree) - same effects
+#                documented in bin/tests/test_local_bin_ds_prefix_install.sh;
+#                empirically idempotent, but none of these runs are
+#                read-only. The .claude section's uninstall.sh run (below)
 #                also calls uninstall_precommit_hook, which resolves the
 #                git hooks directory via `git rev-parse --git-path hooks`
 #                relative to the REAL REPO_DIR, independent of $HOME faking
 #                - left unguarded it would remove this checkout's real
-#                <repo>/.git/hooks/pre-commit. That call is saved before
-#                and restored immediately after via
-#                bin/tests/lib/precommit-hook-guard.sh (same guard used by
-#                bin/tests/test_uninstall_ds_prefix.sh); the guard does not
-#                cover the earlier install.sh pre-commit-hook writes above.
+#                <repo>/.git/hooks/pre-commit. precommit_hook_guard_save is
+#                called at the very top of this file, before the first
+#                install.sh invocation of any adapter, so it covers every
+#                pre-commit-hook write in this file (not just the uninstall
+#                call) - restored unconditionally via
+#                bin/tests/lib/precommit-hook-guard.sh in the EXIT trap
+#                (same guard used by bin/tests/test_uninstall_ds_prefix.sh).
 #
 # Performance: ~20-40 s wall time (4 adapters x 2 install.sh runs each,
 #              each run includes a real build.sh pass).
@@ -70,6 +71,11 @@ _cleanup() {
   precommit_hook_guard_restore
 }
 trap _cleanup EXIT INT TERM
+
+# Save the real pre-commit hook slot BEFORE the first install.sh invocation
+# of any adapter below - see header. precommit_hook_guard_restore in the
+# EXIT trap above covers every exit path once save runs this early.
+precommit_hook_guard_save "$REPO_DIR"
 
 _run_install() {
   local install_sh="$1"
@@ -201,15 +207,13 @@ cat > "$HOME_CLAUDE_UNINSTALL/.claude/settings.json" <<'EOF'
 EOF
 
 # uninstall_precommit_hook (called by .claude/uninstall.sh) resolves the
-# git hooks dir independent of $HOME - save/restore the real checkout's
-# pre-commit hook around this one call (see header and
-# bin/tests/lib/precommit-hook-guard.sh).
-precommit_hook_guard_save "$REPO_DIR"
+# git hooks dir independent of $HOME - already covered by the
+# precommit_hook_guard_save call at the top of this file (see header and
+# bin/tests/lib/precommit-hook-guard.sh). No additional save/restore needed
+# around this specific call.
 if HOME="$HOME_CLAUDE_UNINSTALL" bash "$REPO_DIR/.claude/uninstall.sh" > "$HOME_CLAUDE_UNINSTALL/.uninstall_out" 2>&1; then
-  precommit_hook_guard_restore
   _pass "claude: uninstall.sh run succeeds"
 else
-  precommit_hook_guard_restore
   _fail "claude: uninstall.sh exited non-zero"
   cat "$HOME_CLAUDE_UNINSTALL/.uninstall_out" >&2
 fi

--- a/bin/tests/test_hooks_snapshot_migration.sh
+++ b/bin/tests/test_hooks_snapshot_migration.sh
@@ -67,8 +67,8 @@ _pass() {
 
 TMP_ROOT="$(mktemp -d)"
 _cleanup() {
-  rm -rf "$TMP_ROOT"
   precommit_hook_guard_restore
+  rm -rf "$TMP_ROOT"
 }
 trap _cleanup EXIT INT TERM
 

--- a/bin/tests/test_hooks_snapshot_no_live_rewire.sh
+++ b/bin/tests/test_hooks_snapshot_no_live_rewire.sh
@@ -56,9 +56,9 @@ _pass() {
 
 TMP_ROOT="$(mktemp -d)"
 _cleanup() {
+  precommit_hook_guard_restore
   rm -rf "$TMP_ROOT"
   git -C "$REPO_DIR" checkout -- "$MUTATE_TARGET" 2>/dev/null || true
-  precommit_hook_guard_restore
 }
 trap _cleanup EXIT
 

--- a/bin/tests/test_hooks_snapshot_no_live_rewire.sh
+++ b/bin/tests/test_hooks_snapshot_no_live_rewire.sh
@@ -19,7 +19,16 @@
 #                ~/.codex, ~/.gemini, ~/.kimi, and ~/.agentic/hooks-snapshot
 #                are never touched. The checkout's own hooks/ file IS mutated
 #                during the test and is always restored via `git checkout --`
-#                in a trap, even on failure.
+#                in a trap, even on failure. Separately, each
+#                .claude/install.sh run in this file also calls
+#                install_precommit_hook, which resolves the git hooks
+#                directory via `git rev-parse --git-path hooks` relative to
+#                the REAL REPO_DIR, independent of $HOME faking - left
+#                unguarded it would rewrite this checkout's real
+#                <repo>/.git/hooks/pre-commit symlink. Guarded via
+#                bin/tests/lib/precommit-hook-guard.sh: saved before the
+#                first install.sh call and restored unconditionally in the
+#                EXIT trap.
 #
 # Performance: ~10-15 s wall time (one .claude/install.sh run, which builds
 #              all adapters via .claude/build.sh + .cursor/build.sh).
@@ -28,6 +37,9 @@ set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 MUTATE_TARGET="$REPO_DIR/hooks/skill-auto-load-check.sh"
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 PASS=0
 FAIL=0
@@ -46,11 +58,15 @@ TMP_ROOT="$(mktemp -d)"
 _cleanup() {
   rm -rf "$TMP_ROOT"
   git -C "$REPO_DIR" checkout -- "$MUTATE_TARGET" 2>/dev/null || true
+  precommit_hook_guard_restore
 }
 trap _cleanup EXIT
 
 # Ensure a clean starting point regardless of prior state.
 git -C "$REPO_DIR" checkout -- "$MUTATE_TARGET" 2>/dev/null || true
+
+# Save the real pre-commit hook slot before the first install.sh call below.
+precommit_hook_guard_save "$REPO_DIR"
 
 FAKE_HOME="$TMP_ROOT/home"
 mkdir -p "$FAKE_HOME/.claude"

--- a/bin/tests/test_install_profile_config_dir.sh
+++ b/bin/tests/test_install_profile_config_dir.sh
@@ -15,7 +15,16 @@
 #                HOME so the real user config is never touched.
 #
 # Failure modes: any failing assertion prints and exits 1. Fully hermetic:
-#                all writes land under a throwaway HOME.
+#                all writes land under a throwaway HOME - EXCEPT that every
+#                .claude/install.sh invocation in this file also calls
+#                install_precommit_hook, which resolves the git hooks
+#                directory via `git rev-parse --git-path hooks` relative to
+#                the REAL REPO_DIR, entirely independent of $HOME faking -
+#                left unguarded it would rewrite this checkout's real
+#                <repo>/.git/hooks/pre-commit symlink. Guarded via
+#                bin/tests/lib/precommit-hook-guard.sh: saved once at the
+#                top of this file (before the first install.sh call) and
+#                restored unconditionally in the EXIT trap.
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -23,11 +32,16 @@ FAILS=0
 pass() { echo "  ok: $1"; }
 fail() { echo "  FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
 
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
+precommit_hook_guard_save "$REPO_DIR"
+trap 'precommit_hook_guard_restore' EXIT
+
 # ---------------------------------------------------------------------------
 # Test 1: --config-dir redirects the harness config; shared state stays in HOME
 # ---------------------------------------------------------------------------
 SANDBOX="$(mktemp -d)"
-trap 'rm -rf "$SANDBOX"' EXIT
+trap 'rm -rf "$SANDBOX"; precommit_hook_guard_restore' EXIT
 export HOME="$SANDBOX/home"
 mkdir -p "$HOME"
 PROFILE="$SANDBOX/profile"     # stand-in for ~/.claude-<tenant>

--- a/bin/tests/test_install_profile_config_dir.sh
+++ b/bin/tests/test_install_profile_config_dir.sh
@@ -35,13 +35,20 @@ fail() { echo "  FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
 # shellcheck source=bin/tests/lib/precommit-hook-guard.sh
 . "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 precommit_hook_guard_save "$REPO_DIR"
+# Provisional EXIT trap covering the window before $SANDBOX exists below -
+# a second `trap ... EXIT` REPLACES this one (bash keeps only the latest
+# handler per signal), so this line alone protects nothing past that point,
+# but without it a failure in the mktemp -d call itself (under
+# `set -euo pipefail`) would exit with no restore at all.
 trap 'precommit_hook_guard_restore' EXIT
 
 # ---------------------------------------------------------------------------
 # Test 1: --config-dir redirects the harness config; shared state stays in HOME
 # ---------------------------------------------------------------------------
 SANDBOX="$(mktemp -d)"
-trap 'rm -rf "$SANDBOX"; precommit_hook_guard_restore' EXIT
+# Final EXIT trap, replacing the provisional one above. Restore FIRST so an
+# early exit (or a failure in rm -rf itself) can never skip it.
+trap 'precommit_hook_guard_restore; rm -rf "$SANDBOX"' EXIT
 export HOME="$SANDBOX/home"
 mkdir -p "$HOME"
 PROFILE="$SANDBOX/profile"     # stand-in for ~/.claude-<tenant>

--- a/bin/tests/test_install_profiles.sh
+++ b/bin/tests/test_install_profiles.sh
@@ -27,9 +27,9 @@ fail() {
 precommit_hook_guard_save "$REPO_DIR"
 
 cleanup() {
+	precommit_hook_guard_restore
 	chmod -R u+w "$SANDBOX" 2>/dev/null || true
 	rm -rf "$SANDBOX"
-	precommit_hook_guard_restore
 }
 trap cleanup EXIT
 

--- a/bin/tests/test_install_profiles.sh
+++ b/bin/tests/test_install_profiles.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Purpose: Regression tests for the profile-agnostic installer (D-4).
 #          Hermetic, sandboxed HOME. Exits 0 on all pass, 1 on any failure.
+#          NOT fully hermetic on one axis: every .claude/install.sh
+#          invocation in this file (direct or via scripts/install-profiles.sh)
+#          also calls install_precommit_hook, which resolves the git hooks
+#          directory via `git rev-parse --git-path hooks` relative to the
+#          REAL REPO_DIR, independent of $HOME faking - left unguarded it
+#          would rewrite this checkout's real <repo>/.git/hooks/pre-commit
+#          symlink. Guarded via bin/tests/lib/precommit-hook-guard.sh: saved
+#          once at the top of this file (before the first install.sh call)
+#          and restored unconditionally in the cleanup EXIT trap.
 #
 # Public API: ./bin/tests/test_install_profiles.sh
 set -euo pipefail
@@ -13,9 +22,14 @@ fail() {
 	FAILS=$((FAILS + 1))
 }
 
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
+precommit_hook_guard_save "$REPO_DIR"
+
 cleanup() {
 	chmod -R u+w "$SANDBOX" 2>/dev/null || true
 	rm -rf "$SANDBOX"
+	precommit_hook_guard_restore
 }
 trap cleanup EXIT
 

--- a/bin/tests/test_install_stop_cadence.sh
+++ b/bin/tests/test_install_stop_cadence.sh
@@ -62,8 +62,8 @@ _pass() {
 
 TMP_ROOT="$(mktemp -d)"
 _cleanup() {
-  rm -rf "$TMP_ROOT"
   precommit_hook_guard_restore
+  rm -rf "$TMP_ROOT"
 }
 trap _cleanup EXIT
 

--- a/bin/tests/test_install_stop_cadence.sh
+++ b/bin/tests/test_install_stop_cadence.sh
@@ -27,6 +27,15 @@
 #                hanging: `grep -nE '/dev/tty|ae_confirm|read -p'
 #                .claude/install.sh scripts/lib/identity.sh` (a bare
 #                `/dev/tty` grep on install.sh alone finds only 1 of 4).
+#                Separately, the .claude/install.sh run below also calls
+#                install_precommit_hook, which resolves the git hooks
+#                directory via `git rev-parse --git-path hooks` relative to
+#                the REAL REPO_DIR, independent of $HOME faking - left
+#                unguarded it would rewrite this checkout's real
+#                <repo>/.git/hooks/pre-commit symlink. Guarded via
+#                bin/tests/lib/precommit-hook-guard.sh: saved before the
+#                install.sh call and restored unconditionally in the EXIT
+#                trap.
 #
 # Performance: ~10-15 s wall time (one .claude/install.sh run, which builds
 #              all adapters via .claude/build.sh + .cursor/build.sh).
@@ -34,6 +43,9 @@
 set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 PASS=0
 FAIL=0
@@ -51,11 +63,15 @@ _pass() {
 TMP_ROOT="$(mktemp -d)"
 _cleanup() {
   rm -rf "$TMP_ROOT"
+  precommit_hook_guard_restore
 }
 trap _cleanup EXIT
 
 FAKE_HOME="$TMP_ROOT/home"
 mkdir -p "$FAKE_HOME/.claude"
+
+# Save the real pre-commit hook slot before the install.sh call below.
+precommit_hook_guard_save "$REPO_DIR"
 
 # ---------------------------------------------------------------------------
 # Seed 1: skill_auto_load key present -> suppresses the ae_write_config

--- a/bin/tests/test_precommit_hook_guard_adoption.sh
+++ b/bin/tests/test_precommit_hook_guard_adoption.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Purpose: Regression verifier for the precommit-hook-guard adoption fix
+#          (worktree-hijack sandbox escape: install_precommit_hook / the
+#          _ae_is_ours() re-point rule silently rewrites the REAL,
+#          worktree-shared .git/hooks/pre-commit symlink whenever an
+#          unguarded install.sh runs, and the change is never undone if the
+#          script exits before reaching a guard call placed too late).
+#
+#          This verifier does NOT run the full ~20-40s
+#          bin/tests/test_hooks_snapshot_migration.sh end-to-end (that would
+#          only prove the happy path, which was never the bug - the bug is
+#          an early exit BEFORE the guard's save call). Instead it builds a
+#          truncated copy of that file's ".claude" section, cut immediately
+#          after the FIRST .claude/install.sh invocation and forced to
+#          `exit 1` there - simulating exactly the crash-before-guard-save
+#          scenario that left the real hook dangling in production. It runs
+#          that truncated copy twice: once reconstructed from the PRE-FIX
+#          (origin/main) source, once from the POST-FIX (uncommitted working
+#          tree) source, and asserts the pre-fix copy leaves the real hook
+#          mutated (RED - proves the bug reproduces) while the post-fix
+#          copy restores it (GREEN - proves the fix works). This is the
+#          `bin/tests/test_hooks_snapshot_migration.sh` file named in the
+#          spawn brief as the minimum-required coverage (the UNSAFE file);
+#          the other four fixed files are not separately verified here.
+#
+# Public API: ./bin/tests/test_precommit_hook_guard_adoption.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3, git, mktemp, readlink.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       the bin-sh-tests CI job via the bin/tests/test_*.sh
+#                       glob (.github/workflows/bin-tests.yml).
+#
+# Failure modes: any assertion failure prints the failing assertion and
+#                exits 1. The verifier's OWN access to the real pre-commit
+#                hook slot is wrapped in bin/tests/lib/precommit-hook-guard.sh
+#                (saved before either truncated copy runs, restored
+#                unconditionally in the EXIT trap) - independent of whether
+#                either truncated copy under test remembers its own guard,
+#                so this verifier is safe regardless of which scenario it is
+#                currently exercising.
+#
+# Performance: ~10-20 s wall time (two partial .claude/install.sh runs,
+#              first-install-only, no second run / no build.sh re-verify).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+# The truncated copies below MUST live DIRECTLY in bin/tests/ (not a
+# subdirectory of it, and not $TMP_ROOT) - both the pre-fix and post-fix
+# source compute REPO_DIR as `$(cd "$(dirname "$0")/../.." && pwd)`, which
+# assumes the script sits exactly one level below REPO_DIR/bin/. A copy one
+# directory level deeper (or outside bin/tests/ entirely) would resolve
+# REPO_DIR one level too high (or to the wrong tree entirely). Dot-prefixed
+# filenames so bin-sh-tests' `bin/tests/test_*.sh` glob never picks them up;
+# removed unconditionally in the EXIT trap regardless of outcome.
+PREFIX_COPY="$REPO_DIR/bin/tests/.tmp-precommit-guard-verify-prefix-$$.sh"
+POSTFIX_COPY="$REPO_DIR/bin/tests/.tmp-precommit-guard-verify-postfix-$$.sh"
+_cleanup() {
+  rm -rf "$TMP_ROOT"
+  rm -f "$PREFIX_COPY" "$POSTFIX_COPY"
+  precommit_hook_guard_restore
+}
+trap _cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Verifier's own snapshot of the real hook slot - independent of the guard
+# library's internal state, used only as the assertion side below.
+# ---------------------------------------------------------------------------
+_resolve_precommit_state() {
+  local hooks_dir
+  if ! hooks_dir="$(git -C "$REPO_DIR" rev-parse --git-path hooks 2>/dev/null)" || [[ -z "$hooks_dir" ]]; then
+    echo "(unresolved)"
+    return
+  fi
+  case "$hooks_dir" in
+    /*) : ;;
+    *) hooks_dir="$REPO_DIR/$hooks_dir" ;;
+  esac
+  local hook="$hooks_dir/pre-commit"
+  if [[ -L "$hook" ]]; then
+    readlink "$hook"
+  elif [[ -e "$hook" ]]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      echo "(regular file: $(sha256sum "$hook" | awk '{print $1}'))"
+    else
+      echo "(regular file: $(shasum -a 256 "$hook" | awk '{print $1}'))"
+    fi
+  else
+    echo "(absent)"
+  fi
+}
+
+STATE_INITIAL="$(_resolve_precommit_state)"
+echo "Real pre-commit hook slot before this run: $STATE_INITIAL"
+
+precommit_hook_guard_save "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# Build a truncated "crash before guard save" reproduction from a given
+# source revision of test_hooks_snapshot_migration.sh (pass the literal
+# string WORKTREE to read the current on-disk working-tree copy instead of
+# a git revision - this file's own fix is uncommitted while this verifier
+# runs, so `git show HEAD:...` would still return the pre-fix content).
+# Cuts immediately after the first `fi` closing the first
+# .claude/install.sh's _run_install check, then appends `exit 1` - i.e.
+# everything the file does BEFORE it would reach its own (pre-fix:
+# too-late; post-fix: early-enough) guard save call.
+# ---------------------------------------------------------------------------
+_build_truncated_copy() {
+  local rev="$1"
+  local out_file="$2"
+  local src_file="$TMP_ROOT/_src_$$.sh"
+  if [[ "$rev" == "WORKTREE" ]]; then
+    cp "$REPO_DIR/bin/tests/test_hooks_snapshot_migration.sh" "$src_file" 2>/dev/null || return 1
+  else
+    git -C "$REPO_DIR" show "$rev:bin/tests/test_hooks_snapshot_migration.sh" > "$src_file" 2>/dev/null || return 1
+  fi
+  python3 - "$src_file" "$out_file" <<'PYEOF'
+import sys
+src_path, out_path = sys.argv[1], sys.argv[2]
+with open(src_path) as f:
+    src = f.read()
+marker = 'claude: first install.sh run exited non-zero'
+idx = src.index(marker)
+# Extend to the end of the enclosing "fi" line.
+fi_idx = src.index('\nfi\n', idx)
+truncated = src[: fi_idx + len('\nfi\n')]
+truncated += '\nexit 1\n'
+with open(out_path, 'w') as f:
+    f.write(truncated)
+PYEOF
+}
+
+_run_truncated_copy() {
+  local copy_file="$1"
+  local fake_home="$2"
+  mkdir -p "$fake_home/.claude"
+  HOME="$fake_home" bash "$copy_file" < /dev/null > "$fake_home/.out" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# 1. PRE-FIX (origin/main) truncated copy: prove RED - the real hook is
+#    left mutated because the file's own guard save call, at the time of
+#    origin/main, runs too late to cover this early exit.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 1. Pre-fix (origin/main) reproduction: expect the real hook to be MUTATED ==="
+
+if _build_truncated_copy "origin/main" "$PREFIX_COPY"; then
+  PREFIX_HOME="$TMP_ROOT/home-prefix"
+  mkdir -p "$PREFIX_HOME"
+  _run_truncated_copy "$PREFIX_COPY" "$PREFIX_HOME" || true
+
+  STATE_AFTER_PREFIX="$(_resolve_precommit_state)"
+  echo "  real hook slot after pre-fix truncated run: $STATE_AFTER_PREFIX"
+
+  if [[ "$STATE_AFTER_PREFIX" != "$STATE_INITIAL" ]]; then
+    _pass "pre-fix (origin/main) reproduction confirms the bug: real hook mutated ('$STATE_INITIAL' -> '$STATE_AFTER_PREFIX')"
+  else
+    _fail "pre-fix (origin/main) reproduction did NOT mutate the real hook - the baseline scenario did not reproduce the bug as expected"
+  fi
+
+  # Restore before continuing to the post-fix half, using the guard's saved
+  # pre-run state (not the mutated intermediate state).
+  precommit_hook_guard_restore
+  precommit_hook_guard_save "$REPO_DIR"
+  STATE_RESTORED_AFTER_PREFIX="$(_resolve_precommit_state)"
+  if [[ "$STATE_RESTORED_AFTER_PREFIX" == "$STATE_INITIAL" ]]; then
+    _pass "verifier's own guard restored the real hook after the pre-fix reproduction"
+  else
+    _fail "verifier's own guard did NOT restore the real hook after the pre-fix reproduction ('$STATE_INITIAL' -> '$STATE_RESTORED_AFTER_PREFIX')"
+  fi
+else
+  _fail "could not build the pre-fix (origin/main) truncated reproduction"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. POST-FIX (the uncommitted worktree copy on disk) truncated copy: prove
+#    GREEN - the real hook is restored because the
+#    guard save call now runs before the first install.sh invocation.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 2. Post-fix (working tree) reproduction: expect the real hook to be RESTORED ==="
+
+if _build_truncated_copy "WORKTREE" "$POSTFIX_COPY"; then
+  POSTFIX_HOME="$TMP_ROOT/home-postfix"
+  mkdir -p "$POSTFIX_HOME"
+  _run_truncated_copy "$POSTFIX_COPY" "$POSTFIX_HOME" || true
+
+  STATE_AFTER_POSTFIX="$(_resolve_precommit_state)"
+  echo "  real hook slot after post-fix truncated run: $STATE_AFTER_POSTFIX"
+
+  if [[ "$STATE_AFTER_POSTFIX" == "$STATE_INITIAL" ]]; then
+    _pass "post-fix (working tree) reproduction confirms the fix: real hook slot restored by the truncated copy's own EXIT trap ($STATE_AFTER_POSTFIX)"
+  else
+    _fail "post-fix (working tree) reproduction did NOT restore the real hook - the fix did not close the bug ('$STATE_INITIAL' -> '$STATE_AFTER_POSTFIX')"
+  fi
+else
+  _fail "could not build the post-fix (working tree) truncated reproduction"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Final safety net: whatever happened above, restore via the verifier's
+#    own guard and assert the real hook slot is back to its pre-run state.
+# ---------------------------------------------------------------------------
+precommit_hook_guard_restore
+STATE_FINAL="$(_resolve_precommit_state)"
+echo ""
+echo "Real pre-commit hook slot after this run: $STATE_FINAL"
+if [[ "$STATE_FINAL" == "$STATE_INITIAL" ]]; then
+  _pass "real pre-commit hook slot unchanged end-to-end across this verifier's own run ($STATE_FINAL)"
+else
+  _fail "real pre-commit hook slot NOT restored at end of verifier run - expected '$STATE_INITIAL', got '$STATE_FINAL'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_precommit_hook_guard_adoption.sh
+++ b/bin/tests/test_precommit_hook_guard_adoption.sh
@@ -89,9 +89,9 @@ TMP_ROOT="$(mktemp -d)"
 PREFIX_COPY="$REPO_DIR/bin/tests/.tmp-precommit-guard-verify-prefix-$$.sh"
 POSTFIX_COPY="$REPO_DIR/bin/tests/.tmp-precommit-guard-verify-postfix-$$.sh"
 _cleanup() {
+  precommit_hook_guard_restore
   rm -rf "$TMP_ROOT"
   rm -f "$PREFIX_COPY" "$POSTFIX_COPY"
-  precommit_hook_guard_restore
 }
 trap _cleanup EXIT INT TERM
 

--- a/bin/tests/test_precommit_hook_guard_adoption.sh
+++ b/bin/tests/test_precommit_hook_guard_adoption.sh
@@ -14,14 +14,27 @@
 #          after the FIRST .claude/install.sh invocation and forced to
 #          `exit 1` there - simulating exactly the crash-before-guard-save
 #          scenario that left the real hook dangling in production. It runs
-#          that truncated copy twice: once reconstructed from the PRE-FIX
-#          (origin/main) source, once from the POST-FIX (uncommitted working
-#          tree) source, and asserts the pre-fix copy leaves the real hook
-#          mutated (RED - proves the bug reproduces) while the post-fix
-#          copy restores it (GREEN - proves the fix works). This is the
+#          that truncated copy twice against the CURRENT on-disk source of
+#          bin/tests/test_hooks_snapshot_migration.sh (never git history or
+#          any origin/* ref - hermetic, no fetch-depth dependency, cannot
+#          invert after merge): once as POST-FIX (unmodified - the guard
+#          save call this fix added stays in place before the first
+#          install.sh invocation), once as PRE-FIX (the exact guard-save
+#          block this fix introduced is mechanically stripped back out,
+#          reproducing the too-late-guard structure the file had before
+#          this change - see the "guard block marker" comment in
+#          _build_truncated_copy below). It asserts the pre-fix copy leaves
+#          the real hook mutated (RED - proves the bug reproduces) while
+#          the post-fix copy restores it (GREEN - proves the fix works).
+#          Because both reproductions are derived from the same current
+#          working-tree file, this is unaffected by which SHA is checked
+#          out and independent of `origin/main` being fetched, reachable,
+#          or even existing. This is the
 #          `bin/tests/test_hooks_snapshot_migration.sh` file named in the
 #          spawn brief as the minimum-required coverage (the UNSAFE file);
-#          the other four fixed files are not separately verified here.
+#          the other four fixed files are not separately verified here
+#          (see Major 1 in bin/tests/test_precommit_hook_guard_static.sh
+#          for the static ordering assertion that covers all five).
 #
 # Public API: ./bin/tests/test_precommit_hook_guard_adoption.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -116,30 +129,48 @@ echo "Real pre-commit hook slot before this run: $STATE_INITIAL"
 precommit_hook_guard_save "$REPO_DIR"
 
 # ---------------------------------------------------------------------------
-# Build a truncated "crash before guard save" reproduction from a given
-# source revision of test_hooks_snapshot_migration.sh (pass the literal
-# string WORKTREE to read the current on-disk working-tree copy instead of
-# a git revision - this file's own fix is uncommitted while this verifier
-# runs, so `git show HEAD:...` would still return the pre-fix content).
-# Cuts immediately after the first `fi` closing the first
-# .claude/install.sh's _run_install check, then appends `exit 1` - i.e.
-# everything the file does BEFORE it would reach its own (pre-fix:
-# too-late; post-fix: early-enough) guard save call.
+# Build a truncated "crash before guard save" reproduction from the CURRENT
+# on-disk source of test_hooks_snapshot_migration.sh - never git history or
+# any origin/* ref (see file header). Pass variant POSTFIX to reproduce the
+# file exactly as it stands (guard save call intact, before the first
+# install.sh invocation); pass variant PREFIX to mechanically strip back out
+# the exact guard-save block this fix (75225f67) introduced, reproducing the
+# too-late-guard structure the file had before this change. Both variants
+# then cut immediately after the first `fi` closing the first
+# .claude/install.sh's _run_install check, then append `exit 1` - i.e.
+# everything the file does BEFORE it would reach its own (PREFIX: never;
+# POSTFIX: early-enough) guard save call.
 # ---------------------------------------------------------------------------
 _build_truncated_copy() {
-  local rev="$1"
+  local variant="$1"
   local out_file="$2"
   local src_file="$TMP_ROOT/_src_$$.sh"
-  if [[ "$rev" == "WORKTREE" ]]; then
-    cp "$REPO_DIR/bin/tests/test_hooks_snapshot_migration.sh" "$src_file" 2>/dev/null || return 1
-  else
-    git -C "$REPO_DIR" show "$rev:bin/tests/test_hooks_snapshot_migration.sh" > "$src_file" 2>/dev/null || return 1
-  fi
-  python3 - "$src_file" "$out_file" <<'PYEOF'
+  cp "$REPO_DIR/bin/tests/test_hooks_snapshot_migration.sh" "$src_file" 2>/dev/null || return 1
+  python3 - "$src_file" "$out_file" "$variant" <<'PYEOF'
 import sys
-src_path, out_path = sys.argv[1], sys.argv[2]
+src_path, out_path, variant = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(src_path) as f:
     src = f.read()
+
+if variant == "PREFIX":
+    # Mechanically strip out the early guard-save block this fix (75225f67)
+    # added, reproducing the pre-fix too-late-guard structure. This is a
+    # transform of the CURRENT working-tree file, never git history, so it
+    # is hermetic (no ref-availability dependency) and cannot invert after
+    # merge - removing the very block the fix introduced always reproduces
+    # the pre-fix defect, regardless of which commit is checked out.
+    guard_block_marker = (
+        '# Save the real pre-commit hook slot BEFORE the first '
+        'install.sh invocation'
+    )
+    guard_call_marker = 'precommit_hook_guard_save "$REPO_DIR"\n'
+    start = src.index(guard_block_marker)  # raises if the fix's own block is gone
+    call_idx = src.index(guard_call_marker, start)
+    end = call_idx + len(guard_call_marker)
+    src = src[:start] + src[end:]
+elif variant != "POSTFIX":
+    raise ValueError("unknown variant: %r" % variant)
+
 marker = 'claude: first install.sh run exited non-zero'
 idx = src.index(marker)
 # Extend to the end of the enclosing "fi" line.
@@ -160,14 +191,15 @@ _run_truncated_copy() {
 }
 
 # ---------------------------------------------------------------------------
-# 1. PRE-FIX (origin/main) truncated copy: prove RED - the real hook is
-#    left mutated because the file's own guard save call, at the time of
-#    origin/main, runs too late to cover this early exit.
+# 1. PRE-FIX (synthetic, derived from the current working-tree file with the
+#    fix's own guard-save block mechanically stripped back out) truncated
+#    copy: prove RED - the real hook is left mutated because, with that
+#    block removed, no guard save call covers this early exit.
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== 1. Pre-fix (origin/main) reproduction: expect the real hook to be MUTATED ==="
+echo "=== 1. Pre-fix (synthetic) reproduction: expect the real hook to be MUTATED ==="
 
-if _build_truncated_copy "origin/main" "$PREFIX_COPY"; then
+if _build_truncated_copy "PREFIX" "$PREFIX_COPY"; then
   PREFIX_HOME="$TMP_ROOT/home-prefix"
   mkdir -p "$PREFIX_HOME"
   _run_truncated_copy "$PREFIX_COPY" "$PREFIX_HOME" || true
@@ -176,9 +208,9 @@ if _build_truncated_copy "origin/main" "$PREFIX_COPY"; then
   echo "  real hook slot after pre-fix truncated run: $STATE_AFTER_PREFIX"
 
   if [[ "$STATE_AFTER_PREFIX" != "$STATE_INITIAL" ]]; then
-    _pass "pre-fix (origin/main) reproduction confirms the bug: real hook mutated ('$STATE_INITIAL' -> '$STATE_AFTER_PREFIX')"
+    _pass "pre-fix (synthetic) reproduction confirms the bug: real hook mutated ('$STATE_INITIAL' -> '$STATE_AFTER_PREFIX')"
   else
-    _fail "pre-fix (origin/main) reproduction did NOT mutate the real hook - the baseline scenario did not reproduce the bug as expected"
+    _fail "pre-fix (synthetic) reproduction did NOT mutate the real hook - the baseline scenario did not reproduce the bug as expected"
   fi
 
   # Restore before continuing to the post-fix half, using the guard's saved
@@ -192,18 +224,18 @@ if _build_truncated_copy "origin/main" "$PREFIX_COPY"; then
     _fail "verifier's own guard did NOT restore the real hook after the pre-fix reproduction ('$STATE_INITIAL' -> '$STATE_RESTORED_AFTER_PREFIX')"
   fi
 else
-  _fail "could not build the pre-fix (origin/main) truncated reproduction"
+  _fail "could not build the pre-fix (synthetic) truncated reproduction"
 fi
 
 # ---------------------------------------------------------------------------
-# 2. POST-FIX (the uncommitted worktree copy on disk) truncated copy: prove
-#    GREEN - the real hook is restored because the
-#    guard save call now runs before the first install.sh invocation.
+# 2. POST-FIX (the current working-tree copy on disk, unmodified) truncated
+#    copy: prove GREEN - the real hook is restored because the guard save
+#    call now runs before the first install.sh invocation.
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== 2. Post-fix (working tree) reproduction: expect the real hook to be RESTORED ==="
 
-if _build_truncated_copy "WORKTREE" "$POSTFIX_COPY"; then
+if _build_truncated_copy "POSTFIX" "$POSTFIX_COPY"; then
   POSTFIX_HOME="$TMP_ROOT/home-postfix"
   mkdir -p "$POSTFIX_HOME"
   _run_truncated_copy "$POSTFIX_COPY" "$POSTFIX_HOME" || true

--- a/bin/tests/test_precommit_hook_guard_static.sh
+++ b/bin/tests/test_precommit_hook_guard_static.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Purpose: Static regression coverage for the precommit-hook-guard adoption
+#          fix (75225f67) across all FIVE files it touched -
+#          bin/tests/test_precommit_hook_guard_adoption.sh only exercises
+#          test_hooks_snapshot_migration.sh end-to-end (the UNSAFE file); the
+#          other four (test_install_profiles.sh,
+#          test_hooks_snapshot_no_live_rewire.sh, test_install_stop_cadence.sh,
+#          test_install_profile_config_dir.sh) had zero regression coverage -
+#          proven by mutation: reverting test_install_stop_cadence.sh to its
+#          pre-fix content still yielded a clean run of the adoption
+#          verifier. This file closes that gap with a cheap, deterministic
+#          ordering assertion instead of five more end-to-end reproductions:
+#          for each of the five files, assert (1) the guard library is
+#          sourced, (2) precommit_hook_guard_save "$REPO_DIR" is called, and
+#          (3) that save call's line number is LESS THAN the line number of
+#          the file's first real install.sh invocation. That third
+#          assertion is the one that actually matters - it catches both
+#          "guard removed" (assertion 2 fails) and "guard placed too late"
+#          (assertion 3 fails), which was the exact defect this verifier
+#          exists to catch (test_hooks_snapshot_migration.sh's guard save
+#          originally ran right before the final .claude uninstall leg,
+#          after two earlier install.sh calls had already mutated the real
+#          hook unguarded - see 75225f67's commit message).
+#
+# Public API: ./bin/tests/test_precommit_hook_guard_static.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, awk.
+#
+# Downstream consumers: developer running locally before commit; wired into
+#                       the bin-sh-tests CI job via the bin/tests/test_*.sh
+#                       glob (.github/workflows/bin-tests.yml).
+#
+# Failure modes: any assertion failure prints the failing assertion and file
+#                and exits 1. This file performs no filesystem mutation and
+#                touches no git state - pure static text inspection of the
+#                five target files, so it needs no cleanup trap.
+#
+# Performance: well under 1 s (five small awk passes).
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# The five files 75225f67 adopted the guard in. Set as positional params
+# (not a plain space-separated string) so the `for ... in` below splits
+# correctly under both bash and zsh - zsh does not word-split an unquoted
+# variable reference by default, unlike bash.
+set -- test_install_profiles.sh test_hooks_snapshot_no_live_rewire.sh test_install_stop_cadence.sh test_install_profile_config_dir.sh test_hooks_snapshot_migration.sh
+
+# ---------------------------------------------------------------------------
+# _line_numbers <file>
+#   Prints three space-separated numbers (0 meaning "not found"):
+#     <guard-source-line> <guard-save-line> <first-install-invocation-line>
+#   All three scans skip comment lines (first non-whitespace char '#') so a
+#   mention in a header/prose comment is never mistaken for the real code.
+#   The install-invocation match is `/install\.sh"` (slash immediately
+#   before the literal filename) - deliberately excludes `uninstall.sh`,
+#   whose substring is `uninstall.sh` (no slash directly before `install`).
+# ---------------------------------------------------------------------------
+_line_numbers() {
+  awk '
+    {
+      line = $0
+      trimmed = line
+      sub(/^[ \t]+/, "", trimmed)
+      if (trimmed ~ /^#/) next
+      if (src == 0 && trimmed == ". \"$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh\"") src = NR
+      if (save == 0 && trimmed == "precommit_hook_guard_save \"$REPO_DIR\"") save = NR
+      if (inst == 0 && line ~ /\/install\.sh"/) inst = NR
+    }
+    END { print src+0, save+0, inst+0 }
+  ' "$1"
+}
+
+for fname in "$@"; do
+  fpath="$REPO_DIR/bin/tests/$fname"
+  if [[ ! -f "$fpath" ]]; then
+    _fail "$fname: file not found at $fpath"
+    continue
+  fi
+
+  read -r src_line save_line inst_line < <(_line_numbers "$fpath")
+
+  if [[ "$src_line" -gt 0 ]]; then
+    _pass "$fname: guard library sourced (line $src_line)"
+  else
+    _fail "$fname: guard library is NOT sourced"
+  fi
+
+  if [[ "$save_line" -gt 0 ]]; then
+    _pass "$fname: precommit_hook_guard_save is called (line $save_line)"
+  else
+    _fail "$fname: precommit_hook_guard_save is NOT called"
+  fi
+
+  if [[ "$inst_line" -eq 0 ]]; then
+    _fail "$fname: no install.sh invocation found - cannot assert ordering (test drifted from the file's structure)"
+  elif [[ "$save_line" -gt 0 && "$save_line" -lt "$inst_line" ]]; then
+    _pass "$fname: guard save (line $save_line) runs before the first install.sh invocation (line $inst_line)"
+  else
+    _fail "$fname: guard save (line $save_line) does NOT run before the first install.sh invocation (line $inst_line) - guard is missing or placed too late"
+  fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/bin/tests/test_precommit_hook_guard_static.sh
+++ b/bin/tests/test_precommit_hook_guard_static.sh
@@ -11,16 +11,56 @@
 #          verifier. This file closes that gap with a cheap, deterministic
 #          ordering assertion instead of five more end-to-end reproductions:
 #          for each of the five files, assert (1) the guard library is
-#          sourced, (2) precommit_hook_guard_save "$REPO_DIR" is called, and
+#          sourced, (2) precommit_hook_guard_save "$REPO_DIR" is called,
 #          (3) that save call's line number is LESS THAN the line number of
-#          the file's first real install.sh invocation. That third
-#          assertion is the one that actually matters - it catches both
-#          "guard removed" (assertion 2 fails) and "guard placed too late"
-#          (assertion 3 fails), which was the exact defect this verifier
-#          exists to catch (test_hooks_snapshot_migration.sh's guard save
-#          originally ran right before the final .claude uninstall leg,
+#          the file's first real install.sh invocation (direct or via the
+#          scripts/install-profiles.sh indirect invoker - see assertion 3
+#          below), and (4) precommit_hook_guard_restore is called somewhere
+#          in the file. Assertion (3) is the one that matters most for
+#          "guard placed too late" (test_hooks_snapshot_migration.sh's guard
+#          save originally ran right before the final .claude uninstall leg,
 #          after two earlier install.sh calls had already mutated the real
-#          hook unguarded - see 75225f67's commit message).
+#          hook unguarded - see 75225f67's commit message). Assertion (4) is
+#          the one that matters for "guard removed entirely": save alone
+#          protects nothing if nothing ever puts the real hook back. Save
+#          without a paired restore is precisely the production defect this
+#          PR exists to prevent - the real hook left repointed after a
+#          SUCCESSFUL run, not just a crashed one. Only
+#          test_hooks_snapshot_migration.sh has restore covered end-to-end
+#          elsewhere (the adoption verifier's POSTFIX leg); the other four
+#          have no coverage of restore at all outside this file.
+#
+#          Assertion (4) also makes a best-effort "reachable" check: restore
+#          is reachable if it appears directly inside a `trap ... EXIT` line
+#          (test_install_profile_config_dir.sh's inline-string traps), or
+#          inside a function that some `trap <funcname> EXIT` line later
+#          names (the `cleanup()`/`_cleanup()` pattern used by the other
+#          four files). This is presence-plus-shape, not full control-flow
+#          proof - see the "Static-match limits" section below for what it
+#          does and does not prove; reachability failure is reported as an
+#          additional PASS/FAIL alongside the plain presence assertion, not
+#          a substitute for it, so a restore call this heuristic cannot
+#          classify still counts as covered by assertion (4) alone.
+#
+# Static-match limits (both confirmed by the reviewer during the round that
+# authored this file - stated here so the next reader knows what a green run
+# does and does not prove):
+#   - False negative: a save/restore call wrapped in a conditional that never
+#     executes (e.g. `if false; then precommit_hook_guard_save "$REPO_DIR";
+#     fi`) still matches this file's line-presence and ordering scans and
+#     reports PASS - this checker verifies the call is TEXTUALLY PRESENT and
+#     correctly ORDERED, not that it is reachable at runtime for every
+#     control-flow path.
+#   - False positive direction: the install.sh-invocation scan
+#     (`/install\.sh"/`) matches any line containing that substring
+#     immediately before a closing quote, including lines that merely
+#     REFERENCE install.sh without running it - e.g.
+#     test_install_profile_config_dir.sh:123's
+#     `grep -Fq "_ae_identity_guidance" "$REPO_DIR/.$harness/install.sh"` is
+#     a read, not an invocation, but still counts as an "install.sh
+#     invocation" for ordering purposes. This is conservative in the
+#     direction that matters (an earlier phantom "invocation" only makes the
+#     ordering assertion stricter, never looser), so it is left as-is.
 #
 # Public API: ./bin/tests/test_precommit_hook_guard_static.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -63,13 +103,25 @@ set -- test_install_profiles.sh test_hooks_snapshot_no_live_rewire.sh test_insta
 
 # ---------------------------------------------------------------------------
 # _line_numbers <file>
-#   Prints three space-separated numbers (0 meaning "not found"):
+#   Prints five space-separated numbers (0 meaning "not found", except the
+#   final field which is always 0 or 1):
 #     <guard-source-line> <guard-save-line> <first-install-invocation-line>
-#   All three scans skip comment lines (first non-whitespace char '#') so a
-#   mention in a header/prose comment is never mistaken for the real code.
-#   The install-invocation match is `/install\.sh"` (slash immediately
-#   before the literal filename) - deliberately excludes `uninstall.sh`,
-#   whose substring is `uninstall.sh` (no slash directly before `install`).
+#     <guard-restore-line> <restore-reachable-via-trap:0-or-1>
+#   The first three scans skip comment lines (first non-whitespace char '#')
+#   so a mention in a header/prose comment is never mistaken for the real
+#   code. The install-invocation scan matches EITHER a direct invocation
+#   (`/install\.sh"` - slash immediately before the literal filename,
+#   deliberately excluding `uninstall.sh`, whose substring is
+#   `uninstall.sh` with no slash directly before `install`) OR an indirect
+#   invocation via scripts/install-profiles.sh, the only script any of the
+#   five files call that itself shells out to an adapter install.sh
+#   (scripts/install-profiles.sh:270,326) - grepped for repo-wide at review
+#   time; no other indirect invoker exists today. The restore scan matches
+#   any (non-comment) line containing the literal call, not just an
+#   exact-trimmed match, because two of the five files call it from inside
+#   an inline `trap '...' EXIT` string rather than as a bare statement. The
+#   reachability flag is a best-effort structural check, not a proof - see
+#   the file header's "Static-match limits" section.
 # ---------------------------------------------------------------------------
 _line_numbers() {
   awk '
@@ -78,11 +130,40 @@ _line_numbers() {
       trimmed = line
       sub(/^[ \t]+/, "", trimmed)
       if (trimmed ~ /^#/) next
+
+      # Track the enclosing function (simple, single-level: these five
+      # files never nest a function inside another) so a restore call
+      # inside cleanup()/_cleanup() can be tied back to that function name.
+      if (match(trimmed, /^(function[ \t]+)?[A-Za-z_][A-Za-z0-9_]*\(\)[ \t]*\{[ \t]*$/)) {
+        fname = trimmed
+        sub(/^function[ \t]+/, "", fname)
+        sub(/\(\).*/, "", fname)
+        curfunc = fname
+      } else if (trimmed == "}") {
+        curfunc = ""
+      }
+
       if (src == 0 && trimmed == ". \"$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh\"") src = NR
       if (save == 0 && trimmed == "precommit_hook_guard_save \"$REPO_DIR\"") save = NR
-      if (inst == 0 && line ~ /\/install\.sh"/) inst = NR
+      if (inst == 0 && (line ~ /\/install\.sh"/ || line ~ /\/install-profiles\.sh/)) inst = NR
+
+      if (line ~ /precommit_hook_guard_restore/) {
+        if (rest == 0) rest = NR
+        if (curfunc != "") func_has_restore[curfunc] = 1
+        if (line ~ /trap /) direct_reach = 1
+      }
+
+      if (match(line, /trap[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]+EXIT/)) {
+        t = line
+        sub(/^.*trap[ \t]+/, "", t)
+        sub(/[ \t]+EXIT.*/, "", t)
+        if (t in func_has_restore) reach_via_func = 1
+      }
     }
-    END { print src+0, save+0, inst+0 }
+    END {
+      reach = (direct_reach || reach_via_func) ? 1 : 0
+      print src+0, save+0, inst+0, rest+0, reach
+    }
   ' "$1"
 }
 
@@ -93,7 +174,7 @@ for fname in "$@"; do
     continue
   fi
 
-  read -r src_line save_line inst_line < <(_line_numbers "$fpath")
+  read -r src_line save_line inst_line rest_line reachable < <(_line_numbers "$fpath")
 
   if [[ "$src_line" -gt 0 ]]; then
     _pass "$fname: guard library sourced (line $src_line)"
@@ -113,6 +194,20 @@ for fname in "$@"; do
     _pass "$fname: guard save (line $save_line) runs before the first install.sh invocation (line $inst_line)"
   else
     _fail "$fname: guard save (line $save_line) does NOT run before the first install.sh invocation (line $inst_line) - guard is missing or placed too late"
+  fi
+
+  if [[ "$rest_line" -gt 0 ]]; then
+    _pass "$fname: precommit_hook_guard_restore is called (line $rest_line)"
+  else
+    _fail "$fname: precommit_hook_guard_restore is NOT called - a guard save with no matching restore protects nothing"
+  fi
+
+  if [[ "$rest_line" -gt 0 ]]; then
+    if [[ "$reachable" -eq 1 ]]; then
+      _pass "$fname: precommit_hook_guard_restore is reachable from an EXIT trap (directly or via a trap-named function)"
+    else
+      _fail "$fname: precommit_hook_guard_restore is called but not observably reachable from an EXIT trap - restore may only run on the happy path"
+    fi
   fi
 done
 


### PR DESCRIPTION
Five `bin/tests/*.sh` files invoke the real `.claude/install.sh` without the existing pre-commit-hook guard, so each run silently repoints the developer's live `.git/hooks/pre-commit` and never restores it.

`_ae_is_ours()` (`.claude/install.sh:316-334`) treats **any** symlink whose target contains `/DinoStack/` as "ours to repoint," so on any checkout that has ever run `install.sh`, this fires unconditionally. When the new target is a worktree or a temp fixture, the link dangles the moment that directory is removed - and **git silently does not run a dangling hook**. Commits keep succeeding with no pre-commit checks and no error.

Observed repeatedly on a live checkout during one session, including once pointing into a review agent's `/tmp` scratch directory.

## The fix is adoption, not new mechanism

`bin/tests/lib/precommit-hook-guard.sh` already exists, is worktree-aware (`git rev-parse --git-path hooks`), handles symlink / regular-file / absent cases, and has an idempotent restore. Four files already use it correctly; `test_uninstall_ds_prefix.sh` is the reference implementation.

| File | Before | After |
|---|---|---|
| `test_hooks_snapshot_migration.sh` | **UNSAFE** - guard saved only before the final `.claude` uninstall, leaving **8 earlier `install.sh` calls** unguarded | `save()` moved to the top, before the first call; redundant local pair removed; header comment that documented the gap corrected |
| `test_install_profile_config_dir.sh` | no guard; ≥4 direct `.claude/install.sh` calls | sourced, `save()` before the first call, `restore()` in the existing `SANDBOX` EXIT trap |
| `test_install_profiles.sh` | no guard | sourced, `save()` near the top (covers both the direct calls and the `scripts/install-profiles.sh` loop), `restore()` in `cleanup()` |
| `test_hooks_snapshot_no_live_rewire.sh` | no guard on the hook axis | sourced, `save()` before the first of two calls, `restore()` in `_cleanup` |
| `test_install_stop_cadence.sh` | no guard | sourced, `save()` before the single call, `restore()` in `_cleanup` |

No sandbox restructuring was needed - `precommit_hook_guard_restore` is idempotent, so folding it into each file's existing trap sufficed. `test_install_stop_cadence.sh`'s pre-existing worktree-tolerance branch is left unchanged.

## Verification: the escape was reproduced, not inferred

New `bin/tests/test_precommit_hook_guard_adoption.sh` builds a truncated copy of `test_hooks_snapshot_migration.sh`, cut immediately after the **first** `.claude/install.sh` call and forced to `exit 1` - simulating a crash before the guard save would have run under the old ordering.

**How the pre-fix reproduction is built (revised).** An earlier revision resolved the baseline from `origin/main` - a moving ref. That was wrong twice over: `actions/checkout` never creates it, so `bin-sh-tests` was failing on CI, and post-merge the ref would carry the fix and invert the assertion. It has been removed entirely.

The verifier is now **hermetic**. Both reproductions are built from the current on-disk `test_hooks_snapshot_migration.sh`: POSTFIX as-is, and PREFIX by mechanically stripping the guard-save block this PR introduced, via a marker-anchored transform that fails loudly if the marker is missing, duplicated, or reshaped. No repo history, no fetch depth, no ref dependency.

Verified under three conditions: a normal local run (4/0); an isolated fixture with `refs/remotes/origin/main` confirmed absent, simulating CI's checkout (4/0); and a post-merge revert simulation, which correctly goes RED. Independently re-verified in review, including all three marker degradations. `bin-sh-tests` now passes on GitHub.

When the PREFIX leg runs it genuinely repoints the real hook and the guard restores it within the same run - the bug reproduced on demand, then prevented.

Covers the UNSAFE file; the other four are structural applications of the same proven pattern.

## Gates

- `pytest bin/tests/`: 1150 passed
- Shell suite (all `bin/tests/test_*.sh` plus the 4 orphans): **43 files, 0 failed**, including `test_agentic_update.sh`
- hooks JS: 45 files, 0 failed
- Both shells: `-n` syntax check clean on all 6 touched files; the new verifier executed under **bash** and **zsh**, 4/4 both
- Real hook target verified unchanged across the entire gate run
- Em-dash check on the diff: empty

`bin/tests/` only, so no adapter rebuild. New file is auto-discovered by the `bin-sh-tests` glob.

Doc-sync: predicate not triggered - no doc outside `bin/tests/` references the guard or any touched filename.

## Related

Complementary to #640, which makes the symlink *target* durable when the hook is repointed legitimately. This PR stops tests from repointing it at all. Neither subsumes the other: #640 alone still leaves tests mutating a developer's hook; this alone still leaves a legitimate worktree install pointing at an ephemeral path.

## North Star alignment

**Works for everyone (universality):** the guard resolves the hooks directory from git rather than any assumed layout, and the fix adds no operator-, path-, or harness-specific behavior. It is strictly a save/restore wrapper - the tests assert exactly what they asserted before.

**Enforcement floors preserved:** this restores an enforcement floor rather than relaxing one. A silently repointed pre-commit hook is a gate that stopped running without telling anyone; every affected developer was losing hook coverage from the moment they ran one of these five tests. No assertion was weakened, and the new verifier proves the floor by reproducing its failure.
