### PR TITLE
fix(config): seed worktree_read_guard_exemptions and gate catalog/seed key-set drift (DS-150 follow-on)

### DIFF
--- a/.claude/commands/ds-init-project.md
+++ b/.claude/commands/ds-init-project.md
@@ -902,7 +902,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -930,6 +931,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.claude/skills/dinostack/templates/.agentic/config.json
+++ b/.claude/skills/dinostack/templates/.agentic/config.json
@@ -25,5 +25,6 @@
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }

--- a/.cursor/commands/ds-init-project.md
+++ b/.cursor/commands/ds-init-project.md
@@ -896,7 +896,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -924,6 +925,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.cursor/templates/.agentic/config.json
+++ b/.cursor/templates/.agentic/config.json
@@ -25,5 +25,6 @@
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }

--- a/.gemini/commands/ds-init-project.toml
+++ b/.gemini/commands/ds-init-project.toml
@@ -902,7 +902,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -930,6 +931,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.gemini/templates/.agentic/config.json
+++ b/.gemini/templates/.agentic/config.json
@@ -25,5 +25,6 @@
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }

--- a/.github/prompts/ds-init-project.prompt.md
+++ b/.github/prompts/ds-init-project.prompt.md
@@ -899,7 +899,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -927,6 +928,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -18442,7 +18442,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -18470,6 +18471,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.openclaw/skills/ds-init-project/SKILL.md
+++ b/.openclaw/skills/ds-init-project/SKILL.md
@@ -901,7 +901,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -929,6 +930,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/.opencode/commands/ds-init-project.md
+++ b/.opencode/commands/ds-init-project.md
@@ -900,7 +900,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -928,6 +929,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/bin/tests/test_tracker_writeback_ranking_spec.py
+++ b/bin/tests/test_tracker_writeback_ranking_spec.py
@@ -103,6 +103,7 @@ Run with: python3 -m pytest bin/tests/test_tracker_writeback_ranking_spec.py -q
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -878,6 +879,124 @@ def test_toggle_doc_sync_full_eight_site_checklist():
         assert '"pending_merge_sweep": true,\n  "tracker_state_diagnostic": true' in text, (
             f"{path.relative_to(REPO_ROOT)} seed JSON missing tracker_state_diagnostic "
             "immediately after pending_merge_sweep"
+        )
+
+
+# --- Full key-set membership (regression gate for DS-150's 21-key seed) ----
+#
+# The adjacency check above (test_toggle_doc_sync_full_eight_site_checklist)
+# only proves two SPECIFIC keys sit next to each other in each seed file - it
+# says nothing about whether the seed's key SET actually matches what the
+# catalog documents. That is exactly the gap DS-150 fell through: the
+# `worktree_read_guard_exemptions` toggle was added to the
+# '### Project config' catalog bullets and to the doc-count sentences
+# (TOGGLE_COUNT_FILES above already said "twenty-two"), but shipped in only
+# ONE of the two seed sources - a 21-key seed against 22-toggle doc claims -
+# and nothing here caught it.
+#
+# CATALOG_PATH is deliberately a THIRD, independent origin from either seed
+# file: it is prose documentation authored and maintained separately from
+# both content/templates/.agentic/config.json (a bare JSON template file)
+# and the JSON block embedded in content/commands/ds-init-project.md (a
+# markdown command doc). Comparing the two seeds against this catalog - not
+# against each other - means neither seed can "drift in lockstep" with its
+# sibling and still pass: the catalog is the fixed reference point, and if
+# it and a seed disagree, that is asserted by name.
+CATALOG_PATH = REPO_ROOT / "content" / "references" / "risk-config-and-tiers.md"
+TEMPLATE_SEED_PATH = REPO_ROOT / "content" / "templates" / ".agentic" / "config.json"
+INIT_PROJECT_SEED_ANCHOR = "### 6f. Create `.agentic/config.json`"
+
+# Keys present in both seed JSONs that do NOT get their own catalog bullet:
+# `scaffolding_version` is a schema-version marker, not a behavioral toggle,
+# and is documented separately (never in the bullet list). The five
+# `deferred_wrap_*` tuning params are named inline, in one parenthetical,
+# inside the `deferred_wrap_daemon` bullet (risk-config-and-tiers.md:54)
+# rather than getting individual bullets of their own. This set has to be
+# named and small on purpose: any FUTURE key added to a seed without its own
+# catalog bullet must be added here explicitly, in the same PR, or this test
+# fails it as an undocumented extra key - it cannot silently ride along the
+# way `worktree_read_guard_exemptions` almost did in the other direction.
+_SEED_KEYS_WITHOUT_OWN_BULLET = {
+    "scaffolding_version",
+    "deferred_wrap_idle_minutes",
+    "deferred_wrap_heartbeat_seconds",
+    "deferred_wrap_timeout_minutes",
+    "deferred_wrap_inprogress_reclaim_minutes",
+    "deferred_wrap_pending_ttl_days",
+}
+
+
+def _catalog_toggle_keys() -> set:
+    """Parse the '### Project config' catalog bullets in
+    risk-config-and-tiers.md into a set of toggle key names, bounded to the
+    section between that heading and the next heading (so an unrelated
+    bullet list elsewhere in the file, e.g. under 'Graph-derived risk
+    signal', can never be swept in by accident)."""
+    text = CATALOG_PATH.read_text(encoding="utf-8")
+    start = text.index("### Project config")
+    heading_match = re.search(r"\n#{2,4} ", text[start + 1:])
+    end = start + 1 + heading_match.start() if heading_match else len(text)
+    window = text[start:end]
+    keys = set(re.findall(r"^- `([a-zA-Z_][a-zA-Z0-9_]*)`", window, re.MULTILINE))
+    assert keys, "catalog bullet parse returned no keys - anchor or regex is broken"
+    return keys
+
+
+def _fenced_json_object_keys(text: str, anchor: str) -> set:
+    """Extract the top-level key set of the first fenced ```json code block
+    that appears after `anchor` in `text`. Used for the seed JSON embedded
+    inside content/commands/ds-init-project.md, which is markdown prose
+    around a JSON block rather than a standalone JSON file."""
+    anchor_idx = text.index(anchor)
+    fence_start = text.index("```json", anchor_idx)
+    body_start = text.index("\n", fence_start) + 1
+    fence_end = text.index("```", body_start)
+    obj = json.loads(text[body_start:fence_end])
+    return set(obj.keys())
+
+
+def test_toggle_catalog_key_set_matches_both_seed_sources():
+    """Every key the '### Project config' catalog documents (plus the named
+    schema/tuning exemptions) must appear in BOTH seed sources, and neither
+    seed may carry an undocumented extra key. Two independent seed origins
+    are checked separately against the (third, independent) catalog:
+    content/templates/.agentic/config.json (a bare JSON template file) and
+    the JSON block embedded in content/commands/ds-init-project.md (a
+    fenced block inside a markdown command doc) - so a defect in only one
+    of the two seeds is named by file, not masked by comparing the seeds to
+    each other."""
+    catalog_keys = _catalog_toggle_keys()
+    expected_keys = catalog_keys | _SEED_KEYS_WITHOUT_OWN_BULLET
+
+    template_keys = set(json.loads(TEMPLATE_SEED_PATH.read_text(encoding="utf-8")).keys())
+    init_project_keys = _fenced_json_object_keys(
+        (REPO_ROOT / "content" / "commands" / "ds-init-project.md").read_text(encoding="utf-8"),
+        INIT_PROJECT_SEED_ANCHOR,
+    )
+
+    for label, seed_keys, path in (
+        (
+            "content/templates/.agentic/config.json",
+            template_keys,
+            TEMPLATE_SEED_PATH,
+        ),
+        (
+            "content/commands/ds-init-project.md seed JSON block",
+            init_project_keys,
+            REPO_ROOT / "content" / "commands" / "ds-init-project.md",
+        ),
+    ):
+        rel = path.relative_to(REPO_ROOT)
+        missing_from_seed = expected_keys - seed_keys
+        assert not missing_from_seed, (
+            f"{rel}: {label} is missing key(s) the '### Project config' catalog "
+            f"documents: {sorted(missing_from_seed)}"
+        )
+        extra_in_seed = seed_keys - expected_keys
+        assert not extra_in_seed, (
+            f"{rel}: {label} has key(s) not documented in the '### Project config' "
+            f"catalog and not in the named schema/tuning exemption set: "
+            f"{sorted(extra_in_seed)}"
         )
 
 

--- a/content/commands/ds-init-project.md
+++ b/content/commands/ds-init-project.md
@@ -896,7 +896,8 @@ Seed with these documented defaults exactly:
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }
 ```
 
@@ -924,6 +925,7 @@ Seed with these documented defaults exactly:
 - `pending_merge_sweep` - boolean, default `true`. Absent key resolves to `true`. Controls the session-start pending-merge sweep that pushes the dev-complete transition (`TRACKER_STATE_DEV_COMPLETE`, which defaults to the resolved `TRACKER_STATE_DONE` value) to the tracker once a ticket's PR merges; set `false` to disable.
 - `tracker_state_diagnostic` - boolean, default `true`. Controls whether the tracker writeback subagent emits a live diagnostic naming currently-available states when a configured `TRACKER_STATE_*` name cannot be used; set `false` to disable. See `content/references/tracker-writeback.md` `## Tracker Writeback Helper` for full semantics.
 - `turn_shape_guard_enabled` - boolean, default `true` (absent key resolves to on - the inverse of the abdication guard's fail-open-to-inactive default). When active, a Stop hook (`hooks/enforce-turn-shape.py`) checks the conductor's final turn against the fixed-shape/warranted-turn rule. As of DS-156 this is NOT uniformly advisory: `_execution_prose_flag` (a non-Answer turn's structural shape) is BLOCKING and can block the stop; `_answer_relevance_flag` (opening-preamble/closing-recap phrasing on an Answer turn) remains advisory-only and only logs. **DS-156 CONTRACT, NOT YET SHIPPED:** the currently shipped hook remains uniformly advisory until Unit 2 implements `_execution_prose_flag`. Set to `false` to opt out of both. Disable per-session via `AE_TURN_SHAPE_GUARD_DISABLE=1`. See `content/references/conductor-turn-format.md` for full semantics.
+- `worktree_read_guard_exemptions` - list of strings, default `[]` (empty, no built-in entries). Each entry is a path prefix relative to the primary checkout root; a `Read` target whose normalized-relative-path starts with an exempt prefix (path-segment aware) is allowed even when it would otherwise be flagged as a worktree-isolated subagent reading outside its own worktree. Read by `hooks/enforce-worktree-read.py` (PreToolUse(Read) guard, DS-150); absent/malformed config is treated as an empty list. Disable the guard entirely per-session via `AE_WORKTREE_READ_GUARD_DISABLE=1`.
 
 
 ### 6g. Seed `~/.agentic/role-models.yml` (Pi/omp role-model routing)

--- a/content/templates/.agentic/config.json
+++ b/content/templates/.agentic/config.json
@@ -25,5 +25,6 @@
   "rework_detection": true,
   "pending_merge_sweep": true,
   "tracker_state_diagnostic": true,
-  "turn_shape_guard_enabled": true
+  "turn_shape_guard_enabled": true,
+  "worktree_read_guard_exemptions": []
 }


### PR DESCRIPTION
## Summary

Follow-on to DS-150 (#642). That PR added a 22nd behavioral toggle, `worktree_read_guard_exemptions`, and updated every count and catalog site - but not the two seeded-config sources. So `README.md`, `content/references/conventions-detail.md`, and `docs/configuration-reference.md` all asserted the config "is seeded with defaults by `/ds-init-project`" alongside a twenty-two-toggle catalog, while a freshly scaffolded project got 21 keys.

Behavior was graceful (an absent key resolves to `[]`, per `hooks/enforce-worktree-read.py:197`), so this was a consistency defect rather than a functional bug - but the docs made a claim the seed did not satisfy.

Two commits:

1. **Seed the key.** Adds `"worktree_read_guard_exemptions": []` to `content/templates/.agentic/config.json` and the embedded seed JSON in `content/commands/ds-init-project.md`, plus the matching per-key bullet, positioned to match the catalogs' existing ordering (last, after `turn_shape_guard_enabled`). The `[]` default is taken from the hook's own loading code, not assumed.

2. **Add the gate that would have caught it.** `TOGGLE_SEED_FILES` only asserted a two-key adjacency substring - a local ordering check, never key-set membership. Nothing verified the seed JSON contained every key the catalog documents, which is exactly how a 21-key seed shipped against 22-toggle doc claims.

   The new `test_toggle_catalog_key_set_matches_both_seed_sources` derives the expected key set by parsing the `### Project config` catalog rather than hardcoding a list - a hand-typed list of 22 names would be the same defect one layer up. It checks each of the two seed sources **independently against the catalog** rather than against each other, so lockstep drift between the two seeds cannot hide. Set-equality semantics, so an undocumented extra key is caught as well as a missing one.

## North Star alignment

- **Works for everyone (universality).** A project scaffolded by `/ds-init-project` now receives the same toggle set the documentation describes, on any machine and for any operator. Nothing operator-, workspace-, or path-specific is introduced; the seeded value is the hook's own documented default.
- **Produce verifiable outcomes autonomously.** The gate closes a defect *class*, not just this instance: any future toggle added to the catalog without reaching both seed sources now fails CI by name and file. All three failure directions were mutation-verified (key missing from each seed independently, and an undocumented extra key), rather than assumed.
- **Guard operator attention.** The failure message names the specific missing key and the specific file, so a future contributor gets an actionable diagnosis instead of a set-difference dump.
- **No enforcement floor removed.** Purely additive. The pre-existing `TOGGLE_SEED_FILES` adjacency assertion guards a different property (key ordering) and was left intact rather than folded in.

## Test plan

- [x] `test_toggle_catalog_key_set_matches_both_seed_sources` - mutation-verified in all three directions, each confirmed red with the expected message then restored to green:
      remove the key from `content/templates/.agentic/config.json` only; remove it from the `ds-init-project.md` seed block only; add a fictitious undocumented key to a seed.
- [x] `bin/tests/test_tracker_writeback_ranking_spec.py`: 65 passed (was 64).
- [x] `bin/tests/` full suite: 1151 passed (was 1150).
- [x] `scripts/build-all.sh` + `git diff --exit-code` over the verbatim `adapter-sync.yml` pathspec: clean after staging the regenerated adapter copies.
- [x] `check-methodology-drift.sh` OK, baseline hash unchanged (no `content/sections/**` edit). `check-symlinks-relative.sh` OK.
