### PR TITLE
fix(DS-152): stop a scratch worktree from dangling the repo's shared pre-commit hook

### DIFF
--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -865,19 +865,18 @@ case "$DANGLE_LEGACY_HOOKS_DIR" in
 esac
 DANGLE_LEGACY_HOOK_DST="$DANGLE_LEGACY_HOOKS_DIR/pre-commit"
 
-# resolve_primary_checkout canonicalises repo_dir (via _pc_canonicalize_dir)
-# before uninstall_precommit_hook passes it to _pc_is_legacy_sibling_hook's
-# path-prefix check, so the fixture's target path must be built from the
-# SAME canonical form - not the raw $DANGLE_LEGACY_MAIN string, which can
-# differ on a symlinked TMPDIR/HOME (e.g. macOS's
-# /var/folders -> /private/var/folders).
-DANGLE_LEGACY_MAIN_CANON="$(cd "$DANGLE_LEGACY_MAIN" && pwd -P)"
-
-# The dangling target's path lies under the repo's own known worktree root
-# (.claude/worktrees/) even though that directory no longer exists on disk -
-# simulating a Claude-harness worktree that was already deleted without its
-# legacy hook being uninstalled first.
-DANGLE_LEGACY_TARGET_DIR="$DANGLE_LEGACY_MAIN_CANON/.claude/worktrees/agent-deleted-example"
+# DS-152 round 4 (Major, was relocated here in round 3): the dangling
+# target's path is built from the RAW $DANGLE_LEGACY_MAIN string (as
+# `.claude/install.sh`'s pre-fix `REPO_DIR="$(cd ... && pwd)"` - logical
+# pwd, NOT `pwd -P` - would actually have spelled it for any checkout
+# reached through a symlinked component), NOT a pre-canonicalised form. This
+# is the shape the defect lives in: on a symlinked TMPDIR/HOME (e.g. macOS's
+# /var/folders -> /private/var/folders) this raw spelling differs, on disk,
+# from `primary_checkout`'s canonical form even though both name the exact
+# same real directory. A fixture built from the canonical form (round 3's
+# shape) cannot exercise this - see _pc_canonicalize_missing_dir below for
+# the fix that makes comparing these two spellings actually work.
+DANGLE_LEGACY_TARGET_DIR="$DANGLE_LEGACY_MAIN/.claude/worktrees/agent-deleted-example"
 mkdir -p "$DANGLE_LEGACY_HOOKS_DIR"
 ln -s "$DANGLE_LEGACY_TARGET_DIR/hooks/pre-commit" "$DANGLE_LEGACY_HOOK_DST"
 

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -123,6 +123,33 @@ _fail() {
   FAIL=$((FAIL + 1))
 }
 
+# ------------------------------------------------------------------
+# DS-152 round 6 (Minor 3): `timeout` is not a stock macOS binary - it is
+# present on this machine only via Homebrew coreutils, and its absence
+# under `command -v timeout` yields rc=127 from `timeout 8 ...`, which is
+# NOT 124. Test 13/13b's sole hang-detection assertion checks `rc -ne 124`,
+# so an absent `timeout` makes those assertions PASS while testing nothing
+# (the "green means the check never ran" class - see
+# bin/tests/test_check_resident_budget.sh:155-156 for the canonical
+# guarded-assertion pattern this follows). Resolve `timeout` or its GNU
+# coreutils alias `gtimeout` explicitly once, up front, and hard-fail under
+# `${CI}` rather than silently skipping if neither is found - CI is ubuntu
+# (stock `timeout`), so this only ever fires for a local dev sandbox
+# missing GNU coreutils, and the fix is a one-line `brew install
+# coreutils`, not a broken assertion someone has to root-cause blind.
+# ------------------------------------------------------------------
+PC_TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  PC_TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  PC_TIMEOUT_BIN="gtimeout"
+elif [[ -n "${CI:-}" ]]; then
+  echo "FAIL: neither 'timeout' nor 'gtimeout' found on PATH - required in CI for the round-5 hang-regression assertions (Tests 13/13b)" >&2
+  exit 1
+else
+  echo "SKIP: neither 'timeout' nor 'gtimeout' found on PATH - skipping the round-5 hang-regression assertions (Tests 13/13b non-hang-detection checks still run unguarded, but the hang-detection assertion itself cannot be trusted without a timeout binary). Install GNU coreutils (e.g. 'brew install coreutils') for local coverage."
+fi
+
 _pass() {
   echo "PASS: $1"
   PASS=$((PASS + 1))
@@ -954,49 +981,53 @@ fi
 #          suite (and CI) - a hung test is its own incident.
 # ============================================================
 
-HANG_MAIN="$TMP_ROOT/hang-main-repo"
-_make_fixture_repo "$HANG_MAIN"
+if [[ -n "$PC_TIMEOUT_BIN" ]]; then
+  HANG_MAIN="$TMP_ROOT/hang-main-repo"
+  _make_fixture_repo "$HANG_MAIN"
 
-HANG_HOOKS_DIR="$(git -C "$HANG_MAIN" rev-parse --git-path hooks)"
-case "$HANG_HOOKS_DIR" in
-  /*) : ;;
-  *) HANG_HOOKS_DIR="$HANG_MAIN/$HANG_HOOKS_DIR" ;;
-esac
-HANG_HOOK_DST="$HANG_HOOKS_DIR/pre-commit"
+  HANG_HOOKS_DIR="$(git -C "$HANG_MAIN" rev-parse --git-path hooks)"
+  case "$HANG_HOOKS_DIR" in
+    /*) : ;;
+    *) HANG_HOOKS_DIR="$HANG_MAIN/$HANG_HOOKS_DIR" ;;
+  esac
+  HANG_HOOK_DST="$HANG_HOOKS_DIR/pre-commit"
 
-# A relative symlink target whose first component ("toolbox") does not
-# exist anywhere resolvable - the exact shape that hung pre-fix code, and
-# the exact shape a real relative pre-DS-152 hook target could take
-# (`.husky/hooks/pre-commit`, `toolbox/hooks/pre-commit`, etc).
-mkdir -p "$HANG_HOOKS_DIR"
-ln -s "toolbox/hooks/pre-commit" "$HANG_HOOK_DST"
+  # A relative symlink target whose first component ("toolbox") does not
+  # exist anywhere resolvable - the exact shape that hung pre-fix code, and
+  # the exact shape a real relative pre-DS-152 hook target could take
+  # (`.husky/hooks/pre-commit`, `toolbox/hooks/pre-commit`, etc).
+  mkdir -p "$HANG_HOOKS_DIR"
+  ln -s "toolbox/hooks/pre-commit" "$HANG_HOOK_DST"
 
-HANG_OUT_FILE="$TMP_ROOT/hang-out.txt"
-timeout 8 bash -c "
-  set -uo pipefail
-  . '$LIB'
-  _ae_is_ours() { return 1; }
-  AE_DRY_RUN=false
-  uninstall_precommit_hook '$HANG_MAIN'
-" > "$HANG_OUT_FILE" 2>&1
-HANG_RC=$?
+  HANG_OUT_FILE="$TMP_ROOT/hang-out.txt"
+  "$PC_TIMEOUT_BIN" 8 bash -c "
+    set -uo pipefail
+    . '$LIB'
+    _ae_is_ours() { return 1; }
+    AE_DRY_RUN=false
+    uninstall_precommit_hook '$HANG_MAIN'
+  " > "$HANG_OUT_FILE" 2>&1
+  HANG_RC=$?
 
-if [[ $HANG_RC -ne 124 ]]; then
-  _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook did not hang (rc=$HANG_RC, not 124/timeout)"
+  if [[ $HANG_RC -ne 124 ]]; then
+    _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook did not hang (rc=$HANG_RC, not 124/timeout)"
+  else
+    _fail "hang regression case (DS-152 round 5 regression, Critical): uninstall_precommit_hook HUNG - killed by timeout (rc=124). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+  fi
+
+  if [[ $HANG_RC -eq 0 ]]; then
+    _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exits 0 (non-fatal - a relative target anchored against the hooks dir cannot be verified as a legacy sibling without an existing directory, so it is correctly left alone)"
+  else
+    _fail "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exited $HANG_RC (expected 0, non-fatal). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+  fi
+
+  if grep -qi "not ours" "$HANG_OUT_FILE"; then
+    _pass "hang regression case (DS-152 round 5, Critical): correctly reported as not ours rather than silently removed"
+  else
+    _fail "hang regression case (DS-152 round 5 regression, Critical): did not report the expected 'not ours' outcome. Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+  fi
 else
-  _fail "hang regression case (DS-152 round 5 regression, Critical): uninstall_precommit_hook HUNG - killed by timeout (rc=124). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
-fi
-
-if [[ $HANG_RC -eq 0 ]]; then
-  _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exits 0 (non-fatal - a relative target anchored against the hooks dir cannot be verified as a legacy sibling without an existing directory, so it is correctly left alone)"
-else
-  _fail "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exited $HANG_RC (expected 0, non-fatal). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
-fi
-
-if grep -qi "not ours" "$HANG_OUT_FILE"; then
-  _pass "hang regression case (DS-152 round 5, Critical): correctly reported as not ours rather than silently removed"
-else
-  _fail "hang regression case (DS-152 round 5 regression, Critical): did not report the expected 'not ours' outcome. Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+  echo "SKIP: Test 13 (hang regression case) - no timeout binary resolved"
 fi
 
 # ------------------------------------------------------------------
@@ -1009,24 +1040,28 @@ fi
 #           root-cause anchor.
 # ------------------------------------------------------------------
 
-HANG_UNIT_OUT_FILE="$TMP_ROOT/hang-unit-out.txt"
-timeout 8 bash -c "
-  set -uo pipefail
-  . '$LIB'
-  _pc_canonicalize_missing_dir 'toolbox'
-" > "$HANG_UNIT_OUT_FILE" 2>&1
-HANG_UNIT_RC=$?
+if [[ -n "$PC_TIMEOUT_BIN" ]]; then
+  HANG_UNIT_OUT_FILE="$TMP_ROOT/hang-unit-out.txt"
+  "$PC_TIMEOUT_BIN" 8 bash -c "
+    set -uo pipefail
+    . '$LIB'
+    _pc_canonicalize_missing_dir 'toolbox'
+  " > "$HANG_UNIT_OUT_FILE" 2>&1
+  HANG_UNIT_RC=$?
 
-if [[ $HANG_UNIT_RC -ne 124 ]]; then
-  _pass "hang regression unit case (DS-152 round 5, Critical): _pc_canonicalize_missing_dir('toolbox') did not hang (rc=$HANG_UNIT_RC, not 124/timeout)"
+  if [[ $HANG_UNIT_RC -ne 124 ]]; then
+    _pass "hang regression unit case (DS-152 round 5, Critical): _pc_canonicalize_missing_dir('toolbox') did not hang (rc=$HANG_UNIT_RC, not 124/timeout)"
+  else
+    _fail "hang regression unit case (DS-152 round 5 regression, Critical): _pc_canonicalize_missing_dir('toolbox') HUNG - killed by timeout (rc=124)."
+  fi
 else
-  _fail "hang regression unit case (DS-152 round 5 regression, Critical): _pc_canonicalize_missing_dir('toolbox') HUNG - killed by timeout (rc=124)."
+  echo "SKIP: Test 13b (hang regression unit case) - no timeout binary resolved"
 fi
 
 # ------------------------------------------------------------------
 # Test 13c: DS-152 round 5 (Critical, anchor correctness) - isolates the
 #           anchoring fix from the termination guard: this fixture's
-#           dangling... no, EXISTING target resolves correctly ONLY when
+#           EXISTING target resolves correctly ONLY when
 #           the relative readlink target is anchored against the
 #           symlink's own directory (hooks_dir), never against the
 #           process CWD. Without the anchor, `-d target_repo_dir` is

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -943,6 +943,139 @@ else
   _fail "dangling-foreign-target case (DS-152 round 3 regression): dangling hook outside known worktree roots was removed - the path constraint failed to scope the fix. Output: $OUT"
 fi
 
+# ============================================================
+# Test 13: DS-152 round 5 (Critical) - a dangling legacy hook whose RAW
+#          (readlink) target is a RELATIVE path, whose first path component
+#          does not exist, must not hang uninstall_precommit_hook.
+#          `${existing%/*}` is a no-op on a slash-free string, so pre-fix
+#          code (d2af1489) walked "toolbox" -> "toolbox" -> ... forever,
+#          growing `tail` unbounded. Wrapped in `timeout` so a regression
+#          here fails a single assertion instead of hanging the whole
+#          suite (and CI) - a hung test is its own incident.
+# ============================================================
+
+HANG_MAIN="$TMP_ROOT/hang-main-repo"
+_make_fixture_repo "$HANG_MAIN"
+
+HANG_HOOKS_DIR="$(git -C "$HANG_MAIN" rev-parse --git-path hooks)"
+case "$HANG_HOOKS_DIR" in
+  /*) : ;;
+  *) HANG_HOOKS_DIR="$HANG_MAIN/$HANG_HOOKS_DIR" ;;
+esac
+HANG_HOOK_DST="$HANG_HOOKS_DIR/pre-commit"
+
+# A relative symlink target whose first component ("toolbox") does not
+# exist anywhere resolvable - the exact shape that hung pre-fix code, and
+# the exact shape a real relative pre-DS-152 hook target could take
+# (`.husky/hooks/pre-commit`, `toolbox/hooks/pre-commit`, etc).
+mkdir -p "$HANG_HOOKS_DIR"
+ln -s "toolbox/hooks/pre-commit" "$HANG_HOOK_DST"
+
+HANG_OUT_FILE="$TMP_ROOT/hang-out.txt"
+timeout 8 bash -c "
+  set -uo pipefail
+  . '$LIB'
+  _ae_is_ours() { return 1; }
+  AE_DRY_RUN=false
+  uninstall_precommit_hook '$HANG_MAIN'
+" > "$HANG_OUT_FILE" 2>&1
+HANG_RC=$?
+
+if [[ $HANG_RC -ne 124 ]]; then
+  _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook did not hang (rc=$HANG_RC, not 124/timeout)"
+else
+  _fail "hang regression case (DS-152 round 5 regression, Critical): uninstall_precommit_hook HUNG - killed by timeout (rc=124). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+fi
+
+if [[ $HANG_RC -eq 0 ]]; then
+  _pass "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exits 0 (non-fatal - a relative target anchored against the hooks dir cannot be verified as a legacy sibling without an existing directory, so it is correctly left alone)"
+else
+  _fail "hang regression case (DS-152 round 5, Critical): uninstall_precommit_hook exited $HANG_RC (expected 0, non-fatal). Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+fi
+
+if grep -qi "not ours" "$HANG_OUT_FILE"; then
+  _pass "hang regression case (DS-152 round 5, Critical): correctly reported as not ours rather than silently removed"
+else
+  _fail "hang regression case (DS-152 round 5 regression, Critical): did not report the expected 'not ours' outcome. Output: $(cat "$HANG_OUT_FILE" 2>&1)"
+fi
+
+# ------------------------------------------------------------------
+# Test 13b: DS-152 round 5 (Critical, safety-net unit) - the termination
+#           guard inside _pc_canonicalize_missing_dir itself must hold
+#           even when called directly with an unanchored, slash-free,
+#           non-existent path - i.e. independent of
+#           _pc_is_legacy_sibling_hook's own anchoring fix. This is the
+#           safety net the round-5 fix explicitly adds on top of the
+#           root-cause anchor.
+# ------------------------------------------------------------------
+
+HANG_UNIT_OUT_FILE="$TMP_ROOT/hang-unit-out.txt"
+timeout 8 bash -c "
+  set -uo pipefail
+  . '$LIB'
+  _pc_canonicalize_missing_dir 'toolbox'
+" > "$HANG_UNIT_OUT_FILE" 2>&1
+HANG_UNIT_RC=$?
+
+if [[ $HANG_UNIT_RC -ne 124 ]]; then
+  _pass "hang regression unit case (DS-152 round 5, Critical): _pc_canonicalize_missing_dir('toolbox') did not hang (rc=$HANG_UNIT_RC, not 124/timeout)"
+else
+  _fail "hang regression unit case (DS-152 round 5 regression, Critical): _pc_canonicalize_missing_dir('toolbox') HUNG - killed by timeout (rc=124)."
+fi
+
+# ------------------------------------------------------------------
+# Test 13c: DS-152 round 5 (Critical, anchor correctness) - isolates the
+#           anchoring fix from the termination guard: this fixture's
+#           dangling... no, EXISTING target resolves correctly ONLY when
+#           the relative readlink target is anchored against the
+#           symlink's own directory (hooks_dir), never against the
+#           process CWD. Without the anchor, `-d target_repo_dir` is
+#           checked against a path relative to the test runner's CWD (this
+#           repo checkout) rather than the real sibling worktree, so the
+#           hook is wrongly left in place - it would NOT hang (the
+#           termination guard alone prevents that), so Test 13/13b cannot
+#           distinguish "anchored correctly" from "merely didn't hang".
+#           This test can.
+# ------------------------------------------------------------------
+
+ANCHOR_MAIN="$TMP_ROOT/anchor-main-repo"
+_make_fixture_repo "$ANCHOR_MAIN"
+
+ANCHOR_WT="$TMP_ROOT/anchor-wt"
+git -C "$ANCHOR_MAIN" worktree add -q "$ANCHOR_WT" -b anchor-wt-test-branch >/dev/null 2>&1
+
+ANCHOR_HOOKS_DIR="$(git -C "$ANCHOR_MAIN" rev-parse --git-path hooks)"
+case "$ANCHOR_HOOKS_DIR" in
+  /*) : ;;
+  *) ANCHOR_HOOKS_DIR="$ANCHOR_MAIN/$ANCHOR_HOOKS_DIR" ;;
+esac
+ANCHOR_HOOK_DST="$ANCHOR_HOOKS_DIR/pre-commit"
+
+# The RELATIVE path from the symlink's own directory (ANCHOR_HOOKS_DIR) to
+# the real sibling worktree's hooks/pre-commit - exactly the raw text a
+# relative pre-DS-152 install would have written via `ln -s`.
+ANCHOR_REL_TARGET="$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" "$ANCHOR_WT/hooks/pre-commit" "$ANCHOR_HOOKS_DIR")"
+
+mkdir -p "$ANCHOR_HOOKS_DIR"
+ln -s "$ANCHOR_REL_TARGET" "$ANCHOR_HOOK_DST"
+
+OUT="$(uninstall_precommit_hook "$ANCHOR_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "anchor-correctness case (DS-152 round 5, Critical): uninstall_precommit_hook exits 0"
+else
+  _fail "anchor-correctness case (DS-152 round 5, Critical): uninstall_precommit_hook exited $RC. Output: $OUT"
+fi
+
+# `! -e` alone follows symlinks and would false-pass on a dangling
+# leftover symlink - assert `! -L` too.
+if [[ ! -e "$ANCHOR_HOOK_DST" ]] && [[ ! -L "$ANCHOR_HOOK_DST" ]]; then
+  _pass "anchor-correctness case (DS-152 round 5, Critical): relative legacy target correctly resolved against the symlink's own directory and removed"
+else
+  _fail "anchor-correctness case (DS-152 round 5 regression, Critical): relative legacy target was NOT removed - it was resolved against the wrong base directory (CWD instead of the symlink's own directory: $ANCHOR_HOOKS_DIR). Output: $OUT"
+fi
+
 # ---- Results ----
 
 echo ""

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -12,6 +12,16 @@
 # failing on top of that corruption. Clearing these before any other line
 # runs defeats that class of leak outright.
 unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CEILING_DIRECTORIES
+# DS-152 round 3 (Minor - hostile global git config): a global
+# `core.hooksPath` collapses every fixture's hooks dir onto one directory
+# (`git rev-parse --git-path hooks` honours it, and it is not one of the
+# GIT_* env vars unset above). GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM point git
+# at /dev/null instead of the operator's real global/system config for
+# every git invocation in this process, neutralising the vector - same
+# pattern already used by bin/tests/test_agentic_tracker.py and
+# bin/tests/lib/git_fixture.py.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
 # Purpose: Regression test for scripts/lib/precommit.sh's install_precommit_hook
 #          and uninstall_precommit_hook. Ensures both resolve the REAL git
 #          hooks directory (via `git rev-parse --git-path hooks`) instead of
@@ -333,7 +343,10 @@ else
   _fail "uninstall-from-worktree case: uninstall_precommit_hook exited $RC. Output: $OUT"
 fi
 
-if [[ ! -e "$UNINSTALL_HOOK_DST" ]]; then
+# `! -e` alone follows symlinks and would false-pass on a dangling
+# leftover symlink (target gone, link itself still present) - assert
+# `! -L` too so a botched removal that leaves a dangling symlink is caught.
+if [[ ! -e "$UNINSTALL_HOOK_DST" ]] && [[ ! -L "$UNINSTALL_HOOK_DST" ]]; then
   _pass "uninstall-from-worktree case (DS-58 fixed): AE-owned pre-commit hook actually removed"
 else
   _fail "uninstall-from-worktree case (DS-58 regression): pre-commit hook still present at $UNINSTALL_HOOK_DST. Output: $OUT"
@@ -583,7 +596,9 @@ else
   _fail "missing-source case (DS-152 round 2 regression, Major 2): no loud warning for a missing hook_src. Output: $OUT"
 fi
 
-if [[ ! -e "$MISSING_SRC_HOOK_DST" ]]; then
+# `! -e` alone follows symlinks and would false-pass if a dangling symlink
+# were created instead of no symlink at all - assert `! -L` too.
+if [[ ! -e "$MISSING_SRC_HOOK_DST" ]] && [[ ! -L "$MISSING_SRC_HOOK_DST" ]]; then
   _pass "missing-source case (DS-152 round 2, Major 2): no NEW dangling symlink was created"
 else
   _fail "missing-source case (DS-152 round 2 regression, Major 2): a dangling symlink was created at $MISSING_SRC_HOOK_DST despite a missing source"
@@ -678,6 +693,56 @@ else
 fi
 
 # ============================================================
+# Test 9b: DS-152 round 3 (bare-repo coverage gap) - a linked worktree of a
+#          BARE primary repo hits the same resolve_primary_checkout failure
+#          mode as Test 9's --separate-git-dir case (a common-dir that does
+#          not end in a literal "/.git" path component), but via a
+#          different git construct. The header's failure-modes block claims
+#          this was "measured for --separate-git-dir AND bare linked
+#          worktrees" - this test makes that claim true instead of aspirational.
+# ============================================================
+
+BARE_SOURCE="$TMP_ROOT/bare-source-repo"
+_make_fixture_repo "$BARE_SOURCE"
+
+BARE_MAIN="$TMP_ROOT/bare-main-repo.git"
+git clone -q --bare "$BARE_SOURCE" "$BARE_MAIN" >/dev/null 2>&1
+
+BARE_WT="$TMP_ROOT/bare-wt"
+git -C "$BARE_MAIN" worktree add -q "$BARE_WT" -b bare-wt-test-branch >/dev/null 2>&1
+
+OUT="$(install_precommit_hook "$BARE_WT" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "bare-repo case: install_precommit_hook exits 0 (non-fatal)"
+else
+  _fail "bare-repo case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "could not resolve the primary checkout"; then
+  _pass "bare-repo case (DS-152 round 3, bare-repo coverage gap): loud warning printed for the silent primary-checkout fallback"
+else
+  _fail "bare-repo case (DS-152 round 3 regression, bare-repo coverage gap): resolve_primary_checkout fell back to repo_dir with no warning. Output: $OUT"
+fi
+
+# Falls back to repo_dir's own hooks/pre-commit (BARE_WT's own copy, which
+# `git worktree add` checks out from the bare repo's committed tree) and
+# still installs successfully rather than aborting.
+BARE_HOOKS_DIR="$(git -C "$BARE_WT" rev-parse --git-path hooks)"
+case "$BARE_HOOKS_DIR" in
+  /*) : ;;
+  *) BARE_HOOKS_DIR="$BARE_WT/$BARE_HOOKS_DIR" ;;
+esac
+BARE_HOOK_DST="$BARE_HOOKS_DIR/pre-commit"
+
+if [[ -L "$BARE_HOOK_DST" ]] && [[ "$BARE_HOOK_DST" -ef "$BARE_WT/hooks/pre-commit" ]]; then
+  _pass "bare-repo case (DS-152 round 3, bare-repo coverage gap): falls back to repo_dir's own hooks/pre-commit and installs"
+else
+  _fail "bare-repo case (DS-152 round 3 regression, bare-repo coverage gap): fallback install did not land at repo_dir's own hooks/pre-commit. Output: $OUT"
+fi
+
+# ============================================================
 # Test 10: DS-152 round 2 (Minor) - uninstall must still remove a hook that
 #          was installed by PRE-DS-152 code pointing at a worktree's own
 #          hooks/pre-commit, not the primary checkout's.
@@ -712,7 +777,9 @@ else
   _fail "legacy-target uninstall case: uninstall_precommit_hook exited $RC. Output: $OUT"
 fi
 
-if [[ ! -e "$LEGACY_HOOK_DST" ]]; then
+# `! -e` alone follows symlinks and would false-pass on a dangling
+# leftover symlink - assert `! -L` too.
+if [[ ! -e "$LEGACY_HOOK_DST" ]] && [[ ! -L "$LEGACY_HOOK_DST" ]]; then
   _pass "legacy-target uninstall case (DS-152 round 2, Minor): pre-DS-152 worktree-targeted hook actually removed"
 else
   _fail "legacy-target uninstall case (DS-152 round 2 regression, Minor): pre-DS-152 hook still present at $LEGACY_HOOK_DST, current target: $(readlink "$LEGACY_HOOK_DST" 2>&1). Output: $OUT"
@@ -722,6 +789,159 @@ if echo "$OUT" | grep -qi "not ours"; then
   _fail "legacy-target uninstall case (DS-152 round 2 regression, Minor): reported 'not ours' despite the target being a legacy sibling worktree hook. Output: $OUT"
 else
   _pass "legacy-target uninstall case (DS-152 round 2, Minor): did not falsely report 'not ours'"
+fi
+
+# ============================================================
+# Test 11: DS-152 round 3 (Major) - _pc_git_common_dir_abs must canonicalise,
+#          not just concatenate. Test 10 above only exercises the WORKTREE
+#          invocation of uninstall (both the calling repo_dir AND the legacy
+#          target are worktrees), which - even pre-fix - takes git's own
+#          already-canonical --git-common-dir output on both sides and so
+#          cannot redden this bug. The measured failure requires the
+#          PRIMARY-checkout invocation: repo_common_dir is computed from the
+#          non-worktree branch (pre-fix: raw string concatenation of
+#          repo_dir + ".git", NOT canonicalised) while target_common_dir (a
+#          worktree) is computed from git's own canonical
+#          --git-common-dir output - these differ whenever TMPDIR/HOME has a
+#          symlinked component (e.g. macOS's
+#          /var/folders -> /private/var/folders), and
+#          _pc_is_legacy_sibling_hook silently returns false, leaving the
+#          hook in place. This test targets that exact invocation shape.
+# ============================================================
+
+PRIMARY_INVOKE_MAIN="$TMP_ROOT/primary-invoke-main-repo"
+_make_fixture_repo "$PRIMARY_INVOKE_MAIN"
+
+PRIMARY_INVOKE_WT="$TMP_ROOT/primary-invoke-wt"
+git -C "$PRIMARY_INVOKE_MAIN" worktree add -q "$PRIMARY_INVOKE_WT" -b primary-invoke-wt-test-branch >/dev/null 2>&1
+
+# The shared hooks dir is common to both the primary checkout and its
+# worktree - resolve it from either side.
+PRIMARY_INVOKE_HOOKS_DIR="$(git -C "$PRIMARY_INVOKE_MAIN" rev-parse --git-path hooks)"
+case "$PRIMARY_INVOKE_HOOKS_DIR" in
+  /*) : ;;
+  *) PRIMARY_INVOKE_HOOKS_DIR="$PRIMARY_INVOKE_MAIN/$PRIMARY_INVOKE_HOOKS_DIR" ;;
+esac
+PRIMARY_INVOKE_HOOK_DST="$PRIMARY_INVOKE_HOOKS_DIR/pre-commit"
+
+# Hand-craft the PRE-DS-152 install shape at the shared hooks dir: symlinked
+# at the WORKTREE's own hooks/pre-commit, exactly as Test 10 does, but this
+# time the removal call below targets the PRIMARY checkout, not the
+# worktree.
+mkdir -p "$PRIMARY_INVOKE_HOOKS_DIR"
+ln -s "$PRIMARY_INVOKE_WT/hooks/pre-commit" "$PRIMARY_INVOKE_HOOK_DST"
+
+OUT="$(uninstall_precommit_hook "$PRIMARY_INVOKE_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "primary-checkout-invocation legacy-target case (DS-152 round 3, Major): uninstall_precommit_hook exits 0"
+else
+  _fail "primary-checkout-invocation legacy-target case (DS-152 round 3, Major): uninstall_precommit_hook exited $RC. Output: $OUT"
+fi
+
+# `! -e` alone follows symlinks and would false-pass on a dangling leftover
+# symlink - assert `! -L` too.
+if [[ ! -e "$PRIMARY_INVOKE_HOOK_DST" ]] && [[ ! -L "$PRIMARY_INVOKE_HOOK_DST" ]]; then
+  _pass "primary-checkout-invocation legacy-target case (DS-152 round 3, Major): legacy sibling hook removed when uninstall is invoked from the PRIMARY checkout"
+else
+  _fail "primary-checkout-invocation legacy-target case (DS-152 round 3 regression, Major): legacy sibling hook still present at $PRIMARY_INVOKE_HOOK_DST when uninstall was invoked from the primary checkout (this is the _pc_git_common_dir_abs canonicalisation bug), current target: $(readlink "$PRIMARY_INVOKE_HOOK_DST" 2>&1). Output: $OUT"
+fi
+
+# ============================================================
+# Test 12: DS-152 round 3 (dangling-legacy-target-can-never-be-cleaned) - a
+#          legacy hook whose target worktree has ALREADY BEEN DELETED must
+#          still be removable, provided it lies under the repo's own known
+#          worktree roots (.claude/worktrees/ or .agentic/worktrees/).
+# ============================================================
+
+DANGLE_LEGACY_MAIN="$TMP_ROOT/dangle-legacy-main-repo"
+_make_fixture_repo "$DANGLE_LEGACY_MAIN"
+
+DANGLE_LEGACY_HOOKS_DIR="$(git -C "$DANGLE_LEGACY_MAIN" rev-parse --git-path hooks)"
+case "$DANGLE_LEGACY_HOOKS_DIR" in
+  /*) : ;;
+  *) DANGLE_LEGACY_HOOKS_DIR="$DANGLE_LEGACY_MAIN/$DANGLE_LEGACY_HOOKS_DIR" ;;
+esac
+DANGLE_LEGACY_HOOK_DST="$DANGLE_LEGACY_HOOKS_DIR/pre-commit"
+
+# resolve_primary_checkout canonicalises repo_dir (via _pc_canonicalize_dir)
+# before uninstall_precommit_hook passes it to _pc_is_legacy_sibling_hook's
+# path-prefix check, so the fixture's target path must be built from the
+# SAME canonical form - not the raw $DANGLE_LEGACY_MAIN string, which can
+# differ on a symlinked TMPDIR/HOME (e.g. macOS's
+# /var/folders -> /private/var/folders).
+DANGLE_LEGACY_MAIN_CANON="$(cd "$DANGLE_LEGACY_MAIN" && pwd -P)"
+
+# The dangling target's path lies under the repo's own known worktree root
+# (.claude/worktrees/) even though that directory no longer exists on disk -
+# simulating a Claude-harness worktree that was already deleted without its
+# legacy hook being uninstalled first.
+DANGLE_LEGACY_TARGET_DIR="$DANGLE_LEGACY_MAIN_CANON/.claude/worktrees/agent-deleted-example"
+mkdir -p "$DANGLE_LEGACY_HOOKS_DIR"
+ln -s "$DANGLE_LEGACY_TARGET_DIR/hooks/pre-commit" "$DANGLE_LEGACY_HOOK_DST"
+
+# Verify the fixture actually models "already deleted" - the target
+# directory must NOT exist.
+if [[ ! -d "$DANGLE_LEGACY_TARGET_DIR" ]]; then
+  _pass "dangling-legacy-target fixture: target worktree directory does not exist (fixture models an already-deleted worktree)"
+else
+  _fail "dangling-legacy-target fixture: target worktree directory unexpectedly exists (fixture setup bug)"
+fi
+
+OUT="$(uninstall_precommit_hook "$DANGLE_LEGACY_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "dangling-legacy-target case (DS-152 round 3): uninstall_precommit_hook exits 0"
+else
+  _fail "dangling-legacy-target case (DS-152 round 3): uninstall_precommit_hook exited $RC. Output: $OUT"
+fi
+
+# `! -e` alone follows symlinks and would false-pass on the exact dangling
+# case this test exists to check - assert `! -L` too.
+if [[ ! -e "$DANGLE_LEGACY_HOOK_DST" ]] && [[ ! -L "$DANGLE_LEGACY_HOOK_DST" ]]; then
+  _pass "dangling-legacy-target case (DS-152 round 3): dangling legacy hook under a known worktree root actually removed"
+else
+  _fail "dangling-legacy-target case (DS-152 round 3 regression): dangling legacy hook still present at $DANGLE_LEGACY_HOOK_DST, current target: $(readlink "$DANGLE_LEGACY_HOOK_DST" 2>&1). Output: $OUT"
+fi
+
+# ------------------------------------------------------------------
+# Test 12b: the SAME dangling-target shape, but OUTSIDE the repo's known
+#           worktree roots, must NOT be removed - the path constraint exists
+#           precisely to avoid widening into a foreign dangling hook that
+#           merely happens to be unreachable.
+# ------------------------------------------------------------------
+
+DANGLE_FOREIGN_MAIN="$TMP_ROOT/dangle-foreign-main-repo"
+_make_fixture_repo "$DANGLE_FOREIGN_MAIN"
+
+DANGLE_FOREIGN_HOOKS_DIR="$(git -C "$DANGLE_FOREIGN_MAIN" rev-parse --git-path hooks)"
+case "$DANGLE_FOREIGN_HOOKS_DIR" in
+  /*) : ;;
+  *) DANGLE_FOREIGN_HOOKS_DIR="$DANGLE_FOREIGN_MAIN/$DANGLE_FOREIGN_HOOKS_DIR" ;;
+esac
+DANGLE_FOREIGN_HOOK_DST="$DANGLE_FOREIGN_HOOKS_DIR/pre-commit"
+
+# Target lies outside both known worktree roots - some unrelated, already
+# deleted directory that happens to end in /hooks/pre-commit.
+DANGLE_FOREIGN_TARGET_DIR="$TMP_ROOT/some-unrelated-deleted-checkout"
+mkdir -p "$DANGLE_FOREIGN_HOOKS_DIR"
+ln -s "$DANGLE_FOREIGN_TARGET_DIR/hooks/pre-commit" "$DANGLE_FOREIGN_HOOK_DST"
+
+OUT="$(uninstall_precommit_hook "$DANGLE_FOREIGN_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "dangling-foreign-target case (DS-152 round 3): uninstall_precommit_hook exits 0"
+else
+  _fail "dangling-foreign-target case (DS-152 round 3): uninstall_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if [[ -L "$DANGLE_FOREIGN_HOOK_DST" ]] && [[ "$(readlink "$DANGLE_FOREIGN_HOOK_DST")" == "$DANGLE_FOREIGN_TARGET_DIR/hooks/pre-commit" ]]; then
+  _pass "dangling-foreign-target case (DS-152 round 3): dangling hook outside known worktree roots left untouched, not widened into"
+else
+  _fail "dangling-foreign-target case (DS-152 round 3 regression): dangling hook outside known worktree roots was removed - the path constraint failed to scope the fix. Output: $OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -6,7 +6,11 @@
 #          a git worktree - there ".git" is a FILE (a gitdir pointer), not a
 #          directory, so a plain `ln -s`/`rm` against
 #          "$REPO_DIR/.git/hooks/..." fails or silently no-ops (DS-58, both
-#          the install side and the symmetric uninstall side).
+#          the install side and the symmetric uninstall side). Also covers
+#          DS-152: install_precommit_hook must source the hook BODY from the
+#          durable PRIMARY checkout, never from whichever worktree repo_dir
+#          happens to be, so an ephemeral/scratch worktree's removal can
+#          never dangle the ONE shared hook every worktree of a repo uses.
 #
 # Public API: ./bin/tests/test_precommit_worktree.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -37,6 +41,17 @@
 #     the real (shared, main-repo) hooks dir; a foreign hook is preserved.
 #   This test re-creates worktree fixtures for both sides to prevent
 #   regression.
+#   - DS-152: install_precommit_hook always symlinks the shared hooks dir
+#     at the PRIMARY checkout's hooks/pre-commit, even when invoked with an
+#     ephemeral worktree as repo_dir - so removing that worktree afterward
+#     can never dangle the shared hook. Tests 2 and 3 below assert against
+#     the primary checkout's hook_src (not repo_dir's) to reflect this: DS-58
+#     only ever needed the DESTINATION (the real, shared hooks dir) resolved
+#     correctly and a working, non-"Not a directory" symlink installed -
+#     which worktree's own copy of hooks/pre-commit happened to be the
+#     SOURCE was an incidental implementation detail of DS-58, not part of
+#     what it was fixing. Test 6 covers the DS-152 scratch-worktree-removal
+#     scenario directly.
 
 set -uo pipefail
 
@@ -78,6 +93,25 @@ _cleanup() {
   [[ -n "${TMP_ROOT:-}" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
 }
 trap _cleanup EXIT
+
+# ------------------------------------------------------------------
+# Sandbox-isolation guarantee: every fixture below lives under a fresh
+# `mktemp -d` directory (TMP_ROOT), never under $REPO_DIR (this real
+# checkout's own .git/hooks are never touched, by construction - fixture
+# repos are `git init`-ed from scratch and are their own independent
+# repositories with their own independent .git dirs). Assert TMP_ROOT is
+# genuinely outside REPO_DIR before creating any fixture, so a future
+# change to the mktemp call cannot silently reintroduce the "fakes $HOME
+# but not git --git-path hooks, escapes its sandbox" hazard recorded for
+# this class of test.
+# ------------------------------------------------------------------
+case "$TMP_ROOT" in
+  "$REPO_DIR"/*|"$REPO_DIR")
+    echo "FAIL: TMP_ROOT ($TMP_ROOT) is inside REPO_DIR ($REPO_DIR) - refusing to run, this would risk touching the real repo's .git/hooks" >&2
+    exit 1
+    ;;
+esac
+_pass "sandbox isolation: TMP_ROOT ($TMP_ROOT) is outside REPO_DIR ($REPO_DIR)"
 
 # _make_fixture_repo <dir>
 #   git-inits <dir>, commits a tracked hooks/pre-commit file.
@@ -122,7 +156,12 @@ else
 fi
 
 NORMAL_HOOK_DST="$NORMAL_REPO/.git/hooks/pre-commit"
-if [[ -L "$NORMAL_HOOK_DST" ]] && [[ "$(readlink "$NORMAL_HOOK_DST")" == "$NORMAL_REPO/hooks/pre-commit" ]]; then
+# -ef (same-inode) rather than a literal string match: the primary-checkout
+# resolution canonicalises repo_dir (`pwd -P`), so on a host where TMPDIR
+# itself is a symlink (e.g. macOS /var/folders -> /private/var/folders) the
+# resolved hook_src legitimately differs, byte-for-byte, from the literal
+# $NORMAL_REPO string while still pointing at the exact same file.
+if [[ -L "$NORMAL_HOOK_DST" ]] && [[ "$NORMAL_HOOK_DST" -ef "$NORMAL_REPO/hooks/pre-commit" ]]; then
   _pass "normal case: pre-commit symlink installed at $NORMAL_HOOK_DST"
 else
   _fail "normal case: pre-commit symlink not found/correct at $NORMAL_HOOK_DST. Output: $OUT"
@@ -174,8 +213,12 @@ else
   _fail "worktree case: real hooks dir resolved to unexpected path: $REAL_HOOKS_DIR"
 fi
 
-if [[ -L "$WT_HOOK_DST" ]] && [[ "$(readlink "$WT_HOOK_DST")" == "$WT_BRANCH/hooks/pre-commit" ]]; then
-  _pass "worktree case: pre-commit symlink installed at real hooks dir ($WT_HOOK_DST)"
+# DS-152: source is the PRIMARY checkout (WT_MAIN), not the invoking
+# worktree (WT_BRANCH) - see the file header note above. -ef (same-inode)
+# rather than a literal string match, for the same TMPDIR-symlink reason as
+# Test 1's NORMAL_HOOK_DST assertion.
+if [[ -L "$WT_HOOK_DST" ]] && [[ "$WT_HOOK_DST" -ef "$WT_MAIN/hooks/pre-commit" ]]; then
+  _pass "worktree case: pre-commit symlink installed at real hooks dir, sourced from primary checkout ($WT_HOOK_DST)"
 else
   _fail "worktree case: pre-commit symlink not found/correct at $WT_HOOK_DST. Output: $OUT"
 fi
@@ -201,7 +244,10 @@ case "$UNINSTALL_REAL_HOOKS_DIR" in
 esac
 UNINSTALL_HOOK_DST="$UNINSTALL_REAL_HOOKS_DIR/pre-commit"
 
-if [[ -L "$UNINSTALL_HOOK_DST" ]] && [[ "$(readlink "$UNINSTALL_HOOK_DST")" == "$UNINSTALL_WT_BRANCH/hooks/pre-commit" ]]; then
+# DS-152: source is the PRIMARY checkout (UNINSTALL_WT_MAIN), not the
+# invoking worktree (UNINSTALL_WT_BRANCH) - see the file header note above.
+# -ef (same-inode) for the same TMPDIR-symlink reason as Test 1/2 above.
+if [[ -L "$UNINSTALL_HOOK_DST" ]] && [[ "$UNINSTALL_HOOK_DST" -ef "$UNINSTALL_WT_MAIN/hooks/pre-commit" ]]; then
   _pass "uninstall setup: pre-commit hook installed at real hooks dir before uninstall test"
 else
   _fail "uninstall setup: pre-commit hook not installed at $UNINSTALL_HOOK_DST as expected"
@@ -302,6 +348,129 @@ if echo "$OUT" | grep -qi "skipping pre-commit hook removal"; then
   _pass "non-repo case: uninstall prints a non-fatal skip warning"
 else
   _fail "non-repo case: uninstall expected a non-fatal skip warning. Output: $OUT"
+fi
+
+# ============================================================
+# Test 6: DS-152 - installing FROM an ephemeral scratch worktree must not
+#         dangle the shared hook once that worktree is removed. This is the
+#         direct regression test for the bug: running install.sh with
+#         repo_dir pointed at a soon-to-be-deleted worktree (e.g. a Skeptic
+#         QA-regression scratch dir) must symlink the shared hook at the
+#         durable PRIMARY checkout's hooks/pre-commit, not at the scratch
+#         worktree's own copy.
+# ============================================================
+
+SCRATCH_MAIN="$TMP_ROOT/scratch-main-repo"
+_make_fixture_repo "$SCRATCH_MAIN"
+
+SCRATCH_WT="$TMP_ROOT/scratch-wt"
+git -C "$SCRATCH_MAIN" worktree add -q "$SCRATCH_WT" -b scratch-wt-test-branch >/dev/null 2>&1
+
+# Install run directly from the scratch worktree - simulates an install.sh
+# invocation whose repo_dir happens to be the ephemeral worktree, with no
+# prior install having run from the primary checkout first.
+OUT="$(install_precommit_hook "$SCRATCH_WT" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "scratch-worktree case: install_precommit_hook exits 0"
+else
+  _fail "scratch-worktree case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+SCRATCH_REAL_HOOKS_DIR="$(git -C "$SCRATCH_WT" rev-parse --git-path hooks)"
+case "$SCRATCH_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) SCRATCH_REAL_HOOKS_DIR="$SCRATCH_WT/$SCRATCH_REAL_HOOKS_DIR" ;;
+esac
+SCRATCH_HOOK_DST="$SCRATCH_REAL_HOOKS_DIR/pre-commit"
+
+# -ef (same-inode) rather than a literal string match, for the same
+# TMPDIR-symlink reason as Test 1/2/3 above.
+if [[ -L "$SCRATCH_HOOK_DST" ]] && [[ "$SCRATCH_HOOK_DST" -ef "$SCRATCH_MAIN/hooks/pre-commit" ]]; then
+  _pass "scratch-worktree case (DS-152): shared hook sourced from the primary checkout, not the scratch worktree"
+else
+  _fail "scratch-worktree case (DS-152 regression): shared hook not sourced from primary checkout ($SCRATCH_MAIN/hooks/pre-commit); got $(readlink "$SCRATCH_HOOK_DST" 2>&1). Output: $OUT"
+fi
+
+# Now delete the scratch worktree entirely, exactly as the Skeptic
+# QA-regression protocol would after a scratch session ends.
+git -C "$SCRATCH_MAIN" worktree remove --force "$SCRATCH_WT" >/dev/null 2>&1
+
+if [[ -e "$SCRATCH_HOOK_DST" ]]; then
+  _pass "scratch-worktree case (DS-152): shared hook still resolves after the scratch worktree is removed (not dangling)"
+else
+  _fail "scratch-worktree case (DS-152 regression): shared hook is DANGLING after scratch worktree removal - readlink: $(readlink "$SCRATCH_HOOK_DST" 2>&1)"
+fi
+
+# Re-running install from the (now-durable, still-present) primary checkout
+# must report the hook as already correctly linked - no re-point needed.
+OUT="$(install_precommit_hook "$SCRATCH_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  _pass "scratch-worktree case (DS-152): re-running install from the primary checkout reports the hook already linked"
+else
+  _fail "scratch-worktree case (DS-152 regression): re-running install from the primary checkout did not report already-linked. Output: $OUT"
+fi
+
+# ============================================================
+# Test 7: DS-152 - a dangling hook target is warned about loudly
+# ============================================================
+
+DANGLE_MAIN="$TMP_ROOT/dangle-main-repo"
+_make_fixture_repo "$DANGLE_MAIN"
+
+DANGLE_REAL_HOOKS_DIR="$(git -C "$DANGLE_MAIN" rev-parse --git-path hooks)"
+case "$DANGLE_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DANGLE_REAL_HOOKS_DIR="$DANGLE_MAIN/$DANGLE_REAL_HOOKS_DIR" ;;
+esac
+DANGLE_HOOK_DST="$DANGLE_REAL_HOOKS_DIR/pre-commit"
+
+# Hand-craft a dangling symlink whose target string contains a DinoStack
+# path component (so a real _ae_is_ours reclaims it) but the target itself
+# is gone - simulating the exact post-cleanup state the bug report
+# describes. The module-level _ae_is_ours stub (see top of file) always
+# returns "not ours" by design for the other tests above; temporarily
+# override it here to match the real per-adapter predicate's actual
+# broken-symlink-reclaim behaviour (see .claude/install.sh _ae_is_ours),
+# then restore the stub so later tests are unaffected.
+mkdir -p "$DANGLE_REAL_HOOKS_DIR"
+ln -s "$TMP_ROOT/gone-DinoStack/hooks/pre-commit" "$DANGLE_HOOK_DST"
+
+_ae_is_ours() {
+  local dst="$1"
+  [[ -L "$dst" ]] || return 1
+  local current_target
+  current_target="$(readlink "$dst")"
+  [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+  return 1
+}
+
+OUT="$(install_precommit_hook "$DANGLE_MAIN" 2>&1)"
+RC=$?
+
+_ae_is_ours() {
+  return 1
+}
+
+if [[ $RC -eq 0 ]]; then
+  _pass "dangling-hook case: install_precommit_hook exits 0"
+else
+  _fail "dangling-hook case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "dangling"; then
+  _pass "dangling-hook case (DS-152): dangling target is warned about loudly"
+else
+  _fail "dangling-hook case (DS-152 regression): no loud warning about the dangling hook target. Output: $OUT"
+fi
+
+if [[ -L "$DANGLE_HOOK_DST" ]] && [[ "$DANGLE_HOOK_DST" -ef "$DANGLE_MAIN/hooks/pre-commit" ]]; then
+  _pass "dangling-hook case (DS-152): dangling hook repaired to point at the primary checkout"
+else
+  _fail "dangling-hook case (DS-152 regression): dangling hook not repaired. Output: $OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# DS-152 round 2 (Major 1 sandbox hazard) - this MUST be the first
+# executable statement in the file, before REPO_DIR or anything else is
+# resolved. If GIT_DIR (in particular) is set in the invoking environment,
+# git IGNORES `-C <dir>` entirely for every `git -C <dir> rev-parse ...`
+# call - both in this suite's own fixture setup and in the
+# scripts/lib/precommit.sh functions under test - and resolves against the
+# AMBIENT GIT_DIR instead of the intended fixture repo. Demonstrated: a
+# caller exporting GIT_DIR before invoking this script caused
+# install_precommit_hook to write a pre-commit symlink into the REAL
+# repo's ambient hooks dir (not a fixture), with 12/27 assertions then
+# failing on top of that corruption. Clearing these before any other line
+# runs defeats that class of leak outright.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CEILING_DIRECTORIES
 # Purpose: Regression test for scripts/lib/precommit.sh's install_precommit_hook
 #          and uninstall_precommit_hook. Ensures both resolve the REAL git
 #          hooks directory (via `git rev-parse --git-path hooks`) instead of
@@ -52,19 +65,45 @@
 #     SOURCE was an incidental implementation detail of DS-58, not part of
 #     what it was fixing. Test 6 covers the DS-152 scratch-worktree-removal
 #     scenario directly.
+#   - DS-152 round 2 (Skeptic findings):
+#     Major 1 (sandbox hazard): the leading `unset GIT_DIR ...` line above,
+#     plus Test 0 below asserting those vars are actually empty, plus
+#     wrapping the whole suite in bin/tests/lib/precommit-hook-guard.sh's
+#     save/restore (defense in depth - restores the REAL repo's hook if
+#     anything still slips through). Verified by re-running this suite with
+#     GIT_DIR exported before invocation; see the fix commit message for the
+#     transcript.
+#     Major 2 (missing hook_src is now reachable): Test 8 asserts
+#     install_precommit_hook refuses to create a dangling symlink when the
+#     primary checkout's own hooks/pre-commit does not exist, and warns
+#     loudly rather than silently succeeding.
+#     Minor (silent primary-checkout fallback): Test 9 asserts a loud
+#     warning fires when resolve_primary_checkout fails and
+#     install_precommit_hook falls back to repo_dir directly.
+#     Minor (uninstall ownership too narrow for legacy targets): Test 10
+#     asserts uninstall_precommit_hook still removes a hook that was
+#     installed by pre-DS-152 code pointing at a worktree's own
+#     hooks/pre-commit rather than the primary checkout's.
 
 set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 LIB="$REPO_DIR/scripts/lib/precommit.sh"
+GUARD="$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 if [[ ! -f "$LIB" ]]; then
   echo "FAIL: $LIB not found" >&2
   exit 1
 fi
+if [[ ! -f "$GUARD" ]]; then
+  echo "FAIL: $GUARD not found" >&2
+  exit 1
+fi
 
 # shellcheck source=scripts/lib/precommit.sh
 . "$LIB"
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$GUARD"
 
 PASS=0
 FAIL=0
@@ -88,11 +127,41 @@ _ae_is_ours() {
 
 AE_DRY_RUN=false
 
+# ------------------------------------------------------------------
+# DS-152 round 2 (Major 1): save the REAL repo's pre-commit hook slot
+# before ANY fixture is created and restore it unconditionally on exit -
+# defense in depth alongside the leading `unset GIT_DIR ...` above. Even if
+# some future change to this suite (or an ambient git env var this file did
+# not anticipate) causes a library call to resolve against REPO_DIR instead
+# of a fixture, the real hook is protected and restored. This is the same
+# guard used by the four suites that invoke a REAL install.sh/uninstall.sh
+# against this live checkout (bin/tests/test_uninstall_ds_prefix.sh,
+# bin/tests/test_hooks_snapshot_migration.sh,
+# bin/tests/test_local_bin_ds_prefix_install.sh,
+# .claude/tests/install-converge.test.sh) - do not hand-roll a second,
+# weaker guard beside it.
+# ------------------------------------------------------------------
+precommit_hook_guard_save "$REPO_DIR"
+
 TMP_ROOT="$(mktemp -d)"
 _cleanup() {
   [[ -n "${TMP_ROOT:-}" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
+  precommit_hook_guard_restore
 }
 trap _cleanup EXIT
+
+# ============================================================
+# Test 0: DS-152 round 2 (Major 1) - the leaked-git-env-var sandbox hazard
+#         is actually neutralised, not merely documented.
+# ============================================================
+
+if [[ -z "${GIT_DIR:-}" && -z "${GIT_WORK_TREE:-}" && -z "${GIT_COMMON_DIR:-}" \
+      && -z "${GIT_INDEX_FILE:-}" && -z "${GIT_OBJECT_DIRECTORY:-}" \
+      && -z "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" && -z "${GIT_CEILING_DIRECTORIES:-}" ]]; then
+  _pass "sandbox isolation: no leaked GIT_* environment overrides are set"
+else
+  _fail "sandbox isolation: a GIT_* environment override survived the leading unset (GIT_DIR=${GIT_DIR:-<unset>})"
+fi
 
 # ------------------------------------------------------------------
 # Sandbox-isolation guarantee: every fixture below lives under a fresh
@@ -103,7 +172,9 @@ trap _cleanup EXIT
 # genuinely outside REPO_DIR before creating any fixture, so a future
 # change to the mktemp call cannot silently reintroduce the "fakes $HOME
 # but not git --git-path hooks, escapes its sandbox" hazard recorded for
-# this class of test.
+# this class of test. This is a PATH check only - it does not by itself
+# guard against a leaked GIT_DIR (which ignores -C entirely regardless of
+# path); that hazard is handled by the unset + guard above.
 # ------------------------------------------------------------------
 case "$TMP_ROOT" in
   "$REPO_DIR"/*|"$REPO_DIR")
@@ -471,6 +542,186 @@ if [[ -L "$DANGLE_HOOK_DST" ]] && [[ "$DANGLE_HOOK_DST" -ef "$DANGLE_MAIN/hooks/
   _pass "dangling-hook case (DS-152): dangling hook repaired to point at the primary checkout"
 else
   _fail "dangling-hook case (DS-152 regression): dangling hook not repaired. Output: $OUT"
+fi
+
+# ============================================================
+# Test 8: DS-152 round 2 (Major 2) - install must refuse to create a NEW
+#         dangling symlink when the primary checkout's own hooks/pre-commit
+#         does not exist (a pruned/moved primary checkout, or one checked
+#         out to a commit without hooks/pre-commit). Pre-DS-152 this state
+#         was unreachable, because the source was always the invoking
+#         checkout itself, which necessarily existed.
+# ============================================================
+
+MISSING_SRC_MAIN="$TMP_ROOT/missing-src-main-repo"
+_make_fixture_repo "$MISSING_SRC_MAIN"
+# Remove the primary checkout's own hooks/pre-commit AFTER the fixture repo
+# is committed (so it is still a valid git repo, just missing this one
+# tracked-but-now-deleted-on-disk file) - simulates a primary checkout that
+# was moved/pruned or checked out to a commit predating hooks/pre-commit.
+rm -f "$MISSING_SRC_MAIN/hooks/pre-commit"
+
+MISSING_SRC_HOOKS_DIR="$(git -C "$MISSING_SRC_MAIN" rev-parse --git-path hooks)"
+case "$MISSING_SRC_HOOKS_DIR" in
+  /*) : ;;
+  *) MISSING_SRC_HOOKS_DIR="$MISSING_SRC_MAIN/$MISSING_SRC_HOOKS_DIR" ;;
+esac
+MISSING_SRC_HOOK_DST="$MISSING_SRC_HOOKS_DIR/pre-commit"
+
+OUT="$(install_precommit_hook "$MISSING_SRC_MAIN" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "missing-source case: install_precommit_hook exits 0 (non-fatal)"
+else
+  _fail "missing-source case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "hook source is missing"; then
+  _pass "missing-source case (DS-152 round 2, Major 2): loud warning printed for a missing hook_src"
+else
+  _fail "missing-source case (DS-152 round 2 regression, Major 2): no loud warning for a missing hook_src. Output: $OUT"
+fi
+
+if [[ ! -e "$MISSING_SRC_HOOK_DST" ]]; then
+  _pass "missing-source case (DS-152 round 2, Major 2): no NEW dangling symlink was created"
+else
+  _fail "missing-source case (DS-152 round 2 regression, Major 2): a dangling symlink was created at $MISSING_SRC_HOOK_DST despite a missing source"
+fi
+
+# Symmetric sub-case: a re-point (via _ae_is_ours) onto a missing source
+# must also refuse, leaving the existing (foreign-checkout) symlink intact.
+MISSING_SRC_REPOINT_MAIN="$TMP_ROOT/missing-src-repoint-main-repo"
+_make_fixture_repo "$MISSING_SRC_REPOINT_MAIN"
+rm -f "$MISSING_SRC_REPOINT_MAIN/hooks/pre-commit"
+
+MISSING_SRC_REPOINT_HOOKS_DIR="$(git -C "$MISSING_SRC_REPOINT_MAIN" rev-parse --git-path hooks)"
+case "$MISSING_SRC_REPOINT_HOOKS_DIR" in
+  /*) : ;;
+  *) MISSING_SRC_REPOINT_HOOKS_DIR="$MISSING_SRC_REPOINT_MAIN/$MISSING_SRC_REPOINT_HOOKS_DIR" ;;
+esac
+MISSING_SRC_REPOINT_HOOK_DST="$MISSING_SRC_REPOINT_HOOKS_DIR/pre-commit"
+
+mkdir -p "$MISSING_SRC_REPOINT_HOOKS_DIR"
+ln -s "$TMP_ROOT/gone-DinoStack/hooks/pre-commit" "$MISSING_SRC_REPOINT_HOOK_DST"
+
+_ae_is_ours() {
+  local dst="$1"
+  [[ -L "$dst" ]] || return 1
+  local current_target
+  current_target="$(readlink "$dst")"
+  [[ "$current_target" == */DinoStack/* || "$current_target" == *-DinoStack/* ]] && return 0
+  return 1
+}
+
+OUT="$(install_precommit_hook "$MISSING_SRC_REPOINT_MAIN" 2>&1)"
+RC=$?
+
+_ae_is_ours() {
+  return 1
+}
+
+if echo "$OUT" | grep -qi "hook source is missing"; then
+  _pass "missing-source re-point case (DS-152 round 2, Major 2): loud warning printed instead of re-pointing onto a missing source"
+else
+  _fail "missing-source re-point case (DS-152 round 2 regression, Major 2): no loud warning for a missing hook_src during a re-point. Output: $OUT"
+fi
+
+if [[ -L "$MISSING_SRC_REPOINT_HOOK_DST" ]] && [[ "$(readlink "$MISSING_SRC_REPOINT_HOOK_DST")" == "$TMP_ROOT/gone-DinoStack/hooks/pre-commit" ]]; then
+  _pass "missing-source re-point case (DS-152 round 2, Major 2): existing symlink left untouched rather than re-pointed onto a missing source"
+else
+  _fail "missing-source re-point case (DS-152 round 2 regression, Major 2): existing symlink was altered despite the intended re-point target missing"
+fi
+
+# ============================================================
+# Test 9: DS-152 round 2 (Minor) - a silent fallback to repo_dir when
+#         resolve_primary_checkout fails must warn loudly, not just be
+#         documented in a comment.
+# ============================================================
+
+# A STANDALONE --separate-git-dir checkout (no worktrees added from it) is
+# NOT the failure case: --git-dir == --git-common-dir there (both point at
+# the relocated gitdir), so resolve_primary_checkout correctly takes its
+# "not a linked worktree" branch and repo_dir is authoritative - no
+# fallback needed. The measured failure (per Skeptic round 2) requires a
+# LINKED WORKTREE of a --separate-git-dir primary: --git-common-dir then
+# resolves to the relocated gitdir path, which does not end in a literal
+# "/.git" path component the way a normal-worktree's common-dir always
+# does, so resolve_primary_checkout's suffix-strip fails (rc=1).
+SEPARATE_GITDIR_ROOT="$TMP_ROOT/separate-gitdir-root"
+SEPARATE_GITDIR_ACTUAL="$TMP_ROOT/separate-gitdir-actual-dotgit"
+mkdir -p "$SEPARATE_GITDIR_ROOT/hooks"
+git init -q --separate-git-dir="$SEPARATE_GITDIR_ACTUAL" "$SEPARATE_GITDIR_ROOT"
+git -C "$SEPARATE_GITDIR_ROOT" config user.email test@test.com
+git -C "$SEPARATE_GITDIR_ROOT" config user.name test
+printf '#!/usr/bin/env bash\necho fixture pre-commit\n' > "$SEPARATE_GITDIR_ROOT/hooks/pre-commit"
+chmod +x "$SEPARATE_GITDIR_ROOT/hooks/pre-commit"
+git -C "$SEPARATE_GITDIR_ROOT" add hooks/pre-commit
+git -C "$SEPARATE_GITDIR_ROOT" commit -q -m "fixture: add pre-commit hook"
+
+SEPARATE_GITDIR_WT="$TMP_ROOT/separate-gitdir-wt"
+git -C "$SEPARATE_GITDIR_ROOT" worktree add -q "$SEPARATE_GITDIR_WT" -b separate-gitdir-wt-branch >/dev/null 2>&1
+
+OUT="$(install_precommit_hook "$SEPARATE_GITDIR_WT" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "separate-git-dir case: install_precommit_hook exits 0 (non-fatal)"
+else
+  _fail "separate-git-dir case: install_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "could not resolve the primary checkout"; then
+  _pass "separate-git-dir case (DS-152 round 2, Minor): loud warning printed for the silent primary-checkout fallback"
+else
+  _fail "separate-git-dir case (DS-152 round 2 regression, Minor): resolve_primary_checkout fell back to repo_dir with no warning. Output: $OUT"
+fi
+
+# ============================================================
+# Test 10: DS-152 round 2 (Minor) - uninstall must still remove a hook that
+#          was installed by PRE-DS-152 code pointing at a worktree's own
+#          hooks/pre-commit, not the primary checkout's.
+# ============================================================
+
+LEGACY_MAIN="$TMP_ROOT/legacy-main-repo"
+_make_fixture_repo "$LEGACY_MAIN"
+
+LEGACY_WT="$TMP_ROOT/legacy-wt"
+git -C "$LEGACY_MAIN" worktree add -q "$LEGACY_WT" -b legacy-wt-test-branch >/dev/null 2>&1
+
+LEGACY_HOOKS_DIR="$(git -C "$LEGACY_WT" rev-parse --git-path hooks)"
+case "$LEGACY_HOOKS_DIR" in
+  /*) : ;;
+  *) LEGACY_HOOKS_DIR="$LEGACY_WT/$LEGACY_HOOKS_DIR" ;;
+esac
+LEGACY_HOOK_DST="$LEGACY_HOOKS_DIR/pre-commit"
+
+# Hand-craft the PRE-DS-152 install shape: the shared hook symlinked
+# directly at the WORKTREE's own hooks/pre-commit (what
+# `hook_src="$repo_dir/hooks/pre-commit"` would have written), not the
+# primary checkout's.
+mkdir -p "$LEGACY_HOOKS_DIR"
+ln -s "$LEGACY_WT/hooks/pre-commit" "$LEGACY_HOOK_DST"
+
+OUT="$(uninstall_precommit_hook "$LEGACY_WT" 2>&1)"
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  _pass "legacy-target uninstall case: uninstall_precommit_hook exits 0"
+else
+  _fail "legacy-target uninstall case: uninstall_precommit_hook exited $RC. Output: $OUT"
+fi
+
+if [[ ! -e "$LEGACY_HOOK_DST" ]]; then
+  _pass "legacy-target uninstall case (DS-152 round 2, Minor): pre-DS-152 worktree-targeted hook actually removed"
+else
+  _fail "legacy-target uninstall case (DS-152 round 2 regression, Minor): pre-DS-152 hook still present at $LEGACY_HOOK_DST, current target: $(readlink "$LEGACY_HOOK_DST" 2>&1). Output: $OUT"
+fi
+
+if echo "$OUT" | grep -qi "not ours"; then
+  _fail "legacy-target uninstall case (DS-152 round 2 regression, Minor): reported 'not ours' despite the target being a legacy sibling worktree hook. Output: $OUT"
+else
+  _pass "legacy-target uninstall case (DS-152 round 2, Minor): did not falsely report 'not ours'"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -147,7 +147,7 @@ elif [[ -n "${CI:-}" ]]; then
   echo "FAIL: neither 'timeout' nor 'gtimeout' found on PATH - required in CI for the round-5 hang-regression assertions (Tests 13/13b)" >&2
   exit 1
 else
-  echo "SKIP: neither 'timeout' nor 'gtimeout' found on PATH - skipping the round-5 hang-regression assertions (Tests 13/13b non-hang-detection checks still run unguarded, but the hang-detection assertion itself cannot be trusted without a timeout binary). Install GNU coreutils (e.g. 'brew install coreutils') for local coverage."
+  echo "SKIP: neither 'timeout' nor 'gtimeout' found on PATH - skipping the entirety of Tests 13 and 13b (all 4 of their assertions - 3 from Test 13, 1 from Test 13b; total PASS count drops from 54 to 50), since none of them can run safely without a timeout binary to bound a potential hang. Test 13c (anchor correctness) is unaffected and still runs. Install GNU coreutils (e.g. 'brew install coreutils') for local coverage of Tests 13/13b."
 fi
 
 _pass() {

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -74,11 +74,13 @@
 #     ownership check the original per-adapter uninstall blocks used,
 #     extended so a hook installed by pre-DS-152 code from a worktree can
 #     still be removed post-upgrade. Also removed when the legacy target's
-#     own worktree directory has already been deleted, PROVIDED its path
-#     lies under the primary checkout's own ".claude/worktrees/" or
-#     ".agentic/worktrees/" (see _pc_is_legacy_sibling_hook's dangling-target
-#     branch) - the most common pre-fix residue, since a dangling hook is
-#     already broken regardless. Never deletes a foreign hook, a real
+#     own worktree directory has already been deleted, PROVIDED its path -
+#     canonicalised via _pc_canonicalize_missing_dir, so a target spelled
+#     through a symlinked TMPDIR/HOME component still matches - lies under
+#     the primary checkout's own ".claude/worktrees/" or ".agentic/worktrees/"
+#     (see _pc_is_legacy_sibling_hook's dangling-target branch) - the most
+#     common pre-fix residue, since a dangling hook is already broken
+#     regardless. Never deletes a foreign hook, a real
 #     file, or a symlink pointing at an unrelated repo. If hooks-dir
 #     resolution fails for any reason, prints a non-fatal warning and
 #     returns 0 - never aborts the caller. On primary-checkout resolution
@@ -147,21 +149,38 @@ resolve_git_hooks_dir() {
 # ---------------------------------------------------------------------------
 # _pc_canonicalize_dir <dir>
 #   Internal helper (not part of the public API). Echoes the canonical
-#   (symlink-resolved) absolute form of <dir> via `cd <dir> && pwd -P`,
-#   falling back to echoing <dir> unchanged (and still returning 0) when
-#   canonicalisation fails (e.g. <dir> does not exist). Shared by
-#   resolve_primary_checkout and _pc_git_common_dir_abs so every absolute
-#   path either of them produces is canonicalised the SAME way - a
+#   (symlink-resolved) absolute form of <dir> via `cd <dir> && pwd -P`.
+#   Shared by resolve_primary_checkout and _pc_git_common_dir_abs so every
+#   absolute path either of them produces is canonicalised the SAME way - a
 #   symlinked TMPDIR/HOME path component (e.g. macOS's
 #   /tmp -> /private/tmp or /var/folders -> /private/var/folders) would
 #   otherwise leave one call site's output canonical and the other's raw,
 #   causing string-equality comparisons downstream to spuriously fail.
-#   Always returns 0 - callers that need to distinguish "could not
-#   canonicalise" should check whether the echoed value differs from what
-#   they passed in; none of the current callers need to.
+#   <dir>="" is rejected up front (returns 1, echoes nothing) rather than
+#   passed to `cd` - bash's `cd ""` fails (rc=1, "null directory") but zsh's
+#   `cd ""` SUCCEEDS and resolves to the shell's CURRENT working directory,
+#   so without this guard the two shells would echo different, silently
+#   wrong answers for the same empty input. No current caller passes an
+#   empty <dir> (verified: _pc_git_common_dir_abs already returns early on
+#   an empty git-common-dir before ever calling this; resolve_primary_checkout
+#   returns 1 on `repo_dir=""` via its own upstream `git -C ""` failure) -
+#   the guard exists so a FUTURE caller cannot be silently bitten by this
+#   inter-shell divergence.
+#   On any OTHER canonicalisation failure (a non-empty <dir> that does not
+#   exist, a permission error, or a path that is a file, not a directory),
+#   falls back to echoing <dir> unchanged and still returns 0 - this
+#   fallback is UNREACHABLE by every current caller (each already guards
+#   its own non-existence case upstream, per the callers documented at each
+#   call site) and exists purely as documented dead-code behaviour, not as
+#   a contract any caller relies on. Do not add a caller that depends on
+#   distinguishing "canonicalised" from "fell back" via this return value
+#   without first re-auditing this comment.
 # ---------------------------------------------------------------------------
 _pc_canonicalize_dir() {
   local dir="$1"
+  if [[ -z "$dir" ]]; then
+    return 1
+  fi
   local canonical
   if canonical="$(cd "$dir" 2>/dev/null && pwd -P)" && [[ -n "$canonical" ]]; then
     echo "$canonical"
@@ -169,6 +188,38 @@ _pc_canonicalize_dir() {
     echo "$dir"
   fi
   return 0
+}
+
+# ---------------------------------------------------------------------------
+# _pc_canonicalize_missing_dir <path>
+#   Internal helper (not part of the public API). Canonicalises <path> even
+#   when <path> itself does not exist on disk (e.g. a deleted worktree),
+#   which `_pc_canonicalize_dir` cannot do - `cd`/`pwd -P` require the
+#   target directory to exist. Walks upward from <path> to find its longest
+#   EXISTING ancestor, canonicalises that ancestor (via
+#   _pc_canonicalize_dir, resolving any symlinked component such as macOS's
+#   /var/folders -> /private/var/folders), then re-appends the missing
+#   trailing path components verbatim - they cannot contain a symlink to
+#   resolve, because a symlink target must itself exist to be dereferenced.
+#   Echoes the resulting path and always returns 0; the degenerate case
+#   <path>="/" is its own existing ancestor, so the loop always terminates.
+#   <path>="" is treated as "/" up front - `existing` is then guaranteed to
+#   be either "/" or a "/"-stripped, still-non-empty prefix of <path> by the
+#   time _pc_canonicalize_dir is called, so it is never the empty string
+#   that helper now rejects.
+# ---------------------------------------------------------------------------
+_pc_canonicalize_missing_dir() {
+  local path="$1"
+  local existing="${path:-/}"
+  local tail=""
+  while [[ ! -d "$existing" && "$existing" != "/" && -n "$existing" ]]; do
+    tail="/${existing##*/}${tail}"
+    existing="${existing%/*}"
+    [[ -z "$existing" ]] && existing="/"
+  done
+  local canonical_existing
+  canonical_existing="$(_pc_canonicalize_dir "$existing")"
+  echo "${canonical_existing%/}${tail}"
 }
 
 # ---------------------------------------------------------------------------
@@ -215,14 +266,22 @@ _pc_git_common_dir_abs() {
 #     - the directory it hangs off of has already been DELETED (the most
 #       common pre-fix residue - a scratch/ephemeral worktree that was
 #       cleaned up without ever uninstalling its legacy hook first) AND
-#       [primary_checkout] is given AND <target>'s worktree path lies under
-#       "<primary_checkout>/.claude/worktrees/" or
-#       "<primary_checkout>/.agentic/worktrees/" - the repo's own known
-#       worktree roots. Ownership cannot be verified via git-common-dir once
-#       the directory is gone, so this path constraint stands in for it: the
-#       hook is already broken either way (its target cannot be executed),
-#       and constraining to the repo's own worktree roots prevents widening
-#       into a foreign dangling hook that merely happens to be unreachable.
+#       [primary_checkout] is given AND <target>'s worktree path,
+#       CANONICALISED via _pc_canonicalize_missing_dir (its own directory
+#       component is gone, so it cannot be canonicalised the normal way -
+#       see that helper), lies under "<primary_checkout>/.claude/worktrees/"
+#       or "<primary_checkout>/.agentic/worktrees/" - the repo's own known
+#       worktree roots, compared in the SAME canonical form primary_checkout
+#       is already in. Without this canonicalisation step a target spelled
+#       via a symlinked TMPDIR/HOME component (e.g. the raw, non-`pwd -P`
+#       form a pre-DS-152 install could have written) would raw-string
+#       mismatch against primary_checkout's canonical form even though both
+#       name the identical real directory (DS-152 round 4). Ownership cannot
+#       be verified via git-common-dir once the directory is gone, so this
+#       path constraint stands in for it: the hook is already broken either
+#       way (its target cannot be executed), and constraining to the repo's
+#       own worktree roots prevents widening into a foreign dangling hook
+#       that merely happens to be unreachable.
 #   Returns 1 (false) - never aborts - when <target> does not match the
 #   suffix, or (for an existing target directory) its common-dir resolves to
 #   a different repo, or (for an already-deleted target directory) no
@@ -239,7 +298,9 @@ _pc_is_legacy_sibling_hook() {
 
   if [[ ! -d "$target_repo_dir" ]]; then
     if [[ -n "$primary_checkout" ]]; then
-      case "$target_repo_dir" in
+      local canonical_target_repo_dir
+      canonical_target_repo_dir="$(_pc_canonicalize_missing_dir "$target_repo_dir")"
+      case "$canonical_target_repo_dir" in
         "$primary_checkout"/.claude/worktrees/*|"$primary_checkout"/.agentic/worktrees/*)
           return 0
           ;;

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -22,8 +22,14 @@
 #          static-analysis prefix that actually runs when invoked via a
 #          worktree's own copy is identical to the primary checkout's copy
 #          at the same commit - sourcing from the primary checkout changes
-#          WHICH FILE is symlinked, never what the hook does when triggered
-#          from a worktree commit.
+#          WHICH FILE is symlinked, not what the hook does when triggered
+#          from a worktree commit, PROVIDED the primary checkout's own
+#          hooks/pre-commit exists. install_precommit_hook verifies this
+#          before writing or re-pointing any symlink (DS-152 round 2) and
+#          refuses - loudly, non-fatally - to create a NEW dangling symlink
+#          if the primary checkout's copy is itself missing (a pruned
+#          worktree, or a primary checkout checked out to a commit that
+#          predates hooks/pre-commit).
 #
 # Public API:
 #   resolve_git_hooks_dir <repo_dir>
@@ -45,25 +51,34 @@
 #   install_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir, mkdir -p's it
 #     if needed, and symlinks the PRIMARY checkout's hooks/pre-commit
-#     (via resolve_primary_checkout; falls back to repo_dir's own
-#     hooks/pre-commit if primary-checkout resolution fails) into it.
-#     Honours the caller's $AE_DRY_RUN ("true"/"false") and reuses the
+#     (via resolve_primary_checkout; on primary-checkout resolution failure,
+#     warns loudly and falls back to repo_dir's own hooks/pre-commit) into
+#     it. Honours the caller's $AE_DRY_RUN ("true"/"false") and reuses the
 #     caller's _ae_is_ours function (must already be defined in the sourcing
 #     script) to detect and re-point stale symlinks from another
-#     methodology checkout. Warns loudly (without aborting) whenever the
-#     existing hook target is found dangling, and whenever a re-point is
-#     refused because the existing symlink is not "ours". If hooks-dir
-#     resolution fails for any reason, prints a non-fatal warning and
-#     returns 0 - never aborts the caller.
+#     methodology checkout. Verifies the resolved hook_src actually exists
+#     before EVER writing or re-pointing a symlink to it - a fresh install
+#     or a re-point onto a missing source warns loudly and skips (non-fatal)
+#     rather than creating a new dangling symlink. Also warns loudly
+#     (without aborting) whenever the PRE-EXISTING hook target is found
+#     dangling, and whenever a re-point is refused because the existing
+#     symlink is not "ours". If hooks-dir resolution fails for any reason,
+#     prints a non-fatal warning and returns 0 - never aborts the caller.
 #
 #   uninstall_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir and removes the
 #     pre-commit symlink there iff it is a symlink pointing exactly at the
-#     primary checkout's "hooks/pre-commit" (the same ownership check the
-#     original per-adapter uninstall blocks used - never deletes a foreign
-#     hook, a real file, or a symlink pointing elsewhere). If hooks-dir
+#     primary checkout's "hooks/pre-commit" OR at a "legacy" pre-DS-152
+#     target: some OTHER worktree's own hooks/pre-commit that still shares
+#     repo_dir's git-common-dir (see _pc_is_legacy_sibling_hook) - the same
+#     ownership check the original per-adapter uninstall blocks used,
+#     extended so a hook installed by pre-DS-152 code from a worktree can
+#     still be removed post-upgrade. Never deletes a foreign hook, a real
+#     file, or a symlink pointing at an unrelated repo. If hooks-dir
 #     resolution fails for any reason, prints a non-fatal warning and
-#     returns 0 - never aborts the caller.
+#     returns 0 - never aborts the caller. On primary-checkout resolution
+#     failure, warns loudly and falls back to repo_dir's own hooks/pre-commit
+#     for the ownership comparison.
 #
 # Upstream dependencies:
 #   git (rev-parse --git-path/--git-dir/--git-common-dir), the primary
@@ -80,17 +95,25 @@
 #   - `git rev-parse --git-path hooks` fails (not a git repo, git missing):
 #     resolve_git_hooks_dir returns 1; both install_precommit_hook and
 #     uninstall_precommit_hook print a non-fatal warning and return 0.
-#   - `resolve_primary_checkout` fails (rev-parse error, or a common-dir
-#     that does not end in "/.git"): install_precommit_hook falls back to
-#     repo_dir's own hooks/pre-commit, matching the pre-DS-152 behaviour
-#     rather than aborting.
+#   - `resolve_primary_checkout` fails (rev-parse error, a common-dir that
+#     does not end in "/.git" - measured for --separate-git-dir and bare
+#     linked worktrees): both install_precommit_hook and
+#     uninstall_precommit_hook print a loud, non-fatal warning and fall
+#     back to repo_dir's own hooks/pre-commit, matching the pre-DS-152
+#     behaviour rather than aborting.
+#   - The resolved hook_src does not exist (a pruned/moved primary
+#     checkout, or one checked out to a commit without hooks/pre-commit):
+#     install_precommit_hook warns loudly and skips the write (non-fatal) -
+#     it never creates a NEW dangling symlink. A PRE-EXISTING dangling
+#     symlink is separately detected and warned about every install run.
 #   - Resolved hooks dir does not yet exist (fresh worktree/repo): created
 #     via mkdir -p before the symlink is written (install only).
 #   - Safe to source under set -euo pipefail; no top-level side effects
 #     beyond the function definitions.
 #
 # Performance: up to three `git rev-parse` calls per install invocation
-#   (hooks dir, git-dir, git-common-dir); one for uninstall.
+#   (hooks dir, git-dir, git-common-dir); up to two for uninstall (hooks
+#   dir, plus one more when a legacy-target ownership check is needed).
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -117,6 +140,57 @@ resolve_git_hooks_dir() {
 }
 
 # ---------------------------------------------------------------------------
+# _pc_git_common_dir_abs <dir>
+#   Internal helper (not part of the public API). Echoes the absolute
+#   `git -C <dir> rev-parse --git-common-dir` for <dir>, normalising a
+#   checkout-relative result to absolute exactly like resolve_git_hooks_dir
+#   does. Returns non-zero and echoes nothing if <dir> is not a git checkout
+#   (missing, deleted, or never a repo). Shared by resolve_primary_checkout
+#   and _pc_is_legacy_sibling_hook so both compare common-dirs computed the
+#   SAME way - avoids the raw-string mismatches a symlinked TMPDIR/HOME
+#   component would otherwise cause between the two call sites.
+# ---------------------------------------------------------------------------
+_pc_git_common_dir_abs() {
+  local dir="$1"
+  local common_dir
+  if ! common_dir="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)" || [[ -z "$common_dir" ]]; then
+    return 1
+  fi
+  case "$common_dir" in
+    /*) : ;;
+    *) common_dir="$dir/$common_dir" ;;
+  esac
+  echo "$common_dir"
+}
+
+# ---------------------------------------------------------------------------
+# _pc_is_legacy_sibling_hook <target> <repo_common_dir>
+#   Internal helper (not part of the public API). A pre-DS-152 install could
+#   have symlinked the shared hook at ANY worktree's own
+#   "<worktree>/hooks/pre-commit" (repo_dir itself, not necessarily the
+#   primary checkout). Returns 0 (true) iff <target> ends in
+#   "/hooks/pre-commit", the directory it hangs off of still exists, and
+#   THAT directory's own git-common-dir matches <repo_common_dir> - i.e.
+#   <target> is some worktree of the exact same repo family repo_dir
+#   belongs to, regardless of which worktree wrote it or how its path was
+#   originally spelled. Returns 1 (false) - never aborts - when <target>
+#   does not match the suffix, the directory no longer exists (cannot be
+#   verified), or its common-dir resolves to a different repo.
+# ---------------------------------------------------------------------------
+_pc_is_legacy_sibling_hook() {
+  local target="$1" repo_common_dir="$2"
+  case "$target" in
+    */hooks/pre-commit) : ;;
+    *) return 1 ;;
+  esac
+  local target_repo_dir="${target%/hooks/pre-commit}"
+  [[ -d "$target_repo_dir" ]] || return 1
+  local target_common_dir
+  target_common_dir="$(_pc_git_common_dir_abs "$target_repo_dir")" || return 1
+  [[ "$target_common_dir" == "$repo_common_dir" ]]
+}
+
+# ---------------------------------------------------------------------------
 # resolve_primary_checkout <repo_dir>
 #   See "Public API" above.
 # ---------------------------------------------------------------------------
@@ -124,20 +198,14 @@ resolve_primary_checkout() {
   local repo_dir="$1"
   local common_dir git_dir canonical_repo_dir
 
-  if ! common_dir="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)" || [[ -z "$common_dir" ]]; then
-    return 1
-  fi
+  common_dir="$(_pc_git_common_dir_abs "$repo_dir")" || return 1
   if ! git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)" || [[ -z "$git_dir" ]]; then
     return 1
   fi
 
-  # Both `--git-common-dir` and `--git-dir` can be checkout-relative in a
-  # normal (non-worktree) repo; normalise to absolute either way, matching
-  # resolve_git_hooks_dir's own normalisation above.
-  case "$common_dir" in
-    /*) : ;;
-    *) common_dir="$repo_dir/$common_dir" ;;
-  esac
+  # `--git-dir` can be checkout-relative in a normal (non-worktree) repo;
+  # normalise to absolute, matching _pc_git_common_dir_abs's own
+  # normalisation of --git-common-dir above.
   case "$git_dir" in
     /*) : ;;
     *) git_dir="$repo_dir/$git_dir" ;;
@@ -181,8 +249,10 @@ install_precommit_hook() {
 
   local primary_checkout
   if ! primary_checkout="$(resolve_primary_checkout "$repo_dir")"; then
-    # Resolution failed - fall back to repo_dir's own hooks/pre-commit
-    # rather than aborting (pre-DS-152 behaviour).
+    # Resolution failed (e.g. a --separate-git-dir or bare linked worktree)
+    # - warn loudly and fall back to repo_dir's own hooks/pre-commit rather
+    # than aborting (pre-DS-152 behaviour).
+    echo "  ! could not resolve the primary checkout for $repo_dir - falling back to its own hooks/pre-commit"
     primary_checkout="$repo_dir"
   fi
   local hook_src="$primary_checkout/hooks/pre-commit"
@@ -209,8 +279,12 @@ install_precommit_hook() {
     elif _ae_is_ours "$hook_dst"; then
       # Stale symlink pointing to another methodology checkout (including a
       # now-deleted ephemeral worktree) - re-point at the durable primary
-      # checkout, never at repo_dir directly.
-      if [[ "$AE_DRY_RUN" == "true" ]]; then
+      # checkout, never at repo_dir directly. Never write a NEW symlink at a
+      # source that does not exist - that would trade one dangling target
+      # for another.
+      if [[ ! -e "$hook_src" ]]; then
+        echo "  ! cannot re-point pre-commit hook - primary checkout's hook source is missing: $hook_src (leaving existing symlink untouched, non-fatal)"
+      elif [[ "$AE_DRY_RUN" == "true" ]]; then
         echo "  ~ pre-commit hook (would re-point to primary checkout)"
       else
         ln -sfn "$hook_src" "$hook_dst"
@@ -226,7 +300,11 @@ install_precommit_hook() {
   elif [[ -e "$hook_dst" ]]; then
     echo "  ! pre-commit hook is a real file (not a symlink) - skipping to preserve existing hook"
   else
-    if [[ "$AE_DRY_RUN" == "true" ]]; then
+    # Never symlink to a source that does not exist - a fresh install must
+    # not create a new dangling hook (DS-152 round 2).
+    if [[ ! -e "$hook_src" ]]; then
+      echo "  ! cannot install pre-commit hook - primary checkout's hook source is missing: $hook_src (non-fatal, skipping)"
+    elif [[ "$AE_DRY_RUN" == "true" ]]; then
       echo "  + pre-commit hook (would create)"
     else
       ln -s "$hook_src" "$hook_dst"
@@ -244,6 +322,7 @@ uninstall_precommit_hook() {
 
   local primary_checkout
   if ! primary_checkout="$(resolve_primary_checkout "$repo_dir")"; then
+    echo "  ! could not resolve the primary checkout for $repo_dir - falling back to its own hooks/pre-commit"
     primary_checkout="$repo_dir"
   fi
   local hook_src="$primary_checkout/hooks/pre-commit"
@@ -259,11 +338,23 @@ uninstall_precommit_hook() {
   if [[ -L "$hook_dst" ]]; then
     local current_target
     current_target="$(readlink "$hook_dst")"
+
     if [[ "$current_target" == "$hook_src" ]]; then
       rm "$hook_dst"
       echo "  - pre-commit hook removed"
     else
-      echo "  = pre-commit hook points elsewhere: $current_target - not ours, skipping"
+      # Not a match against the primary checkout's own hook_src - check
+      # whether it is a "legacy" pre-DS-152 target: some other worktree of
+      # the exact same repo family, which older install_precommit_hook code
+      # would have symlinked directly.
+      local repo_common_dir
+      if repo_common_dir="$(_pc_git_common_dir_abs "$repo_dir" 2>/dev/null)" \
+        && _pc_is_legacy_sibling_hook "$current_target" "$repo_common_dir"; then
+        rm "$hook_dst"
+        echo "  - pre-commit hook removed (legacy pre-DS-152 target: $current_target)"
+      else
+        echo "  = pre-commit hook points elsewhere: $current_target - not ours, skipping"
+      fi
     fi
   elif [[ -e "$hook_dst" ]]; then
     echo "  = pre-commit hook is a real file - not removing"

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -8,6 +8,23 @@
 #          pointer) and not a directory (DS-58, both the install side and
 #          the symmetric uninstall side).
 #
+#          The install side also always sources the hook BODY from the
+#          PRIMARY checkout, never from the invoking repo_dir directly
+#          (DS-152). The shared hooks dir (resolved by resolve_git_hooks_dir)
+#          is common to every worktree of a repo, so a symlink written while
+#          running from an ephemeral/scratch worktree (e.g. a Skeptic
+#          QA-regression scratch dir) would otherwise repoint the ONE shared
+#          hook at a soon-to-be-deleted path, dangling it for the primary
+#          checkout and every other worktree the moment that scratch
+#          worktree is removed. hooks/pre-commit's own adapter-build section
+#          early-exits in any worktree context (see its
+#          `git rev-parse --git-common-dir` != `--git-dir` check), so the
+#          static-analysis prefix that actually runs when invoked via a
+#          worktree's own copy is identical to the primary checkout's copy
+#          at the same commit - sourcing from the primary checkout changes
+#          WHICH FILE is symlinked, never what the hook does when triggered
+#          from a worktree commit.
+#
 # Public API:
 #   resolve_git_hooks_dir <repo_dir>
 #     Echoes the absolute real git hooks dir for <repo_dir> via
@@ -17,29 +34,42 @@
 #     and echoes nothing on resolution failure (not a git repo, git
 #     missing, etc).
 #
+#   resolve_primary_checkout <repo_dir>
+#     Echoes the durable primary checkout for <repo_dir>: <repo_dir> itself
+#     when it is not a linked worktree (`--git-dir` == `--git-common-dir`),
+#     otherwise the parent of the shared ".git" directory that
+#     `--git-common-dir` points at (i.e. the main worktree, not whichever
+#     linked worktree repo_dir happens to be). Returns non-zero and echoes
+#     nothing on resolution failure.
+#
 #   install_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir, mkdir -p's it
-#     if needed, and symlinks hooks/pre-commit into it. Honours the
-#     caller's $AE_DRY_RUN ("true"/"false") and reuses the caller's
-#     _ae_is_ours function (must already be defined in the sourcing script)
-#     to detect and re-point stale symlinks from another methodology
-#     checkout. If hooks-dir resolution fails for any reason, prints a
-#     non-fatal warning and returns 0 - never aborts the caller.
+#     if needed, and symlinks the PRIMARY checkout's hooks/pre-commit
+#     (via resolve_primary_checkout; falls back to repo_dir's own
+#     hooks/pre-commit if primary-checkout resolution fails) into it.
+#     Honours the caller's $AE_DRY_RUN ("true"/"false") and reuses the
+#     caller's _ae_is_ours function (must already be defined in the sourcing
+#     script) to detect and re-point stale symlinks from another
+#     methodology checkout. Warns loudly (without aborting) whenever the
+#     existing hook target is found dangling, and whenever a re-point is
+#     refused because the existing symlink is not "ours". If hooks-dir
+#     resolution fails for any reason, prints a non-fatal warning and
+#     returns 0 - never aborts the caller.
 #
 #   uninstall_precommit_hook <repo_dir>
 #     Resolves the real hooks dir via resolve_git_hooks_dir and removes the
-#     pre-commit symlink there iff it is a symlink pointing exactly at
-#     "<repo_dir>/hooks/pre-commit" (the same ownership check the original
-#     per-adapter uninstall blocks used - never deletes a foreign hook, a
-#     real file, or a symlink pointing elsewhere). If hooks-dir resolution
-#     fails for any reason, prints a non-fatal warning and returns 0 -
-#     never aborts the caller.
+#     pre-commit symlink there iff it is a symlink pointing exactly at the
+#     primary checkout's "hooks/pre-commit" (the same ownership check the
+#     original per-adapter uninstall blocks used - never deletes a foreign
+#     hook, a real file, or a symlink pointing elsewhere). If hooks-dir
+#     resolution fails for any reason, prints a non-fatal warning and
+#     returns 0 - never aborts the caller.
 #
 # Upstream dependencies:
-#   git (rev-parse --git-path), the caller's $REPO_DIR/hooks/pre-commit
-#   source file, the caller's $AE_DRY_RUN variable (install only), the
-#   caller's _ae_is_ours function (install only; duplicated per-adapter
-#   helper).
+#   git (rev-parse --git-path/--git-dir/--git-common-dir), the primary
+#   checkout's hooks/pre-commit source file, the caller's $AE_DRY_RUN
+#   variable (install only), the caller's _ae_is_ours function (install
+#   only; duplicated per-adapter helper).
 #
 # Downstream consumers:
 #   .claude/install.sh, .cursor/install.sh, .opencode/install.sh,
@@ -50,12 +80,17 @@
 #   - `git rev-parse --git-path hooks` fails (not a git repo, git missing):
 #     resolve_git_hooks_dir returns 1; both install_precommit_hook and
 #     uninstall_precommit_hook print a non-fatal warning and return 0.
+#   - `resolve_primary_checkout` fails (rev-parse error, or a common-dir
+#     that does not end in "/.git"): install_precommit_hook falls back to
+#     repo_dir's own hooks/pre-commit, matching the pre-DS-152 behaviour
+#     rather than aborting.
 #   - Resolved hooks dir does not yet exist (fresh worktree/repo): created
 #     via mkdir -p before the symlink is written (install only).
 #   - Safe to source under set -euo pipefail; no top-level side effects
 #     beyond the function definitions.
 #
-# Performance: one `git rev-parse` call per invocation.
+# Performance: up to three `git rev-parse` calls per install invocation
+#   (hooks dir, git-dir, git-common-dir); one for uninstall.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -82,12 +117,75 @@ resolve_git_hooks_dir() {
 }
 
 # ---------------------------------------------------------------------------
+# resolve_primary_checkout <repo_dir>
+#   See "Public API" above.
+# ---------------------------------------------------------------------------
+resolve_primary_checkout() {
+  local repo_dir="$1"
+  local common_dir git_dir canonical_repo_dir
+
+  if ! common_dir="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)" || [[ -z "$common_dir" ]]; then
+    return 1
+  fi
+  if ! git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)" || [[ -z "$git_dir" ]]; then
+    return 1
+  fi
+
+  # Both `--git-common-dir` and `--git-dir` can be checkout-relative in a
+  # normal (non-worktree) repo; normalise to absolute either way, matching
+  # resolve_git_hooks_dir's own normalisation above.
+  case "$common_dir" in
+    /*) : ;;
+    *) common_dir="$repo_dir/$common_dir" ;;
+  esac
+  case "$git_dir" in
+    /*) : ;;
+    *) git_dir="$repo_dir/$git_dir" ;;
+  esac
+
+  if [[ "$common_dir" == "$git_dir" ]]; then
+    # repo_dir is not a linked worktree (or is itself the primary checkout)
+    # - it is authoritative for its own hook source. Canonicalise via
+    # `pwd -P` (resolving any symlink components, e.g. macOS's
+    # /tmp -> /private/tmp or /var/folders -> /private/var/folders) so this
+    # branch's output is comparable, byte-for-byte, with the linked-worktree
+    # branch below - which is unavoidably canonicalised because that is what
+    # `git rev-parse --git-common-dir` returns for a worktree. Without this,
+    # installing once from a worktree (canonical form) and again directly
+    # from the primary checkout (raw form) would compute two DIFFERENT
+    # hook_src strings for the same real directory, and the "already linked"
+    # equality check below would spuriously treat the hook as stale forever.
+    if canonical_repo_dir="$(cd "$repo_dir" 2>/dev/null && pwd -P)" && [[ -n "$canonical_repo_dir" ]]; then
+      echo "$canonical_repo_dir"
+    else
+      echo "$repo_dir"
+    fi
+    return 0
+  fi
+
+  # repo_dir is a linked worktree; the primary checkout is the parent of the
+  # shared ".git" directory that the common dir points at - i.e. the main
+  # worktree, not whichever linked worktree repo_dir happens to be.
+  case "$common_dir" in
+    */.git) echo "${common_dir%/.git}" ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
 # install_precommit_hook <repo_dir>
 #   See "Public API" above.
 # ---------------------------------------------------------------------------
 install_precommit_hook() {
   local repo_dir="$1"
-  local hook_src="$repo_dir/hooks/pre-commit"
+
+  local primary_checkout
+  if ! primary_checkout="$(resolve_primary_checkout "$repo_dir")"; then
+    # Resolution failed - fall back to repo_dir's own hooks/pre-commit
+    # rather than aborting (pre-DS-152 behaviour).
+    primary_checkout="$repo_dir"
+  fi
+  local hook_src="$primary_checkout/hooks/pre-commit"
 
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then
@@ -101,21 +199,28 @@ install_precommit_hook() {
   if [[ -L "$hook_dst" ]]; then
     local current_target
     current_target="$(readlink "$hook_dst")"
+
+    if [[ ! -e "$hook_dst" ]]; then
+      echo "  ! existing pre-commit hook symlink is dangling (target missing): $current_target"
+    fi
+
     if [[ "$current_target" == "$hook_src" ]]; then
       echo "  = pre-commit hook already linked"
     elif _ae_is_ours "$hook_dst"; then
-      # Stale symlink pointing to another methodology checkout - re-point it.
+      # Stale symlink pointing to another methodology checkout (including a
+      # now-deleted ephemeral worktree) - re-point at the durable primary
+      # checkout, never at repo_dir directly.
       if [[ "$AE_DRY_RUN" == "true" ]]; then
-        echo "  ~ pre-commit hook (would re-point to repo_dir)"
+        echo "  ~ pre-commit hook (would re-point to primary checkout)"
       else
         ln -sfn "$hook_src" "$hook_dst"
-        echo "  ~ pre-commit hook (re-pointed to repo_dir)"
+        echo "  ~ pre-commit hook (re-pointed to primary checkout)"
       fi
     else
       if [[ "$AE_DRY_RUN" == "true" ]]; then
         echo "  ! pre-commit hook (would skip: symlink points outside methodology checkout: $current_target)"
       else
-        echo "  ! pre-commit hook points elsewhere: $current_target - skipping"
+        echo "  ! pre-commit hook points elsewhere: $current_target - skipping (repair manually if this is a dangling methodology hook)"
       fi
     fi
   elif [[ -e "$hook_dst" ]]; then
@@ -136,7 +241,12 @@ install_precommit_hook() {
 # ---------------------------------------------------------------------------
 uninstall_precommit_hook() {
   local repo_dir="$1"
-  local hook_src="$repo_dir/hooks/pre-commit"
+
+  local primary_checkout
+  if ! primary_checkout="$(resolve_primary_checkout "$repo_dir")"; then
+    primary_checkout="$repo_dir"
+  fi
+  local hook_src="$primary_checkout/hooks/pre-commit"
 
   local hooks_dir
   if ! hooks_dir="$(resolve_git_hooks_dir "$repo_dir")"; then

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -73,7 +73,12 @@
 #     repo_dir's git-common-dir (see _pc_is_legacy_sibling_hook) - the same
 #     ownership check the original per-adapter uninstall blocks used,
 #     extended so a hook installed by pre-DS-152 code from a worktree can
-#     still be removed post-upgrade. Never deletes a foreign hook, a real
+#     still be removed post-upgrade. Also removed when the legacy target's
+#     own worktree directory has already been deleted, PROVIDED its path
+#     lies under the primary checkout's own ".claude/worktrees/" or
+#     ".agentic/worktrees/" (see _pc_is_legacy_sibling_hook's dangling-target
+#     branch) - the most common pre-fix residue, since a dangling hook is
+#     already broken regardless. Never deletes a foreign hook, a real
 #     file, or a symlink pointing at an unrelated repo. If hooks-dir
 #     resolution fails for any reason, prints a non-fatal warning and
 #     returns 0 - never aborts the caller. On primary-checkout resolution
@@ -140,15 +145,47 @@ resolve_git_hooks_dir() {
 }
 
 # ---------------------------------------------------------------------------
+# _pc_canonicalize_dir <dir>
+#   Internal helper (not part of the public API). Echoes the canonical
+#   (symlink-resolved) absolute form of <dir> via `cd <dir> && pwd -P`,
+#   falling back to echoing <dir> unchanged (and still returning 0) when
+#   canonicalisation fails (e.g. <dir> does not exist). Shared by
+#   resolve_primary_checkout and _pc_git_common_dir_abs so every absolute
+#   path either of them produces is canonicalised the SAME way - a
+#   symlinked TMPDIR/HOME path component (e.g. macOS's
+#   /tmp -> /private/tmp or /var/folders -> /private/var/folders) would
+#   otherwise leave one call site's output canonical and the other's raw,
+#   causing string-equality comparisons downstream to spuriously fail.
+#   Always returns 0 - callers that need to distinguish "could not
+#   canonicalise" should check whether the echoed value differs from what
+#   they passed in; none of the current callers need to.
+# ---------------------------------------------------------------------------
+_pc_canonicalize_dir() {
+  local dir="$1"
+  local canonical
+  if canonical="$(cd "$dir" 2>/dev/null && pwd -P)" && [[ -n "$canonical" ]]; then
+    echo "$canonical"
+  else
+    echo "$dir"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # _pc_git_common_dir_abs <dir>
-#   Internal helper (not part of the public API). Echoes the absolute
-#   `git -C <dir> rev-parse --git-common-dir` for <dir>, normalising a
-#   checkout-relative result to absolute exactly like resolve_git_hooks_dir
-#   does. Returns non-zero and echoes nothing if <dir> is not a git checkout
-#   (missing, deleted, or never a repo). Shared by resolve_primary_checkout
-#   and _pc_is_legacy_sibling_hook so both compare common-dirs computed the
-#   SAME way - avoids the raw-string mismatches a symlinked TMPDIR/HOME
-#   component would otherwise cause between the two call sites.
+#   Internal helper (not part of the public API). Echoes the CANONICAL
+#   absolute `git -C <dir> rev-parse --git-common-dir` for <dir>: the raw
+#   result is normalised to absolute exactly like resolve_git_hooks_dir
+#   does, then run through _pc_canonicalize_dir. Returns non-zero and
+#   echoes nothing if <dir> is not a git checkout (missing, deleted, or
+#   never a repo). Shared by resolve_primary_checkout and
+#   _pc_is_legacy_sibling_hook so both compare common-dirs computed the
+#   SAME way and in the SAME (canonical) form - `git rev-parse
+#   --git-common-dir` returns a checkout-RELATIVE path from a primary
+#   (non-worktree) checkout but a fully canonical ABSOLUTE path from a
+#   linked worktree, so without this canonicalisation step the two forms
+#   would raw-string-mismatch on any TMPDIR/HOME with a symlinked
+#   component even though they resolve to the identical directory.
 # ---------------------------------------------------------------------------
 _pc_git_common_dir_abs() {
   local dir="$1"
@@ -160,31 +197,57 @@ _pc_git_common_dir_abs() {
     /*) : ;;
     *) common_dir="$dir/$common_dir" ;;
   esac
-  echo "$common_dir"
+  _pc_canonicalize_dir "$common_dir"
 }
 
 # ---------------------------------------------------------------------------
-# _pc_is_legacy_sibling_hook <target> <repo_common_dir>
+# _pc_is_legacy_sibling_hook <target> <repo_common_dir> [primary_checkout]
 #   Internal helper (not part of the public API). A pre-DS-152 install could
 #   have symlinked the shared hook at ANY worktree's own
 #   "<worktree>/hooks/pre-commit" (repo_dir itself, not necessarily the
 #   primary checkout). Returns 0 (true) iff <target> ends in
-#   "/hooks/pre-commit", the directory it hangs off of still exists, and
-#   THAT directory's own git-common-dir matches <repo_common_dir> - i.e.
-#   <target> is some worktree of the exact same repo family repo_dir
-#   belongs to, regardless of which worktree wrote it or how its path was
-#   originally spelled. Returns 1 (false) - never aborts - when <target>
-#   does not match the suffix, the directory no longer exists (cannot be
-#   verified), or its common-dir resolves to a different repo.
+#   "/hooks/pre-commit" AND either:
+#     - the directory it hangs off of still exists, and THAT directory's own
+#       git-common-dir matches <repo_common_dir> - i.e. <target> is some
+#       worktree of the exact same repo family repo_dir belongs to,
+#       regardless of which worktree wrote it or how its path was
+#       originally spelled; or
+#     - the directory it hangs off of has already been DELETED (the most
+#       common pre-fix residue - a scratch/ephemeral worktree that was
+#       cleaned up without ever uninstalling its legacy hook first) AND
+#       [primary_checkout] is given AND <target>'s worktree path lies under
+#       "<primary_checkout>/.claude/worktrees/" or
+#       "<primary_checkout>/.agentic/worktrees/" - the repo's own known
+#       worktree roots. Ownership cannot be verified via git-common-dir once
+#       the directory is gone, so this path constraint stands in for it: the
+#       hook is already broken either way (its target cannot be executed),
+#       and constraining to the repo's own worktree roots prevents widening
+#       into a foreign dangling hook that merely happens to be unreachable.
+#   Returns 1 (false) - never aborts - when <target> does not match the
+#   suffix, or (for an existing target directory) its common-dir resolves to
+#   a different repo, or (for an already-deleted target directory) no
+#   primary_checkout was given or the path falls outside both known
+#   worktree roots.
 # ---------------------------------------------------------------------------
 _pc_is_legacy_sibling_hook() {
-  local target="$1" repo_common_dir="$2"
+  local target="$1" repo_common_dir="$2" primary_checkout="${3:-}"
   case "$target" in
     */hooks/pre-commit) : ;;
     *) return 1 ;;
   esac
   local target_repo_dir="${target%/hooks/pre-commit}"
-  [[ -d "$target_repo_dir" ]] || return 1
+
+  if [[ ! -d "$target_repo_dir" ]]; then
+    if [[ -n "$primary_checkout" ]]; then
+      case "$target_repo_dir" in
+        "$primary_checkout"/.claude/worktrees/*|"$primary_checkout"/.agentic/worktrees/*)
+          return 0
+          ;;
+      esac
+    fi
+    return 1
+  fi
+
   local target_common_dir
   target_common_dir="$(_pc_git_common_dir_abs "$target_repo_dir")" || return 1
   [[ "$target_common_dir" == "$repo_common_dir" ]]
@@ -196,7 +259,7 @@ _pc_is_legacy_sibling_hook() {
 # ---------------------------------------------------------------------------
 resolve_primary_checkout() {
   local repo_dir="$1"
-  local common_dir git_dir canonical_repo_dir
+  local common_dir git_dir
 
   common_dir="$(_pc_git_common_dir_abs "$repo_dir")" || return 1
   if ! git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)" || [[ -z "$git_dir" ]]; then
@@ -205,29 +268,31 @@ resolve_primary_checkout() {
 
   # `--git-dir` can be checkout-relative in a normal (non-worktree) repo;
   # normalise to absolute, matching _pc_git_common_dir_abs's own
-  # normalisation of --git-common-dir above.
+  # normalisation of --git-common-dir above. Deliberately NOT run through
+  # _pc_canonicalize_dir - it does not need to match common_dir's exact
+  # string form, only its identity (see the `-ef` comparison below).
   case "$git_dir" in
     /*) : ;;
     *) git_dir="$repo_dir/$git_dir" ;;
   esac
 
-  if [[ "$common_dir" == "$git_dir" ]]; then
+  # Compare by inode identity (`-ef`), not string equality: common_dir is
+  # now always canonicalised (via _pc_git_common_dir_abs) while git_dir may
+  # still be a raw, non-canonicalised concatenation on a symlinked
+  # TMPDIR/HOME. Both paths exist as real directories whenever repo_dir is a
+  # valid checkout, so `-ef` correctly identifies "same directory" without
+  # requiring either side's string form to match.
+  if [[ "$common_dir" -ef "$git_dir" ]]; then
     # repo_dir is not a linked worktree (or is itself the primary checkout)
-    # - it is authoritative for its own hook source. Canonicalise via
-    # `pwd -P` (resolving any symlink components, e.g. macOS's
-    # /tmp -> /private/tmp or /var/folders -> /private/var/folders) so this
-    # branch's output is comparable, byte-for-byte, with the linked-worktree
-    # branch below - which is unavoidably canonicalised because that is what
-    # `git rev-parse --git-common-dir` returns for a worktree. Without this,
-    # installing once from a worktree (canonical form) and again directly
-    # from the primary checkout (raw form) would compute two DIFFERENT
-    # hook_src strings for the same real directory, and the "already linked"
-    # equality check below would spuriously treat the hook as stale forever.
-    if canonical_repo_dir="$(cd "$repo_dir" 2>/dev/null && pwd -P)" && [[ -n "$canonical_repo_dir" ]]; then
-      echo "$canonical_repo_dir"
-    else
-      echo "$repo_dir"
-    fi
+    # - it is authoritative for its own hook source. Canonicalise via the
+    # shared helper so this branch's output is comparable, byte-for-byte,
+    # with the linked-worktree branch below (whose common_dir is already
+    # canonical). Without this, installing once from a worktree (canonical
+    # form) and again directly from the primary checkout (raw form) would
+    # compute two DIFFERENT hook_src strings for the same real directory,
+    # and the "already linked" equality check downstream would spuriously
+    # treat the hook as stale forever.
+    _pc_canonicalize_dir "$repo_dir"
     return 0
   fi
 
@@ -349,7 +414,7 @@ uninstall_precommit_hook() {
       # would have symlinked directly.
       local repo_common_dir
       if repo_common_dir="$(_pc_git_common_dir_abs "$repo_dir" 2>/dev/null)" \
-        && _pc_is_legacy_sibling_hook "$current_target" "$repo_common_dir"; then
+        && _pc_is_legacy_sibling_hook "$current_target" "$repo_common_dir" "$primary_checkout"; then
         rm "$hook_dst"
         echo "  - pre-commit hook removed (legacy pre-DS-152 target: $current_target)"
       else

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -175,8 +175,12 @@ resolve_git_hooks_dir() {
 #   linked-worktree branch instead (which echoes a case-stripped
 #   common_dir directly, never calling this helper) rather than the
 #   primary-checkout branch that would. Verified: `resolve_primary_checkout
-#   ""` returns rc=0 and echoes this checkout's own resolved path, in both
-#   shells - not a failure at all. The guard exists so a FUTURE caller
+#   ""` returns rc=0 and echoes the EMPTY STRING, in both shells - not a
+#   failure at all, but not a real path either (traced:
+#   `_pc_git_common_dir_abs ""` -> "/.git", `git_dir` -> "/.git", `-ef`
+#   false since neither exists, so the linked-worktree branch strips the
+#   "/.git" suffix off "/.git" itself, yielding ""). The guard exists so a
+#   FUTURE caller
 #   cannot be silently bitten by the bash/zsh inter-shell divergence
 #   documented above, independent of how today's callers happen to avoid
 #   it.
@@ -307,7 +311,13 @@ _pc_git_common_dir_abs() {
 #   evaluated against CWD names the wrong directory) and because an
 #   unanchored relative target with a slash-free first component could
 #   otherwise reach _pc_canonicalize_missing_dir's walk-up in a form that
-#   never becomes absolute. Returns 0 (true) iff <target> ends in
+#   never becomes absolute. When <target> is not absolute and [hooks_dir]
+#   is OMITTED, returns 1 (fails closed - no removal) rather than falling
+#   back to resolving the relative target against the process CWD (DS-152
+#   round 6, Minor 2): the sole production caller always passes hooks_dir,
+#   so this is unreachable today, but the failure direction here is hook
+#   DELETION, so an unreachable-and-fail-open combination would be the
+#   wrong one to leave in place. Returns 0 (true) iff <target> ends in
 #   "/hooks/pre-commit" AND either:
 #     - the directory it hangs off of still exists, and THAT directory's own
 #       git-common-dir matches <repo_common_dir> - i.e. <target> is some
@@ -334,8 +344,9 @@ _pc_git_common_dir_abs() {
 #       own worktree roots prevents widening into a foreign dangling hook
 #       that merely happens to be unreachable.
 #   Returns 1 (false) - never aborts - when <target> does not match the
-#   suffix, or (for an existing target directory) its common-dir resolves to
-#   a different repo, or (for an already-deleted target directory) no
+#   suffix, or <target> is relative and [hooks_dir] was omitted (see
+#   above), or (for an existing target directory) its common-dir resolves
+#   to a different repo, or (for an already-deleted target directory) no
 #   primary_checkout was given or the path falls outside both known
 #   worktree roots.
 # ---------------------------------------------------------------------------
@@ -348,12 +359,20 @@ _pc_is_legacy_sibling_hook() {
   local target_repo_dir="${target%/hooks/pre-commit}"
 
   # Anchor a relative target against the symlink's own directory (see
-  # docstring above) - never against the process CWD.
+  # docstring above) - never against the process CWD. Fail CLOSED (return
+  # 1, no removal) rather than falling back to an unanchored, CWD-relative
+  # resolution when [hooks_dir] is omitted: the one production call site
+  # always passes it, so this branch is unreachable today, but the
+  # direction of a wrong decision here is HOOK DELETION - an
+  # unreachable-and-fail-OPEN combination is the wrong one to ship
+  # (DS-152 round 6, Minor 2).
   case "$target_repo_dir" in
     /*) : ;;
     *)
       if [[ -n "$hooks_dir" ]]; then
         target_repo_dir="$hooks_dir/$target_repo_dir"
+      else
+        return 1
       fi
       ;;
   esac

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -161,11 +161,25 @@ resolve_git_hooks_dir() {
 #   `cd ""` SUCCEEDS and resolves to the shell's CURRENT working directory,
 #   so without this guard the two shells would echo different, silently
 #   wrong answers for the same empty input. No current caller passes an
-#   empty <dir> (verified: _pc_git_common_dir_abs already returns early on
-#   an empty git-common-dir before ever calling this; resolve_primary_checkout
-#   returns 1 on `repo_dir=""` via its own upstream `git -C ""` failure) -
-#   the guard exists so a FUTURE caller cannot be silently bitten by this
-#   inter-shell divergence.
+#   empty <dir> today, but NOT because any upstream `git -C ""` call fails -
+#   it does not: `git -C "" rev-parse ...` is treated the same as omitting
+#   `-C` entirely and succeeds against the process CWD (verified both
+#   shells). Concretely: _pc_git_common_dir_abs already returns early on an
+#   empty git-common-dir before ever calling this helper (and an empty
+#   <dir> passed to IT would still succeed via `git -C ""`'s CWD fallback,
+#   so this guard is never reached that way either); resolve_primary_checkout
+#   never calls this helper with `repo_dir=""` because its own `-ef`
+#   identity check (comparing a real common-dir against a malformed,
+#   literal "/.git" git-dir - "" concatenated with the relative ".git" -
+#   for repo_dir="") evaluates false for empty input, so it takes the
+#   linked-worktree branch instead (which echoes a case-stripped
+#   common_dir directly, never calling this helper) rather than the
+#   primary-checkout branch that would. Verified: `resolve_primary_checkout
+#   ""` returns rc=0 and echoes this checkout's own resolved path, in both
+#   shells - not a failure at all. The guard exists so a FUTURE caller
+#   cannot be silently bitten by the bash/zsh inter-shell divergence
+#   documented above, independent of how today's callers happen to avoid
+#   it.
 #   On any OTHER canonicalisation failure (a non-empty <dir> that does not
 #   exist, a permission error, or a path that is a file, not a directory),
 #   falls back to echoing <dir> unchanged and still returns 0 - this
@@ -201,18 +215,45 @@ _pc_canonicalize_dir() {
 #   /var/folders -> /private/var/folders), then re-appends the missing
 #   trailing path components verbatim - they cannot contain a symlink to
 #   resolve, because a symlink target must itself exist to be dereferenced.
-#   Echoes the resulting path and always returns 0; the degenerate case
-#   <path>="/" is its own existing ancestor, so the loop always terminates.
-#   <path>="" is treated as "/" up front - `existing` is then guaranteed to
-#   be either "/" or a "/"-stripped, still-non-empty prefix of <path> by the
-#   time _pc_canonicalize_dir is called, so it is never the empty string
-#   that helper now rejects.
+#   Always returns 0.
+#
+#   Known, harmless edge behaviours (none of these are bugs - documented so
+#   a future change doesn't "fix" them into something that IS a bug):
+#     - <path>="/" (or any input whose only existing ancestor is "/") echoes
+#       the EMPTY STRING, not "/" - the final `${canonical_existing%/}`
+#       strip removes a lone trailing slash unconditionally. Every current
+#       caller only ever appends this result as a prefix, so an empty
+#       prefix is equivalent to no prefix.
+#     - A trailing slash on <path> itself survives verbatim into the
+#       output's tail (e.g. "/tmp/gone/" canonicalises to
+#       "/private/tmp/gone/", not "/private/tmp/gone") - the walk only
+#       strips components from the END via `${existing%/*}`, which does not
+#       touch a trailing slash already present.
+#     - <path>="" is treated as "/" up front, so it produces the same empty
+#       string as the "/" case above.
+#
+#   Termination guard (DS-152 round 5, Critical): if the walk-up reduces
+#   `existing` to a slash-free, still-nonexistent fragment (e.g. a
+#   relative <path> like "toolbox/hooks" evaluated in a CWD that has no
+#   "toolbox" entry), `${existing%/*}` becomes a no-op on that fragment and
+#   the loop would otherwise never terminate, growing `tail` without bound.
+#   The `*/*` case guard below detects exactly this and stops climbing,
+#   leaving the unresolved fragment as the base for _pc_canonicalize_dir
+#   (which fails closed - falls back to echoing it unchanged - rather than
+#   hanging). This is a safety net: _pc_is_legacy_sibling_hook anchors its
+#   own input to an absolute path before ever reaching here specifically to
+#   avoid needing it, but a future caller that does not anchor its input is
+#   still protected from a hang rather than merely from a wrong answer.
 # ---------------------------------------------------------------------------
 _pc_canonicalize_missing_dir() {
   local path="$1"
   local existing="${path:-/}"
   local tail=""
-  while [[ ! -d "$existing" && "$existing" != "/" && -n "$existing" ]]; do
+  while [[ ! -d "$existing" && "$existing" != "/" ]]; do
+    case "$existing" in
+      */*) : ;;
+      *) break ;;
+    esac
     tail="/${existing##*/}${tail}"
     existing="${existing%/*}"
     [[ -z "$existing" ]] && existing="/"
@@ -252,11 +293,21 @@ _pc_git_common_dir_abs() {
 }
 
 # ---------------------------------------------------------------------------
-# _pc_is_legacy_sibling_hook <target> <repo_common_dir> [primary_checkout]
+# _pc_is_legacy_sibling_hook <target> <repo_common_dir> [primary_checkout] [hooks_dir]
 #   Internal helper (not part of the public API). A pre-DS-152 install could
 #   have symlinked the shared hook at ANY worktree's own
 #   "<worktree>/hooks/pre-commit" (repo_dir itself, not necessarily the
-#   primary checkout). Returns 0 (true) iff <target> ends in
+#   primary checkout). <target> is the RAW symlink target text (from
+#   `readlink`), which may be a RELATIVE path - per POSIX symlink semantics
+#   a relative target resolves against the symlink's OWN directory
+#   (<hooks_dir>, the directory the pre-commit symlink itself lives in),
+#   NOT the calling process's CWD. When <target> is not absolute and
+#   [hooks_dir] is given, it is anchored against <hooks_dir> before any
+#   further use (DS-152 round 5) - both for correctness (a relative target
+#   evaluated against CWD names the wrong directory) and because an
+#   unanchored relative target with a slash-free first component could
+#   otherwise reach _pc_canonicalize_missing_dir's walk-up in a form that
+#   never becomes absolute. Returns 0 (true) iff <target> ends in
 #   "/hooks/pre-commit" AND either:
 #     - the directory it hangs off of still exists, and THAT directory's own
 #       git-common-dir matches <repo_common_dir> - i.e. <target> is some
@@ -289,12 +340,23 @@ _pc_git_common_dir_abs() {
 #   worktree roots.
 # ---------------------------------------------------------------------------
 _pc_is_legacy_sibling_hook() {
-  local target="$1" repo_common_dir="$2" primary_checkout="${3:-}"
+  local target="$1" repo_common_dir="$2" primary_checkout="${3:-}" hooks_dir="${4:-}"
   case "$target" in
     */hooks/pre-commit) : ;;
     *) return 1 ;;
   esac
   local target_repo_dir="${target%/hooks/pre-commit}"
+
+  # Anchor a relative target against the symlink's own directory (see
+  # docstring above) - never against the process CWD.
+  case "$target_repo_dir" in
+    /*) : ;;
+    *)
+      if [[ -n "$hooks_dir" ]]; then
+        target_repo_dir="$hooks_dir/$target_repo_dir"
+      fi
+      ;;
+  esac
 
   if [[ ! -d "$target_repo_dir" ]]; then
     if [[ -n "$primary_checkout" ]]; then
@@ -475,7 +537,7 @@ uninstall_precommit_hook() {
       # would have symlinked directly.
       local repo_common_dir
       if repo_common_dir="$(_pc_git_common_dir_abs "$repo_dir" 2>/dev/null)" \
-        && _pc_is_legacy_sibling_hook "$current_target" "$repo_common_dir" "$primary_checkout"; then
+        && _pc_is_legacy_sibling_hook "$current_target" "$repo_common_dir" "$primary_checkout" "$hooks_dir"; then
         rm "$hook_dst"
         echo "  - pre-commit hook removed (legacy pre-DS-152 target: $current_target)"
       else


### PR DESCRIPTION
## Summary

`ds-doctor` found this repo's `.git/hooks/pre-commit` pointing at `/tmp/skeptic-621-SB4Cfv/hooks/pre-commit` - a scratch worktree deleted weeks earlier. The hook had been silently dead ever since.

Root cause: `install_precommit_hook <repo_dir>` resolved the hook **destination** to the shared common `.git/hooks` (correct - hooks are shared across all worktrees) but sourced the hook **body** from `<repo_dir>/hooks/pre-commit`, i.e. whatever directory it was handed. Running any adapter's `install.sh` from an ephemeral scratch worktree therefore repointed the entire repo's shared hook at a directory about to be deleted, and `_ae_is_ours()` had no durable-vs-ephemeral distinction so it did this without warning.

Scratch worktrees of exactly that shape are routine under `content/references/qa-regression-obligation.md`. The bug reproduced itself twice more during the work on it.

## What changed

- **`resolve_primary_checkout`** - the hook body is now always sourced from the primary checkout, never the invoking `repo_dir`. Sourcing from a worktree only made sense if the design provided per-worktree hook *content*, and it does not: `hooks/pre-commit` early-exits its whole adapter-build section inside any worktree.
- **Existence check before symlinking** - install refuses, loudly and non-fatally, rather than writing a link to a nonexistent target.
- **Canonicalization** - `git rev-parse --git-path hooks` returns a *relative* `.git` from a primary checkout but a *canonical absolute* path from a linked worktree, so raw string comparison silently failed on any path with a symlinked component.
- **Legacy residue cleanup** - a hook installed by the old code, including one whose target worktree is already deleted, is now recognized and removed when it lies under the repo's own worktree directories.
- **Relative link targets are anchored against the hooks directory**, per POSIX, instead of the process CWD.

## Nothing shipped broken

The dead hook caused no bad merge. `hooks/pre-commit` skips its adapter-build and staging section inside any worktree, so it was never load-bearing for the worktree-isolated PR workflow - and `check-adapter-sync` rebuilds all 11 adapters server-side on every PR regardless of local hook state. A full `build-all.sh` against `main` produces zero diff.

## Review

Six Skeptic rounds. Findings resolved, each reproduced by execution rather than argued:

- **The test suite could dangle the live repo's shared hook.** With `GIT_DIR` set in the environment, git ignores `-C <dir>` entirely, so the fixture harness silently operated on the ambient repo and wrote a symlink into it pointing at a deleted fixture. Reproduced, then closed by unsetting the git env vars and adopting the existing hook guard.
- **A Critical infinite loop.** The walk-up over a dangling path never terminated on a slash-free component, hanging `uninstall_precommit_hook` and all three adapter uninstall scripts with unbounded memory growth. Reproduced at rc=124 under both shells.
- **A regression test that tested nothing.** The hang test wrapped its call in `timeout` and asserted `rc != 124` - but `timeout` is not a stock macOS binary, so without it the call returns 127 and the assertion passes while verifying nothing. Now resolves `timeout`/`gtimeout` explicitly and hard-fails under `CI`.
- **The uninstall path was hardened to fail closed**, since its failure direction is deletion.

Two findings were the same defect relocated rather than removed, and three fixtures were built to match the fix instead of the defect - each caught only because the reviewer executed the repro rather than reading the diff.

- 54/54 in all four {bash, zsh} x {symlinked, non-symlinked} combinations, at equal assertion counts
- `bin/tests` 38/38 suites; pytest 1149; JS 44/44; all three budget gates OK
- Every new assertion mutation-tested; the anchor and the termination guard proven independently load-bearing

**CI cannot catch this class.** macOS `TMPDIR` is symlinked and ubuntu's `/tmp` is not, so a symlink-sensitive assertion only ever fails on a developer's machine. The suite is therefore run from both a symlinked and a non-symlinked root.

## North Star alignment

**Works for everyone.** The bug was pure path-spelling portability: it fired for any checkout reached through a symlinked home, dev directory, or macOS `TMPDIR`, and was invisible to CI and to anyone on a non-symlinked path.

**Produce verifiable outcomes.** A silently dead pre-commit hook is the worst kind of green - present, executable-looking, and doing nothing. This makes every failure path loud and non-fatal, and closes a test-suite escape that could corrupt the operator's real repository.

**Enforcement floors are not weakened.** The uninstall ownership predicate was widened only as far as measurement justified, and was verified against six adversarial targets (unrelated repo, user script, husky-style path, non-repo path, foreign symlink, target destruction) that must all be preserved. The deletion blast radius is bounded to the hook symlink itself, never its target.

Doc-sync: predicate not triggered - internal shell library plus its test suite; no public count, list, or path assertion in `README.md`, `CONTRIBUTING.md`, `content/SKILL.md`, or `docs/` is affected.
