### PR TITLE
fix(DS-158): retry session-log lock timeout instead of silently dropping the record

### DIFF
--- a/bin/ds-identity
+++ b/bin/ds-identity
@@ -135,6 +135,16 @@ PENDING_CAP = 100
 PENDING_SCAN_LIMIT = PENDING_CAP + 1
 PENDING_DIRECTORY_SCAN_LIMIT = (PENDING_CAP * 4) + 1
 PENDING_INTERNAL_STALE_SECONDS = 60
+# DS-158 round 2: total wall-clock budget for the session-log lock retry loop
+# in _write_jsonl_safely, spent across all attempts (not per attempt), not
+# per attempt in isolation. Kept at parity with round 1's flat single-attempt
+# 5.0s wait (not shrunk) - the fix here is that a lock timeout now gets a
+# retry at all within this budget, not that the budget itself grew, since
+# the JS caller's subprocess ceiling (see hooks/stop-context.js
+# writeTelemetrySafely's spawnSync `timeout` comment) sets the same total
+# ceiling either way. Bumping one obliges bumping the other, by construction.
+SESSION_LOG_LOCK_BUDGET_SECONDS = 5.0
+SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 1.0
 
 
 def _contains_unicode_control(value: str) -> bool:
@@ -704,6 +714,15 @@ def _acquire_validated_file_lock(
         os.close(parent_fd)
 
 
+class _LockTimeoutError(RuntimeError):
+    """One flock() attempt exhausted its bounded wait.
+
+    DS-158 round 2: kept distinct from a bare RuntimeError so a caller-side
+    retry loop can catch specifically this transient, retryable condition
+    without also absorbing an unrelated RuntimeError it did not anticipate.
+    """
+
+
 def _lock_fd_exclusive(fd: int, *, timeout: float) -> None:
     """Acquire one fd lock with a monotonic bounded retry loop."""
     deadline = time.monotonic() + timeout
@@ -713,7 +732,7 @@ def _lock_fd_exclusive(fd: int, *, timeout: float) -> None:
             return
         except BlockingIOError:
             if time.monotonic() >= deadline:
-                raise RuntimeError(f"lock timeout after {timeout:.0f}s")
+                raise _LockTimeoutError(f"lock timeout after {timeout:.0f}s")
             time.sleep(0.02)
 
 
@@ -1153,7 +1172,18 @@ def _write_jsonl_safely(
         # A pair of legitimate writers can each replace the inode while its
         # peer is performing the post-publication check. Eight bounded passes
         # let that finite handoff converge without weakening rotation checks.
+        # DS-158 round 2: the same attempt budget also backstops a holder that
+        # stalls mid-critical-section (slow fsync, CPU steal on a shared
+        # runner) - that stall previously converted into a permanently,
+        # silently dropped telemetry record because a lock-timeout RuntimeError
+        # from _lock_fd_exclusive escaped this loop's `except FileNotFoundError`
+        # entirely (caught only by the function-level outer except, one shot,
+        # no retry). _LockTimeoutError is now caught here too and retried with
+        # backoff, bounded by SESSION_LOG_LOCK_BUDGET_SECONDS of total wall
+        # clock across every attempt (not per attempt) so a run of unlucky
+        # collisions cannot compound into an unbounded wait.
         max_attempts = 8
+        lock_deadline = time.monotonic() + SESSION_LOG_LOCK_BUDGET_SECONDS
         for attempt in range(max_attempts):
             parent_fd: int | None = None
             log_fd: int | None = None
@@ -1165,16 +1195,14 @@ def _write_jsonl_safely(
             try:
                 parent_fd = _open_directory_nofollow(path.parent, create=True)
                 log_fd = _open_safe_log_at(parent_fd, path.name, create=True)
-                # A holder that stalls mid-critical-section (slow fsync, CPU
-                # steal on a shared runner) blocks a waiter for the full
-                # stall, not just its own tiny read/render/write. DS-158: a
-                # too-tight budget here previously converted that stall into
-                # a permanently, silently dropped telemetry record - nothing
-                # above this call retries or surfaces the loss. The JS caller
-                # (hooks/stop-context.js writeTelemetrySafely) bounds the
-                # whole write-hook subprocess at 6000ms, so this budget must
-                # stay under that with headroom for the surrounding work.
-                _lock_fd_exclusive(log_fd, timeout=5.0)
+                lock_timeout = max(
+                    0.05,
+                    min(
+                        SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS,
+                        lock_deadline - time.monotonic(),
+                    ),
+                )
+                _lock_fd_exclusive(log_fd, timeout=lock_timeout)
                 log_locked = True
                 if not _directory_fd_is_canonical(path.parent, parent_fd):
                     raise FileNotFoundError("session log parent rotated before lock")
@@ -1255,6 +1283,23 @@ def _write_jsonl_safely(
             except FileNotFoundError:
                 if attempt == max_attempts - 1:
                     raise
+            except RuntimeError:
+                # Only _lock_fd_exclusive raises RuntimeError on this path
+                # (as _LockTimeoutError, a RuntimeError subclass); caught by
+                # base class rather than the subclass so this stays correct
+                # if a caller substitutes a differently-typed but still
+                # RuntimeError-based lock helper (e.g. in a test double).
+                remaining = lock_deadline - time.monotonic()
+                if attempt == max_attempts - 1 or remaining <= 0:
+                    raise
+                # Linear backoff (capped) gives a contended writer
+                # successive, increasingly patient chances instead of
+                # hammering the same lock at a fixed interval. Also capped
+                # by the remaining budget so backoff sleeps are spent from
+                # inside SESSION_LOG_LOCK_BUDGET_SECONDS, never added on top
+                # of it - the JS-side spawnSync ceiling is derived from that
+                # budget and must not be exceeded by backoff overhead.
+                time.sleep(min(0.5, 0.05 * (attempt + 1), remaining))
             finally:
                 if temp_fd is not None:
                     os.close(temp_fd)

--- a/bin/ds-identity
+++ b/bin/ds-identity
@@ -1165,7 +1165,16 @@ def _write_jsonl_safely(
             try:
                 parent_fd = _open_directory_nofollow(path.parent, create=True)
                 log_fd = _open_safe_log_at(parent_fd, path.name, create=True)
-                _lock_fd_exclusive(log_fd, timeout=2.0)
+                # A holder that stalls mid-critical-section (slow fsync, CPU
+                # steal on a shared runner) blocks a waiter for the full
+                # stall, not just its own tiny read/render/write. DS-158: a
+                # too-tight budget here previously converted that stall into
+                # a permanently, silently dropped telemetry record - nothing
+                # above this call retries or surfaces the loss. The JS caller
+                # (hooks/stop-context.js writeTelemetrySafely) bounds the
+                # whole write-hook subprocess at 6000ms, so this budget must
+                # stay under that with headroom for the surrounding work.
+                _lock_fd_exclusive(log_fd, timeout=5.0)
                 log_locked = True
                 if not _directory_fd_is_canonical(path.parent, parent_fd):
                     raise FileNotFoundError("session log parent rotated before lock")

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -785,6 +785,113 @@ def test_append_retries_when_canonical_parent_rotates_before_publication():
         print("PASS test_append_retries_when_canonical_parent_rotates_before_publication")
 
 
+def test_lock_timeout_retries_with_backoff_and_succeeds():
+    """DS-158 round 2: a transient lock-timeout RuntimeError from
+    _lock_fd_exclusive must be retried by _write_jsonl_safely's attempt
+    loop, not swallowed after a single attempt. Round 1 only raised the
+    per-attempt timeout (2.0s -> 5.0s); that timeout still escaped the
+    loop's `except FileNotFoundError` entirely and was caught only by the
+    function's outer except, one shot, no retry - a bigger single wait does
+    not change that shape. This forces two consecutive lock-timeout raises
+    (matching what a real flock timeout raises, regardless of exact
+    exception subclass) before delegating to the real flock, and asserts
+    the record still lands durably and that more than one attempt occurred.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "lock-timeout-dev.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps(
+            {"session_uuid": "lock-timeout-retry", "data": {"tokens": {"total": 3}}},
+            separators=(",", ":"),
+        )
+
+        original_lock = _mod._lock_fd_exclusive
+        attempts = {"n": 0}
+
+        def flaky_lock(fd, *, timeout):
+            attempts["n"] += 1
+            if attempts["n"] <= 2:
+                # Same exception family a real flock timeout raises
+                # (RuntimeError); a plain RuntimeError here (rather than the
+                # production-only _LockTimeoutError subclass) keeps this
+                # test meaningful against a checkout that has not yet
+                # defined that subclass, since what must be proven is that
+                # the RETRY LOOP catches the timeout family, not that one
+                # specific subclass exists.
+                raise RuntimeError("forced test lock timeout")
+            return original_lock(fd, timeout=timeout)
+
+        _mod._lock_fd_exclusive = flaky_lock
+        try:
+            ok = _mod._append_jsonl_safely(log_path, line)
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+
+        assert ok is True, "a transient lock timeout must not drop the record"
+        assert attempts["n"] == 3, (
+            "expected exactly two forced timeouts before the real lock "
+            f"succeeded on the third attempt, got {attempts['n']}"
+        )
+        rows = [
+            json.loads(raw)
+            for raw in log_path.read_text(encoding="utf-8").splitlines()
+            if raw.strip()
+        ]
+        assert [row["session_uuid"] for row in rows] == ["lock-timeout-retry"], rows
+        print("PASS test_lock_timeout_retries_with_backoff_and_succeeds")
+
+
+def test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller():
+    """A permanently-contended lock must still fail closed: _append_jsonl_safely
+    returns False rather than raising to its caller, and the give-up path
+    terminates within a bounded window rather than hanging. Shrinks the
+    module's lock-retry budget/per-attempt cap for the duration of the test
+    so the exhaustion path resolves quickly and deterministically."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "lock-timeout-exhausted.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps({"session_uuid": "lock-timeout-exhausted"}, separators=(",", ":"))
+
+        original_lock = _mod._lock_fd_exclusive
+        original_budget = getattr(_mod, "SESSION_LOG_LOCK_BUDGET_SECONDS", None)
+        original_cap = getattr(
+            _mod, "SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS", None
+        )
+
+        def always_timeout(fd, *, timeout):
+            raise RuntimeError("forced permanent test lock timeout")
+
+        _mod._lock_fd_exclusive = always_timeout
+        # Shrink the budget (when present - round-1 code has no such
+        # constant, and the give-up path there is bounded by its own single
+        # 5.0s attempt regardless) so this resolves quickly under test.
+        if original_budget is not None:
+            _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = 0.2
+        if original_cap is not None:
+            _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 0.05
+        try:
+            started = time.monotonic()
+            ok = _mod._append_jsonl_safely(log_path, line)
+            elapsed = time.monotonic() - started
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+            if original_budget is not None:
+                _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = original_budget
+            if original_cap is not None:
+                _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = original_cap
+
+        assert ok is False, "a permanently-contended lock must fail closed, not raise"
+        assert elapsed < 5.0, (
+            f"give-up path must not exceed a bounded budget, took {elapsed:.2f}s"
+        )
+        assert log_path.read_text(encoding="utf-8") == ""
+        print(
+            "PASS test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller"
+        )
+
+
 def test_missing_log_race_dedups_against_locked_append_fd():
     """The first flush reads UUIDs only after opening and locking the log fd."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -3513,6 +3620,8 @@ if __name__ == "__main__":
     test_flush_replaces_attributed_total_published_immediately_after_claim()
     test_append_retries_when_canonical_log_rotates_before_flock()
     test_append_retries_when_canonical_parent_rotates_before_publication()
+    test_lock_timeout_retries_with_backoff_and_succeeds()
+    test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller()
     test_missing_log_race_dedups_against_locked_append_fd()
     test_profile_confirmed_beats_confirmed_global()
     test_project_confirmed_beats_confirmed_profile()

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -872,7 +872,12 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
     });
     const result = spawnSync(helper, ['write-hook', '--cwd', cwd], {
       encoding: 'utf8',
-      timeout: 3000,
+      // DS-158: bin/ds-identity's session-log append can wait up to 5000ms
+      // on its own flock (see the comment beside that timeout constant).
+      // This ceiling must stay above that budget with headroom, or a
+      // genuinely-contended write gets SIGKILLed here before it ever gets
+      // to report a graceful failure back to recordHealth().
+      timeout: 6000,
       maxBuffer: 64 * 1024,
       stdio: ['pipe', 'pipe', 'ignore'],
       input: request,

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -845,6 +845,17 @@ function generateUuid() {
  * Identity resolution is compared again in the helper before any write, so an
  * identity swap between resolution and persistence fails closed. The helper
  * independently reports project/global/pending outcomes for health telemetry.
+ *
+ * DS-158 round 2: this call is deliberately single-shot, not wrapped in its
+ * own retry. The Python helper already retries its flock acquisition with
+ * backoff across its own bounded wall-clock budget (see the spawnSync
+ * `timeout` comment below); a caller-side retry here would re-spawn the
+ * whole subprocess and could double the worst-case Stop-hook latency for no
+ * added chance of success, since a second attempt would race the same
+ * contention the first one just spent its full budget failing to clear.
+ * On a project/global write failure, status is surfaced through
+ * recordHealth() -> flushHealth() (unconditional, not debug-gated) rather
+ * than retried here.
  */
 function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
   const confirmed = Boolean(identity && !identity.provisional);
@@ -872,11 +883,22 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
     });
     const result = spawnSync(helper, ['write-hook', '--cwd', cwd], {
       encoding: 'utf8',
-      // DS-158: bin/ds-identity's session-log append can wait up to 5000ms
-      // on its own flock (see the comment beside that timeout constant).
-      // This ceiling must stay above that budget with headroom, or a
-      // genuinely-contended write gets SIGKILLed here before it ever gets
-      // to report a graceful failure back to recordHealth().
+      // DS-158 round 2: bin/ds-identity's session-log append now retries its
+      // flock with backoff across SESSION_LOG_LOCK_BUDGET_SECONDS (5.0s) of
+      // total wall clock, capped at SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS
+      // (1.0s) per attempt - the same total ceiling round 1 gave its single
+      // flat attempt (the fix is that a timeout now gets retried within that
+      // ceiling, not that the ceiling grew). Backoff sleeps are themselves
+      // capped by the remaining budget, so worst case is that budget plus a
+      // small (<=0.05s) floor overshoot on the final attempt, not the
+      // budget plus backoff on top of it. This ceiling is derived from that
+      // budget plus headroom for
+      // process startup, imports, and the surrounding read/render/write
+      // work, not chosen independently - raising the Python-side budget
+      // obliges raising this one to match, and vice versa. A genuinely
+      // contended write must exhaust its own retry budget and report a
+      // graceful failure back to recordHealth(), not get SIGKILLed here
+      // first.
       timeout: 6000,
       maxBuffer: 64 * 1024,
       stdio: ['pipe', 'pipe', 'ignore'],


### PR DESCRIPTION
## Summary

DS-158. A `hooks-js-tests` failure on an unrelated documentation-only PR (#657) turned out to expose a real production defect in telemetry writes, not just a flaky test.

**The defect.** `bin/ds-identity`'s session-log append acquires an exclusive `flock` with a bounded timeout. That call sits inside an 8-attempt retry loop whose `except` clause caught only `FileNotFoundError` (for log rotation), so a lock-timeout `RuntimeError` **escaped the loop entirely** and landed in the outer `except (OSError, RuntimeError): return False, False`. A timeout therefore got exactly one attempt, no retry, and was swallowed. `hooks/stop-context.js:writeTelemetrySafely` calls `write-hook` once and does not retry either.

Net effect: two genuine concurrent conductor sessions on the same project could permanently drop one session's telemetry record. Rare, silent, and exactly the soft-failing-telemetry pattern that has hidden real breakage in this repo before.

## The fix

- **The timeout is now retried, not dropped.** `_lock_fd_exclusive` raises a dedicated `_LockTimeoutError(RuntimeError)`, and `_write_jsonl_safely`'s attempt loop catches it alongside `FileNotFoundError` - caught by the base class rather than the subclass, so it stays correct against any RuntimeError-based lock helper including a test double.
- **Budget is bounded on both axes.** Attempts share the existing `max_attempts = 8`; wall-clock is bounded by `SESSION_LOG_LOCK_BUDGET_SECONDS` computed once at entry. Attempts alone cannot bound worst-case latency (which the JS subprocess ceiling depends on); wall-clock alone cannot guarantee a minimum number of tries. Backoff is linear-capped and itself bounded by the remaining budget, so it is spent *inside* the ceiling rather than added on top.
- **Total ceiling held at parity.** The per-attempt timeout was replaced by a total budget plus a per-attempt cap, deliberately keeping the overall ceiling where round 1 left it. The fix is that a timeout is now retried within the budget, not that the budget grew.

**Surfacing was already correct** - verified rather than assumed. `hooks/stop-context.js` already calls `recordHealth('writeSessionLog', status.project === true, ...)` on every invocation, and `flushHealth(cwd)` runs unconditionally (not gated on `AE_IDENTITY_DEBUG`), writing `.agentic/.telemetry-health.json`. Since `status.project` is exactly the append's return value, a give-up was already observable without a debug flag. No Python-side change needed.

**Caller-side retry judged not warranted**, documented inline: re-spawning the subprocess would double worst-case Stop-hook latency while racing the same contention the first attempt just spent its full budget failing to clear. The Python side is the right layer.

## Verification

A real forced-overlap subprocess race **cannot discriminate** the two versions - both bound total lock-wait to the same ceiling by construction, so a stall over it fails identically and a stall under it succeeds identically. The defect lives only in the narrow one-shot-vs-retry boundary, which a wall-clock race cannot reliably land inside without flakiness. That is stated plainly rather than papered over with a demonstration that proves nothing.

The deterministic equivalent was used instead: `_lock_fd_exclusive` monkeypatched to raise two forced timeouts before delegating to the real flock, run against the literal pre-fix commit via `git stash`.

- **Pre-fix:** `AssertionError: a transient lock timeout must not drop the record` - the defect reproduces.
- **Post-fix:** passes, with `attempts["n"] == 3` confirming the retry actually occurred and the record readable back from the log.

Plus an OS-level sanity check with a genuine `fcntl.flock` held for 2s by a second real process: the writer waited ~2.02s, acquired, and wrote.

Two regression tests added and wired into the runner - one pinning the retry path, one pinning that give-up stays soft-fail (returns `False`, never raises) and stays bounded.

`hooks/tests/test-stop-context-identity.js:891-937` is untouched and still asserts both the project-scoped and global-scoped logs receive both complete records.

## North Star alignment

**Pillar 2, verifiable outcomes** - the primary win. A silently dropped telemetry record produces no verifiable outcome at all, and the drop path is now retried and, on give-up, observable through the existing health record.

**Pillar 1, guard operator attention** - indirect but real: this class of flake reds CI on PRs that did not cause it, which costs an operator a diagnosis cycle each time.

**Pillar 3, low friction** - worst-case Stop-hook latency is unchanged; the ceiling was held at parity and backoff spends the budget rather than extending it.

**Pillar 4, universality** - neutral; no operator identity, tracker, or harness assumption introduced.

## Test plan

- `pytest bin/tests/` - 1157 → 1159 (two new regression tests)
- `node hooks/tests/test-stop-context-identity.js` × 20 clean and × 20 under full-core CPU saturation - 20/20 both
- Hooks JS suite, verbatim CI loop - 45 files, 0 failures
- `test-enforce-turn-shape.py` 157, `test-turn-charge-model.py` 18
- methodology-drift, resident-budget, skill-embed-budget, symlinks-relative, command-file-budget - all OK

Doc-sync: predicate not triggered - no doc states a concrete lock-timeout figure (re-checked), and both the retry behavior and the health-record surfacing are internal mechanisms with no documented user-facing contract.
