### PR TITLE
feat(DS-154): supply SESSION_KEY in every spawn brief (Unit D)

### DIFF
--- a/.copilot/references/agent-team.md
+++ b/.copilot/references/agent-team.md
@@ -184,6 +184,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`.agentic/context.md` content, supplied verbatim by the main agent - a worktree-isolated Worker cannot read this path directly, since its worktree branches from `origin/main`, where `.agentic/` is untracked)
+- `SESSION_KEY: <value>` - the session's learnings-shard key, supplied verbatim by the main agent on every spawn. Derive it once per session and reuse the same value; a brief that omits the line makes the Worker skip shard capture silently, with no error anywhere. Derivation rule and rationale: `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**"
 - For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/ds-implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.

--- a/.copilot/references/delegation-detail.md
+++ b/.copilot/references/delegation-detail.md
@@ -257,10 +257,13 @@ Execution contract template:
 - task_id: [unique task identifier for multi-unit correlation, or omit for single-unit]
 - brief_path: [path to the Brief governing this unit, or "n/a" if architect plan is the sole artifact - arrives already absolute in the engineer's contract, normalized at spawn construction]
 - plan_path: [path to the Plan directory governing this unit, or "n/a" if Brief-tier or below - arrives already absolute in the engineer's contract, normalized at spawn construction]
+- SESSION_KEY: [the session's learnings-shard key, derived once per session and passed verbatim on every spawn thereafter]
 
 When `brief_path` or `plan_path` is populated, the engineer reads it before starting. Success criteria, non-goals, and the verification gate supersede any informal interpretation of the ticket. If the engineer discovers a conflict between the Brief and the architect plan, it returns BLOCKED so the conductor can resolve.
 
 The `verification` field is **mandatory**. Its purpose is to force the conductor to specify *how the change will be verified before implementation begins*, not as a Skeptic afterthought. As coding gets cheaper, verification is the expensive thing, and the protocol reorganizes around verification rather than around shipping code. If the verification path is not knowable up front (truly novel surface, no existing tests, no feasible new test), state that explicitly as `"self-evident review"` and accept that the Skeptic and any QA gate are the only line of defense - do not leave the field blank.
+
+The `SESSION_KEY` field is **mandatory and never omitted**. It is the one line in this template whose obligation is wider than the template itself: it belongs in **every** Worker's spawn prompt, including Trivial-path solo spawns and the non-`engineer` roles this contract does not otherwise cover. Omitting it raises no error - the Worker simply skips shard capture in silence, so the learning is lost with no signal. Derive the value once per session and pass that same value every time; the derivation rule, the harness caveats, and the reason the scope is blanket rather than per-role live in `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**".
 
 The `task_id` field is included for Elevated multi-unit spawns only (when `.agentic/tasks.jsonl` is in use). Omit for Trivial or single-unit spawns. Workers receive `task_id` for identification; the conductor correlates the worker's return summary with the correct task entry and handles all writes to the task-state file.
 

--- a/.copilot/references/learnings-capture-instruction.md
+++ b/.copilot/references/learnings-capture-instruction.md
@@ -13,7 +13,11 @@ Public API: Read-only reference. Two consumable parts: the capture procedure
 Upstream deps: bin/ds-learning-shard (owns the --event-type enum, the flag
                names, and the per-session cap this document describes);
                content/references/capture-classification.md (the conductor-side
-               gate that classifies what this document collects).
+               gate that classifies what this document collects);
+               content/references/subagent-protocol.md §11 Output Expectations,
+               "SESSION_KEY at spawn time" (the producing side of the SESSION_KEY
+               contract - it owns the derivation rule and the every-spawn scope
+               that §Session identity below consumes).
 
 Downstream consumers: every agent in content/agents/ (via a pointer);
                       content/agents/engineer.md,
@@ -176,10 +180,13 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
-The producing side of that contract is `content/references/subagent-protocol.md`
-§"Spawning Workers", which obliges the conductor to derive one key per session and
-include it in **every** Worker's spawn prompt. That is where the derivation rule
-lives; do not restate it here, and never apply it yourself.
+Never derive one yourself. The conductor owns the derivation and is obliged to put
+the key in **every** Worker's spawn prompt; that obligation, its rule, and its
+harness caveats live in `content/references/subagent-protocol.md` §11 Output
+Expectations, "**`SESSION_KEY` at spawn time**", and are restated at the two spawn
+checklists a conductor actually fills - `content/references/agent-team.md`
+§Spawning and `content/references/delegation-detail.md` §Worker Preamble and
+Execution Contract Template.
 
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and

--- a/.copilot/references/learnings-capture-instruction.md
+++ b/.copilot/references/learnings-capture-instruction.md
@@ -176,6 +176,11 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
+The producing side of that contract is `content/references/subagent-protocol.md`
+§"Spawning Workers", which obliges the conductor to derive one key per session and
+include it in **every** Worker's spawn prompt. That is where the derivation rule
+lives; do not restate it here, and never apply it yourself.
+
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
   needs no session key.

--- a/.copilot/references/subagent-protocol.md
+++ b/.copilot/references/subagent-protocol.md
@@ -412,6 +412,29 @@ When a Worker returns to the main agent under this protocol, the main agent expe
 
 **Spawning Workers:** The main agent must include the project context file content (`.agentic/context.md`) in each Worker's spawn prompt. Workers must not be expected to self-direct context reads - they may not have reliable access to the path or the protocol, and a worktree-isolated Worker cannot reach `.agentic/context.md` at all (`.agentic/` is gitignored, so it is absent from a fresh worktree checkout). The main agent is responsible for providing session context at spawn time.
 
+**`SESSION_KEY` at spawn time:** The main agent must also include a `SESSION_KEY` line in **every** Worker's spawn prompt. This is the same shape of obligation as the context file above and holds for the same reason: `SESSION_KEY` is conductor-supplied session state, not something a Worker can derive. `content/references/learnings-capture-instruction.md` §Session identity makes the spawn brief the *only* source an agent may read it from, and an agent whose brief omits it skips shard capture **silently**. A missing line therefore raises no error anywhere; it just means the learning was never recorded.
+
+Derive the value **once per session**, at the first Worker spawn, and pass that same value on every spawn thereafter:
+
+1. If `$CLAUDE_CODE_SESSION_ID` is set and non-empty, use it verbatim.
+2. Otherwise generate one key and carry it in the session's own working state:
+
+```bash
+printf 'ds-session-%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" \
+  "$(od -An -N2 -tx1 /dev/urandom | tr -d ' \n')"
+# ds-session-20260810T142233Z-9f2c
+```
+
+Three rules govern that derivation, each with a live counter-example in this repo:
+
+- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process (`payload.session_id`; OpenCode's `.opencode/plugins/session-context.ts` reads `event.properties.sessionID`) and never exports it to the model's shell. On Claude Code a subagent inherits the identical `$CLAUDE_CODE_SESSION_ID`, so the brief line is belt-and-braces there rather than load-bearing. Pass it regardless, so one rule holds on every harness.
+- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session, and `bin/ds-migrate` is silently degraded today precisely because it reads them. `content/commands/ds-wrap.md` records the same measurement for the wrap lock's `--session-id`.
+- **Never synthesize a value inside Claude's id namespace.** The `ds-session-` prefix exists to keep a generated key visibly outside it. This mirrors the rule `content/commands/ds-implement-ticket.md` already applies to `loop-state-<LOOP_KEY>.json`, which writes `session_id: null` on a harness with no id of its own rather than inventing a uuid in the wrong namespace.
+
+**Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
+
+**Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 
 **When The Skeptic Protocol was not invoked** (e.g., the task was Low risk pure research or investigation with no artifact produced), the Worker states explicitly: "No Skeptic Protocol invoked — task was [description]. No artifact requiring review." This prevents ambiguity in a return without a review record.

--- a/.copilot/references/subagent-protocol.md
+++ b/.copilot/references/subagent-protocol.md
@@ -1,3 +1,41 @@
+<!--
+Purpose: The outer orchestration frame for multi-agent sessions: when the main
+         agent delegates, how it spawns, what it must put into a spawn prompt, and
+         what it expects back. Normative for every spawn in the methodology.
+
+Public API: Read-only reference, reached on trigger from the pointer table in
+            `content/sections/12-protocol-details.md`. Consumable parts most often
+            cited elsewhere: Section 2 (the Seven Rules), Section 6 (decomposition
+            and review scope), Section 7 (shared-repo and worktree isolation),
+            Section 10 (Input Contract), Section 11 (Output Expectations, including
+            the two spawn-prompt obligations: `.agentic/context.md` content and
+            `SESSION_KEY`), and Section 13 (conductor context budget).
+
+Upstream deps: content/references/risk-config-and-tiers.md (role-default tier table
+               the Input Contract's model-param rule defers to);
+               content/references/learnings-capture-instruction.md §Session identity
+               (the consuming side of the `SESSION_KEY` contract, which fixes the
+               spawn brief as the only source an agent may read the key from).
+
+Downstream consumers: content/references/agent-team.md §Spawning and
+                      content/references/delegation-detail.md §Worker Preamble and
+                      Execution Contract Template, the two spawn checklists a
+                      conductor actually fills - both restate the `SESSION_KEY`
+                      line and point back here for its derivation rule, so a change
+                      to that rule must be reflected in both;
+                      content/references/skeptic-protocol.md (Section 9 of this file
+                      defines their relationship);
+                      content/sections/12-protocol-details.md (the pointer table
+                      naming which sections are reachable on which trigger).
+
+Failure modes: Prose; does not execute. Its characteristic failure is silence, not
+               error: a spawn obligation stated only here, with no pointer from the
+               table and no restatement in a spawn checklist, is not resident in a
+               conductor's context and is simply never performed.
+
+Performance: Standard.
+-->
+
 # The Subagent Protocol — Orchestration Methodology
 
 ## 1. Overview
@@ -392,6 +430,8 @@ When spawning an `engineer` Worker on an Elevated-risk task, the conductor inclu
 
 The conductor OMITS the `model` param to accept the spawned agent's frontmatter role-default tier (see the Role-default tier table in `content/references/risk-config-and-tiers.md`); it passes an explicit `model` param only to OVERRIDE a specific spawn - upgrading a Tier-2 agent to Tier 3 for a novel-architecture unit, asserting a mandated-Tier-3 Skeptic, or a Tier-1 mechanical task. Claude Code: `haiku`/`opus` for the override; other harnesses resolve from tier-map or omit. Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 
+Two spawn-prompt obligations are wider than this contract and are stated in Section 11 rather than here, because they hold for every Worker on every path rather than for contract-carrying `engineer` spawns only: the `.agentic/context.md` content, and the `SESSION_KEY` line. See Section 11, "**Spawning Workers**" and "**`SESSION_KEY` at spawn time**".
+
 Scope: this contract applies to `engineer` spawns only for Phase 1.1. Other named Workers (`architect`, `investigator`, `debugger`, `qa-engineer`, `security-auditor`, `perf-analyst`, `release-orchestrator`, `dependency-auditor`, `orchestration-planner`, `general-purpose`) and Trivial-path solo `engineer` spawns are out of scope - use the existing freeform preamble for those.
 
 ---
@@ -434,6 +474,8 @@ Three rules govern that derivation, each with a live counter-example in this rep
 **Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
 
 **Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
+**Where a conductor actually meets this rule.** This file is trigger-loaded, so a rule stated only here is not resident when a conductor composes a spawn prompt. The `SESSION_KEY` line therefore also appears in the two checklists a conductor fills at spawn time: `content/references/agent-team.md` §Spawning (the ``When spawning `engineer`, include:`` list) and `content/references/delegation-detail.md` §Worker Preamble and Execution Contract Template. Both carry the field and defer to this paragraph for the derivation rule, so neither restates the four-role list either. Change all three together.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/.cursor/references/agent-team.md
+++ b/.cursor/references/agent-team.md
@@ -184,6 +184,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`.agentic/context.md` content, supplied verbatim by the main agent - a worktree-isolated Worker cannot read this path directly, since its worktree branches from `origin/main`, where `.agentic/` is untracked)
+- `SESSION_KEY: <value>` - the session's learnings-shard key, supplied verbatim by the main agent on every spawn. Derive it once per session and reuse the same value; a brief that omits the line makes the Worker skip shard capture silently, with no error anywhere. Derivation rule and rationale: `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**"
 - For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/ds-implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.

--- a/.cursor/references/delegation-detail.md
+++ b/.cursor/references/delegation-detail.md
@@ -257,10 +257,13 @@ Execution contract template:
 - task_id: [unique task identifier for multi-unit correlation, or omit for single-unit]
 - brief_path: [path to the Brief governing this unit, or "n/a" if architect plan is the sole artifact - arrives already absolute in the engineer's contract, normalized at spawn construction]
 - plan_path: [path to the Plan directory governing this unit, or "n/a" if Brief-tier or below - arrives already absolute in the engineer's contract, normalized at spawn construction]
+- SESSION_KEY: [the session's learnings-shard key, derived once per session and passed verbatim on every spawn thereafter]
 
 When `brief_path` or `plan_path` is populated, the engineer reads it before starting. Success criteria, non-goals, and the verification gate supersede any informal interpretation of the ticket. If the engineer discovers a conflict between the Brief and the architect plan, it returns BLOCKED so the conductor can resolve.
 
 The `verification` field is **mandatory**. Its purpose is to force the conductor to specify *how the change will be verified before implementation begins*, not as a Skeptic afterthought. As coding gets cheaper, verification is the expensive thing, and the protocol reorganizes around verification rather than around shipping code. If the verification path is not knowable up front (truly novel surface, no existing tests, no feasible new test), state that explicitly as `"self-evident review"` and accept that the Skeptic and any QA gate are the only line of defense - do not leave the field blank.
+
+The `SESSION_KEY` field is **mandatory and never omitted**. It is the one line in this template whose obligation is wider than the template itself: it belongs in **every** Worker's spawn prompt, including Trivial-path solo spawns and the non-`engineer` roles this contract does not otherwise cover. Omitting it raises no error - the Worker simply skips shard capture in silence, so the learning is lost with no signal. Derive the value once per session and pass that same value every time; the derivation rule, the harness caveats, and the reason the scope is blanket rather than per-role live in `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**".
 
 The `task_id` field is included for Elevated multi-unit spawns only (when `.agentic/tasks.jsonl` is in use). Omit for Trivial or single-unit spawns. Workers receive `task_id` for identification; the conductor correlates the worker's return summary with the correct task entry and handles all writes to the task-state file.
 

--- a/.cursor/references/learnings-capture-instruction.md
+++ b/.cursor/references/learnings-capture-instruction.md
@@ -13,7 +13,11 @@ Public API: Read-only reference. Two consumable parts: the capture procedure
 Upstream deps: bin/ds-learning-shard (owns the --event-type enum, the flag
                names, and the per-session cap this document describes);
                content/references/capture-classification.md (the conductor-side
-               gate that classifies what this document collects).
+               gate that classifies what this document collects);
+               content/references/subagent-protocol.md §11 Output Expectations,
+               "SESSION_KEY at spawn time" (the producing side of the SESSION_KEY
+               contract - it owns the derivation rule and the every-spawn scope
+               that §Session identity below consumes).
 
 Downstream consumers: every agent in content/agents/ (via a pointer);
                       content/agents/engineer.md,
@@ -176,10 +180,13 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
-The producing side of that contract is `content/references/subagent-protocol.md`
-§"Spawning Workers", which obliges the conductor to derive one key per session and
-include it in **every** Worker's spawn prompt. That is where the derivation rule
-lives; do not restate it here, and never apply it yourself.
+Never derive one yourself. The conductor owns the derivation and is obliged to put
+the key in **every** Worker's spawn prompt; that obligation, its rule, and its
+harness caveats live in `content/references/subagent-protocol.md` §11 Output
+Expectations, "**`SESSION_KEY` at spawn time**", and are restated at the two spawn
+checklists a conductor actually fills - `content/references/agent-team.md`
+§Spawning and `content/references/delegation-detail.md` §Worker Preamble and
+Execution Contract Template.
 
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and

--- a/.cursor/references/learnings-capture-instruction.md
+++ b/.cursor/references/learnings-capture-instruction.md
@@ -176,6 +176,11 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
+The producing side of that contract is `content/references/subagent-protocol.md`
+§"Spawning Workers", which obliges the conductor to derive one key per session and
+include it in **every** Worker's spawn prompt. That is where the derivation rule
+lives; do not restate it here, and never apply it yourself.
+
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
   needs no session key.

--- a/.cursor/references/subagent-protocol.md
+++ b/.cursor/references/subagent-protocol.md
@@ -412,6 +412,29 @@ When a Worker returns to the main agent under this protocol, the main agent expe
 
 **Spawning Workers:** The main agent must include the project context file content (`.agentic/context.md`) in each Worker's spawn prompt. Workers must not be expected to self-direct context reads - they may not have reliable access to the path or the protocol, and a worktree-isolated Worker cannot reach `.agentic/context.md` at all (`.agentic/` is gitignored, so it is absent from a fresh worktree checkout). The main agent is responsible for providing session context at spawn time.
 
+**`SESSION_KEY` at spawn time:** The main agent must also include a `SESSION_KEY` line in **every** Worker's spawn prompt. This is the same shape of obligation as the context file above and holds for the same reason: `SESSION_KEY` is conductor-supplied session state, not something a Worker can derive. `content/references/learnings-capture-instruction.md` §Session identity makes the spawn brief the *only* source an agent may read it from, and an agent whose brief omits it skips shard capture **silently**. A missing line therefore raises no error anywhere; it just means the learning was never recorded.
+
+Derive the value **once per session**, at the first Worker spawn, and pass that same value on every spawn thereafter:
+
+1. If `$CLAUDE_CODE_SESSION_ID` is set and non-empty, use it verbatim.
+2. Otherwise generate one key and carry it in the session's own working state:
+
+```bash
+printf 'ds-session-%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" \
+  "$(od -An -N2 -tx1 /dev/urandom | tr -d ' \n')"
+# ds-session-20260810T142233Z-9f2c
+```
+
+Three rules govern that derivation, each with a live counter-example in this repo:
+
+- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process (`payload.session_id`; OpenCode's `.opencode/plugins/session-context.ts` reads `event.properties.sessionID`) and never exports it to the model's shell. On Claude Code a subagent inherits the identical `$CLAUDE_CODE_SESSION_ID`, so the brief line is belt-and-braces there rather than load-bearing. Pass it regardless, so one rule holds on every harness.
+- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session, and `bin/ds-migrate` is silently degraded today precisely because it reads them. `content/commands/ds-wrap.md` records the same measurement for the wrap lock's `--session-id`.
+- **Never synthesize a value inside Claude's id namespace.** The `ds-session-` prefix exists to keep a generated key visibly outside it. This mirrors the rule `content/commands/ds-implement-ticket.md` already applies to `loop-state-<LOOP_KEY>.json`, which writes `session_id: null` on a harness with no id of its own rather than inventing a uuid in the wrong namespace.
+
+**Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
+
+**Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 
 **When The Skeptic Protocol was not invoked** (e.g., the task was Low risk pure research or investigation with no artifact produced), the Worker states explicitly: "No Skeptic Protocol invoked — task was [description]. No artifact requiring review." This prevents ambiguity in a return without a review record.

--- a/.cursor/references/subagent-protocol.md
+++ b/.cursor/references/subagent-protocol.md
@@ -1,3 +1,41 @@
+<!--
+Purpose: The outer orchestration frame for multi-agent sessions: when the main
+         agent delegates, how it spawns, what it must put into a spawn prompt, and
+         what it expects back. Normative for every spawn in the methodology.
+
+Public API: Read-only reference, reached on trigger from the pointer table in
+            `content/sections/12-protocol-details.md`. Consumable parts most often
+            cited elsewhere: Section 2 (the Seven Rules), Section 6 (decomposition
+            and review scope), Section 7 (shared-repo and worktree isolation),
+            Section 10 (Input Contract), Section 11 (Output Expectations, including
+            the two spawn-prompt obligations: `.agentic/context.md` content and
+            `SESSION_KEY`), and Section 13 (conductor context budget).
+
+Upstream deps: content/references/risk-config-and-tiers.md (role-default tier table
+               the Input Contract's model-param rule defers to);
+               content/references/learnings-capture-instruction.md §Session identity
+               (the consuming side of the `SESSION_KEY` contract, which fixes the
+               spawn brief as the only source an agent may read the key from).
+
+Downstream consumers: content/references/agent-team.md §Spawning and
+                      content/references/delegation-detail.md §Worker Preamble and
+                      Execution Contract Template, the two spawn checklists a
+                      conductor actually fills - both restate the `SESSION_KEY`
+                      line and point back here for its derivation rule, so a change
+                      to that rule must be reflected in both;
+                      content/references/skeptic-protocol.md (Section 9 of this file
+                      defines their relationship);
+                      content/sections/12-protocol-details.md (the pointer table
+                      naming which sections are reachable on which trigger).
+
+Failure modes: Prose; does not execute. Its characteristic failure is silence, not
+               error: a spawn obligation stated only here, with no pointer from the
+               table and no restatement in a spawn checklist, is not resident in a
+               conductor's context and is simply never performed.
+
+Performance: Standard.
+-->
+
 # The Subagent Protocol — Orchestration Methodology
 
 ## 1. Overview
@@ -392,6 +430,8 @@ When spawning an `engineer` Worker on an Elevated-risk task, the conductor inclu
 
 The conductor OMITS the `model` param to accept the spawned agent's frontmatter role-default tier (see the Role-default tier table in `content/references/risk-config-and-tiers.md`); it passes an explicit `model` param only to OVERRIDE a specific spawn - upgrading a Tier-2 agent to Tier 3 for a novel-architecture unit, asserting a mandated-Tier-3 Skeptic, or a Tier-1 mechanical task. Claude Code: `haiku`/`opus` for the override; other harnesses resolve from tier-map or omit. Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 
+Two spawn-prompt obligations are wider than this contract and are stated in Section 11 rather than here, because they hold for every Worker on every path rather than for contract-carrying `engineer` spawns only: the `.agentic/context.md` content, and the `SESSION_KEY` line. See Section 11, "**Spawning Workers**" and "**`SESSION_KEY` at spawn time**".
+
 Scope: this contract applies to `engineer` spawns only for Phase 1.1. Other named Workers (`architect`, `investigator`, `debugger`, `qa-engineer`, `security-auditor`, `perf-analyst`, `release-orchestrator`, `dependency-auditor`, `orchestration-planner`, `general-purpose`) and Trivial-path solo `engineer` spawns are out of scope - use the existing freeform preamble for those.
 
 ---
@@ -434,6 +474,8 @@ Three rules govern that derivation, each with a live counter-example in this rep
 **Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
 
 **Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
+**Where a conductor actually meets this rule.** This file is trigger-loaded, so a rule stated only here is not resident when a conductor composes a spawn prompt. The `SESSION_KEY` line therefore also appears in the two checklists a conductor fills at spawn time: `content/references/agent-team.md` §Spawning (the ``When spawning `engineer`, include:`` list) and `content/references/delegation-detail.md` §Worker Preamble and Execution Contract Template. Both carry the field and defer to this paragraph for the derivation rule, so neither restates the four-role list either. Change all three together.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/.gemini/references/agent-team.md
+++ b/.gemini/references/agent-team.md
@@ -184,6 +184,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`.agentic/context.md` content, supplied verbatim by the main agent - a worktree-isolated Worker cannot read this path directly, since its worktree branches from `origin/main`, where `.agentic/` is untracked)
+- `SESSION_KEY: <value>` - the session's learnings-shard key, supplied verbatim by the main agent on every spawn. Derive it once per session and reuse the same value; a brief that omits the line makes the Worker skip shard capture silently, with no error anywhere. Derivation rule and rationale: `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**"
 - For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/ds-implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.

--- a/.gemini/references/delegation-detail.md
+++ b/.gemini/references/delegation-detail.md
@@ -257,10 +257,13 @@ Execution contract template:
 - task_id: [unique task identifier for multi-unit correlation, or omit for single-unit]
 - brief_path: [path to the Brief governing this unit, or "n/a" if architect plan is the sole artifact - arrives already absolute in the engineer's contract, normalized at spawn construction]
 - plan_path: [path to the Plan directory governing this unit, or "n/a" if Brief-tier or below - arrives already absolute in the engineer's contract, normalized at spawn construction]
+- SESSION_KEY: [the session's learnings-shard key, derived once per session and passed verbatim on every spawn thereafter]
 
 When `brief_path` or `plan_path` is populated, the engineer reads it before starting. Success criteria, non-goals, and the verification gate supersede any informal interpretation of the ticket. If the engineer discovers a conflict between the Brief and the architect plan, it returns BLOCKED so the conductor can resolve.
 
 The `verification` field is **mandatory**. Its purpose is to force the conductor to specify *how the change will be verified before implementation begins*, not as a Skeptic afterthought. As coding gets cheaper, verification is the expensive thing, and the protocol reorganizes around verification rather than around shipping code. If the verification path is not knowable up front (truly novel surface, no existing tests, no feasible new test), state that explicitly as `"self-evident review"` and accept that the Skeptic and any QA gate are the only line of defense - do not leave the field blank.
+
+The `SESSION_KEY` field is **mandatory and never omitted**. It is the one line in this template whose obligation is wider than the template itself: it belongs in **every** Worker's spawn prompt, including Trivial-path solo spawns and the non-`engineer` roles this contract does not otherwise cover. Omitting it raises no error - the Worker simply skips shard capture in silence, so the learning is lost with no signal. Derive the value once per session and pass that same value every time; the derivation rule, the harness caveats, and the reason the scope is blanket rather than per-role live in `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**".
 
 The `task_id` field is included for Elevated multi-unit spawns only (when `.agentic/tasks.jsonl` is in use). Omit for Trivial or single-unit spawns. Workers receive `task_id` for identification; the conductor correlates the worker's return summary with the correct task entry and handles all writes to the task-state file.
 

--- a/.gemini/references/learnings-capture-instruction.md
+++ b/.gemini/references/learnings-capture-instruction.md
@@ -13,7 +13,11 @@ Public API: Read-only reference. Two consumable parts: the capture procedure
 Upstream deps: bin/ds-learning-shard (owns the --event-type enum, the flag
                names, and the per-session cap this document describes);
                content/references/capture-classification.md (the conductor-side
-               gate that classifies what this document collects).
+               gate that classifies what this document collects);
+               content/references/subagent-protocol.md §11 Output Expectations,
+               "SESSION_KEY at spawn time" (the producing side of the SESSION_KEY
+               contract - it owns the derivation rule and the every-spawn scope
+               that §Session identity below consumes).
 
 Downstream consumers: every agent in content/agents/ (via a pointer);
                       content/agents/engineer.md,
@@ -176,10 +180,13 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
-The producing side of that contract is `content/references/subagent-protocol.md`
-§"Spawning Workers", which obliges the conductor to derive one key per session and
-include it in **every** Worker's spawn prompt. That is where the derivation rule
-lives; do not restate it here, and never apply it yourself.
+Never derive one yourself. The conductor owns the derivation and is obliged to put
+the key in **every** Worker's spawn prompt; that obligation, its rule, and its
+harness caveats live in `content/references/subagent-protocol.md` §11 Output
+Expectations, "**`SESSION_KEY` at spawn time**", and are restated at the two spawn
+checklists a conductor actually fills - `content/references/agent-team.md`
+§Spawning and `content/references/delegation-detail.md` §Worker Preamble and
+Execution Contract Template.
 
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and

--- a/.gemini/references/learnings-capture-instruction.md
+++ b/.gemini/references/learnings-capture-instruction.md
@@ -176,6 +176,11 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
+The producing side of that contract is `content/references/subagent-protocol.md`
+§"Spawning Workers", which obliges the conductor to derive one key per session and
+include it in **every** Worker's spawn prompt. That is where the derivation rule
+lives; do not restate it here, and never apply it yourself.
+
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
   needs no session key.

--- a/.gemini/references/subagent-protocol.md
+++ b/.gemini/references/subagent-protocol.md
@@ -412,6 +412,29 @@ When a Worker returns to the main agent under this protocol, the main agent expe
 
 **Spawning Workers:** The main agent must include the project context file content (`.agentic/context.md`) in each Worker's spawn prompt. Workers must not be expected to self-direct context reads - they may not have reliable access to the path or the protocol, and a worktree-isolated Worker cannot reach `.agentic/context.md` at all (`.agentic/` is gitignored, so it is absent from a fresh worktree checkout). The main agent is responsible for providing session context at spawn time.
 
+**`SESSION_KEY` at spawn time:** The main agent must also include a `SESSION_KEY` line in **every** Worker's spawn prompt. This is the same shape of obligation as the context file above and holds for the same reason: `SESSION_KEY` is conductor-supplied session state, not something a Worker can derive. `content/references/learnings-capture-instruction.md` §Session identity makes the spawn brief the *only* source an agent may read it from, and an agent whose brief omits it skips shard capture **silently**. A missing line therefore raises no error anywhere; it just means the learning was never recorded.
+
+Derive the value **once per session**, at the first Worker spawn, and pass that same value on every spawn thereafter:
+
+1. If `$CLAUDE_CODE_SESSION_ID` is set and non-empty, use it verbatim.
+2. Otherwise generate one key and carry it in the session's own working state:
+
+```bash
+printf 'ds-session-%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" \
+  "$(od -An -N2 -tx1 /dev/urandom | tr -d ' \n')"
+# ds-session-20260810T142233Z-9f2c
+```
+
+Three rules govern that derivation, each with a live counter-example in this repo:
+
+- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process (`payload.session_id`; OpenCode's `.opencode/plugins/session-context.ts` reads `event.properties.sessionID`) and never exports it to the model's shell. On Claude Code a subagent inherits the identical `$CLAUDE_CODE_SESSION_ID`, so the brief line is belt-and-braces there rather than load-bearing. Pass it regardless, so one rule holds on every harness.
+- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session, and `bin/ds-migrate` is silently degraded today precisely because it reads them. `content/commands/ds-wrap.md` records the same measurement for the wrap lock's `--session-id`.
+- **Never synthesize a value inside Claude's id namespace.** The `ds-session-` prefix exists to keep a generated key visibly outside it. This mirrors the rule `content/commands/ds-implement-ticket.md` already applies to `loop-state-<LOOP_KEY>.json`, which writes `session_id: null` on a harness with no id of its own rather than inventing a uuid in the wrong namespace.
+
+**Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
+
+**Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 
 **When The Skeptic Protocol was not invoked** (e.g., the task was Low risk pure research or investigation with no artifact produced), the Worker states explicitly: "No Skeptic Protocol invoked — task was [description]. No artifact requiring review." This prevents ambiguity in a return without a review record.

--- a/.gemini/references/subagent-protocol.md
+++ b/.gemini/references/subagent-protocol.md
@@ -1,3 +1,41 @@
+<!--
+Purpose: The outer orchestration frame for multi-agent sessions: when the main
+         agent delegates, how it spawns, what it must put into a spawn prompt, and
+         what it expects back. Normative for every spawn in the methodology.
+
+Public API: Read-only reference, reached on trigger from the pointer table in
+            `content/sections/12-protocol-details.md`. Consumable parts most often
+            cited elsewhere: Section 2 (the Seven Rules), Section 6 (decomposition
+            and review scope), Section 7 (shared-repo and worktree isolation),
+            Section 10 (Input Contract), Section 11 (Output Expectations, including
+            the two spawn-prompt obligations: `.agentic/context.md` content and
+            `SESSION_KEY`), and Section 13 (conductor context budget).
+
+Upstream deps: content/references/risk-config-and-tiers.md (role-default tier table
+               the Input Contract's model-param rule defers to);
+               content/references/learnings-capture-instruction.md §Session identity
+               (the consuming side of the `SESSION_KEY` contract, which fixes the
+               spawn brief as the only source an agent may read the key from).
+
+Downstream consumers: content/references/agent-team.md §Spawning and
+                      content/references/delegation-detail.md §Worker Preamble and
+                      Execution Contract Template, the two spawn checklists a
+                      conductor actually fills - both restate the `SESSION_KEY`
+                      line and point back here for its derivation rule, so a change
+                      to that rule must be reflected in both;
+                      content/references/skeptic-protocol.md (Section 9 of this file
+                      defines their relationship);
+                      content/sections/12-protocol-details.md (the pointer table
+                      naming which sections are reachable on which trigger).
+
+Failure modes: Prose; does not execute. Its characteristic failure is silence, not
+               error: a spawn obligation stated only here, with no pointer from the
+               table and no restatement in a spawn checklist, is not resident in a
+               conductor's context and is simply never performed.
+
+Performance: Standard.
+-->
+
 # The Subagent Protocol — Orchestration Methodology
 
 ## 1. Overview
@@ -392,6 +430,8 @@ When spawning an `engineer` Worker on an Elevated-risk task, the conductor inclu
 
 The conductor OMITS the `model` param to accept the spawned agent's frontmatter role-default tier (see the Role-default tier table in `content/references/risk-config-and-tiers.md`); it passes an explicit `model` param only to OVERRIDE a specific spawn - upgrading a Tier-2 agent to Tier 3 for a novel-architecture unit, asserting a mandated-Tier-3 Skeptic, or a Tier-1 mechanical task. Claude Code: `haiku`/`opus` for the override; other harnesses resolve from tier-map or omit. Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 
+Two spawn-prompt obligations are wider than this contract and are stated in Section 11 rather than here, because they hold for every Worker on every path rather than for contract-carrying `engineer` spawns only: the `.agentic/context.md` content, and the `SESSION_KEY` line. See Section 11, "**Spawning Workers**" and "**`SESSION_KEY` at spawn time**".
+
 Scope: this contract applies to `engineer` spawns only for Phase 1.1. Other named Workers (`architect`, `investigator`, `debugger`, `qa-engineer`, `security-auditor`, `perf-analyst`, `release-orchestrator`, `dependency-auditor`, `orchestration-planner`, `general-purpose`) and Trivial-path solo `engineer` spawns are out of scope - use the existing freeform preamble for those.
 
 ---
@@ -434,6 +474,8 @@ Three rules govern that derivation, each with a live counter-example in this rep
 **Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
 
 **Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
+**Where a conductor actually meets this rule.** This file is trigger-loaded, so a rule stated only here is not resident when a conductor composes a spawn prompt. The `SESSION_KEY` line therefore also appears in the two checklists a conductor fills at spawn time: `content/references/agent-team.md` §Spawning (the ``When spawning `engineer`, include:`` list) and `content/references/delegation-detail.md` §Worker Preamble and Execution Contract Template. Both carry the field and defer to this paragraph for the derivation rule, so neither restates the four-role list either. Change all three together.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -4408,6 +4408,11 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
+The producing side of that contract is `content/references/subagent-protocol.md`
+§"Spawning Workers", which obliges the conductor to derive one key per session and
+include it in **every** Worker's spawn prompt. That is where the derivation rule
+lives; do not restate it here, and never apply it yourself.
+
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
   needs no session key.
@@ -6892,6 +6897,29 @@ When a Worker returns to the main agent under this protocol, the main agent expe
 **Side effects:** Workers must not apply irreversible changes (file overwrites, database mutations, published state) without informing the main agent that sign-off is required before those changes are safe. Workers that must stage irreversible changes as part of their implementation must include a revert procedure in their return output.
 
 **Spawning Workers:** The main agent must include the project context file content (`.agentic/context.md`) in each Worker's spawn prompt. Workers must not be expected to self-direct context reads - they may not have reliable access to the path or the protocol, and a worktree-isolated Worker cannot reach `.agentic/context.md` at all (`.agentic/` is gitignored, so it is absent from a fresh worktree checkout). The main agent is responsible for providing session context at spawn time.
+
+**`SESSION_KEY` at spawn time:** The main agent must also include a `SESSION_KEY` line in **every** Worker's spawn prompt. This is the same shape of obligation as the context file above and holds for the same reason: `SESSION_KEY` is conductor-supplied session state, not something a Worker can derive. `content/references/learnings-capture-instruction.md` §Session identity makes the spawn brief the *only* source an agent may read it from, and an agent whose brief omits it skips shard capture **silently**. A missing line therefore raises no error anywhere; it just means the learning was never recorded.
+
+Derive the value **once per session**, at the first Worker spawn, and pass that same value on every spawn thereafter:
+
+1. If `$CLAUDE_CODE_SESSION_ID` is set and non-empty, use it verbatim.
+2. Otherwise generate one key and carry it in the session's own working state:
+
+```bash
+printf 'ds-session-%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" \
+  "$(od -An -N2 -tx1 /dev/urandom | tr -d ' \n')"
+# ds-session-20260810T142233Z-9f2c
+```
+
+Three rules govern that derivation, each with a live counter-example in this repo:
+
+- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process (`payload.session_id`; OpenCode's `.opencode/plugins/session-context.ts` reads `event.properties.sessionID`) and never exports it to the model's shell. On Claude Code a subagent inherits the identical `$CLAUDE_CODE_SESSION_ID`, so the brief line is belt-and-braces there rather than load-bearing. Pass it regardless, so one rule holds on every harness.
+- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session, and `bin/ds-migrate` is silently degraded today precisely because it reads them. `content/commands/ds-wrap.md` records the same measurement for the wrap lock's `--session-id`.
+- **Never synthesize a value inside Claude's id namespace.** The `ds-session-` prefix exists to keep a generated key visibly outside it. This mirrors the rule `content/commands/ds-implement-ticket.md` already applies to `loop-state-<LOOP_KEY>.json`, which writes `session_id: null` on a harness with no id of its own rather than inventing a uuid in the wrong namespace.
+
+**Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
+
+**Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -1060,6 +1060,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`.agentic/context.md` content, supplied verbatim by the main agent - a worktree-isolated Worker cannot read this path directly, since its worktree branches from `origin/main`, where `.agentic/` is untracked)
+- `SESSION_KEY: <value>` - the session's learnings-shard key, supplied verbatim by the main agent on every spawn. Derive it once per session and reuse the same value; a brief that omits the line makes the Worker skip shard capture silently, with no error anywhere. Derivation rule and rationale: `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**"
 - For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/ds-implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.
@@ -3282,10 +3283,13 @@ Execution contract template:
 - task_id: [unique task identifier for multi-unit correlation, or omit for single-unit]
 - brief_path: [path to the Brief governing this unit, or "n/a" if architect plan is the sole artifact - arrives already absolute in the engineer's contract, normalized at spawn construction]
 - plan_path: [path to the Plan directory governing this unit, or "n/a" if Brief-tier or below - arrives already absolute in the engineer's contract, normalized at spawn construction]
+- SESSION_KEY: [the session's learnings-shard key, derived once per session and passed verbatim on every spawn thereafter]
 
 When `brief_path` or `plan_path` is populated, the engineer reads it before starting. Success criteria, non-goals, and the verification gate supersede any informal interpretation of the ticket. If the engineer discovers a conflict between the Brief and the architect plan, it returns BLOCKED so the conductor can resolve.
 
 The `verification` field is **mandatory**. Its purpose is to force the conductor to specify *how the change will be verified before implementation begins*, not as a Skeptic afterthought. As coding gets cheaper, verification is the expensive thing, and the protocol reorganizes around verification rather than around shipping code. If the verification path is not knowable up front (truly novel surface, no existing tests, no feasible new test), state that explicitly as `"self-evident review"` and accept that the Skeptic and any QA gate are the only line of defense - do not leave the field blank.
+
+The `SESSION_KEY` field is **mandatory and never omitted**. It is the one line in this template whose obligation is wider than the template itself: it belongs in **every** Worker's spawn prompt, including Trivial-path solo spawns and the non-`engineer` roles this contract does not otherwise cover. Omitting it raises no error - the Worker simply skips shard capture in silence, so the learning is lost with no signal. Derive the value once per session and pass that same value every time; the derivation rule, the harness caveats, and the reason the scope is blanket rather than per-role live in `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**".
 
 The `task_id` field is included for Elevated multi-unit spawns only (when `.agentic/tasks.jsonl` is in use). Omit for Trivial or single-unit spawns. Workers receive `task_id` for identification; the conductor correlates the worker's return summary with the correct task entry and handles all writes to the task-state file.
 
@@ -4245,7 +4249,11 @@ Public API: Read-only reference. Two consumable parts: the capture procedure
 Upstream deps: bin/ds-learning-shard (owns the --event-type enum, the flag
                names, and the per-session cap this document describes);
                content/references/capture-classification.md (the conductor-side
-               gate that classifies what this document collects).
+               gate that classifies what this document collects);
+               content/references/subagent-protocol.md §11 Output Expectations,
+               "SESSION_KEY at spawn time" (the producing side of the SESSION_KEY
+               contract - it owns the derivation rule and the every-spawn scope
+               that §Session identity below consumes).
 
 Downstream consumers: every agent in content/agents/ (via a pointer);
                       content/agents/engineer.md,
@@ -4408,10 +4416,13 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
-The producing side of that contract is `content/references/subagent-protocol.md`
-§"Spawning Workers", which obliges the conductor to derive one key per session and
-include it in **every** Worker's spawn prompt. That is where the derivation rule
-lives; do not restate it here, and never apply it yourself.
+Never derive one yourself. The conductor owns the derivation and is obliged to put
+the key in **every** Worker's spawn prompt; that obligation, its rule, and its
+harness caveats live in `content/references/subagent-protocol.md` §11 Output
+Expectations, "**`SESSION_KEY` at spawn time**", and are restated at the two spawn
+checklists a conductor actually fills - `content/references/agent-team.md`
+§Spawning and `content/references/delegation-detail.md` §Worker Preamble and
+Execution Contract Template.
 
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
@@ -6484,6 +6495,44 @@ See `content/references/spawn-presets-example.yml` for an example library to cop
 
 ### subagent-protocol
 
+<!--
+Purpose: The outer orchestration frame for multi-agent sessions: when the main
+         agent delegates, how it spawns, what it must put into a spawn prompt, and
+         what it expects back. Normative for every spawn in the methodology.
+
+Public API: Read-only reference, reached on trigger from the pointer table in
+            `content/sections/12-protocol-details.md`. Consumable parts most often
+            cited elsewhere: Section 2 (the Seven Rules), Section 6 (decomposition
+            and review scope), Section 7 (shared-repo and worktree isolation),
+            Section 10 (Input Contract), Section 11 (Output Expectations, including
+            the two spawn-prompt obligations: `.agentic/context.md` content and
+            `SESSION_KEY`), and Section 13 (conductor context budget).
+
+Upstream deps: content/references/risk-config-and-tiers.md (role-default tier table
+               the Input Contract's model-param rule defers to);
+               content/references/learnings-capture-instruction.md §Session identity
+               (the consuming side of the `SESSION_KEY` contract, which fixes the
+               spawn brief as the only source an agent may read the key from).
+
+Downstream consumers: content/references/agent-team.md §Spawning and
+                      content/references/delegation-detail.md §Worker Preamble and
+                      Execution Contract Template, the two spawn checklists a
+                      conductor actually fills - both restate the `SESSION_KEY`
+                      line and point back here for its derivation rule, so a change
+                      to that rule must be reflected in both;
+                      content/references/skeptic-protocol.md (Section 9 of this file
+                      defines their relationship);
+                      content/sections/12-protocol-details.md (the pointer table
+                      naming which sections are reachable on which trigger).
+
+Failure modes: Prose; does not execute. Its characteristic failure is silence, not
+               error: a spawn obligation stated only here, with no pointer from the
+               table and no restatement in a spawn checklist, is not resident in a
+               conductor's context and is simply never performed.
+
+Performance: Standard.
+-->
+
 # The Subagent Protocol — Orchestration Methodology
 
 ## 1. Overview
@@ -6878,6 +6927,8 @@ When spawning an `engineer` Worker on an Elevated-risk task, the conductor inclu
 
 The conductor OMITS the `model` param to accept the spawned agent's frontmatter role-default tier (see the Role-default tier table in `content/references/risk-config-and-tiers.md`); it passes an explicit `model` param only to OVERRIDE a specific spawn - upgrading a Tier-2 agent to Tier 3 for a novel-architecture unit, asserting a mandated-Tier-3 Skeptic, or a Tier-1 mechanical task. Claude Code: `haiku`/`opus` for the override; other harnesses resolve from tier-map or omit. Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 
+Two spawn-prompt obligations are wider than this contract and are stated in Section 11 rather than here, because they hold for every Worker on every path rather than for contract-carrying `engineer` spawns only: the `.agentic/context.md` content, and the `SESSION_KEY` line. See Section 11, "**Spawning Workers**" and "**`SESSION_KEY` at spawn time**".
+
 Scope: this contract applies to `engineer` spawns only for Phase 1.1. Other named Workers (`architect`, `investigator`, `debugger`, `qa-engineer`, `security-auditor`, `perf-analyst`, `release-orchestrator`, `dependency-auditor`, `orchestration-planner`, `general-purpose`) and Trivial-path solo `engineer` spawns are out of scope - use the existing freeform preamble for those.
 
 ---
@@ -6920,6 +6971,8 @@ Three rules govern that derivation, each with a live counter-example in this rep
 **Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
 
 **Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
+**Where a conductor actually meets this rule.** This file is trigger-loaded, so a rule stated only here is not resident when a conductor composes a spawn prompt. The `SESSION_KEY` line therefore also appears in the two checklists a conductor fills at spawn time: `content/references/agent-team.md` §Spawning (the ``When spawning `engineer`, include:`` list) and `content/references/delegation-detail.md` §Worker Preamble and Execution Contract Template. Both carry the field and defer to this paragraph for the derivation rule, so neither restates the four-role list either. Change all three together.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/content/references/agent-team.md
+++ b/content/references/agent-team.md
@@ -184,6 +184,7 @@ When spawning `engineer`, include:
 - Relevant file paths or codebase root
 - Acceptance criteria
 - Session context (`.agentic/context.md` content, supplied verbatim by the main agent - a worktree-isolated Worker cannot read this path directly, since its worktree branches from `origin/main`, where `.agentic/` is untracked)
+- `SESSION_KEY: <value>` - the session's learnings-shard key, supplied verbatim by the main agent on every spawn. Derive it once per session and reuse the same value; a brief that omits the line makes the Worker skip shard capture silently, with no error anywhere. Derivation rule and rationale: `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**"
 - For Elevated-path spawns: the execution contract block from `METHODOLOGY.md` (Worker preamble section), with all required fields filled in from the architect's plan or orchestration-planner output
 
 When spawned via `/ds-implement-ticket` Phase 5 with a `task_id` in the execution contract, the engineer includes `task_id` in its return summary for conductor correlation. The conductor handles all `.agentic/tasks.jsonl` writes.

--- a/content/references/delegation-detail.md
+++ b/content/references/delegation-detail.md
@@ -257,10 +257,13 @@ Execution contract template:
 - task_id: [unique task identifier for multi-unit correlation, or omit for single-unit]
 - brief_path: [path to the Brief governing this unit, or "n/a" if architect plan is the sole artifact - arrives already absolute in the engineer's contract, normalized at spawn construction]
 - plan_path: [path to the Plan directory governing this unit, or "n/a" if Brief-tier or below - arrives already absolute in the engineer's contract, normalized at spawn construction]
+- SESSION_KEY: [the session's learnings-shard key, derived once per session and passed verbatim on every spawn thereafter]
 
 When `brief_path` or `plan_path` is populated, the engineer reads it before starting. Success criteria, non-goals, and the verification gate supersede any informal interpretation of the ticket. If the engineer discovers a conflict between the Brief and the architect plan, it returns BLOCKED so the conductor can resolve.
 
 The `verification` field is **mandatory**. Its purpose is to force the conductor to specify *how the change will be verified before implementation begins*, not as a Skeptic afterthought. As coding gets cheaper, verification is the expensive thing, and the protocol reorganizes around verification rather than around shipping code. If the verification path is not knowable up front (truly novel surface, no existing tests, no feasible new test), state that explicitly as `"self-evident review"` and accept that the Skeptic and any QA gate are the only line of defense - do not leave the field blank.
+
+The `SESSION_KEY` field is **mandatory and never omitted**. It is the one line in this template whose obligation is wider than the template itself: it belongs in **every** Worker's spawn prompt, including Trivial-path solo spawns and the non-`engineer` roles this contract does not otherwise cover. Omitting it raises no error - the Worker simply skips shard capture in silence, so the learning is lost with no signal. Derive the value once per session and pass that same value every time; the derivation rule, the harness caveats, and the reason the scope is blanket rather than per-role live in `content/references/subagent-protocol.md` §11 Output Expectations, "**`SESSION_KEY` at spawn time**".
 
 The `task_id` field is included for Elevated multi-unit spawns only (when `.agentic/tasks.jsonl` is in use). Omit for Trivial or single-unit spawns. Workers receive `task_id` for identification; the conductor correlates the worker's return summary with the correct task entry and handles all writes to the task-state file.
 

--- a/content/references/learnings-capture-instruction.md
+++ b/content/references/learnings-capture-instruction.md
@@ -13,7 +13,11 @@ Public API: Read-only reference. Two consumable parts: the capture procedure
 Upstream deps: bin/ds-learning-shard (owns the --event-type enum, the flag
                names, and the per-session cap this document describes);
                content/references/capture-classification.md (the conductor-side
-               gate that classifies what this document collects).
+               gate that classifies what this document collects);
+               content/references/subagent-protocol.md §11 Output Expectations,
+               "SESSION_KEY at spawn time" (the producing side of the SESSION_KEY
+               contract - it owns the derivation rule and the every-spawn scope
+               that §Session identity below consumes).
 
 Downstream consumers: every agent in content/agents/ (via a pointer);
                       content/agents/engineer.md,
@@ -176,10 +180,13 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
-The producing side of that contract is `content/references/subagent-protocol.md`
-§"Spawning Workers", which obliges the conductor to derive one key per session and
-include it in **every** Worker's spawn prompt. That is where the derivation rule
-lives; do not restate it here, and never apply it yourself.
+Never derive one yourself. The conductor owns the derivation and is obliged to put
+the key in **every** Worker's spawn prompt; that obligation, its rule, and its
+harness caveats live in `content/references/subagent-protocol.md` §11 Output
+Expectations, "**`SESSION_KEY` at spawn time**", and are restated at the two spawn
+checklists a conductor actually fills - `content/references/agent-team.md`
+§Spawning and `content/references/delegation-detail.md` §Worker Preamble and
+Execution Contract Template.
 
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and

--- a/content/references/learnings-capture-instruction.md
+++ b/content/references/learnings-capture-instruction.md
@@ -176,6 +176,11 @@ four values by construction.
 
 `SESSION_KEY` arrives **in your spawn brief**. It is the only source.
 
+The producing side of that contract is `content/references/subagent-protocol.md`
+§"Spawning Workers", which obliges the conductor to derive one key per session and
+include it in **every** Worker's spawn prompt. That is where the derivation rule
+lives; do not restate it here, and never apply it yourself.
+
 - **If your brief has no `SESSION_KEY`, skip shard capture silently.** Do not invent
   a key, do not ask for one, do not block. `learnings_candidate[]` still applies and
   needs no session key.

--- a/content/references/subagent-protocol.md
+++ b/content/references/subagent-protocol.md
@@ -412,6 +412,29 @@ When a Worker returns to the main agent under this protocol, the main agent expe
 
 **Spawning Workers:** The main agent must include the project context file content (`.agentic/context.md`) in each Worker's spawn prompt. Workers must not be expected to self-direct context reads - they may not have reliable access to the path or the protocol, and a worktree-isolated Worker cannot reach `.agentic/context.md` at all (`.agentic/` is gitignored, so it is absent from a fresh worktree checkout). The main agent is responsible for providing session context at spawn time.
 
+**`SESSION_KEY` at spawn time:** The main agent must also include a `SESSION_KEY` line in **every** Worker's spawn prompt. This is the same shape of obligation as the context file above and holds for the same reason: `SESSION_KEY` is conductor-supplied session state, not something a Worker can derive. `content/references/learnings-capture-instruction.md` §Session identity makes the spawn brief the *only* source an agent may read it from, and an agent whose brief omits it skips shard capture **silently**. A missing line therefore raises no error anywhere; it just means the learning was never recorded.
+
+Derive the value **once per session**, at the first Worker spawn, and pass that same value on every spawn thereafter:
+
+1. If `$CLAUDE_CODE_SESSION_ID` is set and non-empty, use it verbatim.
+2. Otherwise generate one key and carry it in the session's own working state:
+
+```bash
+printf 'ds-session-%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" \
+  "$(od -An -N2 -tx1 /dev/urandom | tr -d ' \n')"
+# ds-session-20260810T142233Z-9f2c
+```
+
+Three rules govern that derivation, each with a live counter-example in this repo:
+
+- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process (`payload.session_id`; OpenCode's `.opencode/plugins/session-context.ts` reads `event.properties.sessionID`) and never exports it to the model's shell. On Claude Code a subagent inherits the identical `$CLAUDE_CODE_SESSION_ID`, so the brief line is belt-and-braces there rather than load-bearing. Pass it regardless, so one rule holds on every harness.
+- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session, and `bin/ds-migrate` is silently degraded today precisely because it reads them. `content/commands/ds-wrap.md` records the same measurement for the wrap lock's `--session-id`.
+- **Never synthesize a value inside Claude's id namespace.** The `ds-session-` prefix exists to keep a generated key visibly outside it. This mirrors the rule `content/commands/ds-implement-ticket.md` already applies to `loop-state-<LOOP_KEY>.json`, which writes `session_id: null` on a harness with no id of its own rather than inventing a uuid in the wrong namespace.
+
+**Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
+
+**Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 
 **When The Skeptic Protocol was not invoked** (e.g., the task was Low risk pure research or investigation with no artifact produced), the Worker states explicitly: "No Skeptic Protocol invoked — task was [description]. No artifact requiring review." This prevents ambiguity in a return without a review record.

--- a/content/references/subagent-protocol.md
+++ b/content/references/subagent-protocol.md
@@ -1,3 +1,41 @@
+<!--
+Purpose: The outer orchestration frame for multi-agent sessions: when the main
+         agent delegates, how it spawns, what it must put into a spawn prompt, and
+         what it expects back. Normative for every spawn in the methodology.
+
+Public API: Read-only reference, reached on trigger from the pointer table in
+            `content/sections/12-protocol-details.md`. Consumable parts most often
+            cited elsewhere: Section 2 (the Seven Rules), Section 6 (decomposition
+            and review scope), Section 7 (shared-repo and worktree isolation),
+            Section 10 (Input Contract), Section 11 (Output Expectations, including
+            the two spawn-prompt obligations: `.agentic/context.md` content and
+            `SESSION_KEY`), and Section 13 (conductor context budget).
+
+Upstream deps: content/references/risk-config-and-tiers.md (role-default tier table
+               the Input Contract's model-param rule defers to);
+               content/references/learnings-capture-instruction.md §Session identity
+               (the consuming side of the `SESSION_KEY` contract, which fixes the
+               spawn brief as the only source an agent may read the key from).
+
+Downstream consumers: content/references/agent-team.md §Spawning and
+                      content/references/delegation-detail.md §Worker Preamble and
+                      Execution Contract Template, the two spawn checklists a
+                      conductor actually fills - both restate the `SESSION_KEY`
+                      line and point back here for its derivation rule, so a change
+                      to that rule must be reflected in both;
+                      content/references/skeptic-protocol.md (Section 9 of this file
+                      defines their relationship);
+                      content/sections/12-protocol-details.md (the pointer table
+                      naming which sections are reachable on which trigger).
+
+Failure modes: Prose; does not execute. Its characteristic failure is silence, not
+               error: a spawn obligation stated only here, with no pointer from the
+               table and no restatement in a spawn checklist, is not resident in a
+               conductor's context and is simply never performed.
+
+Performance: Standard.
+-->
+
 # The Subagent Protocol — Orchestration Methodology
 
 ## 1. Overview
@@ -392,6 +430,8 @@ When spawning an `engineer` Worker on an Elevated-risk task, the conductor inclu
 
 The conductor OMITS the `model` param to accept the spawned agent's frontmatter role-default tier (see the Role-default tier table in `content/references/risk-config-and-tiers.md`); it passes an explicit `model` param only to OVERRIDE a specific spawn - upgrading a Tier-2 agent to Tier 3 for a novel-architecture unit, asserting a mandated-Tier-3 Skeptic, or a Tier-1 mechanical task. Claude Code: `haiku`/`opus` for the override; other harnesses resolve from tier-map or omit. Codex/Gemini: if a tier-map file exists (`.agentic/tier-map.yml` project-local or `~/.agentic/tier-map.yml` user-global), pass `--model <resolved-name>` from it; if no tier-map exists, omit `--model` and the CLI uses its session default (there is no hardcoded fallback). The model param is an implementation detail of the spawn call, not part of the spawn prompt text.
 
+Two spawn-prompt obligations are wider than this contract and are stated in Section 11 rather than here, because they hold for every Worker on every path rather than for contract-carrying `engineer` spawns only: the `.agentic/context.md` content, and the `SESSION_KEY` line. See Section 11, "**Spawning Workers**" and "**`SESSION_KEY` at spawn time**".
+
 Scope: this contract applies to `engineer` spawns only for Phase 1.1. Other named Workers (`architect`, `investigator`, `debugger`, `qa-engineer`, `security-auditor`, `perf-analyst`, `release-orchestrator`, `dependency-auditor`, `orchestration-planner`, `general-purpose`) and Trivial-path solo `engineer` spawns are out of scope - use the existing freeform preamble for those.
 
 ---
@@ -434,6 +474,8 @@ Three rules govern that derivation, each with a live counter-example in this rep
 **Pass it as a literal string and persist nothing.** No file records the key. Nothing needs it to survive a restart: a shard is a per-session file by construction, and `ds-learning-shard rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would in any case be unreachable from a worktree-isolated Worker, for exactly the reason given above about `.agentic/context.md`.
 
 **Every spawn, not only the roles that can capture.** Just four roles can call `ds-learning-shard append`, and that membership list is enumerated in `content/references/learnings-capture-instruction.md` and cross-checked against the agent files by `bin/tests/test_agent_capability_claim_consistency.py`, which exists because the list has desynchronized before. Scoping this obligation to those four would make this paragraph a further site restating the list; a blanket rule cannot desync from a list it never restates. The cost is one ignored line in the briefs of roles that will not use it.
+
+**Where a conductor actually meets this rule.** This file is trigger-loaded, so a rule stated only here is not resident when a conductor composes a spawn prompt. The `SESSION_KEY` line therefore also appears in the two checklists a conductor fills at spawn time: `content/references/agent-team.md` §Spawning (the ``When spawning `engineer`, include:`` list) and `content/references/delegation-detail.md` §Worker Preamble and Execution Contract Template. Both carry the field and defer to this paragraph for the derivation rule, so neither restates the four-role list either. Change all three together.
 
 **Memory update serialization:** When parallel Workers produce memory update requests, the main agent serializes these writes: it invokes `/ds-memory-update` for each request sequentially after all Workers have returned. Workers must not invoke `/ds-memory-update` directly from within a parallel session — concurrent writes to `.claude/rules/decisions.md` may conflict.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1663,7 +1663,7 @@
       <div class="rel-card" style="border-left: 2px solid var(--gold);">
         <h4 style="color: var(--gold);">Implementation Agent</h4>
         <ul>
-          <li><strong>engineer</strong> - the primary agent that writes files. Reads codebase conventions, implements the change, runs quality gates (lint, typecheck, test), and returns a clear summary. Writes module manifests on non-trivial files and adds regression tests when fixing Critical/Major findings. Receives the architect's plan, file paths, acceptance criteria, and session context. Can return <code>NEEDS_CONTEXT</code>, <code>BLOCKED</code>, or <code>DONE_WITH_CONCERNS</code> statuses.</li>
+          <li><strong>engineer</strong> - the primary agent that writes files. Reads codebase conventions, implements the change, runs quality gates (lint, typecheck, test), and returns a clear summary. Writes module manifests on non-trivial files and adds regression tests when fixing Critical/Major findings. Receives the architect's plan, file paths, acceptance criteria, session context, and the session's <code>SESSION_KEY</code> (the learnings-shard key, supplied on every spawn - a brief that omits it makes the Worker skip shard capture silently). Can return <code>NEEDS_CONTEXT</code>, <code>BLOCKED</code>, or <code>DONE_WITH_CONCERNS</code> statuses.</li>
         </ul>
       </div>
       <div class="rel-card" style="margin-top: 12px; border-left: 2px solid var(--violet);">


### PR DESCRIPTION
Unit D of DS-154. Makes the conductor supply `SESSION_KEY` in every spawn brief.

**This is the unit that makes A, B and C actually run.** `content/references/learnings-capture-instruction.md` says `SESSION_KEY` arrives in the spawn brief and is its only source, and that an agent without one skips capture *silently*. Nothing produced it. So as of Unit C the entire capture path was a silent no-op - complete on both the CLI side and the agent-instruction side, and 100% dead because the one line joining them was never written.

`/ds-wrap` is untouched and is not going away. The goal is that it stop being *necessary*.

## Where the obligation lives, and why only there

`content/references/subagent-protocol.md` §"Spawning Workers", immediately after the paragraph mandating the conductor inject `.agentic/context.md` content into every Worker prompt. That is the exact precedent: conductor-supplied because it is not agent-derivable, and because a worktree-isolated Worker cannot reach the file it would otherwise read.

That precedent is stated **once** in `content/` and restated in **zero** command files, so this follows it to the same single site. `ds-implement-ticket.md`, `ds-brief.md`, `ds-skeptic.md`, and the rest are untouched: six restatements would be six drift sites.

## Derivation

`$CLAUDE_CODE_SESSION_ID` when set, else a generated `ds-session-<UTC compact ISO>-<4 hex>` key, derived once per session and passed on every spawn. Passed as a literal string, persisting nothing.

Three rules govern it, each with a live counter-example in this repo:

- **Only Claude Code exposes a session id to the conductor's shell.** Every other adapter keeps its id inside its own hook or plugin process and never exports it. On Claude a subagent inherits the identical value, so the brief line is belt-and-braces there rather than load-bearing - passed anyway so one rule holds everywhere.
- **Never substitute a cross-harness environment variable.** `AGENTIC_SESSION_ID` and `CLAUDE_SESSION_UUID` are both empty in a live session and `bin/ds-migrate` is silently degraded today because it reads them. Re-verified against `ds-wrap.md:84` rather than assumed.
- **Never synthesize into Claude's id namespace.** The `ds-session-` prefix keeps a generated key visibly outside it, mirroring the `session_id: null` doctrine `ds-implement-ticket.md:1774` already applies rather than inventing a parallel one.

Nothing needs the key to survive a restart: a shard is a per-session file by construction and `rollup` reads every shard under the repo's shard directory regardless of how many sessions produced them. A key file under the conductor's `.agentic/` would be unreachable from a worktree-isolated Worker anyway.

The format is in the CLI's `[A-Za-z0-9._-]` safe set and under 64 chars, so `session_stem()` uses it verbatim instead of hashing and the shard filename stays readable.

## Blanket scope, deliberately

Only four roles can call `append`, so scoping the obligation to them looks obviously right. It is the trap. That membership list already exists in four places and `bin/tests/test_agent_capability_claim_consistency.py` exists precisely because it has desynchronized before - the class recurred across four review rounds in Unit C. A scoped rule would either restate the list, creating a **fifth site outside the guard's parse scope**, or force a reference read on every spawn.

A rule that never restates a list cannot desync from it. The cost is one ignored line in 14 briefs, against a failure mode that is silent by design.

## The loop closes - demonstrated, not asserted

Both derivation branches exercised end to end:

```
$ ds-learning-shard append --repo . --session-key ds-session-20260810T230143Z-861d ...
ds-learning-shard: appended 1 entry (1/5).
$ ds-learning-shard rollup --repo . --session-key ds-session-20260810T230143Z-861d
[ { "id": "4e40f384-...", "ts": "2026-08-10T23:01:51Z", "role": "engineer", ... } ]
```

Also confirmed: `--repo .` from inside an isolation worktree resolves to the same repo-key as the primary checkout, so worktree captures land in the shared store, as Unit A intended.

One near-miss worth recording. An unscoped `rollup` after a scoped one returned 1 entry, and a second returned `[]`. That is `rollup` being at-most-once by design via `.rolled-up.json`, not data loss - `list` shows both entries intact on disk. Stopping at the first number would have reported a false bug.

## Verification

- `bin/tests/` **1157 passed**; hooks JS 45 files, hooks Python 16, hooks shell 1, all 0 failures. CI case arms re-derived from `hooks-tests.yml` rather than hand-counted.
- Adapter drift clean using the pathspec copied verbatim from `adapter-sync.yml`, run on a committed tree after an idempotence rebuild.
- `check-resident-budget` 391 B / 600 B. `check-skill-embed-budget` 127478 B, floor 100000, ceiling 139160. `check-symlinks-relative`, `check-codex-skill-sync`, `check-methodology-drift` all clean.
- `git merge-tree --write-tree origin/main HEAD` exits 0.

## North Star alignment

- **Guard operator attention** - closes the last gap between the capture machinery and it actually running, with no operator action.
- **Works for everyone** - one derivation rule holds on all 11 adapters; the fallback needs no harness capability, no environment variable, and no file.
- **Verifiable outcomes** - the loop is demonstrated with real command output rather than asserted.

Doc-sync: predicate not triggered (no reality-asserting change). `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md` and `content/SKILL.md` were enumerated and the decks grepped by hand rather than trusting `check-slides-sync`. No doc surface asserts what a spawn brief contains, and the reference-doc count is unchanged at 37.
