### PR TITLE
fix(precommit): clean orphaned worktree hooks and harden the test suite's sandbox

### DIFF
--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -45,8 +45,16 @@
 #                silently ignore `-C` and operate against a DIFFERENT repo
 #                entirely - see Test 0 and Test 13.
 #
-# Performance: ~3 s wall time (pure git + shell, no network; 68 assertions
-#              across 23 fixture scenarios as of this revision).
+# Performance: ~3 s wall time (pure git + shell, no network). Do NOT
+#              hand-maintain an assertion/scenario count here - two prior
+#              rounds each shipped a stale figure the moment a test was
+#              added without updating this comment (round 2 wrote "68
+#              assertions across 23 fixture scenarios" and immediately
+#              undercounted its own round-2 addition; round 3 found that
+#              same miss again). The one number that can never drift is
+#              printed by this script itself on every run: the final
+#              "Results: N passed, N failed." line - read that instead of
+#              trusting any count written here.
 #
 # Regression coverage:
 #   - DS-58 (install side): `ln -s "$REPO_DIR/hooks/pre-commit"
@@ -128,10 +136,43 @@
 #     unrelated repo must still be left alone).
 #   - Hang guard (Test 18): _precommit_is_orphaned_worktree_target must
 #     return promptly for a pathological, deeply-nested, non-existent
-#     dangling target - pins the deliberate choice not to implement a
-#     generic walk-up-the-target's-ancestors algorithm (see the helper's
-#     own manifest), so a future regression to an unguarded walk-up loop
-#     is caught by a timeout kill, not a silent merge.
+#     dangling target. As of round 3 this function DOES implement a
+#     bounded upward ancestor walk (see Major 2 below and the helper's own
+#     manifest for why the round-1/round-2 fixed-strip design was
+#     replaced) - this test now pins that the walk's own bound
+#     (_PRECOMMIT_MAX_ANCESTOR_DEPTH and its termination guard) keeps it
+#     fast even on a pathological input, not that no walk exists at all.
+#   - Exact-match guard, both directions (round 3, Minor 1): a candidate
+#     comparison that degrades from exact string equality to a prefix
+#     match in either direction is wrong. Test 23 covers the FORWARD
+#     direction (target is a superstring of a real candidate, e.g.
+#     ".worktrees-decoy" vs ".worktrees"); Test 27 covers the REVERSE
+#     direction (an ancestor being tested canonicalizes to a STRING PREFIX
+#     of a real candidate, e.g. repo_dir itself is a prefix of
+#     "repo_dir/.claude/worktrees") - a sibling mutation class Test 23
+#     alone does not reach, found missing by a round-3 Skeptic review.
+#   - Danglingness-gate ordering and existence (round 3, Major 1 - a live,
+#     resolving relative-target hook was silently deleted because `[[ -e
+#     "$target" ]]` ran before the relative-target anchoring block,
+#     testing existence against this script's own process CWD instead of
+#     hooks_dir): Test 24 (relative live target, isolates the reorder fix
+#     - reddens under the pre-fix ordering) and Test 25 (absolute live
+#     target, isolates the gate's mere EXISTENCE from its ordering -
+#     reddens if the `-e` check is deleted outright, which round 3 found
+#     was NOT covered by any assertion before Test 25 was added; deleting
+#     it left the full suite green).
+#   - Bounded upward search / depth-2 evidence (round 3, Major 2 - the
+#     round-2 "every candidate resolves at exactly ONE directory level
+#     below its container" premise was false:
+#     content/references/subagent-protocol.md:333-334's own documented
+#     worktree-add command uses a FEATURE_BRANCH value that, under this
+#     repo's branch-naming convention, contains a "/" - landing the
+#     worktree TWO levels below ".worktrees", not one; AGENTS.md:48's
+#     ".agentic/worktrees/<branch-name>" has the identical hazard for any
+#     slash-containing branch name): Test 26, both for ".worktrees/" (the
+#     literal subagent-protocol.md example shape) and for
+#     ".agentic/worktrees/" (the AGENTS.md sibling shape). Reddens against
+#     a reverted fixed-single-strip mutation of the container computation.
 #   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
@@ -1052,7 +1093,7 @@ else
   _fail "Test 14 (orphan cleanup): uninstall_precommit_hook exited $ORPHAN_RC. Output: $ORPHAN_OUT"
 fi
 
-if [[ ! -L "$ORPHAN_HOOK_DST" ]]; then
+if [[ ! -L "$ORPHAN_HOOK_DST" ]] && [[ ! -e "$ORPHAN_HOOK_DST" ]]; then
   _pass "Test 14 (orphan cleanup, delta over #640): dangling hook naming an already-removed .claude/worktrees/ worktree is REMOVED. Output: $ORPHAN_OUT"
 else
   _fail "Test 14 (orphan cleanup regression): dangling hook naming an already-removed worktree still present at $ORPHAN_HOOK_DST - the live defect this delta exists to fix. Output: $ORPHAN_OUT"
@@ -1083,7 +1124,7 @@ git -C "$ORPHAN2_MAIN" worktree remove -f "$ORPHAN2_WT" >/dev/null 2>&1
 
 ORPHAN2_OUT="$(uninstall_precommit_hook "$ORPHAN2_MAIN" 2>&1)"
 
-if [[ ! -L "$ORPHAN2_HOOK_DST" ]]; then
+if [[ ! -L "$ORPHAN2_HOOK_DST" ]] && [[ ! -e "$ORPHAN2_HOOK_DST" ]]; then
   _pass "Test 15 (orphan cleanup, .agentic/worktrees/): dangling hook naming an already-removed .agentic/worktrees/ worktree is removed. Output: $ORPHAN2_OUT"
 else
   _fail "Test 15 (orphan cleanup regression, .agentic/worktrees/): dangling hook still present at $ORPHAN2_HOOK_DST. Output: $ORPHAN2_OUT"
@@ -1173,7 +1214,7 @@ git -C "$ORPHAN3_MAIN" worktree remove -f "$ORPHAN3_WT" >/dev/null 2>&1
 
 ORPHAN3_OUT="$(uninstall_precommit_hook "$ORPHAN3_MAIN" 2>&1)"
 
-if [[ ! -L "$ORPHAN3_HOOK_DST" ]]; then
+if [[ ! -L "$ORPHAN3_HOOK_DST" ]] && [[ ! -e "$ORPHAN3_HOOK_DST" ]]; then
   _pass "Test 17 (relative-target orphan cleanup): a RELATIVE dangling target naming an already-removed worktree is also removed. Output: $ORPHAN3_OUT"
 else
   _fail "Test 17 (relative-target orphan cleanup regression): relative-target dangling hook still present at $ORPHAN3_HOOK_DST. Output: $ORPHAN3_OUT"
@@ -1413,6 +1454,253 @@ if [[ -L "$DECOY_HOOK_DST" ]]; then
   _pass "Test 23 (exact-match guard): a dangling hook rooted at a sibling '.worktrees-decoy' directory (shares a string PREFIX with the real '.worktrees' candidate, but is not it) is left untouched"
 else
   _fail "Test 23 (exact-match guard regression): a dangling hook under a merely-prefix-sharing sibling directory was incorrectly removed - the candidate comparison is matching by prefix, not exact identity. Output: $DECOY_OUT"
+fi
+
+# ============================================================
+# Test 24: danglingness-gate ordering (round-3 Major 1) - a RELATIVE
+#          symlink target naming a LIVE, still-existing worktree (never
+#          removed) must be PRESERVED, not deleted. Pre-fix, `[[ -e
+#          "$target" ]]` was evaluated BEFORE the relative-target
+#          anchoring block, so it tested existence against this test
+#          script's own process CWD (never guaranteed to be hooks_dir) -
+#          a live, correctly-resolving-from-hooks_dir target looked
+#          "dangling" purely because of that mismatch, and was deleted.
+#          Matched control: an ABSOLUTE live target (unaffected by the
+#          anchoring reorder, since absolute paths skip that block
+#          entirely) is verified separately in Test 25 below - together
+#          the two isolate "the reorder fix" from "the danglingness gate
+#          existing at all", the second of which round 3 also found
+#          entirely uncovered (deleting the gate line outright still
+#          passed 69/69 pre this test's addition).
+# ============================================================
+
+LIVE_MAIN="$TMP_ROOT/live-main-repo"
+_make_fixture_repo "$LIVE_MAIN"
+mkdir -p "$LIVE_MAIN/.claude/worktrees"
+
+LIVE_WT="$LIVE_MAIN/.claude/worktrees/agent-LIVE"
+git -C "$LIVE_MAIN" worktree add -q "$LIVE_WT" -b live-wt-test-branch >/dev/null 2>&1
+# Deliberately NEVER removed - this worktree stays alive for the whole test.
+
+LIVE_REAL_HOOKS_DIR="$(git -C "$LIVE_MAIN" rev-parse --git-path hooks)"
+case "$LIVE_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) LIVE_REAL_HOOKS_DIR="$LIVE_MAIN/$LIVE_REAL_HOOKS_DIR" ;;
+esac
+LIVE_HOOK_DST="$LIVE_REAL_HOOKS_DIR/pre-commit"
+
+LIVE_RELATIVE_TARGET="../../.claude/worktrees/agent-LIVE/hooks/pre-commit"
+mkdir -p "$LIVE_REAL_HOOKS_DIR"
+ln -s "$LIVE_RELATIVE_TARGET" "$LIVE_HOOK_DST"
+
+# Fixture-correctness precondition 1: the relative target genuinely
+# resolves when anchored against its own directory (hooks_dir) - i.e. it
+# is a LIVE hook, not actually dangling.
+if [[ -e "$LIVE_HOOK_DST" ]]; then
+  _pass "Test 24 setup: relative live-worktree target resolves correctly via its own symlink directory (genuinely live, not dangling)"
+else
+  _fail "Test 24 setup: relative live-worktree target does NOT resolve at $LIVE_HOOK_DST -> $LIVE_RELATIVE_TARGET (fixture bug, not a library bug)"
+fi
+
+# Fixture-correctness precondition 2: this is the exact CWD-mismatch this
+# Major exercises - the SAME relative string, tested bare against this
+# script's own process CWD (never hooks_dir), reports FALSE. This is not
+# a library call - it is establishing that the reproduction's precondition
+# genuinely holds in this fixture, independent of any library code.
+if [[ ! -e "$LIVE_RELATIVE_TARGET" ]]; then
+  _pass "Test 24 setup: the bare relative target string does NOT resolve from this script's own CWD (confirms the CWD-mismatch precondition the round-3 Major depends on)"
+else
+  _fail "Test 24 setup: the bare relative target unexpectedly resolved from this script's CWD - fixture does not exercise the CWD-mismatch bug (or this script happens to be running from hooks_dir, which would be a coincidence, not a guarantee)"
+fi
+
+LIVE_OUT="$(uninstall_precommit_hook "$LIVE_MAIN" 2>&1)"
+LIVE_RC=$?
+
+if [[ $LIVE_RC -eq 0 ]]; then
+  _pass "Test 24 (danglingness-gate ordering): uninstall_precommit_hook exits 0"
+else
+  _fail "Test 24 (danglingness-gate ordering): uninstall_precommit_hook exited $LIVE_RC. Output: $LIVE_OUT"
+fi
+
+if [[ -L "$LIVE_HOOK_DST" ]] && [[ -e "$LIVE_HOOK_DST" ]] && [[ "$(readlink "$LIVE_HOOK_DST")" == "$LIVE_RELATIVE_TARGET" ]]; then
+  _pass "Test 24 (round-3 Major 1 fixed): a RELATIVE target naming a LIVE, still-existing worktree is PRESERVED, not deleted, by uninstall_precommit_hook. Output: $LIVE_OUT"
+else
+  _fail "Test 24 (round-3 Major 1 regression): a LIVE worktree's relative-target hook was deleted (readlink target after: $(readlink "$LIVE_HOOK_DST" 2>&1 || echo '<gone>')) - the danglingness gate misjudged a live, resolving target as dangling. Output: $LIVE_OUT"
+fi
+
+# ============================================================
+# Test 25: danglingness-gate existence (round-3 Major 1's Minor sibling) -
+#          an ABSOLUTE target naming the SAME live, still-existing
+#          worktree must ALSO be preserved. Absolute targets skip the
+#          relative-anchoring block entirely, so this case is UNAFFECTED
+#          by the reorder fix in Test 24 - it isolates the danglingness
+#          gate's own EXISTENCE (as opposed to its ordering): deleting
+#          `[[ -e "$target" ]] && return 1` outright, regardless of where
+#          it sits, reddens this test but not Test 24 alone (an absolute
+#          live target was never subject to the CWD-mismatch bug - only a
+#          missing gate would delete it).
+# ============================================================
+
+LIVE2_MAIN="$TMP_ROOT/live2-main-repo"
+_make_fixture_repo "$LIVE2_MAIN"
+mkdir -p "$LIVE2_MAIN/.claude/worktrees"
+
+LIVE2_WT="$LIVE2_MAIN/.claude/worktrees/agent-LIVE2"
+git -C "$LIVE2_MAIN" worktree add -q "$LIVE2_WT" -b live2-wt-test-branch >/dev/null 2>&1
+# Deliberately never removed.
+
+LIVE2_REAL_HOOKS_DIR="$(git -C "$LIVE2_MAIN" rev-parse --git-path hooks)"
+case "$LIVE2_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) LIVE2_REAL_HOOKS_DIR="$LIVE2_MAIN/$LIVE2_REAL_HOOKS_DIR" ;;
+esac
+LIVE2_HOOK_DST="$LIVE2_REAL_HOOKS_DIR/pre-commit"
+
+# Absolute target, naming the live worktree's OWN hooks/pre-commit - the
+# same shape install_precommit_hook's KNOWN-RESIDUAL fallback produces,
+# but for a worktree that has NOT been removed (still genuinely live).
+mkdir -p "$LIVE2_REAL_HOOKS_DIR"
+ln -s "$LIVE2_WT/hooks/pre-commit" "$LIVE2_HOOK_DST"
+
+if [[ -e "$LIVE2_HOOK_DST" ]]; then
+  _pass "Test 25 setup: absolute live-worktree target resolves correctly (genuinely live, not dangling)"
+else
+  _fail "Test 25 setup: absolute live-worktree target does NOT resolve at $LIVE2_HOOK_DST (fixture bug, not a library bug)"
+fi
+
+LIVE2_OUT="$(uninstall_precommit_hook "$LIVE2_MAIN" 2>&1)"
+
+if [[ -L "$LIVE2_HOOK_DST" ]] && [[ -e "$LIVE2_HOOK_DST" ]]; then
+  _pass "Test 25 (danglingness-gate existence): an ABSOLUTE target naming a LIVE, still-existing worktree is PRESERVED, not deleted. Output: $LIVE2_OUT"
+else
+  _fail "Test 25 (danglingness-gate existence regression): a LIVE worktree's absolute-target hook was deleted - the danglingness gate is missing or broken independent of ordering. Output: $LIVE2_OUT"
+fi
+
+# ============================================================
+# Test 26: depth-2 evidence (round-3 Major 2) -
+#          content/references/subagent-protocol.md:333-334's own
+#          documented, copy-pasteable worktree-add command uses a
+#          FEATURE_BRANCH value that, per this repo's branch-naming
+#          convention (content/rules/conventions.md), takes the form
+#          "feature/<name>" / "fix/<name>" / "chore/<name>" - so the
+#          resulting worktree lands at
+#          ".worktrees/feature/<name>-<unit_slug>", TWO path components
+#          below ".worktrees", not one. A fixed single-strip
+#          implementation would compute ".worktrees/feature" as the
+#          candidate root, matching nothing, and leave a genuine orphan
+#          uncleaned (visible only as a DANGLING warning, not silent -
+#          Major, not Critical, per the round-3 finding).
+# ============================================================
+
+DEPTH2_MAIN="$TMP_ROOT/depth2-main-repo"
+_make_fixture_repo "$DEPTH2_MAIN"
+mkdir -p "$DEPTH2_MAIN/.worktrees"
+
+DEPTH2_WT="$DEPTH2_MAIN/.worktrees/feature/my-thing-unit1"
+git -C "$DEPTH2_MAIN" worktree add -q "$DEPTH2_WT" -b feature/my-thing-unit1 >/dev/null 2>&1
+
+if [[ -d "$DEPTH2_WT/hooks" ]]; then
+  _pass "Test 26 setup: depth-2 worktree fixture created at $DEPTH2_WT (two path components below .worktrees, matching subagent-protocol.md's own FEATURE_BRANCH=feature/<name> example)"
+else
+  _fail "Test 26 setup: depth-2 worktree fixture missing at $DEPTH2_WT (fixture setup bug)"
+fi
+
+DEPTH2_REAL_HOOKS_DIR="$(git -C "$DEPTH2_MAIN" rev-parse --git-path hooks)"
+case "$DEPTH2_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DEPTH2_REAL_HOOKS_DIR="$DEPTH2_MAIN/$DEPTH2_REAL_HOOKS_DIR" ;;
+esac
+DEPTH2_HOOK_DST="$DEPTH2_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$DEPTH2_REAL_HOOKS_DIR"
+ln -s "$DEPTH2_WT/hooks/pre-commit" "$DEPTH2_HOOK_DST"
+
+git -C "$DEPTH2_MAIN" worktree remove -f "$DEPTH2_WT" >/dev/null 2>&1
+
+DEPTH2_OUT="$(uninstall_precommit_hook "$DEPTH2_MAIN" 2>&1)"
+
+if [[ ! -L "$DEPTH2_HOOK_DST" ]] && [[ ! -e "$DEPTH2_HOOK_DST" ]]; then
+  _pass "Test 26 (round-3 Major 2 fixed, depth-2 evidence): a dangling hook naming an already-removed depth-2 '.worktrees/feature/<name>-<unit>' worktree is removed by the bounded upward search. Output: $DEPTH2_OUT"
+else
+  _fail "Test 26 (round-3 Major 2 regression): depth-2 dangling hook still present at $DEPTH2_HOOK_DST - a fixed single-strip container computation cannot reach '.worktrees' from two levels down. Output: $DEPTH2_OUT"
+fi
+
+# Also exercise the equivalent AGENTS.md:48 hazard for .agentic/worktrees -
+# a branch name containing a slash (".agentic/worktrees/<branch-name>",
+# where <branch-name> is itself "fix/my-thing") lands the worktree at
+# depth 2 under .agentic/worktrees the same way.
+DEPTH2B_MAIN="$TMP_ROOT/depth2b-main-repo"
+_make_fixture_repo "$DEPTH2B_MAIN"
+mkdir -p "$DEPTH2B_MAIN/.agentic/worktrees"
+
+DEPTH2B_WT="$DEPTH2B_MAIN/.agentic/worktrees/fix/my-thing"
+git -C "$DEPTH2B_MAIN" worktree add -q "$DEPTH2B_WT" -b fix/my-thing >/dev/null 2>&1
+
+DEPTH2B_REAL_HOOKS_DIR="$(git -C "$DEPTH2B_MAIN" rev-parse --git-path hooks)"
+case "$DEPTH2B_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DEPTH2B_REAL_HOOKS_DIR="$DEPTH2B_MAIN/$DEPTH2B_REAL_HOOKS_DIR" ;;
+esac
+DEPTH2B_HOOK_DST="$DEPTH2B_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$DEPTH2B_REAL_HOOKS_DIR"
+ln -s "$DEPTH2B_WT/hooks/pre-commit" "$DEPTH2B_HOOK_DST"
+
+git -C "$DEPTH2B_MAIN" worktree remove -f "$DEPTH2B_WT" >/dev/null 2>&1
+
+DEPTH2B_OUT="$(uninstall_precommit_hook "$DEPTH2B_MAIN" 2>&1)"
+
+if [[ ! -L "$DEPTH2B_HOOK_DST" ]] && [[ ! -e "$DEPTH2B_HOOK_DST" ]]; then
+  _pass "Test 26 (depth-2 evidence, .agentic/worktrees/<slash-branch>): a dangling hook naming an already-removed depth-2 '.agentic/worktrees/fix/<name>' worktree (AGENTS.md:48's <branch-name> containing a slash) is removed. Output: $DEPTH2B_OUT"
+else
+  _fail "Test 26 (depth-2 evidence regression, .agentic/worktrees/<slash-branch>): dangling hook still present at $DEPTH2B_HOOK_DST. Output: $DEPTH2B_OUT"
+fi
+
+# ============================================================
+# Test 27: reverse-prefix guard (round-3 Minor 1) - Test 23 above only
+#          covers the FORWARD prefix direction (target is a superstring of
+#          a real candidate). The REVERSE direction is a distinct mutation
+#          class: `[[ "$canonical_candidate" == "$canonical_target_root"* ]]`
+#          would match whenever the ANCESTOR being tested canonicalizes to
+#          exactly <repo_dir> itself (or any ancestor of a real candidate),
+#          since every real candidate's path literally starts with
+#          <repo_dir> as a string prefix. Shipped code uses `==` (exact
+#          identity, symmetric), which is correct; this test pins that a
+#          reverse-direction prefix match would also be wrong, closing the
+#          sibling mutation class Test 23 does not reach.
+# ============================================================
+
+REVPFX_MAIN="$TMP_ROOT/revpfx-main-repo"
+_make_fixture_repo "$REVPFX_MAIN"
+mkdir -p "$REVPFX_MAIN/.claude/worktrees"
+
+# A dangling target whose "container" ancestor, at some depth of the
+# bounded upward walk, canonicalizes to <repo_dir> ITSELF - a real,
+# existing directory that is a PREFIX of every one of the four real
+# candidates' own paths (e.g. "$REVPFX_MAIN/.claude/worktrees" starts with
+# "$REVPFX_MAIN"). A reverse-prefix mutation would treat repo_dir itself
+# as matching "$REVPFX_MAIN/.claude/worktrees"* purely by string prefix
+# and delete a target rooted at the repo's OWN top-level directory - never
+# a real worktree-container relationship.
+REVPFX_ROGUE_DIR="$REVPFX_MAIN/some-unrelated-subdir"
+mkdir -p "$REVPFX_ROGUE_DIR/hooks"
+
+REVPFX_REAL_HOOKS_DIR="$(git -C "$REVPFX_MAIN" rev-parse --git-path hooks)"
+case "$REVPFX_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) REVPFX_REAL_HOOKS_DIR="$REVPFX_MAIN/$REVPFX_REAL_HOOKS_DIR" ;;
+esac
+REVPFX_HOOK_DST="$REVPFX_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$REVPFX_REAL_HOOKS_DIR"
+ln -s "$REVPFX_ROGUE_DIR/hooks/pre-commit" "$REVPFX_HOOK_DST"
+
+REVPFX_OUT="$(uninstall_precommit_hook "$REVPFX_MAIN" 2>&1)"
+
+if [[ -L "$REVPFX_HOOK_DST" ]]; then
+  _pass "Test 27 (reverse-prefix guard): a dangling target rooted at an unrelated top-level subdirectory of repo_dir (which is itself a string PREFIX of every real candidate) is left untouched"
+else
+  _fail "Test 27 (reverse-prefix guard regression): a dangling target under an unrelated repo-root subdirectory was incorrectly removed - the candidate comparison is matching by reverse prefix, not exact identity. Output: $REVPFX_OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -173,6 +173,23 @@
 #     literal subagent-protocol.md example shape) and for
 #     ".agentic/worktrees/" (the AGENTS.md sibling shape). Reddens against
 #     a reverted fixed-single-strip mutation of the container computation.
+#   - ".." escape guard (round 4, Minor 1 - round 3's ancestor walk
+#     derived ancestors by naively string-stripping the target's raw
+#     spelling, which is not ancestor-derivation when ".." segments
+#     appear after a container name: a target of
+#     "<repo>/.worktrees/../../../../../x/hooks/pre-commit" physically
+#     resolves far outside the repo, but the naive walk still reached
+#     "<repo>/.worktrees" - a real, canonicalizable candidate - and
+#     answered DELETE): Test 28, fixed by
+#     _precommit_lexical_normalize'ing the worktree directory once,
+#     before the walk begins.
+#   - Empty-hooks_dir guard coverage (round 4, Minor 2 - a documented
+#     FAILS-CLOSED clause, "hooks_dir is empty and target is relative",
+#     had zero assertion coverage; deleting the guard left the round-3
+#     suite unchanged): Test 29, constructed so the unguarded
+#     concatenation would reconstruct a real candidate path if the guard
+#     were absent - a weaker construction would not distinguish
+#     guard-present from guard-absent.
 #   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
@@ -1701,6 +1718,94 @@ if [[ -L "$REVPFX_HOOK_DST" ]]; then
   _pass "Test 27 (reverse-prefix guard): a dangling target rooted at an unrelated top-level subdirectory of repo_dir (which is itself a string PREFIX of every real candidate) is left untouched"
 else
   _fail "Test 27 (reverse-prefix guard regression): a dangling target under an unrelated repo-root subdirectory was incorrectly removed - the candidate comparison is matching by reverse prefix, not exact identity. Output: $REVPFX_OUT"
+fi
+
+# ============================================================
+# Test 28: ".." escape guard (round 4, Minor 1) - a dangling target whose
+#          SPELLING contains ".." segments after a real candidate name
+#          must be resolved LEXICALLY before the ancestor walk, not
+#          walked as a naive string-strip. The exact probe verified live
+#          by the round-4 Skeptic:
+#          "<repo>/.worktrees/../../../../../x/hooks/pre-commit" - a
+#          target that PHYSICALLY resolves far outside the repo (this
+#          fixture's own $TMP_ROOT, several levels above), but whose raw
+#          string, naively stripped one component at a time, still passes
+#          through "<repo>/.worktrees" - a real, canonicalizable
+#          candidate - and pre-fix answered DELETE. Round 2's fixed
+#          single-strip design answered KEEP for the same input (it never
+#          walked far enough to reach ".worktrees" from this depth), so
+#          round 3's bounded walk widened this class rather than closing
+#          it.
+# ============================================================
+
+DOTDOT_MAIN="$TMP_ROOT/dotdot-main-repo"
+_make_fixture_repo "$DOTDOT_MAIN"
+mkdir -p "$DOTDOT_MAIN/.worktrees"
+
+DOTDOT_REAL_HOOKS_DIR="$(git -C "$DOTDOT_MAIN" rev-parse --git-path hooks)"
+case "$DOTDOT_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DOTDOT_REAL_HOOKS_DIR="$DOTDOT_MAIN/$DOTDOT_REAL_HOOKS_DIR" ;;
+esac
+DOTDOT_HOOK_DST="$DOTDOT_REAL_HOOKS_DIR/pre-commit"
+
+# The exact probe from the round-4 finding, anchored at this fixture's own
+# repo - five ".." segments from ".worktrees" walk well above $TMP_ROOT
+# itself, landing at some entirely unrelated "/x/hooks/pre-commit".
+DOTDOT_ESCAPE_TARGET="$DOTDOT_MAIN/.worktrees/../../../../../x/hooks/pre-commit"
+mkdir -p "$DOTDOT_REAL_HOOKS_DIR"
+ln -s "$DOTDOT_ESCAPE_TARGET" "$DOTDOT_HOOK_DST"
+
+DOTDOT_OUT="$(uninstall_precommit_hook "$DOTDOT_MAIN" 2>&1)"
+
+if [[ -L "$DOTDOT_HOOK_DST" ]]; then
+  _pass "Test 28 (round-4 Minor 1 fixed, ..-escape guard): a dangling target whose spelling contains '..' segments reaching far outside the repo is left untouched (KEEP), not deleted by a naive string-ancestor match. Output: $DOTDOT_OUT"
+else
+  _fail "Test 28 (round-4 Minor 1 regression, ..-escape guard): a '..'-escaping dangling target was incorrectly removed - the ancestor walk is matching a string-stripped ancestor that is not a genuine ancestor of the resolved path. Output: $DOTDOT_OUT"
+fi
+
+# ============================================================
+# Test 29: empty-hooks_dir guard coverage (round 4, Minor 2) -
+#          _precommit_is_orphaned_worktree_target's own manifest documents
+#          "<hooks_dir> is empty and <target> is relative" as a
+#          FAILS-CLOSED case, but nothing asserted it: deleting
+#          `[[ -z "$hooks_dir" ]] && return 1` left the round-3 suite at
+#          79/0 unchanged. Unreachable from any of this file's other
+#          fixtures (uninstall_precommit_hook always resolves a real
+#          hooks_dir before calling in), so this test calls the internal
+#          helper directly with an empty hooks_dir - the only way to
+#          exercise this documented invariant at all.
+#
+#          A weaker construction (an arbitrary relative target under an
+#          arbitrary repo_dir) does NOT distinguish "guard present" from
+#          "guard absent": with hooks_dir="", the unguarded concatenation
+#          `target="$hooks_dir/$target"` still produces SOME absolute-
+#          looking string ("/$target"), and an arbitrary such string
+#          almost never happens to walk through a real candidate
+#          directory regardless of the guard - so deleting the guard
+#          would silently pass a naively-constructed test too. This
+#          fixture instead constructs the relative target to be exactly
+#          repo_dir's OWN path with its leading "/" stripped, followed by
+#          a real candidate suffix - so the unguarded concatenation
+#          "" + "/" + target reconstructs repo_dir's real, EXISTING
+#          ".claude/worktrees" candidate exactly, which the guard's
+#          absence would then let match.
+# ============================================================
+
+EMPTYHD_REPO="$TMP_ROOT/emptyhd-repo"
+mkdir -p "$EMPTYHD_REPO/.claude/worktrees"
+
+EMPTYHD_TARGET_RELATIVE="${EMPTYHD_REPO#/}/.claude/worktrees/some-nonexistent-worktree/hooks/pre-commit"
+
+EMPTYHD_RESULT_RC=1
+if _precommit_is_orphaned_worktree_target "$EMPTYHD_TARGET_RELATIVE" "$EMPTYHD_REPO" ""; then
+  EMPTYHD_RESULT_RC=0
+fi
+
+if [[ $EMPTYHD_RESULT_RC -eq 1 ]]; then
+  _pass "Test 29 (round-4 Minor 2 fixed, empty-hooks_dir guard): a relative target with an empty hooks_dir anchor fails closed (returns 1, not ours) even when the unguarded concatenation would reconstruct a real candidate path"
+else
+  _fail "Test 29 (round-4 Minor 2 regression, empty-hooks_dir guard): a relative target with an empty hooks_dir anchor was NOT rejected - the documented FAILS-CLOSED clause for this case has no effect"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -17,7 +17,14 @@
 # Public API: ./bin/tests/test_precommit_worktree.sh
 #             Exits 0 on all pass, 1 on any failure.
 #
-# Upstream deps: bash, git, mktemp.
+# Upstream deps: bash, git, mktemp. HARD dependency (the script `exit 1`s at
+#                startup if missing): bin/tests/lib/precommit-hook-guard.sh
+#                (real-hook save/restore, see the sandbox-guard block
+#                below). Optional: `timeout` or `gtimeout` (Test 18's hang
+#                guard is skipped with a printed SKIP line when neither is
+#                available and ${CI} is not "true"; hard-fails at startup
+#                under CI when neither is available - see the resolver
+#                block below).
 #
 # Downstream consumers: developer running locally before commit; can be
 #                       wired into CI (.github/workflows/bin-tests.yml).
@@ -30,9 +37,16 @@
 #                checksum alone is insufficient because `shasum` follows a
 #                symlink and hashes its resolved content, so it cannot
 #                detect a re-point at a byte-identical hooks/pre-commit in
-#                a different checkout; see Test 7).
+#                a different checkout; see Test 7 - plus, as of the sandbox
+#                guard below, bin/tests/lib/precommit-hook-guard.sh's own
+#                save/restore of the real hook as a second, independent
+#                layer). An ambient GIT_DIR (or its sibling env vars, or a
+#                global core.hooksPath) could otherwise make `git -C <dir>`
+#                silently ignore `-C` and operate against a DIFFERENT repo
+#                entirely - see Test 0 and Test 13.
 #
-# Performance: < 2 s wall time (pure git + shell, no network).
+# Performance: ~3 s wall time (pure git + shell, no network; 68 assertions
+#              across 23 fixture scenarios as of this revision).
 #
 # Regression coverage:
 #   - DS-58 (install side): `ln -s "$REPO_DIR/hooks/pre-commit"
@@ -82,6 +96,42 @@
 #     parent, non-canonical repo_dir spelling - the cross-version boundary
 #     where pre-this-PR code always used the raw spelling but the legacy
 #     candidate had become canonical-only): Test 12.
+#   - Sandbox guard (Test 0, Test 13): an ambient GIT_DIR (or sibling env
+#     vars, or a global core.hooksPath) makes `git -C <dir>` silently
+#     IGNORE `-C` and operate against a DIFFERENT repo - Test 13
+#     reproduces the escape directly (env-prefix scoped, never leaked into
+#     this script's own shell) and confirms resolve_git_hooks_dir fails
+#     closed with the guard genuinely in effect; Test 0 pins that the
+#     guard's `unset` block actually ran before any fixture.
+#   - Orphan cleanup, delta over #640 (live defect, reproduced against
+#     origin/main pre-fix - a dangling hook naming a DIFFERENT,
+#     already-removed worktree of the SAME repo can never match either of
+#     uninstall_precommit_hook's two exact-match candidates, both derived
+#     from the CURRENTLY invoking repo_dir): Test 14 (.claude/worktrees/),
+#     Test 15 (.agentic/worktrees/), Test 17 (a RELATIVE dangling target,
+#     anchored against the hooks dir per POSIX, not the process CWD),
+#     Test 20 (.worktrees/, added after Major 1 round 2 found the
+#     "fixed two-candidate shape" premise was false), Test 21
+#     (evals/.worktrees/, same round). Test 19 covers the deliberate
+#     positive-match case where the dangling target reaches one of these
+#     candidates through a symlink OUTSIDE the repo (still removed - see
+#     _precommit_is_orphaned_worktree_target's own manifest for why).
+#   - Distinct DANGLING warning (round 2, Major 2 predecessor bullet folded
+#     in here): a dangling hook matching none of the three
+#     uninstall_precommit_hook cases now gets a distinct "DANGLING"
+#     warning instead of the generic "points elsewhere" message - Test 16.
+#   - False-positive guard (a genuinely foreign dangling hook, or one with
+#     the RIGHT shape but the WRONG repo_dir, must never be deleted):
+#     Test 16 (outside any worktrees root entirely), Test 22 (re-run after
+#     Major 1 round 2 widened the candidate list to four - a same-shaped
+#     ".worktrees/<name>/hooks/pre-commit" target rooted at a different,
+#     unrelated repo must still be left alone).
+#   - Hang guard (Test 18): _precommit_is_orphaned_worktree_target must
+#     return promptly for a pathological, deeply-nested, non-existent
+#     dangling target - pins the deliberate choice not to implement a
+#     generic walk-up-the-target's-ancestors algorithm (see the helper's
+#     own manifest), so a future regression to an unguarded walk-up loop
+#     is caught by a timeout kill, not a silent merge.
 #   This test re-creates worktree fixtures for all of the above to prevent
 #   regression.
 
@@ -387,7 +437,7 @@ else
   _fail "uninstall-from-worktree case: uninstall_precommit_hook exited $RC. Output: $OUT"
 fi
 
-if [[ ! -e "$UNINSTALL_HOOK_DST" ]]; then
+if [[ ! -L "$UNINSTALL_HOOK_DST" ]] && [[ ! -e "$UNINSTALL_HOOK_DST" ]]; then
   _pass "uninstall-from-worktree case (DS-58 fixed): AE-owned pre-commit hook actually removed"
 else
   _fail "uninstall-from-worktree case (DS-58 regression): pre-commit hook still present at $UNINSTALL_HOOK_DST. Output: $OUT"
@@ -690,7 +740,7 @@ else
   _fail "Test 9 (Major 2): uninstall_precommit_hook exited $LEGACY_RC. Output: $LEGACY_OUT"
 fi
 
-if [[ ! -e "$LEGACY_HOOK_DST" ]]; then
+if [[ ! -L "$LEGACY_HOOK_DST" ]] && [[ ! -e "$LEGACY_HOOK_DST" ]]; then
   _pass "Test 9 (Major 2): legacy-targeted (pre-this-PR) hook is removed by uninstall"
 else
   _fail "Test 9 (Major 2 regression): legacy-targeted hook still present at $LEGACY_HOOK_DST after uninstall - orphaned, will dangle once the worktree is removed. Output: $LEGACY_OUT"
@@ -839,7 +889,7 @@ else
   _fail "Test 11 (Minor 3): uninstall_precommit_hook exited $CANON_UNINSTALL_RC. Output: $CANON_UNINSTALL_OUT"
 fi
 
-if [[ ! -e "$CANON_HOOK_DST" ]]; then
+if [[ ! -L "$CANON_HOOK_DST" ]] && [[ ! -e "$CANON_HOOK_DST" ]]; then
   _pass "Test 11 (Minor 3 fixed): hook installed via a trailing-slash repo_dir is correctly removed by uninstall using the canonical spelling"
 else
   _fail "Test 11 (Minor 3 regression): hook installed via a trailing-slash repo_dir was left ORPHANED by uninstall using the canonical spelling - legacy_hook_src is not canonicalized consistently with the installed target. Output: $CANON_UNINSTALL_OUT"
@@ -894,7 +944,7 @@ else
   _fail "Test 12 (Major 1): uninstall_precommit_hook exited $MAJOR1_RC. Output: $MAJOR1_OUT"
 fi
 
-if [[ ! -e "$MAJOR1_HOOK_DST" ]]; then
+if [[ ! -L "$MAJOR1_HOOK_DST" ]] && [[ ! -e "$MAJOR1_HOOK_DST" ]]; then
   _pass "Test 12 (Major 1 fixed): legacy hook installed under a non-canonical (symlinked-parent) spelling is removed by uninstall"
 else
   _fail "Test 12 (Major 1 regression): legacy hook installed under a non-canonical spelling was left ORPHANED by uninstall - the legacy candidate must match both the raw and the canonical repo_dir spellings. Output: $MAJOR1_OUT"
@@ -1159,6 +1209,210 @@ if [[ -n "$_TIMEOUT_BIN" ]]; then
   fi
 else
   echo "SKIP: Test 18 (hang guard) - neither timeout nor gtimeout available locally (non-CI); the CI guard above hard-fails this scenario when \${CI}=true"
+fi
+
+# ============================================================
+# Test 19: a dangling target that reaches one of the four enumerated
+#          worktrees-container candidates THROUGH a symlink located
+#          OUTSIDE <repo_dir> is still recognised and removed - the
+#          physical, `cd`-canonicalized container directory is what is
+#          compared, not the symlinked spelling of the path that reaches
+#          it. Documented as a deliberate positive-match case in the
+#          helper's own manifest (distinct from the FAILS-CLOSED
+#          enumeration, since it is a removal, not a refusal).
+# ============================================================
+
+SYMOUT_MAIN="$TMP_ROOT/symout-main-repo"
+_make_fixture_repo "$SYMOUT_MAIN"
+mkdir -p "$SYMOUT_MAIN/.claude/worktrees"
+
+SYMOUT_WT="$SYMOUT_MAIN/.claude/worktrees/agent-symout-test"
+git -C "$SYMOUT_MAIN" worktree add -q "$SYMOUT_WT" -b symout-wt-test-branch >/dev/null 2>&1
+
+# A symlink OUTSIDE $SYMOUT_MAIN that resolves into the real worktree - the
+# dangling target below is spelled THROUGH this external symlink, never
+# through $SYMOUT_MAIN's own (canonical) path.
+SYMOUT_EXTERNAL_LINK="$TMP_ROOT/symout-external-alias"
+ln -s "$SYMOUT_MAIN" "$SYMOUT_EXTERNAL_LINK"
+
+SYMOUT_REAL_HOOKS_DIR="$(git -C "$SYMOUT_MAIN" rev-parse --git-path hooks)"
+case "$SYMOUT_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) SYMOUT_REAL_HOOKS_DIR="$SYMOUT_MAIN/$SYMOUT_REAL_HOOKS_DIR" ;;
+esac
+SYMOUT_HOOK_DST="$SYMOUT_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$SYMOUT_REAL_HOOKS_DIR"
+ln -s "$SYMOUT_EXTERNAL_LINK/.claude/worktrees/agent-symout-test/hooks/pre-commit" "$SYMOUT_HOOK_DST"
+
+if [[ -L "$SYMOUT_HOOK_DST" ]] && [[ "$(readlink "$SYMOUT_HOOK_DST")" == "$SYMOUT_EXTERNAL_LINK"* ]]; then
+  _pass "Test 19 setup: hook installed via a target spelled through an EXTERNAL symlink, not the repo's own canonical path"
+else
+  _fail "Test 19 setup: hook not installed as expected at $SYMOUT_HOOK_DST"
+fi
+
+git -C "$SYMOUT_MAIN" worktree remove -f "$SYMOUT_WT" >/dev/null 2>&1
+
+SYMOUT_OUT="$(uninstall_precommit_hook "$SYMOUT_MAIN" 2>&1)"
+
+if [[ ! -L "$SYMOUT_HOOK_DST" ]] && [[ ! -e "$SYMOUT_HOOK_DST" ]]; then
+  _pass "Test 19 (symlink-outside-repo orphan cleanup): a dangling target reaching this repo's own .claude/worktrees THROUGH an external symlink is still removed. Output: $SYMOUT_OUT"
+else
+  _fail "Test 19 (symlink-outside-repo orphan cleanup regression): hook still present at $SYMOUT_HOOK_DST. Output: $SYMOUT_OUT"
+fi
+
+# ============================================================
+# Test 20: orphan cleanup, the ".worktrees/" candidate added for Major 1
+#          (content/references/subagent-protocol.md:333's manually-managed
+#          fan-out path, "${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug}").
+# ============================================================
+
+DOTWT_MAIN="$TMP_ROOT/dotwt-main-repo"
+_make_fixture_repo "$DOTWT_MAIN"
+mkdir -p "$DOTWT_MAIN/.worktrees"
+
+DOTWT_WT="$DOTWT_MAIN/.worktrees/feature-x-unit1"
+git -C "$DOTWT_MAIN" worktree add -q "$DOTWT_WT" -b feature-x-unit1 >/dev/null 2>&1
+
+DOTWT_REAL_HOOKS_DIR="$(git -C "$DOTWT_MAIN" rev-parse --git-path hooks)"
+case "$DOTWT_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DOTWT_REAL_HOOKS_DIR="$DOTWT_MAIN/$DOTWT_REAL_HOOKS_DIR" ;;
+esac
+DOTWT_HOOK_DST="$DOTWT_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$DOTWT_REAL_HOOKS_DIR"
+ln -s "$DOTWT_WT/hooks/pre-commit" "$DOTWT_HOOK_DST"
+
+git -C "$DOTWT_MAIN" worktree remove -f "$DOTWT_WT" >/dev/null 2>&1
+
+DOTWT_OUT="$(uninstall_precommit_hook "$DOTWT_MAIN" 2>&1)"
+
+if [[ ! -L "$DOTWT_HOOK_DST" ]] && [[ ! -e "$DOTWT_HOOK_DST" ]]; then
+  _pass "Test 20 (orphan cleanup, .worktrees/ candidate): dangling hook naming an already-removed .worktrees/ worktree is removed. Output: $DOTWT_OUT"
+else
+  _fail "Test 20 (orphan cleanup regression, .worktrees/): dangling hook still present at $DOTWT_HOOK_DST. Output: $DOTWT_OUT"
+fi
+
+# ============================================================
+# Test 21: orphan cleanup, the "evals/.worktrees/" candidate added for
+#          Major 1 (content/commands/ds-cleanup-worktrees.md:38's
+#          "evals/.worktrees/wt-*" instance).
+# ============================================================
+
+EVALSWT_MAIN="$TMP_ROOT/evalswt-main-repo"
+_make_fixture_repo "$EVALSWT_MAIN"
+mkdir -p "$EVALSWT_MAIN/evals/.worktrees"
+
+EVALSWT_WT="$EVALSWT_MAIN/evals/.worktrees/wt-abc123"
+git -C "$EVALSWT_MAIN" worktree add -q "$EVALSWT_WT" -b evalswt-test-branch >/dev/null 2>&1
+
+EVALSWT_REAL_HOOKS_DIR="$(git -C "$EVALSWT_MAIN" rev-parse --git-path hooks)"
+case "$EVALSWT_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) EVALSWT_REAL_HOOKS_DIR="$EVALSWT_MAIN/$EVALSWT_REAL_HOOKS_DIR" ;;
+esac
+EVALSWT_HOOK_DST="$EVALSWT_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$EVALSWT_REAL_HOOKS_DIR"
+ln -s "$EVALSWT_WT/hooks/pre-commit" "$EVALSWT_HOOK_DST"
+
+git -C "$EVALSWT_MAIN" worktree remove -f "$EVALSWT_WT" >/dev/null 2>&1
+
+EVALSWT_OUT="$(uninstall_precommit_hook "$EVALSWT_MAIN" 2>&1)"
+
+if [[ ! -L "$EVALSWT_HOOK_DST" ]] && [[ ! -e "$EVALSWT_HOOK_DST" ]]; then
+  _pass "Test 21 (orphan cleanup, evals/.worktrees/ candidate): dangling hook naming an already-removed evals/.worktrees/ worktree is removed. Output: $EVALSWT_OUT"
+else
+  _fail "Test 21 (orphan cleanup regression, evals/.worktrees/): dangling hook still present at $EVALSWT_HOOK_DST. Output: $EVALSWT_OUT"
+fi
+
+# ============================================================
+# Test 22: false-positive guard, re-run for the WIDENED candidate set - a
+#          dangling target whose shape matches a candidate (e.g.
+#          ".worktrees/<name>/hooks/pre-commit") but under a COMPLETELY
+#          DIFFERENT repo's own directory tree must NOT be recognised as
+#          this repo's orphan, even though the string shape is identical.
+#          The widened candidate list only ever compares against THIS
+#          repo_dir's own four candidate paths - never a generic pattern
+#          match - so a same-shaped target rooted at a different physical
+#          directory must fail closed.
+# ============================================================
+
+FOREIGN4_MAIN="$TMP_ROOT/foreign4-main-repo"
+_make_fixture_repo "$FOREIGN4_MAIN"
+
+FOREIGN4_OTHER_REPO="$TMP_ROOT/foreign4-other-repo"
+mkdir -p "$FOREIGN4_OTHER_REPO/.worktrees/some-other-feature/hooks"
+
+FOREIGN4_REAL_HOOKS_DIR="$(git -C "$FOREIGN4_MAIN" rev-parse --git-path hooks)"
+case "$FOREIGN4_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) FOREIGN4_REAL_HOOKS_DIR="$FOREIGN4_MAIN/$FOREIGN4_REAL_HOOKS_DIR" ;;
+esac
+FOREIGN4_HOOK_DST="$FOREIGN4_REAL_HOOKS_DIR/pre-commit"
+
+# Same SHAPE (".worktrees/<name>/hooks/pre-commit") as Test 20, but rooted
+# at a totally different, unrelated repo directory - never removed by
+# $FOREIGN4_MAIN's own uninstall run.
+FOREIGN4_UNRELATED_TARGET="$FOREIGN4_OTHER_REPO/.worktrees/some-other-feature/hooks/pre-commit"
+mkdir -p "$FOREIGN4_REAL_HOOKS_DIR"
+ln -s "$FOREIGN4_UNRELATED_TARGET" "$FOREIGN4_HOOK_DST"
+
+FOREIGN4_OUT="$(uninstall_precommit_hook "$FOREIGN4_MAIN" 2>&1)"
+
+if [[ -L "$FOREIGN4_HOOK_DST" ]] && [[ "$(readlink "$FOREIGN4_HOOK_DST")" == "$FOREIGN4_UNRELATED_TARGET" ]]; then
+  _pass "Test 22 (no over-match, widened candidate set): a same-shaped dangling hook rooted at a DIFFERENT repo's .worktrees/ is left untouched"
+else
+  _fail "Test 22 (over-match regression, widened candidate set): a same-shaped but foreign dangling hook was removed or altered. Output: $FOREIGN4_OUT"
+fi
+
+# ============================================================
+# Test 23: exact-match guard - a candidate comparison that degraded from
+#          exact string equality to a PREFIX match would still pass every
+#          test above (none of them constructs a sibling directory whose
+#          name happens to start with a real candidate's own path), so it
+#          is asserted directly here: a dangling hook rooted at
+#          "<repo_dir>/.worktrees-decoy" (a real, EXISTING sibling
+#          directory of "<repo_dir>/.worktrees" that is NOT itself a
+#          recognised candidate, and is not a prefix-relationship
+#          coincidence - it merely SHARES ".worktrees" as its own string
+#          prefix) must be left untouched. A `==` comparison correctly
+#          distinguishes these; a `== *` glob comparison would not.
+# ============================================================
+
+DECOY_MAIN="$TMP_ROOT/decoy-main-repo"
+_make_fixture_repo "$DECOY_MAIN"
+# The REAL ".worktrees" candidate must also exist (even though unused) so
+# that a prefix-match mutation has something real to match AGAINST - if
+# only the decoy directory existed, the real candidate's own `cd` would
+# fail and skip the comparison entirely, making this fixture unable to
+# distinguish exact-match from prefix-match regardless of which the
+# library actually implements.
+mkdir -p "$DECOY_MAIN/.worktrees"
+mkdir -p "$DECOY_MAIN/.worktrees-decoy"
+
+DECOY_WT="$DECOY_MAIN/.worktrees-decoy/some-unrelated-dir"
+git -C "$DECOY_MAIN" worktree add -q "$DECOY_WT" -b decoy-test-branch >/dev/null 2>&1
+
+DECOY_REAL_HOOKS_DIR="$(git -C "$DECOY_MAIN" rev-parse --git-path hooks)"
+case "$DECOY_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) DECOY_REAL_HOOKS_DIR="$DECOY_MAIN/$DECOY_REAL_HOOKS_DIR" ;;
+esac
+DECOY_HOOK_DST="$DECOY_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$DECOY_REAL_HOOKS_DIR"
+ln -s "$DECOY_WT/hooks/pre-commit" "$DECOY_HOOK_DST"
+
+git -C "$DECOY_MAIN" worktree remove -f "$DECOY_WT" >/dev/null 2>&1
+
+DECOY_OUT="$(uninstall_precommit_hook "$DECOY_MAIN" 2>&1)"
+
+if [[ -L "$DECOY_HOOK_DST" ]]; then
+  _pass "Test 23 (exact-match guard): a dangling hook rooted at a sibling '.worktrees-decoy' directory (shares a string PREFIX with the real '.worktrees' candidate, but is not it) is left untouched"
+else
+  _fail "Test 23 (exact-match guard regression): a dangling hook under a merely-prefix-sharing sibling directory was incorrectly removed - the candidate comparison is matching by prefix, not exact identity. Output: $DECOY_OUT"
 fi
 
 # ---- Results ----

--- a/bin/tests/test_precommit_worktree.sh
+++ b/bin/tests/test_precommit_worktree.sh
@@ -87,13 +87,97 @@
 
 set -uo pipefail
 
+# Sandbox guard, FIRST executable statement: an ambient GIT_DIR (or its
+# siblings) makes `git -C <dir>` silently IGNORE `-C` and operate on
+# whatever repo the ambient env points at instead - reproduced directly by
+# Test 13 below. Every fixture in this file passes an explicit repo_dir to
+# resolve_git_hooks_dir/resolve_hook_src/install_precommit_hook/
+# uninstall_precommit_hook expecting `-C` to be honoured; an ambient GIT_DIR
+# defeats that silently and can make this file's fixtures operate on an
+# unrelated repo's real hooks (in the worst case, the actual DinoStack
+# checkout's own .git/hooks, if this test happens to run from a session
+# that leaked GIT_DIR into its environment). Unset the full family, not
+# just GIT_DIR - GIT_WORK_TREE/_COMMON_DIR/_INDEX_FILE/_OBJECT_DIRECTORY/
+# _ALTERNATE_OBJECT_DIRECTORIES/_CEILING_DIRECTORIES can each independently
+# redirect git's notion of "which repo" or "which objects".
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CEILING_DIRECTORIES
+
+# A global (or system) `core.hooksPath` is honoured by `--git-path hooks`
+# and is NOT covered by the unset list above (it is read from config, not
+# env) - point both config scopes at /dev/null so no ambient
+# ~/.gitconfig-level hooksPath override can redirect any fixture's
+# resolved hooks directory either.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 LIB="$REPO_DIR/scripts/lib/precommit.sh"
+GUARD_LIB="$REPO_DIR/bin/tests/lib/precommit-hook-guard.sh"
 
 if [[ ! -f "$LIB" ]]; then
   echo "FAIL: $LIB not found" >&2
   exit 1
 fi
+
+if [[ ! -f "$GUARD_LIB" ]]; then
+  echo "FAIL: $GUARD_LIB not found" >&2
+  exit 1
+fi
+
+# shellcheck source=bin/tests/lib/precommit-hook-guard.sh
+. "$GUARD_LIB"
+
+PASS=0
+FAIL=0
+
+_fail() {
+  echo "FAIL: $1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+_pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# Test 0: the sandbox guard above actually took effect in THIS shell before
+# any fixture runs - asserted directly rather than merely trusted. Uses
+# `env` + a literal name list rather than bash's `${!_v}` indirect
+# expansion, which is NOT valid syntax under zsh (this suite is required to
+# pass under both).
+_SANDBOX_GUARD_CLEAN=1
+if env | grep -qE '^(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_CEILING_DIRECTORIES)='; then
+  _SANDBOX_GUARD_CLEAN=0
+fi
+if [[ "$_SANDBOX_GUARD_CLEAN" -eq 1 ]]; then
+  _pass "Test 0 (sandbox guard): all seven ambient git env vars are unset before any fixture runs"
+else
+  _fail "Test 0 (sandbox guard regression): at least one ambient git env var is still set"
+fi
+
+# Resolve a timeout binary once - required to make any hang-guard assertion
+# (Test 18) meaningful. Without a real resolver, a `timeout`-wrapped
+# assertion silently returns 127 (command not found) and the comparison
+# against a non-124 rc passes having tested nothing. Hard-fail under CI
+# rather than silently skip (same pattern as
+# bin/tests/test_check_resident_budget.sh's own guard).
+_TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  _TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  _TIMEOUT_BIN="gtimeout"
+elif [[ "${CI:-}" == "true" ]]; then
+  echo "FAIL: neither timeout nor gtimeout is available under CI - the hang-guard assertion (Test 18) cannot run and must not silently pass" >&2
+  exit 1
+fi
+
+# Belt-and-suspenders: even with the env sandbox guard above, snapshot and
+# guarantee restoration of this REAL checkout's own pre-commit hook, the
+# same guard bin/tests/test_uninstall_ds_prefix.sh and friends already rely
+# on for scripts that invoke real install/uninstall paths against the live
+# repo. This file's own fixtures never pass $REPO_DIR to install/uninstall
+# functions, but the guard is cheap and removes any doubt.
+precommit_hook_guard_save "$REPO_DIR"
 
 # Checksum the REAL checkout's actual hook before running anything, so Test 7
 # (below) can assert this test file never touched it. All fixtures in this
@@ -127,19 +211,6 @@ fi
 # shellcheck source=scripts/lib/precommit.sh
 . "$LIB"
 
-PASS=0
-FAIL=0
-
-_fail() {
-  echo "FAIL: $1" >&2
-  FAIL=$((FAIL + 1))
-}
-
-_pass() {
-  echo "PASS: $1"
-  PASS=$((PASS + 1))
-}
-
 # Stub matching the real per-adapter _ae_is_ours contract closely enough for
 # this test: nothing pre-existing points at another methodology checkout, so
 # it always reports "not ours" (never re-points a stale symlink).
@@ -157,6 +228,11 @@ TMP_ROOT="$(mktemp -d)"
 # semantically the same location but never string-equal.
 TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
 _cleanup() {
+  # Restore the real checkout's own hook FIRST (belt-and-suspenders; see
+  # the precommit_hook_guard_save call above), then remove the temp
+  # fixture root. Order matters only in that both must run unconditionally
+  # even if one of this file's assertions failed earlier.
+  precommit_hook_guard_restore
   [[ -n "${TMP_ROOT:-}" && -d "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
 }
 trap _cleanup EXIT
@@ -822,6 +898,267 @@ if [[ ! -e "$MAJOR1_HOOK_DST" ]]; then
   _pass "Test 12 (Major 1 fixed): legacy hook installed under a non-canonical (symlinked-parent) spelling is removed by uninstall"
 else
   _fail "Test 12 (Major 1 regression): legacy hook installed under a non-canonical spelling was left ORPHANED by uninstall - the legacy candidate must match both the raw and the canonical repo_dir spellings. Output: $MAJOR1_OUT"
+fi
+
+# ============================================================
+# Test 13: sandbox guard - reproduce the ambient-GIT_DIR escape class this
+#          file's top-of-script `unset` guard exists to prevent (a dangling
+#          target confirmed to reproduce against origin/main pre-fix: an
+#          ambient GIT_DIR makes `git -C <dir>` silently IGNORE `-C` and
+#          resolve against the ambient repo instead), using an isolated
+#          decoy repo under $TMP_ROOT - never the real checkout - then
+#          confirms the leak is scoped to a single command (env-prefix, not
+#          export) and that resolve_git_hooks_dir fails closed with the
+#          guard genuinely in effect.
+# ============================================================
+
+SANDBOX_DECOY_REPO="$TMP_ROOT/sandbox-decoy-repo"
+mkdir -p "$SANDBOX_DECOY_REPO"
+git init -q "$SANDBOX_DECOY_REPO"
+
+SANDBOX_PLAIN_DIR="$TMP_ROOT/sandbox-plain-dir"
+mkdir -p "$SANDBOX_PLAIN_DIR"
+
+# Env-PREFIX form (scoped to this one command only, never `export`) - proves
+# the vulnerability class without leaking GIT_DIR into this script's shell.
+SANDBOX_LEAK_OUT="$(GIT_DIR="$SANDBOX_DECOY_REPO/.git" git -C "$SANDBOX_PLAIN_DIR" rev-parse --git-path hooks 2>&1)"
+SANDBOX_LEAK_RC=$?
+
+if [[ $SANDBOX_LEAK_RC -eq 0 ]] && [[ "$SANDBOX_LEAK_OUT" == "$SANDBOX_DECOY_REPO/.git/hooks" ]]; then
+  _pass "Test 13 (sandbox guard): reproduces the ambient-GIT_DIR escape class - 'git -C <plain-dir>' silently resolves to a DIFFERENT repo's hooks dir ($SANDBOX_LEAK_OUT) instead of failing, when GIT_DIR is set"
+else
+  _fail "Test 13 setup: expected the ambient-GIT_DIR escape to reproduce (rc=$SANDBOX_LEAK_RC out=$SANDBOX_LEAK_OUT) - fixture does not demonstrate the vulnerability class this guard defends against"
+fi
+
+if [[ -z "${GIT_DIR:-}" ]]; then
+  _pass "Test 13 (sandbox guard): GIT_DIR was NOT leaked into this script's own shell by the demonstration above (env-prefix scoping worked)"
+else
+  _fail "Test 13 (sandbox guard regression): GIT_DIR leaked into this script's own shell: $GIT_DIR"
+fi
+
+if ! resolve_git_hooks_dir "$SANDBOX_PLAIN_DIR" >/dev/null 2>&1; then
+  _pass "Test 13 (sandbox guard): resolve_git_hooks_dir on a non-repo dir fails closed with no ambient GIT_DIR set (the guard is genuinely in effect for this file's own fixtures)"
+else
+  _fail "Test 13 (sandbox guard regression): resolve_git_hooks_dir unexpectedly succeeded on a non-repo, non-worktree dir"
+fi
+
+# ============================================================
+# Test 14: orphan cleanup (delta over #640) - a DANGLING pre-commit symlink
+#          whose target names a DIFFERENT, ALREADY-REMOVED worktree of this
+#          same repo under "<repo_dir>/.claude/worktrees/<name>" must be
+#          recognised and removed by uninstall_precommit_hook, even though
+#          neither of #640's two exact-match candidates (both derived from
+#          the CURRENTLY invoking repo_dir) can ever match it. Reproduced
+#          against origin/main pre-fix: the dangling symlink survives
+#          uninstall permanently ("not ours, skipping").
+# ============================================================
+
+ORPHAN_MAIN="$TMP_ROOT/orphan-main-repo"
+_make_fixture_repo "$ORPHAN_MAIN"
+mkdir -p "$ORPHAN_MAIN/.claude/worktrees"
+
+ORPHAN_WT="$ORPHAN_MAIN/.claude/worktrees/agent-orphan-test"
+git -C "$ORPHAN_MAIN" worktree add -q "$ORPHAN_WT" -b orphan-wt-test-branch >/dev/null 2>&1
+
+ORPHAN_REAL_HOOKS_DIR="$(git -C "$ORPHAN_MAIN" rev-parse --git-path hooks)"
+case "$ORPHAN_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) ORPHAN_REAL_HOOKS_DIR="$ORPHAN_MAIN/$ORPHAN_REAL_HOOKS_DIR" ;;
+esac
+ORPHAN_HOOK_DST="$ORPHAN_REAL_HOOKS_DIR/pre-commit"
+
+# Simulate a hook that was installed FROM the (now-gone) worktree - the
+# target names the worktree's own hooks/pre-commit, exactly what
+# install_precommit_hook's KNOWN-RESIDUAL fallback produces for this repo's
+# own isolation-worktree layout.
+mkdir -p "$ORPHAN_REAL_HOOKS_DIR"
+ln -s "$ORPHAN_WT/hooks/pre-commit" "$ORPHAN_HOOK_DST"
+
+if [[ -L "$ORPHAN_HOOK_DST" ]] && [[ "$(readlink "$ORPHAN_HOOK_DST")" == "$ORPHAN_WT/hooks/pre-commit" ]]; then
+  _pass "Test 14 setup: orphan-candidate hook installed, targeting the worktree's own hooks/pre-commit"
+else
+  _fail "Test 14 setup: orphan-candidate hook not installed as expected at $ORPHAN_HOOK_DST"
+fi
+
+git -C "$ORPHAN_MAIN" worktree remove -f "$ORPHAN_WT" >/dev/null 2>&1
+
+if [[ -L "$ORPHAN_HOOK_DST" ]] && [[ ! -e "$ORPHAN_HOOK_DST" ]]; then
+  _pass "Test 14 setup: hook is now a DANGLING symlink after the worktree was removed - reproduces the live defect's starting state"
+else
+  _fail "Test 14 setup: expected a dangling symlink at $ORPHAN_HOOK_DST after worktree removal"
+fi
+
+# Run uninstall from the PRIMARY checkout (ORPHAN_MAIN itself) - not from
+# the gone worktree, which no longer exists to run anything from. This is
+# the realistic trigger: a later uninstall run (e.g. via .claude/uninstall.sh
+# from the primary checkout) is the only remaining opportunity to clean up
+# an orphan left behind by a worktree that is already gone.
+ORPHAN_OUT="$(uninstall_precommit_hook "$ORPHAN_MAIN" 2>&1)"
+ORPHAN_RC=$?
+
+if [[ $ORPHAN_RC -eq 0 ]]; then
+  _pass "Test 14 (orphan cleanup): uninstall_precommit_hook exits 0"
+else
+  _fail "Test 14 (orphan cleanup): uninstall_precommit_hook exited $ORPHAN_RC. Output: $ORPHAN_OUT"
+fi
+
+if [[ ! -L "$ORPHAN_HOOK_DST" ]]; then
+  _pass "Test 14 (orphan cleanup, delta over #640): dangling hook naming an already-removed .claude/worktrees/ worktree is REMOVED. Output: $ORPHAN_OUT"
+else
+  _fail "Test 14 (orphan cleanup regression): dangling hook naming an already-removed worktree still present at $ORPHAN_HOOK_DST - the live defect this delta exists to fix. Output: $ORPHAN_OUT"
+fi
+
+# ============================================================
+# Test 15: orphan cleanup, the ".agentic/worktrees/" sibling layout.
+# ============================================================
+
+ORPHAN2_MAIN="$TMP_ROOT/orphan2-main-repo"
+_make_fixture_repo "$ORPHAN2_MAIN"
+mkdir -p "$ORPHAN2_MAIN/.agentic/worktrees"
+
+ORPHAN2_WT="$ORPHAN2_MAIN/.agentic/worktrees/some-feature-branch"
+git -C "$ORPHAN2_MAIN" worktree add -q "$ORPHAN2_WT" -b some-feature-branch >/dev/null 2>&1
+
+ORPHAN2_REAL_HOOKS_DIR="$(git -C "$ORPHAN2_MAIN" rev-parse --git-path hooks)"
+case "$ORPHAN2_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) ORPHAN2_REAL_HOOKS_DIR="$ORPHAN2_MAIN/$ORPHAN2_REAL_HOOKS_DIR" ;;
+esac
+ORPHAN2_HOOK_DST="$ORPHAN2_REAL_HOOKS_DIR/pre-commit"
+
+mkdir -p "$ORPHAN2_REAL_HOOKS_DIR"
+ln -s "$ORPHAN2_WT/hooks/pre-commit" "$ORPHAN2_HOOK_DST"
+
+git -C "$ORPHAN2_MAIN" worktree remove -f "$ORPHAN2_WT" >/dev/null 2>&1
+
+ORPHAN2_OUT="$(uninstall_precommit_hook "$ORPHAN2_MAIN" 2>&1)"
+
+if [[ ! -L "$ORPHAN2_HOOK_DST" ]]; then
+  _pass "Test 15 (orphan cleanup, .agentic/worktrees/): dangling hook naming an already-removed .agentic/worktrees/ worktree is removed. Output: $ORPHAN2_OUT"
+else
+  _fail "Test 15 (orphan cleanup regression, .agentic/worktrees/): dangling hook still present at $ORPHAN2_HOOK_DST. Output: $ORPHAN2_OUT"
+fi
+
+# ============================================================
+# Test 16: false-positive guard - a dangling hook pointing OUTSIDE any
+#          worktrees root (a genuinely foreign, unrelated project) must be
+#          left untouched, and gets the NEW distinct "DANGLING" warning
+#          rather than the generic "points elsewhere" message, so a
+#          permanently-broken foreign hook stays visible instead of being
+#          silently tolerated forever.
+# ============================================================
+
+FOREIGN3_MAIN="$TMP_ROOT/foreign3-main-repo"
+_make_fixture_repo "$FOREIGN3_MAIN"
+
+FOREIGN3_REAL_HOOKS_DIR="$(git -C "$FOREIGN3_MAIN" rev-parse --git-path hooks)"
+case "$FOREIGN3_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) FOREIGN3_REAL_HOOKS_DIR="$FOREIGN3_MAIN/$FOREIGN3_REAL_HOOKS_DIR" ;;
+esac
+FOREIGN3_HOOK_DST="$FOREIGN3_REAL_HOOKS_DIR/pre-commit"
+
+# Points at a path that superficially resembles the orphan shape (ends in
+# "/hooks/pre-commit") but is NOT under this repo's .claude/worktrees or
+# .agentic/worktrees at all - e.g. some unrelated scratch checkout.
+FOREIGN3_UNRELATED_TARGET="$TMP_ROOT/some-other-project/scratch/hooks/pre-commit"
+mkdir -p "$FOREIGN3_REAL_HOOKS_DIR"
+ln -s "$FOREIGN3_UNRELATED_TARGET" "$FOREIGN3_HOOK_DST"
+
+FOREIGN3_OUT="$(uninstall_precommit_hook "$FOREIGN3_MAIN" 2>&1)"
+
+if [[ -L "$FOREIGN3_HOOK_DST" ]] && [[ "$(readlink "$FOREIGN3_HOOK_DST")" == "$FOREIGN3_UNRELATED_TARGET" ]]; then
+  _pass "Test 16 (no over-match): a dangling hook pointing outside any worktrees root is left untouched, not deleted as a false-positive orphan"
+else
+  _fail "Test 16 (over-match regression): a genuinely foreign dangling hook was removed or altered. Output: $FOREIGN3_OUT"
+fi
+
+if echo "$FOREIGN3_OUT" | grep -qi "DANGLING"; then
+  _pass "Test 16 (distinct dangling warning): the foreign dangling hook gets the new distinct DANGLING warning, not just the generic 'points elsewhere' message"
+else
+  _fail "Test 16 regression: expected a distinct DANGLING warning for an unresolvable, non-orphan hook. Output: $FOREIGN3_OUT"
+fi
+
+# ============================================================
+# Test 17: orphan cleanup also recognises a RELATIVE dangling target,
+#          anchored against the hooks dir per POSIX symlink-resolution
+#          semantics (relative to the symlink's OWN directory, never the
+#          process CWD) - not merely the absolute-target shape every other
+#          orphan test above exercises.
+# ============================================================
+
+ORPHAN3_MAIN="$TMP_ROOT/orphan3-main-repo"
+_make_fixture_repo "$ORPHAN3_MAIN"
+mkdir -p "$ORPHAN3_MAIN/.claude/worktrees"
+
+ORPHAN3_WT="$ORPHAN3_MAIN/.claude/worktrees/agent-relative-test"
+git -C "$ORPHAN3_MAIN" worktree add -q "$ORPHAN3_WT" -b orphan3-wt-test-branch >/dev/null 2>&1
+
+ORPHAN3_REAL_HOOKS_DIR="$(git -C "$ORPHAN3_MAIN" rev-parse --git-path hooks)"
+case "$ORPHAN3_REAL_HOOKS_DIR" in
+  /*) : ;;
+  *) ORPHAN3_REAL_HOOKS_DIR="$ORPHAN3_MAIN/$ORPHAN3_REAL_HOOKS_DIR" ;;
+esac
+ORPHAN3_HOOK_DST="$ORPHAN3_REAL_HOOKS_DIR/pre-commit"
+
+# A RELATIVE target from the real hooks dir to the worktree's own
+# hooks/pre-commit (computed with python's relpath equivalent via a plain
+# `..` walk, since both paths are already known and fixed for this
+# fixture).
+ORPHAN3_RELATIVE_TARGET="../../.claude/worktrees/agent-relative-test/hooks/pre-commit"
+mkdir -p "$ORPHAN3_REAL_HOOKS_DIR"
+ln -s "$ORPHAN3_RELATIVE_TARGET" "$ORPHAN3_HOOK_DST"
+
+# Confirm the relative link actually resolves to the real fixture file
+# BEFORE worktree removal (i.e. the relative-path arithmetic above is
+# correct for this fixture's real directory depth), so a failure below is
+# never mistaken for a fixture bug.
+if [[ -e "$ORPHAN3_HOOK_DST" ]]; then
+  _pass "Test 17 setup: relative-target symlink resolves correctly before worktree removal (fixture arithmetic confirmed)"
+else
+  _fail "Test 17 setup: relative-target symlink does NOT resolve before worktree removal at $ORPHAN3_HOOK_DST -> $ORPHAN3_RELATIVE_TARGET (fixture bug, not a library bug)"
+fi
+
+git -C "$ORPHAN3_MAIN" worktree remove -f "$ORPHAN3_WT" >/dev/null 2>&1
+
+ORPHAN3_OUT="$(uninstall_precommit_hook "$ORPHAN3_MAIN" 2>&1)"
+
+if [[ ! -L "$ORPHAN3_HOOK_DST" ]]; then
+  _pass "Test 17 (relative-target orphan cleanup): a RELATIVE dangling target naming an already-removed worktree is also removed. Output: $ORPHAN3_OUT"
+else
+  _fail "Test 17 (relative-target orphan cleanup regression): relative-target dangling hook still present at $ORPHAN3_HOOK_DST. Output: $ORPHAN3_OUT"
+fi
+
+# ============================================================
+# Test 18: hang guard - _precommit_is_orphaned_worktree_target must return
+#          PROMPTLY even for a pathological, deeply-nested, entirely
+#          non-existent dangling target. This module deliberately does NOT
+#          implement a generic walk-up-the-target's-ancestors algorithm
+#          (see the function's own manifest for why) specifically to avoid
+#          needing an unbounded-loop termination guard; this test pins that
+#          design choice so a future edit that reintroduces a walk-up loop
+#          without a termination guard is caught by a hang, not a silent
+#          merge.
+# ============================================================
+
+if [[ -n "$_TIMEOUT_BIN" ]]; then
+  HANG_REPO="$TMP_ROOT/hang-repo"
+  _make_fixture_repo "$HANG_REPO"
+  mkdir -p "$HANG_REPO/.claude/worktrees"
+  PATHOLOGICAL_TARGET="/nope/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/hooks/pre-commit"
+
+  "$_TIMEOUT_BIN" 5 bash -c '. "$1"; _ae_is_ours() { return 1; }; _precommit_is_orphaned_worktree_target "$2" "$3" "$4"' _ "$LIB" "$PATHOLOGICAL_TARGET" "$HANG_REPO" "$HANG_REPO/.git/hooks" >/dev/null 2>&1
+  HANG_RC=$?
+  # 124 is `timeout`'s own "killed after timeout" exit code - anything else
+  # (0 or 1, the function's real true/false result) proves it returned
+  # promptly rather than hanging.
+  if [[ $HANG_RC -ne 124 ]]; then
+    _pass "Test 18 (hang guard): _precommit_is_orphaned_worktree_target returns promptly for a pathological non-existent target (rc=$HANG_RC, not a timeout-124 kill)"
+  else
+    _fail "Test 18 (hang guard regression): _precommit_is_orphaned_worktree_target HUNG on a pathological target and was killed by timeout after 5s"
+  fi
+else
+  echo "SKIP: Test 18 (hang guard) - neither timeout nor gtimeout available locally (non-CI); the CI guard above hard-fails this scenario when \${CI}=true"
 fi
 
 # ---- Results ----

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -201,6 +201,79 @@
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
+# _precommit_lexical_normalize <path>
+#   Internal helper (not part of the public API). Pure STRING (never
+#   filesystem) normalization of an ABSOLUTE path: drops "." segments,
+#   resolves ".." segments against whichever real segment immediately
+#   precedes them, and treats an excess ".." at the root as a no-op
+#   (matching POSIX path resolution - you cannot go above "/"). Must be
+#   pure-string, not `cd`-based, because the input here is frequently a
+#   DANGLING path (or an intermediate ancestor of one) that does not exist
+#   on disk and so cannot be resolved via `cd + pwd -P`.
+#
+#   Exists to close a round-4 Minor:
+#   _precommit_is_orphaned_worktree_target's ancestor walk previously
+#   derived ancestors via naive string-stripping (`${ancestor%/*}`)
+#   directly on the target's raw (possibly ".."-laden) spelling. A target
+#   of "<repo_dir>/.worktrees/../../../../../x/hooks/pre-commit" is NOT
+#   ancestor-derived by stripping one trailing component at a time - each
+#   ".." must be resolved against what precedes it FIRST, or the walk
+#   reaches ancestors that were never really on the path. Verified live:
+#   that exact target physically resolves far outside the repo, but naive
+#   stripping still reached "<repo_dir>/.worktrees" as one of its
+#   "ancestors" - a real, canonicalizable candidate - and answered DELETE;
+#   round 2's fixed single-strip correctly answered KEEP for the same
+#   input, so the round-3 walk widened this class rather than closing it.
+#   Normalizing the string ONCE, before the walk begins, makes every
+#   subsequent single-component strip a genuine ancestor step, restoring
+#   the manifest's "always compares two REAL, cd-canonicalized ancestors"
+#   claim to actually being true (each compared ancestor was still real
+#   and cd-canonicalized before this fix - what was false is that the
+#   STRING fed into that comparison chain was not always a genuine
+#   ancestor path in the first place).
+#
+#   Only meaningful for an ABSOLUTE path - by the time either call site in
+#   this file invokes it, the input has already been anchored to absolute
+#   form (resolve_hook_src's targets are always absolute; this function's
+#   own caller anchors a relative readlink() target against hooks_dir
+#   before ever reaching here). A relative input is echoed back unchanged
+#   rather than guessed at, since "ancestor of what" is undefined without
+#   an anchor.
+# ---------------------------------------------------------------------------
+_precommit_lexical_normalize() {
+  local path="$1"
+  case "$path" in
+    /*) : ;;
+    *) echo "$path"; return 0 ;;
+  esac
+
+  local remaining="$path" stack="" seg
+  while [[ -n "$remaining" ]]; do
+    seg="${remaining%%/*}"
+    if [[ "$seg" == "$remaining" ]]; then
+      remaining=""
+    else
+      remaining="${remaining#*/}"
+    fi
+    case "$seg" in
+      "" | ".") : ;;
+      "..")
+        [[ -n "$stack" ]] && stack="${stack%/*}"
+        ;;
+      *)
+        stack="$stack/$seg"
+        ;;
+    esac
+  done
+
+  if [[ -z "$stack" ]]; then
+    echo "/"
+  else
+    echo "$stack"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # _precommit_canonical_repo_dir <repo_dir>
 #   Internal helper (not part of the public API). Echoes the physical,
 #   symlink-resolved, trailing-slash-free form of <repo_dir> via
@@ -406,6 +479,15 @@ _precommit_is_orphaned_worktree_target() {
 
   local worktree_dir="${target%/hooks/pre-commit}"
   [[ "$worktree_dir" == "$target" || -z "$worktree_dir" ]] && return 1
+
+  # Resolve any "." / ".." segments in the (possibly dangling, possibly
+  # entirely non-existent) target spelling BEFORE the ancestor walk below
+  # begins - see _precommit_lexical_normalize's own manifest for why
+  # walking the RAW string is not ancestor-derivation when ".." is
+  # present. A no-op for the overwhelmingly common case (no "." or ".."
+  # in the spelling at all).
+  worktree_dir="$(_precommit_lexical_normalize "$worktree_dir")"
+  [[ -z "$worktree_dir" ]] && return 1
 
   # BOUNDED upward search: the worktree's own directory is not always
   # exactly one path component below its container (see this function's

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -83,6 +83,19 @@
 #     reason, prints a non-fatal warning and returns 0 - never aborts the
 #     caller.
 #
+#     A THIRD case is also recognised, orthogonal to the two exact-match
+#     candidates above: a DANGLING symlink whose target names a DIFFERENT,
+#     already-removed worktree of this same repo (neither exact-match
+#     candidate is derived from a gone worktree's path, so this case can
+#     never be caught by them - see _precommit_is_orphaned_worktree_target).
+#     This is what "uninstall" means for that stale entry: no live worktree
+#     remains to uninstall FROM, so the only actionable owner is whichever
+#     current repo_dir's uninstall run happens to notice the dangling link.
+#     A dangling hook that does NOT match any of the three cases gets a
+#     distinct "DANGLING" warning (see below) instead of the generic
+#     "points elsewhere" message, so a permanently-broken hook stays
+#     visible on every run rather than being silently tolerated forever.
+#
 # Upstream dependencies:
 #   git (rev-parse --git-path / --git-dir / --git-common-dir), the COMMON
 #   repo's hooks/pre-commit source file (the caller's own
@@ -169,6 +182,124 @@ _precommit_canonical_repo_dir() {
     return 0
   fi
   (cd "$d" 2>/dev/null && pwd -P) || echo "$d"
+}
+
+# ---------------------------------------------------------------------------
+# _precommit_is_orphaned_worktree_target <target> <repo_dir> <hooks_dir>
+#   Internal helper (not part of the public API). Returns 0 (true) iff
+#   <target> - the readlink() of a DANGLING pre-commit symlink, i.e. it has
+#   already been confirmed `[[ ! -e "$target" ]]` by the caller - is a
+#   hook that WOULD have been installed by this module's own
+#   install_precommit_hook for some OTHER, now-removed worktree of the
+#   SAME repo (<repo_dir>, already canonicalized by the caller): a dangling
+#   target ending in "/hooks/pre-commit" whose containing "worktrees"
+#   directory sits directly under "<repo_dir>/.claude/worktrees" or
+#   "<repo_dir>/.agentic/worktrees" - the two locations this repo's own
+#   tooling creates isolation/feature worktrees under (see
+#   content/references/worktree-lifecycle.md). uninstall_precommit_hook's
+#   two existing exact-match candidates (hook_src, legacy_hook_src_*) are
+#   both derived from the CURRENTLY INVOKING repo_dir and so can never
+#   match a target naming a *different*, already-deleted worktree - this
+#   helper is the third, narrower candidate that closes exactly that gap.
+#
+#   Deliberately does NOT use a generic walk-up-the-target's-ancestors
+#   algorithm (canonicalize the target's longest existing ancestor and
+#   re-append the missing tail) - that approach was considered and
+#   rejected for two reasons: (1) it requires an explicit termination
+#   guard against a slash-free non-existent path component (a bare
+#   `${x%/*}` is a no-op there, so an unguarded loop hangs and grows
+#   memory unboundedly - a hazard that does NOT exist on origin/main today
+#   and this helper must not introduce), and (2) it is unnecessary here:
+#   this repo's worktree layout is a FIXED, two-candidate shape
+#   ("<repo_dir>/.claude/worktrees/<name>/hooks/pre-commit" or the
+#   ".agentic/" sibling), so the anchor to canonicalize is already known
+#   up front - "<repo_dir>/.claude/worktrees" or "<repo_dir>/.agentic/worktrees"
+#   - and can be canonicalized directly with a single `cd + pwd -P per
+#   candidate (bounded, no loop) rather than discovered by walking. String
+#   manipulation on the (possibly non-canonical, non-existent) target is
+#   used ONLY to test its coarse SHAPE - does it plausibly look like
+#   ".../.claude/worktrees/<name>/hooks/pre-commit"? - before any
+#   filesystem call; the actual containment decision is always made by
+#   comparing two REAL, `cd`-canonicalized, existing directories
+#   (<repo_dir>'s own ".claude/worktrees" or ".agentic/worktrees", and the
+#   target's own "worktrees" segment, when that segment still exists on
+#   disk) - so a symlinked path component anywhere in either side is
+#   resolved correctly by `cd`, never by fragile string comparison.
+#
+#   A RELATIVE target (readlink() can return either form) is anchored
+#   against <hooks_dir> per POSIX symlink-resolution semantics (relative
+#   to the symlink's OWN directory, never the process's CWD) before the
+#   shape test - never resolved against $PWD.
+#
+#   FAILS CLOSED (returns 1, "not ours - leave it dangling") whenever the
+#   real containment cannot be positively confirmed: <target> is not
+#   dangling, does not end in "/hooks/pre-commit", <hooks_dir> is empty and
+#   <target> is relative, the target's own "worktrees" segment no longer
+#   exists on disk (nothing left to canonicalize and compare), or neither
+#   "<repo_dir>/.claude/worktrees" nor "<repo_dir>/.agentic/worktrees"
+#   exists. The asymmetry is deliberate: the failure direction here is
+#   DELETION, and a false negative (an orphan that stays dangling one more
+#   run) is far cheaper than a false positive (deleting a hook this
+#   function merely guessed was ours).
+# ---------------------------------------------------------------------------
+_precommit_is_orphaned_worktree_target() {
+  local target="$1"
+  local repo_dir="$2"
+  local hooks_dir="$3"
+
+  # Only a DANGLING target is ever eligible - a target that still resolves
+  # is adjudicated by the caller's exact-match checks, never by this guess.
+  [[ -e "$target" ]] && return 1
+
+  case "$target" in
+    /*) : ;;
+    *)
+      # POSIX: a relative symlink target resolves against the symlink's
+      # OWN directory, not the caller's CWD. Anchor it against hooks_dir;
+      # fail closed if that anchor is unavailable.
+      [[ -z "$hooks_dir" ]] && return 1
+      target="$hooks_dir/$target"
+      ;;
+  esac
+
+  case "$target" in
+    */hooks/pre-commit) : ;;
+    *) return 1 ;;
+  esac
+
+  local worktree_dir="${target%/hooks/pre-commit}"
+  [[ "$worktree_dir" == "$target" || -z "$worktree_dir" ]] && return 1
+
+  local worktrees_root="${worktree_dir%/*}"
+  [[ "$worktrees_root" == "$worktree_dir" || -z "$worktrees_root" ]] && return 1
+
+  case "$(basename "$worktrees_root")" in
+    worktrees) : ;;
+    *) return 1 ;;
+  esac
+  case "$(basename "${worktrees_root%/*}")" in
+    .claude | .agentic) : ;;
+    *) return 1 ;;
+  esac
+
+  # The target's own "worktrees" ancestor must still exist on disk to be
+  # canonicalized at all - if the whole container is gone too, there is
+  # nothing real left to compare against; fail closed.
+  [[ -d "$worktrees_root" ]] || return 1
+  local canonical_target_root
+  canonical_target_root="$(cd "$worktrees_root" 2>/dev/null && pwd -P)" || return 1
+  [[ -z "$canonical_target_root" ]] && return 1
+
+  local candidate canonical_candidate
+  for candidate in "$repo_dir/.claude/worktrees" "$repo_dir/.agentic/worktrees"; do
+    canonical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || continue
+    [[ -z "$canonical_candidate" ]] && continue
+    if [[ "$canonical_target_root" == "$canonical_candidate" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -362,6 +493,11 @@ uninstall_precommit_hook() {
     if [[ "$current_target" == "$hook_src" || "$current_target" == "$legacy_hook_src_raw" || "$current_target" == "$legacy_hook_src_canonical" ]]; then
       rm "$hook_dst"
       echo "  - pre-commit hook removed"
+    elif _precommit_is_orphaned_worktree_target "$current_target" "$repo_dir" "$hooks_dir"; then
+      rm "$hook_dst"
+      echo "  - pre-commit hook removed (orphaned symlink from an already-removed worktree: $current_target)"
+    elif [[ ! -e "$hook_dst" ]]; then
+      echo "  ! pre-commit hook is DANGLING (points at a missing target, not ours to remove): $current_target - this hook is currently broken and silently NOT running" >&2
     else
       echo "  = pre-commit hook points elsewhere: $current_target - not ours, skipping"
     fi

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -105,29 +105,57 @@
 #   only), the caller's _ae_is_ours function (install only; duplicated
 #   per-adapter helper).
 #
-# NOTE: bin/ds-doctor:784 (line shifts; search for `expected_src = doc.repo_dir`)
-#   independently hardcodes the same "<repo_dir>/hooks/pre-commit is the
-#   expected symlink target" invariant (`expected_src = doc.repo_dir /
-#   "hooks" / "pre-commit"`) with no shared source between the two -
-#   harmless today only because ds-doctor's own repo_dir/.git/hooks
-#   hardcode already fails first from a worktree, so the two never
-#   actually disagree in a live run. This is a KNOWN, UNFIXED drift as of
-#   this PR (disclosed, not silently missed) - as of this commit,
-#   `bin/ds-doctor` has no `resolve_hook_src` call and no shell-out to this
-#   file, and no `bin/tests/test_ds_doctor_precommit_source_parity.sh` (or
-#   equivalent) exists to pin agreement between the two. The correct fix is
-#   to make bin/ds-doctor call THIS function - e.g. via a shell-out such as
-#   `bash -c 'source "$1"; resolve_hook_src "$2"'` against this file -
-#   rather than reimplement its git-dir-vs-git-common-dir resolution logic
-#   in Python a second time; a concurrent unit may be pursuing exactly
-#   that, but verify both the shell-out and the parity test actually exist
-#   before citing either as landed. If resolve_hook_src's resolution logic
-#   changes again in the meantime, check bin/ds-doctor for drift too.
+# NOTE: bin/ds-doctor's check_git_precommit resolves its expected
+#   pre-commit symlink SOURCE via _resolve_hook_src (a Python function -
+#   search `def _resolve_hook_src`; line numbers shift), which shells out
+#   to `bash -c 'source "$1"; resolve_hook_src "$2"'` against THIS file,
+#   with a git-scrubbed subprocess environment, rather than reimplementing
+#   this function's git-dir-vs-git-common-dir resolution logic in Python a
+#   second time (PR #653 / #640 follow-up). Consequently this function's
+#   NAME, its ARGUMENT SHAPE (exactly one positional <repo_dir>), and its
+#   STDOUT CONTRACT (exactly one path on stdout, all diagnostics to
+#   stderr - the existing `>&2` warning in the worktree-fallback branch
+#   below is load-bearing, not decorative) form a cross-language API.
+#   Renaming this function, adding a required parameter, or writing
+#   anything else to stdout silently breaks bin/ds-doctor's pre-commit
+#   check - each of those three was independently verified by mutation to
+#   redden the parity suite below. The parity test also greps for the
+#   literal `^resolve_hook_src[[:space:]]*\(\)` definition form, so
+#   restyling this function to `function resolve_hook_src {` hard-fails
+#   CI even though the bash semantics are unchanged.
+#
+#   bin/ds-doctor deliberately does NOT mirror this function's own
+#   fallback-to-hardcode behavior: on any resolution failure,
+#   _resolve_hook_src returns None, and check_git_precommit WARNs and
+#   skips the symlink write entirely rather than substituting
+#   "<repo_dir>/hooks/pre-commit" - which is the WRONG target by
+#   construction for a linked-worktree repo_dir, the exact Major #653
+#   exists to close, and unattended `ds-doctor --fix` (via `ds-update`)
+#   has no operator present to catch a bad guess. This bash-side function
+#   keeps its own historical fallback (see resolve_hook_src's Public API
+#   doc above) - the two callers intentionally diverge on failure
+#   handling, not by oversight.
+#
+#   Agreement between the two implementations is pinned by
+#   bin/tests/test_ds_doctor_precommit_source_parity.sh across three
+#   topologies (ordinary checkout, linked worktree - pinned to the
+#   PRIMARY checkout's own hooks/pre-commit specifically, not merely
+#   mutual agreement, since a double regression could still agree with
+#   itself - and a checkout missing hooks/pre-commit entirely); failure
+#   handling is pinned separately by
+#   bin/tests/test_ds_doctor_precommit_fallback_safety.sh. Both tests `cp`
+#   THIS real file into isolated fixtures and hard-fail (never skip) if it
+#   stops defining resolve_hook_src, so a rename or removal cannot pass
+#   silently. If this function's name, argument shape, or stdout contract
+#   changes, both test files need re-verification alongside bin/ds-doctor
+#   itself.
 #
 # Downstream consumers:
 #   .claude/install.sh, .cursor/install.sh, .opencode/install.sh,
 #   .claude/uninstall.sh, .cursor/uninstall.sh, .opencode/uninstall.sh
-#   (the only adapters that install/uninstall a pre-commit hook).
+#   (the only adapters that install/uninstall a pre-commit hook); bin/ds-doctor
+#   (shells out to resolve_hook_src via _resolve_hook_src - see the NOTE
+#   above - as a cross-language API, not a source-level import).
 #
 # Failure modes:
 #   - `git rev-parse --git-path hooks` fails (not a git repo, git missing):
@@ -155,15 +183,21 @@
 #
 # Performance: up to three `git rev-parse` calls per invocation (one in
 # resolve_git_hooks_dir, two in resolve_hook_src). uninstall_precommit_hook
-# additionally, ONLY on the dangling-hook path (an existing symlink whose
-# target does not resolve, and which matched neither exact-match
-# candidate): one call into _precommit_is_orphaned_worktree_target, which
-# spawns up to four `cd` subshells (one per enumerated worktrees-container
-# candidate, short-circuiting on the first match) plus the one `cd`
-# subshell for the target's own container - never more than five `cd`
-# calls total, no `basename` calls (removed along with the basename-shape
-# pre-check; see the helper's own manifest). A live/resolving hook or a
-# clean uninstall never reaches this path at all.
+# additionally, ONLY on the path where an existing symlink matched neither
+# exact-match candidate (live or dangling - see
+# _precommit_is_orphaned_worktree_target's own manifest on why this is not
+# dangling-gated at the call site): one call into
+# _precommit_is_orphaned_worktree_target, which performs a BOUNDED upward
+# ancestor walk capped at _PRECOMMIT_MAX_ANCESTOR_DEPTH (8) iterations,
+# each iteration spawning up to one `cd` subshell for the ancestor itself
+# plus up to four more (one per enumerated worktrees-container candidate,
+# short-circuiting on the first match within the iteration) - worst case
+# 8 * 5 = 40 `cd` subshells for a target that matches no candidate at any
+# depth up to the cap; typically far fewer, since a real match or a
+# non-existent ancestor short-circuits early. No `basename` calls (removed
+# along with the basename-shape pre-check; see the helper's own manifest).
+# A live/resolving hook that matches an exact-match candidate, or a clean
+# uninstall, never reaches this path at all.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -207,10 +241,13 @@ _precommit_canonical_repo_dir() {
 # ---------------------------------------------------------------------------
 # _precommit_is_orphaned_worktree_target <target> <repo_dir> <hooks_dir>
 #   Internal helper (not part of the public API). Returns 0 (true) iff
-#   <target> - the readlink() of a DANGLING pre-commit symlink, i.e. it has
-#   already been confirmed `[[ ! -e "$target" ]]` by the caller - is a
-#   hook that WOULD have been installed by this module's own
-#   install_precommit_hook for some OTHER, now-removed worktree of the
+#   <target> - the readlink() of a pre-commit symlink that matched neither
+#   of uninstall_precommit_hook's two exact-match candidates - is BOTH
+#   confirmed DANGLING (by this function itself, internally - the CALLER
+#   does NOT pre-filter on danglingness; this function is invoked for any
+#   non-exact-match symlink, live or dangling, and must safely say "no" for
+#   a live one) AND a hook that WOULD have been installed by this module's
+#   own install_precommit_hook for some OTHER, now-removed worktree of the
 #   SAME repo (<repo_dir>, already canonicalized by the caller):
 #   uninstall_precommit_hook's two existing exact-match candidates
 #   (hook_src, legacy_hook_src_*) are both derived from the CURRENTLY
@@ -241,41 +278,65 @@ _precommit_canonical_repo_dir() {
 #   dangling, not deleted) until this list is updated - the same outcome
 #   as on origin/main today, not a regression.
 #
-#   Deliberately does NOT use a generic walk-up-the-target's-ancestors
-#   algorithm (canonicalize the target's longest existing ancestor and
-#   re-append the missing tail) - that approach was considered and
-#   rejected for two reasons: (1) it requires an explicit termination
-#   guard against a slash-free non-existent path component (a bare
-#   `${x%/*}` is a no-op there, so an unguarded loop hangs and grows
-#   memory unboundedly - a hazard that does NOT exist on origin/main today
-#   and this helper must not introduce), and (2) it is unnecessary here:
-#   every candidate above resolves to a worktree at exactly ONE directory
-#   level below its container ("<container>/<name>/hooks/pre-commit"), so
-#   the SAME fixed two-strip arithmetic (strip "/hooks/pre-commit", then
-#   strip one more trailing path component) yields the correct container
-#   root for every candidate, and each container path is already known up
-#   front - each can be canonicalized directly with a single `cd + pwd -P`
-#   (bounded, no loop, four iterations of a fixed `for`) rather than
-#   discovered by walking. String manipulation on the (possibly
-#   non-canonical, non-existent) target is used ONLY to compute this fixed
-#   two-strip candidate root before any filesystem call; the actual
-#   containment decision is always made by comparing two REAL,
-#   `cd`-canonicalized, existing directories (one of <repo_dir>'s four
-#   enumerated candidates above, and the target's own container segment,
-#   when that segment still exists on disk) - so a symlinked path
-#   component anywhere in either side is resolved correctly by `cd`, never
-#   by fragile string comparison. There is deliberately no basename-shape
-#   pre-check (e.g. "does the parent directory's own name look like
-#   .claude or .agentic?") - that check does not generalise across the
-#   four candidates above (".worktrees" and "evals/.worktrees" do not share
-#   the ".claude/agentic + worktrees" two-segment shape) and was removed;
-#   the real, `cd`-canonicalized comparison against the enumerated list is
+#   The worktree's own directory is NOT always exactly one path component
+#   below its container. This was assumed in an earlier revision (a fixed
+#   two-strip: strip "/hooks/pre-commit", then strip one more trailing
+#   component) and found false by a round-3 Skeptic review:
+#   content/references/subagent-protocol.md:333-334's own documented,
+#   copy-pasteable command creates a worktree at
+#   "${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug}", and this repo's
+#   branch-naming convention (content/rules/conventions.md) makes
+#   FEATURE_BRANCH a "feature/<name>" / "fix/<name>" / "chore/<name>"
+#   value - so the resulting worktree lands at
+#   ".worktrees/feature/<name>-<unit_slug>", TWO components below
+#   ".worktrees", not one. AGENTS.md:48's ".agentic/worktrees/<branch-name>"
+#   phrasing has the identical hazard for any branch name containing a
+#   slash. A fixed strip count is therefore wrong by construction for any
+#   candidate whose worktree-naming convention can itself contain a "/".
+#
+#   Handled by a BOUNDED upward search instead of a fixed strip count:
+#   starting from the worktree's own directory (target minus
+#   "/hooks/pre-commit"), walk up one path component at a time, testing
+#   each ancestor against the four enumerated candidates, until a match is
+#   found, the walk reaches _PRECOMMIT_MAX_ANCESTOR_DEPTH ancestors (8 -
+#   comfortably deeper than any real worktree-naming convention observed
+#   in this repo; a deeper mismatch fails closed, not a hang), or a strip
+#   stops changing the string (the same slash-free-root termination guard
+#   round 1 required for the walk-up design it rejected THEN - now
+#   required and present, since this IS that walk, deliberately reintroduced
+#   with the guard round 1 said it would need). This differs from the
+#   generic "canonicalize the target's longest existing ancestor" algorithm
+#   round 1 rejected: that walk stops at the first ancestor that EXISTS on
+#   disk and asks no further question; this walk instead tests EVERY
+#   ancestor up to the depth bound against the enumerated candidate list
+#   and only accepts an EXACT match - a non-existent, non-matching
+#   ancestor is simply skipped (via `continue`, not `return`), not treated
+#   as a resolution failure. String manipulation on the (possibly
+#   non-canonical, non-existent) target is used ONLY to compute each
+#   candidate ancestor string before any filesystem call; the actual
+#   containment decision at each step is always made by comparing two
+#   REAL, `cd`-canonicalized, existing directories (one of <repo_dir>'s
+#   four enumerated candidates, and the current ancestor, when that
+#   ancestor exists on disk) - so a symlinked path component anywhere in
+#   either side is resolved correctly by `cd`, never by fragile string
+#   comparison. There is deliberately no basename-shape pre-check (e.g.
+#   "does the parent directory's own name look like .claude or .agentic?")
+#   - that check does not generalise across the four candidates above
+#   (".worktrees" and "evals/.worktrees" do not share the
+#   ".claude/agentic + worktrees" two-segment shape) and was removed; the
+#   real, `cd`-canonicalized comparison against the enumerated list is
 #   both necessary and sufficient on its own.
 #
 #   A RELATIVE target (readlink() can return either form) is anchored
 #   against <hooks_dir> per POSIX symlink-resolution semantics (relative
-#   to the symlink's OWN directory, never the process's CWD) before the
-#   shape test - never resolved against $PWD.
+#   to the symlink's OWN directory, never the process's CWD) BEFORE
+#   anything else - including the danglingness gate itself, not merely the
+#   shape test - never resolved against $PWD. Ordering matters here: this
+#   function is called by uninstall_precommit_hook for ANY symlink that
+#   did not match either exact-match candidate, whether or not it is
+#   actually dangling, so a danglingness test evaluated before anchoring
+#   would judge a relative target's existence against the wrong base and
+#   could misclassify a LIVE, still-resolving hook as dangling.
 #
 #   NOT covered by the FAILS-CLOSED enumeration below, disclosed
 #   separately because it is a positive-match (deletion) case, not a
@@ -296,9 +357,10 @@ _precommit_canonical_repo_dir() {
 #   FAILS CLOSED (returns 1, "not ours - leave it dangling") whenever the
 #   real containment cannot be positively confirmed: <target> is not
 #   dangling, does not end in "/hooks/pre-commit", <hooks_dir> is empty and
-#   <target> is relative, the target's own container segment no longer
-#   exists on disk (nothing left to canonicalize and compare), or none of
-#   the four enumerated candidates above exists / matches. The asymmetry
+#   <target> is relative, no ancestor up to _PRECOMMIT_MAX_ANCESTOR_DEPTH
+#   (8) levels above the worktree's own directory exists on disk and
+#   matches one of the four enumerated candidates, or the walk hits a
+#   slash-free non-existent component before finding a match. The asymmetry
 #   is deliberate: the failure direction here is DELETION, and a false
 #   negative (an orphan that stays dangling one more run) is far cheaper
 #   than a false positive (deleting a hook this function merely guessed
@@ -309,20 +371,33 @@ _precommit_is_orphaned_worktree_target() {
   local repo_dir="$2"
   local hooks_dir="$3"
 
-  # Only a DANGLING target is ever eligible - a target that still resolves
-  # is adjudicated by the caller's exact-match checks, never by this guess.
-  [[ -e "$target" ]] && return 1
-
+  # POSIX: a relative symlink target resolves against the symlink's OWN
+  # directory, not the caller's CWD. Anchor it against hooks_dir FIRST -
+  # fail closed if that anchor is unavailable - so that every subsequent
+  # test (starting with the danglingness gate immediately below) is
+  # evaluated against the correct base. This anchoring step MUST run
+  # before the danglingness gate, not after it: testing `-e` on a raw
+  # relative target against the wrong base (the caller's ambient CWD,
+  # which is never guaranteed to be hooks_dir) can report a LIVE,
+  # still-resolving target as nonexistent purely because of process CWD,
+  # not because the target is actually dangling - a round-3 Major found
+  # exactly this shipped in reversed order, silently deleting a live
+  # worktree's still-in-use hook. See Test 24 in
+  # bin/tests/test_precommit_worktree.sh for the regression coverage this
+  # ordering requires (deleting the gate below entirely, or restoring the
+  # old order, both redden Test 24).
   case "$target" in
     /*) : ;;
     *)
-      # POSIX: a relative symlink target resolves against the symlink's
-      # OWN directory, not the caller's CWD. Anchor it against hooks_dir;
-      # fail closed if that anchor is unavailable.
       [[ -z "$hooks_dir" ]] && return 1
       target="$hooks_dir/$target"
       ;;
   esac
+
+  # Only a DANGLING target is ever eligible - a target that still resolves
+  # is adjudicated by the caller's exact-match checks, never by this guess.
+  # MUST run after the anchoring block above (see the comment there).
+  [[ -e "$target" ]] && return 1
 
   case "$target" in
     */hooks/pre-commit) : ;;
@@ -332,29 +407,48 @@ _precommit_is_orphaned_worktree_target() {
   local worktree_dir="${target%/hooks/pre-commit}"
   [[ "$worktree_dir" == "$target" || -z "$worktree_dir" ]] && return 1
 
-  local worktrees_root="${worktree_dir%/*}"
-  [[ "$worktrees_root" == "$worktree_dir" || -z "$worktrees_root" ]] && return 1
-
-  # The target's own container ancestor must still exist on disk to be
-  # canonicalized at all - if the whole container is gone too, there is
-  # nothing real left to compare against; fail closed.
-  [[ -d "$worktrees_root" ]] || return 1
-  local canonical_target_root
-  canonical_target_root="$(cd "$worktrees_root" 2>/dev/null && pwd -P)" || return 1
-  [[ -z "$canonical_target_root" ]] && return 1
-
-  local candidate canonical_candidate
-  for candidate in \
-    "$repo_dir/.claude/worktrees" \
-    "$repo_dir/.agentic/worktrees" \
-    "$repo_dir/.worktrees" \
-    "$repo_dir/evals/.worktrees"
-  do
-    canonical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || continue
-    [[ -z "$canonical_candidate" ]] && continue
-    if [[ "$canonical_target_root" == "$canonical_candidate" ]]; then
-      return 0
+  # BOUNDED upward search: the worktree's own directory is not always
+  # exactly one path component below its container (see this function's
+  # own manifest for why - subagent-protocol.md's documented worktree
+  # path can itself contain a "/" via a "feature/<name>" branch). Walk up
+  # one component at a time, testing EVERY ancestor against the four
+  # enumerated candidates, capped at _PRECOMMIT_MAX_ANCESTOR_DEPTH
+  # iterations with an explicit termination guard against a slash-free
+  # non-existent component (where `${x%/*}` is a no-op) - both bounds are
+  # required together; either alone is insufficient (the depth cap alone
+  # would still spin needlessly on a pathological input that never
+  # changes, and the termination guard alone provides no upper bound on a
+  # deeply-nested but always-changing string).
+  local -r _PRECOMMIT_MAX_ANCESTOR_DEPTH=8
+  local ancestor="$worktree_dir" prev_ancestor="" depth=0
+  local candidate canonical_candidate canonical_ancestor
+  while [[ $depth -lt $_PRECOMMIT_MAX_ANCESTOR_DEPTH ]]; do
+    prev_ancestor="$ancestor"
+    ancestor="${ancestor%/*}"
+    if [[ "$ancestor" == "$prev_ancestor" || -z "$ancestor" ]]; then
+      break
     fi
+    depth=$((depth + 1))
+
+    # A non-existent or non-canonicalizable ancestor is simply skipped
+    # (not a resolution failure) - the worktree segments below it are
+    # gone, but a candidate container further up may still be real.
+    [[ -d "$ancestor" ]] || continue
+    canonical_ancestor="$(cd "$ancestor" 2>/dev/null && pwd -P)" || continue
+    [[ -z "$canonical_ancestor" ]] && continue
+
+    for candidate in \
+      "$repo_dir/.claude/worktrees" \
+      "$repo_dir/.agentic/worktrees" \
+      "$repo_dir/.worktrees" \
+      "$repo_dir/evals/.worktrees"
+    do
+      canonical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || continue
+      [[ -z "$canonical_candidate" ]] && continue
+      if [[ "$canonical_ancestor" == "$canonical_candidate" ]]; then
+        return 0
+      fi
+    done
   done
 
   return 1

--- a/scripts/lib/precommit.sh
+++ b/scripts/lib/precommit.sh
@@ -105,13 +105,24 @@
 #   only), the caller's _ae_is_ours function (install only; duplicated
 #   per-adapter helper).
 #
-# NOTE: bin/ds-doctor:783 independently hardcodes the same
-#   "<repo_dir>/hooks/pre-commit is the expected symlink target" invariant
-#   (`expected_src = doc.repo_dir / "hooks" / "pre-commit"`) with no shared
-#   source between the two - harmless today only because ds-doctor's own
-#   repo_dir/.git/hooks hardcode already fails first from a worktree, so
-#   the two never actually disagree in a live run. If resolve_hook_src's
-#   resolution logic changes again, check bin/ds-doctor for drift too.
+# NOTE: bin/ds-doctor:784 (line shifts; search for `expected_src = doc.repo_dir`)
+#   independently hardcodes the same "<repo_dir>/hooks/pre-commit is the
+#   expected symlink target" invariant (`expected_src = doc.repo_dir /
+#   "hooks" / "pre-commit"`) with no shared source between the two -
+#   harmless today only because ds-doctor's own repo_dir/.git/hooks
+#   hardcode already fails first from a worktree, so the two never
+#   actually disagree in a live run. This is a KNOWN, UNFIXED drift as of
+#   this PR (disclosed, not silently missed) - as of this commit,
+#   `bin/ds-doctor` has no `resolve_hook_src` call and no shell-out to this
+#   file, and no `bin/tests/test_ds_doctor_precommit_source_parity.sh` (or
+#   equivalent) exists to pin agreement between the two. The correct fix is
+#   to make bin/ds-doctor call THIS function - e.g. via a shell-out such as
+#   `bash -c 'source "$1"; resolve_hook_src "$2"'` against this file -
+#   rather than reimplement its git-dir-vs-git-common-dir resolution logic
+#   in Python a second time; a concurrent unit may be pursuing exactly
+#   that, but verify both the shell-out and the parity test actually exist
+#   before citing either as landed. If resolve_hook_src's resolution logic
+#   changes again in the meantime, check bin/ds-doctor for drift too.
 #
 # Downstream consumers:
 #   .claude/install.sh, .cursor/install.sh, .opencode/install.sh,
@@ -143,7 +154,16 @@
 #     beyond the function definitions.
 #
 # Performance: up to three `git rev-parse` calls per invocation (one in
-# resolve_git_hooks_dir, two in resolve_hook_src).
+# resolve_git_hooks_dir, two in resolve_hook_src). uninstall_precommit_hook
+# additionally, ONLY on the dangling-hook path (an existing symlink whose
+# target does not resolve, and which matched neither exact-match
+# candidate): one call into _precommit_is_orphaned_worktree_target, which
+# spawns up to four `cd` subshells (one per enumerated worktrees-container
+# candidate, short-circuiting on the first match) plus the one `cd`
+# subshell for the target's own container - never more than five `cd`
+# calls total, no `basename` calls (removed along with the basename-shape
+# pre-check; see the helper's own manifest). A live/resolving hook or a
+# clean uninstall never reaches this path at all.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -191,16 +211,35 @@ _precommit_canonical_repo_dir() {
 #   already been confirmed `[[ ! -e "$target" ]]` by the caller - is a
 #   hook that WOULD have been installed by this module's own
 #   install_precommit_hook for some OTHER, now-removed worktree of the
-#   SAME repo (<repo_dir>, already canonicalized by the caller): a dangling
-#   target ending in "/hooks/pre-commit" whose containing "worktrees"
-#   directory sits directly under "<repo_dir>/.claude/worktrees" or
-#   "<repo_dir>/.agentic/worktrees" - the two locations this repo's own
-#   tooling creates isolation/feature worktrees under (see
-#   content/references/worktree-lifecycle.md). uninstall_precommit_hook's
-#   two existing exact-match candidates (hook_src, legacy_hook_src_*) are
-#   both derived from the CURRENTLY INVOKING repo_dir and so can never
-#   match a target naming a *different*, already-deleted worktree - this
-#   helper is the third, narrower candidate that closes exactly that gap.
+#   SAME repo (<repo_dir>, already canonicalized by the caller):
+#   uninstall_precommit_hook's two existing exact-match candidates
+#   (hook_src, legacy_hook_src_*) are both derived from the CURRENTLY
+#   INVOKING repo_dir and so can never match a target naming a *different*,
+#   already-deleted worktree - this helper is the third, narrower candidate
+#   that closes exactly that gap.
+#
+#   "Ours" is decided against a small, ENUMERATED list of candidate
+#   worktree-container directories under <repo_dir> - NOT a generic
+#   pattern match, and NOT a claim that this is every location worktrees
+#   could ever be created. Each candidate is a real, documented location
+#   this repo's own tooling is known to create worktrees under:
+#     - "<repo_dir>/.claude/worktrees"  (the live Claude Code harness's
+#       own isolation-worktree auto-lock directory)
+#     - "<repo_dir>/.agentic/worktrees" (AGENTS.md's documented
+#       isolation/feature worktree path)
+#     - "<repo_dir>/.worktrees"         (content/references/subagent-protocol.md:333's
+#       manually-managed fan-out path,
+#       "${REPO}/.worktrees/${FEATURE_BRANCH}-${unit_slug}")
+#     - "<repo_dir>/evals/.worktrees"   (content/commands/ds-cleanup-worktrees.md:38's
+#       "evals/.worktrees/wt-*" instance)
+#   This list is a known INCOMPLETE enumeration, not a closed set derived
+#   from any single source of truth - if methodology or harness tooling
+#   ever documents creating worktrees under a fifth location, that
+#   location must be added here explicitly; nothing in this function
+#   discovers new locations on its own. A dangling target naming a
+#   worktree under an undocumented fifth location fails closed (left
+#   dangling, not deleted) until this list is updated - the same outcome
+#   as on origin/main today, not a regression.
 #
 #   Deliberately does NOT use a generic walk-up-the-target's-ancestors
 #   algorithm (canonicalize the target's longest existing ancestor and
@@ -210,37 +249,60 @@ _precommit_canonical_repo_dir() {
 #   `${x%/*}` is a no-op there, so an unguarded loop hangs and grows
 #   memory unboundedly - a hazard that does NOT exist on origin/main today
 #   and this helper must not introduce), and (2) it is unnecessary here:
-#   this repo's worktree layout is a FIXED, two-candidate shape
-#   ("<repo_dir>/.claude/worktrees/<name>/hooks/pre-commit" or the
-#   ".agentic/" sibling), so the anchor to canonicalize is already known
-#   up front - "<repo_dir>/.claude/worktrees" or "<repo_dir>/.agentic/worktrees"
-#   - and can be canonicalized directly with a single `cd + pwd -P per
-#   candidate (bounded, no loop) rather than discovered by walking. String
-#   manipulation on the (possibly non-canonical, non-existent) target is
-#   used ONLY to test its coarse SHAPE - does it plausibly look like
-#   ".../.claude/worktrees/<name>/hooks/pre-commit"? - before any
-#   filesystem call; the actual containment decision is always made by
-#   comparing two REAL, `cd`-canonicalized, existing directories
-#   (<repo_dir>'s own ".claude/worktrees" or ".agentic/worktrees", and the
-#   target's own "worktrees" segment, when that segment still exists on
-#   disk) - so a symlinked path component anywhere in either side is
-#   resolved correctly by `cd`, never by fragile string comparison.
+#   every candidate above resolves to a worktree at exactly ONE directory
+#   level below its container ("<container>/<name>/hooks/pre-commit"), so
+#   the SAME fixed two-strip arithmetic (strip "/hooks/pre-commit", then
+#   strip one more trailing path component) yields the correct container
+#   root for every candidate, and each container path is already known up
+#   front - each can be canonicalized directly with a single `cd + pwd -P`
+#   (bounded, no loop, four iterations of a fixed `for`) rather than
+#   discovered by walking. String manipulation on the (possibly
+#   non-canonical, non-existent) target is used ONLY to compute this fixed
+#   two-strip candidate root before any filesystem call; the actual
+#   containment decision is always made by comparing two REAL,
+#   `cd`-canonicalized, existing directories (one of <repo_dir>'s four
+#   enumerated candidates above, and the target's own container segment,
+#   when that segment still exists on disk) - so a symlinked path
+#   component anywhere in either side is resolved correctly by `cd`, never
+#   by fragile string comparison. There is deliberately no basename-shape
+#   pre-check (e.g. "does the parent directory's own name look like
+#   .claude or .agentic?") - that check does not generalise across the
+#   four candidates above (".worktrees" and "evals/.worktrees" do not share
+#   the ".claude/agentic + worktrees" two-segment shape) and was removed;
+#   the real, `cd`-canonicalized comparison against the enumerated list is
+#   both necessary and sufficient on its own.
 #
 #   A RELATIVE target (readlink() can return either form) is anchored
 #   against <hooks_dir> per POSIX symlink-resolution semantics (relative
 #   to the symlink's OWN directory, never the process's CWD) before the
 #   shape test - never resolved against $PWD.
 #
+#   NOT covered by the FAILS-CLOSED enumeration below, disclosed
+#   separately because it is a positive-match (deletion) case, not a
+#   failure: a dangling target whose path reaches one of the four
+#   enumerated candidates THROUGH a symlink located OUTSIDE <repo_dir> (a
+#   symlinked path component anywhere before the container segment) still
+#   matches and IS deleted - `cd`-canonicalization resolves that symlink
+#   on both sides of the comparison before it happens, so the real,
+#   physical container directory is what is actually compared, not the
+#   symlinked spelling. This is deliberate, not an oversight: the object
+#   being deleted is always identified by comparing REAL directories (the
+#   repo's own enumerated container, physically, against the target's own
+#   container, physically) - a symlink hop on the way there changes the
+#   SPELLING of the path, never the physical directory the comparison
+#   ultimately identifies as "ours". Test 19 in
+#   bin/tests/test_precommit_worktree.sh exercises this directly.
+#
 #   FAILS CLOSED (returns 1, "not ours - leave it dangling") whenever the
 #   real containment cannot be positively confirmed: <target> is not
 #   dangling, does not end in "/hooks/pre-commit", <hooks_dir> is empty and
-#   <target> is relative, the target's own "worktrees" segment no longer
-#   exists on disk (nothing left to canonicalize and compare), or neither
-#   "<repo_dir>/.claude/worktrees" nor "<repo_dir>/.agentic/worktrees"
-#   exists. The asymmetry is deliberate: the failure direction here is
-#   DELETION, and a false negative (an orphan that stays dangling one more
-#   run) is far cheaper than a false positive (deleting a hook this
-#   function merely guessed was ours).
+#   <target> is relative, the target's own container segment no longer
+#   exists on disk (nothing left to canonicalize and compare), or none of
+#   the four enumerated candidates above exists / matches. The asymmetry
+#   is deliberate: the failure direction here is DELETION, and a false
+#   negative (an orphan that stays dangling one more run) is far cheaper
+#   than a false positive (deleting a hook this function merely guessed
+#   was ours).
 # ---------------------------------------------------------------------------
 _precommit_is_orphaned_worktree_target() {
   local target="$1"
@@ -273,16 +335,7 @@ _precommit_is_orphaned_worktree_target() {
   local worktrees_root="${worktree_dir%/*}"
   [[ "$worktrees_root" == "$worktree_dir" || -z "$worktrees_root" ]] && return 1
 
-  case "$(basename "$worktrees_root")" in
-    worktrees) : ;;
-    *) return 1 ;;
-  esac
-  case "$(basename "${worktrees_root%/*}")" in
-    .claude | .agentic) : ;;
-    *) return 1 ;;
-  esac
-
-  # The target's own "worktrees" ancestor must still exist on disk to be
+  # The target's own container ancestor must still exist on disk to be
   # canonicalized at all - if the whole container is gone too, there is
   # nothing real left to compare against; fail closed.
   [[ -d "$worktrees_root" ]] || return 1
@@ -291,7 +344,12 @@ _precommit_is_orphaned_worktree_target() {
   [[ -z "$canonical_target_root" ]] && return 1
 
   local candidate canonical_candidate
-  for candidate in "$repo_dir/.claude/worktrees" "$repo_dir/.agentic/worktrees"; do
+  for candidate in \
+    "$repo_dir/.claude/worktrees" \
+    "$repo_dir/.agentic/worktrees" \
+    "$repo_dir/.worktrees" \
+    "$repo_dir/evals/.worktrees"
+  do
     canonical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || continue
     [[ -z "$canonical_candidate" ]] && continue
     if [[ "$canonical_target_root" == "$canonical_candidate" ]]; then


### PR DESCRIPTION
## Summary

Targeted delta on top of #640, which landed the core fix for the shared pre-commit hook being repointed at an ephemeral worktree. This adds only what #640 does not cover. Two gaps were reproduced as live on `main` before this work:

- **Orphan cleanup.** A hook whose target names an already-deleted worktree survives uninstall permanently: #640's two legacy candidates both derive from the invoking `repo_dir`, so they can never match a different, deleted one.
- **Test-suite sandbox escape.** The suite has no `unset GIT_DIR`, and an ambient `GIT_DIR` makes git ignore `-C <dir>` entirely - reproduced writing a symlink into an unrelated repository's hooks directory.

Also adds a distinct warning when an existing hook is already dangling, rather than the generic "points elsewhere".

## What #640 keeps

`resolve_hook_src`'s common-repo resolution and its KNOWN RESIDUAL fallback, `_precommit_canonical_repo_dir`, the unconditional missing-source install guard, and Tests 8/11/12 are byte-unchanged. The diff deletes no line of `scripts/lib/precommit.sh`.

## Review

Three Skeptic rounds, each finding reproduced by execution rather than argued. The two that matter:

**It deleted a live, working hook.** The danglingness gate ran *before* the relative-target anchoring, so a target that resolved fine from the hooks directory looked absent from the process CWD, passed the gate, and was removed - while printing "already-removed worktree", which was false. Same semantic state, opposite outcome purely by whether the symlink target was spelled relatively or absolutely. It survived two rounds because **no assertion covered the danglingness gate at all**: deleting the gate outright still gave a green suite.

**Two successive false shape claims.** Round 1 asserted a fixed two-candidate worktree layout; the repo has four. Round 2 asserted worktrees sit exactly one level below their container; branch names contain slashes, so `subagent-protocol.md`'s own documented command produces a depth-2 path. Both replaced with a bounded upward ancestor walk.

Verified independently: depth 8 matches and depth 9 fails closed; termination confirmed across `/`, empty, relative, `..`-heavy, a 3000-segment path and symlinked components, all sub-second in both shells; a 16-outcome false-positive matrix ({relative, absolute} x {live, dangling} x {inside, outside container}) correct in both shells; decoy siblings for all four containers preserved; `rm` removes only the hook symlink, never a target.

- 79/79 in all four {bash, zsh} x {symlinked, non-symlinked} combinations, equal assertion counts
- Every new assertion mutation-tested and confirmed to redden only its own test
- `bin/tests` 41/41; pytest 1157; JS 45/45; all three budget gates OK

**CI cannot catch this class.** macOS `TMPDIR` is symlinked and ubuntu's `/tmp` is not, so symlink-sensitive assertions only ever fail on a developer's machine. The suite therefore runs from both roots.

## Cross-language API note

#653 made `bin/ds-doctor` a Python consumer of `resolve_hook_src` via a bash shell-out, so this function's name, argument shape, and stdout contract are now a cross-language API. The NOTE in `scripts/lib/precommit.sh` was rewritten against the post-#653 tree to say so, and `bin/ds-doctor` was added to its Downstream consumers list.

## North Star alignment

**Works for everyone.** The orphan-cleanup gap and the canonicalization it depends on are pure path-spelling portability: they fire for any checkout reached through a symlinked home, dev directory, or macOS `TMPDIR`, and are invisible on a non-symlinked path.

**Produce verifiable outcomes.** A silently dead pre-commit hook is the worst kind of green - present, executable-looking, doing nothing. Every failure path here is loud and non-fatal, and the suite can no longer corrupt the operator's real repository.

**Enforcement floors are not weakened.** The uninstall predicate was widened only as far as measurement justified, re-verified against the full false-positive matrix after every widening, and fails closed wherever containment cannot be positively confirmed. Deletion is bounded to the hook symlink itself.

Doc-sync: predicate not triggered - internal shell library and its test suite; no public count, list, path, or behavior assertion in `README.md`, `CONTRIBUTING.md`, `content/SKILL.md`, or `docs/` is affected.
