### PR TITLE
fix(DS-158): retry session-log lock timeout instead of silently dropping the record

### DIFF
--- a/bin/ds-identity
+++ b/bin/ds-identity
@@ -135,6 +135,16 @@ PENDING_CAP = 100
 PENDING_SCAN_LIMIT = PENDING_CAP + 1
 PENDING_DIRECTORY_SCAN_LIMIT = (PENDING_CAP * 4) + 1
 PENDING_INTERNAL_STALE_SECONDS = 60
+# DS-158 round 2: total wall-clock budget for the session-log lock retry loop
+# in _write_jsonl_safely, spent across all attempts (not per attempt), not
+# per attempt in isolation. Kept at parity with round 1's flat single-attempt
+# 5.0s wait (not shrunk) - the fix here is that a lock timeout now gets a
+# retry at all within this budget, not that the budget itself grew, since
+# the JS caller's subprocess ceiling (see hooks/stop-context.js
+# writeTelemetrySafely's spawnSync `timeout` comment) sets the same total
+# ceiling either way. Bumping one obliges bumping the other, by construction.
+SESSION_LOG_LOCK_BUDGET_SECONDS = 5.0
+SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 1.0
 
 
 def _contains_unicode_control(value: str) -> bool:
@@ -704,6 +714,15 @@ def _acquire_validated_file_lock(
         os.close(parent_fd)
 
 
+class _LockTimeoutError(RuntimeError):
+    """One flock() attempt exhausted its bounded wait.
+
+    DS-158 round 2: kept distinct from a bare RuntimeError so a caller-side
+    retry loop can catch specifically this transient, retryable condition
+    without also absorbing an unrelated RuntimeError it did not anticipate.
+    """
+
+
 def _lock_fd_exclusive(fd: int, *, timeout: float) -> None:
     """Acquire one fd lock with a monotonic bounded retry loop."""
     deadline = time.monotonic() + timeout
@@ -713,7 +732,7 @@ def _lock_fd_exclusive(fd: int, *, timeout: float) -> None:
             return
         except BlockingIOError:
             if time.monotonic() >= deadline:
-                raise RuntimeError(f"lock timeout after {timeout:.0f}s")
+                raise _LockTimeoutError(f"lock timeout after {timeout:.0f}s")
             time.sleep(0.02)
 
 
@@ -1153,7 +1172,18 @@ def _write_jsonl_safely(
         # A pair of legitimate writers can each replace the inode while its
         # peer is performing the post-publication check. Eight bounded passes
         # let that finite handoff converge without weakening rotation checks.
+        # DS-158 round 2: the same attempt budget also backstops a holder that
+        # stalls mid-critical-section (slow fsync, CPU steal on a shared
+        # runner) - that stall previously converted into a permanently,
+        # silently dropped telemetry record because a lock-timeout RuntimeError
+        # from _lock_fd_exclusive escaped this loop's `except FileNotFoundError`
+        # entirely (caught only by the function-level outer except, one shot,
+        # no retry). _LockTimeoutError is now caught here too and retried with
+        # backoff, bounded by SESSION_LOG_LOCK_BUDGET_SECONDS of total wall
+        # clock across every attempt (not per attempt) so a run of unlucky
+        # collisions cannot compound into an unbounded wait.
         max_attempts = 8
+        lock_deadline = time.monotonic() + SESSION_LOG_LOCK_BUDGET_SECONDS
         for attempt in range(max_attempts):
             parent_fd: int | None = None
             log_fd: int | None = None
@@ -1165,16 +1195,14 @@ def _write_jsonl_safely(
             try:
                 parent_fd = _open_directory_nofollow(path.parent, create=True)
                 log_fd = _open_safe_log_at(parent_fd, path.name, create=True)
-                # A holder that stalls mid-critical-section (slow fsync, CPU
-                # steal on a shared runner) blocks a waiter for the full
-                # stall, not just its own tiny read/render/write. DS-158: a
-                # too-tight budget here previously converted that stall into
-                # a permanently, silently dropped telemetry record - nothing
-                # above this call retries or surfaces the loss. The JS caller
-                # (hooks/stop-context.js writeTelemetrySafely) bounds the
-                # whole write-hook subprocess at 6000ms, so this budget must
-                # stay under that with headroom for the surrounding work.
-                _lock_fd_exclusive(log_fd, timeout=5.0)
+                lock_timeout = max(
+                    0.05,
+                    min(
+                        SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS,
+                        lock_deadline - time.monotonic(),
+                    ),
+                )
+                _lock_fd_exclusive(log_fd, timeout=lock_timeout)
                 log_locked = True
                 if not _directory_fd_is_canonical(path.parent, parent_fd):
                     raise FileNotFoundError("session log parent rotated before lock")
@@ -1255,6 +1283,23 @@ def _write_jsonl_safely(
             except FileNotFoundError:
                 if attempt == max_attempts - 1:
                     raise
+            except RuntimeError:
+                # Only _lock_fd_exclusive raises RuntimeError on this path
+                # (as _LockTimeoutError, a RuntimeError subclass); caught by
+                # base class rather than the subclass so this stays correct
+                # if a caller substitutes a differently-typed but still
+                # RuntimeError-based lock helper (e.g. in a test double).
+                remaining = lock_deadline - time.monotonic()
+                if attempt == max_attempts - 1 or remaining <= 0:
+                    raise
+                # Linear backoff (capped) gives a contended writer
+                # successive, increasingly patient chances instead of
+                # hammering the same lock at a fixed interval. Also capped
+                # by the remaining budget so backoff sleeps are spent from
+                # inside SESSION_LOG_LOCK_BUDGET_SECONDS, never added on top
+                # of it - the JS-side spawnSync ceiling is derived from that
+                # budget and must not be exceeded by backoff overhead.
+                time.sleep(min(0.5, 0.05 * (attempt + 1), remaining))
             finally:
                 if temp_fd is not None:
                     os.close(temp_fd)

--- a/bin/ds-identity
+++ b/bin/ds-identity
@@ -1165,7 +1165,16 @@ def _write_jsonl_safely(
             try:
                 parent_fd = _open_directory_nofollow(path.parent, create=True)
                 log_fd = _open_safe_log_at(parent_fd, path.name, create=True)
-                _lock_fd_exclusive(log_fd, timeout=2.0)
+                # A holder that stalls mid-critical-section (slow fsync, CPU
+                # steal on a shared runner) blocks a waiter for the full
+                # stall, not just its own tiny read/render/write. DS-158: a
+                # too-tight budget here previously converted that stall into
+                # a permanently, silently dropped telemetry record - nothing
+                # above this call retries or surfaces the loss. The JS caller
+                # (hooks/stop-context.js writeTelemetrySafely) bounds the
+                # whole write-hook subprocess at 6000ms, so this budget must
+                # stay under that with headroom for the surrounding work.
+                _lock_fd_exclusive(log_fd, timeout=5.0)
                 log_locked = True
                 if not _directory_fd_is_canonical(path.parent, parent_fd):
                     raise FileNotFoundError("session log parent rotated before lock")

--- a/bin/ds-identity
+++ b/bin/ds-identity
@@ -15,7 +15,7 @@ Public API:
   ds-identity auto [--force] [--scope {global,profile,project}] [--profile-dir <dir>]
   ds-identity confirm [--scope {global,profile,project}] [--profile-dir <dir>]
   ds-identity resolve-hook --cwd <dir>  (internal Stop-hook API)
-  ds-identity write-hook --cwd <dir>    (internal Stop-hook API)
+  ds-identity write-hook --cwd <dir> [--status-file <path>]  (internal Stop-hook API)
   ds-identity --help
 
   Helpers: ScopeTarget, _resolve_scope_target(args, command),
@@ -88,6 +88,26 @@ Failure modes: exits 1 on validation error, 2 on file-exists-without-force.
                records only to the matching scope. Profile records additionally
                match config_dir; project records match repo_root. Untagged
                legacy records retain their historical filter behavior.
+               write-hook (cmd_write_hook): each session-log append retries a
+               contended flock with linear backoff (attempt-capped by
+               SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS, 1.0s) inside an
+               8-attempt loop, all bounded by a SESSION_LOG_LOCK_BUDGET_SECONDS
+               (5.0s) wall-clock deadline. As of DS-158 round 3, that deadline
+               is SHARED across the whole write-hook invocation - the project
+               and global appends draw from ONE deadline computed once by
+               cmd_write_hook, not one budget each - so a permanently-contended
+               lock on either target costs this budget once. A give-up (budget
+               exhausted or 8 attempts spent) returns False for that target
+               without raising; the record is silently NOT written for that
+               target, project/global outcomes are independent, and hooks/
+               stop-context.js's spawnSync ceiling (WRITE_HOOK_SPAWN_CEILING_MS)
+               is derived from this same budget by construction (see that
+               file and bin/tests/test_agentic_identity.py::
+               test_hook_ceiling_matches_python_budget). The optional
+               --status-file argument lets the caller recover which
+               sub-write(s) actually completed if this process is killed
+               (e.g. by that ceiling) before it can print its final stdout
+               status line - see _write_hook_checkpoint.
 
 Performance: Standard. File I/O is bounded. gh/git subprocesses have strict
              time plus stdout/stderr byte ceilings.
@@ -143,6 +163,15 @@ PENDING_INTERNAL_STALE_SECONDS = 60
 # the JS caller's subprocess ceiling (see hooks/stop-context.js
 # writeTelemetrySafely's spawnSync `timeout` comment) sets the same total
 # ceiling either way. Bumping one obliges bumping the other, by construction.
+#
+# DS-158 round 3 Major 1: this is the budget for ONE write-hook INVOCATION,
+# not one append call. cmd_write_hook calls _append_jsonl_safely twice
+# (project log, then global log); both draw from a single deadline computed
+# once by cmd_write_hook and passed through _append_jsonl_safely's
+# `deadline` parameter, so a permanently-contended lock on one target cannot
+# cost this budget twice. bin/tests/test_agentic_identity.py::
+# test_hook_ceiling_matches_python_budget parses hooks/stop-context.js and
+# fails if its spawnSync ceiling stops being derived from this constant.
 SESSION_LOG_LOCK_BUDGET_SECONDS = 5.0
 SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 1.0
 
@@ -1158,6 +1187,7 @@ def _write_jsonl_safely(
     line: str,
     *,
     session_uuid: str | None,
+    deadline: float | None = None,
 ) -> tuple[bool, bool]:
     """Atomically append/upsert through a locked, still-canonical pathname.
 
@@ -1166,6 +1196,13 @@ def _write_jsonl_safely(
     inode retry after its replacement. A displaced open descriptor is never
     written, and a post-publication displacement is retried through the
     canonical name with session-UUID idempotence.
+
+    `deadline` (a `time.monotonic()` timestamp) lets a caller share one lock-
+    retry budget across multiple calls in the same invocation (DS-158 round
+    3 Major 1) - e.g. cmd_write_hook's project-then-global append pair.
+    Defaults to a fresh SESSION_LOG_LOCK_BUDGET_SECONDS-wide deadline when
+    omitted, preserving this function's single-call behavior for every other
+    caller (including the test suite).
     """
     temp_name: str | None = None
     try:
@@ -1183,7 +1220,11 @@ def _write_jsonl_safely(
         # clock across every attempt (not per attempt) so a run of unlucky
         # collisions cannot compound into an unbounded wait.
         max_attempts = 8
-        lock_deadline = time.monotonic() + SESSION_LOG_LOCK_BUDGET_SECONDS
+        lock_deadline = (
+            deadline
+            if deadline is not None
+            else time.monotonic() + SESSION_LOG_LOCK_BUDGET_SECONDS
+        )
         for attempt in range(max_attempts):
             parent_fd: int | None = None
             log_fd: int | None = None
@@ -1324,8 +1365,17 @@ def _write_jsonl_safely(
         return False, False
 
 
-def _append_jsonl_safely(path: Path, line: str) -> bool:
-    """Safely publish one JSONL record, replacing its cumulative UUID row."""
+def _append_jsonl_safely(
+    path: Path,
+    line: str,
+    *,
+    deadline: float | None = None,
+) -> bool:
+    """Safely publish one JSONL record, replacing its cumulative UUID row.
+
+    `deadline` forwards to `_write_jsonl_safely` - see that function's
+    docstring for the shared-budget use case (DS-158 round 3 Major 1).
+    """
     session_uuid: str | None = None
     try:
         row = json.loads(line)
@@ -1339,6 +1389,7 @@ def _append_jsonl_safely(path: Path, line: str) -> bool:
         path,
         line,
         session_uuid=session_uuid,
+        deadline=deadline,
     )
     return success
 
@@ -2236,6 +2287,37 @@ def cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def _write_hook_checkpoint(status_file: str | None, status: dict) -> None:
+    """Best-effort atomic checkpoint of cmd_write_hook's in-progress status.
+
+    DS-158 round 3 Major 2: the caller (hooks/stop-context.js) SIGKILLs this
+    process if the whole invocation exceeds its own ceiling. A killed
+    process cannot flush a final stdout status line, so without this
+    checkpoint the caller cannot tell "neither write landed" apart from
+    "the project write landed but we never got to global" - it can only see
+    the absence of stdout, and DS-158 round 2 mistakenly reported that as a
+    uniform failure for every target even when a write in fact landed.
+
+    Called after each individual sub-write completes (never before), so
+    `status` only ever contains keys for writes whose outcome is actually
+    known - an absent key means "not yet attempted or interrupted mid-
+    attempt", which the caller must treat as unknown, never as False.
+
+    No-ops when `status_file` is unset (e.g. an older caller, or direct CLI
+    invocation without the flag). Failures are swallowed - this is a
+    diagnostic aid, never a correctness dependency for the write itself.
+    """
+    if not status_file:
+        return
+    try:
+        tmp = f"{status_file}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(status, separators=(",", ":")))
+        os.replace(tmp, status_file)
+    except OSError:
+        pass
+
+
 def cmd_resolve_hook(args: argparse.Namespace) -> int:
     """Emit a bounded JSON identity result for the Node Stop hook."""
     cwd = _absolute_lexical(args.cwd)
@@ -2303,6 +2385,7 @@ def cmd_write_hook(args: argparse.Namespace) -> int:
     ):
         return 1
     status = {"project": False, "global": False, "pending": False}
+    status_file = getattr(args, "status_file", None)
     if current_identity is not None and not current_identity["provisional"]:
         attributed = {
             "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -2318,13 +2401,29 @@ def cmd_write_hook(args: argparse.Namespace) -> int:
         }
         line = json.dumps(attributed, separators=(",", ":"), ensure_ascii=False)
         developer_id = str(current_identity["developer_id"])
+        # DS-158 round 3 Major 1: ONE shared deadline across both appends
+        # below, not one budget per append - a permanently-contended global
+        # lock must not cost this invocation SESSION_LOG_LOCK_BUDGET_SECONDS
+        # twice. See _write_jsonl_safely's docstring and the constant's own
+        # comment at its definition.
+        hook_deadline = time.monotonic() + SESSION_LOG_LOCK_BUDGET_SECONDS
         status["project"] = _append_jsonl_safely(
             cwd / ".agentic" / "session-log" / f"{developer_id}.jsonl",
             line,
+            deadline=hook_deadline,
         )
+        # DS-158 round 3 Major 2: checkpoint after each sub-write so a
+        # SIGKILL between here and the final stdout print still lets the
+        # caller recover which target(s) actually landed.
+        _write_hook_checkpoint(status_file, {"project": status["project"]})
         status["global"] = _append_jsonl_safely(
             GLOBAL_SESSION_LOG_DIR / f"{developer_id}.jsonl",
             line,
+            deadline=hook_deadline,
+        )
+        _write_hook_checkpoint(
+            status_file,
+            {"project": status["project"], "global": status["global"]},
         )
     else:
         pending = {
@@ -2343,6 +2442,7 @@ def cmd_write_hook(args: argparse.Namespace) -> int:
             if current_identity[IDENTITY_SCOPE_FIELD] == "profile":
                 pending["config_dir"] = current_identity["config_dir"]
         status["pending"] = _write_pending_record_safely(pending)
+        _write_hook_checkpoint(status_file, {"pending": status["pending"]})
 
     print(json.dumps(status, separators=(",", ":")))
     return 0
@@ -2405,6 +2505,7 @@ def main(argv: list[str]) -> int:
 
     p_write_hook = sub.add_parser("write-hook", help=argparse.SUPPRESS)
     p_write_hook.add_argument("--cwd", required=True, help=argparse.SUPPRESS)
+    p_write_hook.add_argument("--status-file", default=None, help=argparse.SUPPRESS)
     p_write_hook.set_defaults(func=cmd_write_hook)
 
     args = p.parse_args(argv[1:])

--- a/bin/ds-status
+++ b/bin/ds-status
@@ -458,11 +458,16 @@ def _telemetry_health_block() -> list[str]:
     """Return telemetry-health status lines from .agentic/.telemetry-health.json.
 
     Absent or unreadable file -> return [] (section omitted silently).
-    Tri-state per target via ISO8601 lexicographic string compare:
-      - failures == 0                                         -> OK
+    Four-state per target via ISO8601 lexicographic string compare:
+      - a present last_unknown_ts that is the most recent of
+        {last_success, last_error_ts, last_unknown_ts}          -> UNKNOWN
+        (DS-158 round 3 Major 2: the write-hook helper was killed before
+        it could report this target's outcome - it may or may not have
+        landed. Rendered honestly as unknown, never asserted as failed.)
+      - failures == 0 (and not UNKNOWN)                         -> OK
       - failures > 0 AND last_success present AND
-        last_success > last_error_ts                          -> RECOVERED
-      - otherwise (failures > 0, currently failing)          -> FAILING
+        last_success > last_error_ts (and not UNKNOWN)           -> RECOVERED
+      - otherwise (failures > 0, currently failing)             -> FAILING
     """
     if not HEALTH_FILE_PATH.is_file():
         return []
@@ -488,8 +493,22 @@ def _telemetry_health_block() -> list[str]:
         last_success = info.get("last_success") or ""
         last_error = info.get("last_error") or ""
         last_error_ts = info.get("last_error_ts") or ""
+        last_unknown = info.get("last_unknown") or ""
+        last_unknown_ts = info.get("last_unknown_ts") or ""
 
-        if failures == 0:
+        is_unknown_most_recent = bool(last_unknown_ts) and (
+            last_unknown_ts >= last_success and last_unknown_ts >= last_error_ts
+        )
+
+        if is_unknown_most_recent:
+            status = "UNKNOWN"
+            detail = "write outcome indeterminate (helper killed before reporting)"
+            if last_unknown:
+                detail = last_unknown
+            lines.append(
+                f"  {target}: {status}  ({detail}; last_unknown: {last_unknown_ts})"
+            )
+        elif failures == 0:
             status = "OK"
             lines.append(f"  {target}: {status}  (last_success: {last_success or 'none'})")
         elif failures > 0 and last_success and last_success > last_error_ts:
@@ -519,8 +538,12 @@ def _telemetry_health_line(health_path: Path | None = None) -> str:
 
     Reads .agentic/.telemetry-health.json (or the provided path override).
     Returns 'telemetry-health: OK' when the file is absent or all failure
-    counters are zero. When failures exist, returns a summary of the form:
+    counters are zero and no target has an indeterminate outcome. When
+    failures exist, returns a summary of the form:
       'telemetry-health: N write failures across M targets; last error <target>: <msg> at <ts>'
+    When only indeterminate outcomes exist (DS-158 round 3 Major 2 - a
+    write-hook helper was killed before it could report), returns:
+      'telemetry-health: N target(s) with an indeterminate write outcome; most recent <target> at <ts>'
     Fail-open: any read or parse error returns 'telemetry-health: OK (unreadable)'.
 
     Args:
@@ -540,6 +563,7 @@ def _telemetry_health_line(health_path: Path | None = None) -> str:
 
         total_failures = 0
         failing_targets: list[tuple[str, int, str, str]] = []  # (target, count, msg, ts)
+        unknown_targets: list[tuple[str, str]] = []  # (target, last_unknown_ts)
         for target, info in targets.items():
             if not isinstance(info, dict):
                 continue
@@ -550,9 +574,22 @@ def _telemetry_health_line(health_path: Path | None = None) -> str:
                 safe_msg = _ANSI.sub("", last_msg)[:200]
                 ts = str(info.get("last_error_ts", ""))
                 failing_targets.append((target, count, safe_msg, ts))
+            unknown_ts = str(info.get("last_unknown_ts") or "")
+            if unknown_ts:
+                success_ts = str(info.get("last_success") or "")
+                error_ts = str(info.get("last_error_ts") or "")
+                if unknown_ts >= success_ts and unknown_ts >= error_ts:
+                    unknown_targets.append((target, unknown_ts))
 
-        if total_failures == 0:
+        if total_failures == 0 and not unknown_targets:
             return "telemetry-health: OK"
+        if total_failures == 0 and unknown_targets:
+            unknown_targets.sort(key=lambda x: x[1], reverse=True)
+            last_target, last_ts = unknown_targets[0]
+            return (
+                f"telemetry-health: {len(unknown_targets)} target(s) with an "
+                f"indeterminate write outcome; most recent {last_target} at {last_ts}"
+            )
 
         # Report most-recently-failed target for the one-line summary.
         failing_targets.sort(key=lambda x: x[3], reverse=True)

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -37,6 +37,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import socket
 import stat
 import subprocess
@@ -847,7 +848,19 @@ def test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller(
     returns False rather than raising to its caller, and the give-up path
     terminates within a bounded window rather than hanging. Shrinks the
     module's lock-retry budget/per-attempt cap for the duration of the test
-    so the exhaustion path resolves quickly and deterministically."""
+    so the exhaustion path resolves quickly and deterministically.
+
+    DS-158 round 3 Minor 1: this is a version-agnostic INVARIANT test (it
+    also passes against the pre-round-2 code, verified in an ephemeral
+    worktree at base 6701a1c5 with only this test file applied: 1 failed,
+    1 passed) - it provides zero regression coverage for round 2 or round
+    3's specific fixes. It is deliberately kept loose (elapsed < 5.0) so it
+    keeps holding across future budget-shape changes; the tight,
+    round-3-specific wall-clock bound lives in
+    test_lock_retry_lock_timeout_clamped_to_remaining_budget and
+    test_lock_retry_backoff_sleep_clamped_to_remaining_budget below, which
+    are the actual regression coverage for Major 1/Major 3 of this round.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp).resolve()
         log_path = root / "session-log" / "lock-timeout-exhausted.jsonl"
@@ -890,6 +903,360 @@ def test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller(
         print(
             "PASS test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller"
         )
+
+
+class _FakeTimeModule:
+    """Deterministic stand-in for the `time` module used by DS-158 round 3's
+    total-wall-clock regression tests.
+
+    Rebinding `_mod.time` (not patching attributes on the real stdlib `time`
+    module) means only lookups from inside ds-identity's own functions are
+    affected - every other module's `import time` binding is untouched, so
+    this carries none of the risk of globally freezing `time.monotonic()`
+    for the whole test process (e.g. confusing a pytest-timeout watchdog).
+    `monotonic()` and `sleep()` are faked against an internal fake clock
+    that only ever advances by exactly what `sleep()` is asked to advance
+    it by; unrecognized attributes fall through to the real module via
+    `__getattr__`.
+    """
+
+    def __init__(self, real_time_module):
+        self._real = real_time_module
+        self._now = 0.0
+
+    def monotonic(self):
+        return self._now
+
+    def sleep(self, seconds):
+        self._now += seconds
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_hook_ceiling_matches_python_budget():
+    """DS-158 round 3 Major 1: the JS caller's spawnSync ceiling must stay
+    provably derived from this module's SESSION_LOG_LOCK_BUDGET_SECONDS,
+    not merely agree with it by coincidence of two hand-maintained numbers.
+    Parses both source files and asserts:
+      - hooks/stop-context.js's SESSION_LOG_LOCK_BUDGET_MS (in
+        milliseconds) equals SESSION_LOG_LOCK_BUDGET_SECONDS (in seconds)
+        here, exactly (no unit-conversion drift).
+      - the JS ceiling constant is literally the SUM of that budget
+        constant and a named headroom constant (WRITE_HOOK_SPAWN_CEILING_MS
+        = SESSION_LOG_LOCK_BUDGET_MS + HELPER_STARTUP_HEADROOM_MS), not a
+        third, independently-chosen literal - so bumping the Python budget
+        without touching the JS file already breaks this test, and vice
+        versa for a JS-side ceiling bump that isn't grounded in these two
+        named constants.
+    """
+    hook_js_path = _REPO_ROOT / "hooks" / "stop-context.js"
+    js_source = hook_js_path.read_text(encoding="utf-8")
+
+    budget_ms_match = re.search(
+        r"const SESSION_LOG_LOCK_BUDGET_MS\s*=\s*(\d+);", js_source
+    )
+    headroom_ms_match = re.search(
+        r"const HELPER_STARTUP_HEADROOM_MS\s*=\s*(\d+);", js_source
+    )
+    ceiling_match = re.search(
+        r"const WRITE_HOOK_SPAWN_CEILING_MS\s*=\s*"
+        r"SESSION_LOG_LOCK_BUDGET_MS\s*\+\s*HELPER_STARTUP_HEADROOM_MS;",
+        js_source,
+    )
+    assert budget_ms_match, (
+        "hooks/stop-context.js must define SESSION_LOG_LOCK_BUDGET_MS as a "
+        "literal integer constant"
+    )
+    assert headroom_ms_match, (
+        "hooks/stop-context.js must define HELPER_STARTUP_HEADROOM_MS as a "
+        "literal integer constant"
+    )
+    assert ceiling_match, (
+        "hooks/stop-context.js's WRITE_HOOK_SPAWN_CEILING_MS must be defined "
+        "as the literal sum of SESSION_LOG_LOCK_BUDGET_MS + "
+        "HELPER_STARTUP_HEADROOM_MS, not an independent literal"
+    )
+
+    budget_ms = int(budget_ms_match.group(1))
+    assert budget_ms / 1000.0 == _mod.SESSION_LOG_LOCK_BUDGET_SECONDS, (
+        f"hooks/stop-context.js SESSION_LOG_LOCK_BUDGET_MS ({budget_ms}ms) "
+        "must equal bin/ds-identity's SESSION_LOG_LOCK_BUDGET_SECONDS "
+        f"({_mod.SESSION_LOG_LOCK_BUDGET_SECONDS}s) exactly"
+    )
+
+    assert re.search(
+        r"timeout:\s*WRITE_HOOK_SPAWN_CEILING_MS,", js_source
+    ), (
+        "the spawnSync call's `timeout` must reference "
+        "WRITE_HOOK_SPAWN_CEILING_MS, not a standalone literal"
+    )
+
+    print("PASS test_hook_ceiling_matches_python_budget")
+
+
+def test_lock_retry_lock_timeout_clamped_to_remaining_budget():
+    """DS-158 round 3 Major 3: pins that a single lock attempt's `timeout`
+    argument is clamped to the REMAINING shared budget, not the flat
+    per-attempt cap. Mutation table (measured against this test):
+      - unmutated code                                    -> PASS
+      - drop the `lock_deadline - time.monotonic()` term
+        from lock_timeout's min(...) (M3)                  -> FAILS
+
+    Uses a fake, deterministic clock (see _FakeTimeModule) rather than real
+    wall-clock sleeps, so this test has zero timing-jitter flakiness: the
+    mocked lock call advances the fake clock by exactly the `timeout` value
+    it was passed (modeling a real flock that blocks for its full timeout
+    before giving up), and every other duration in this test is exact
+    floating-point addition, not measured real time.
+
+    Budget (0.2s) is deliberately SMALLER than the per-attempt cap (0.4s):
+    with the clamp intact, attempt 0's lock_timeout is clipped to the full
+    remaining budget (0.2s) and the retry loop gives up immediately after
+    (remaining hits exactly 0). Without the clamp, attempt 0 spends the
+    full uncapped 0.4s before the same give-up check fires - double the
+    correct total.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "lock-clamp-dev.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps({"session_uuid": "lock-clamp"}, separators=(",", ":"))
+
+        original_lock = _mod._lock_fd_exclusive
+        original_time = _mod.time
+        original_budget = _mod.SESSION_LOG_LOCK_BUDGET_SECONDS
+        original_cap = _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS
+
+        fake_time = _FakeTimeModule(original_time)
+
+        def blocking_timeout(fd, *, timeout):
+            # Models a real flock that genuinely blocks for its full
+            # timeout before reporting contention - this is what makes the
+            # `timeout` argument's own magnitude observable as elapsed
+            # wall clock, which is exactly what M3 corrupts.
+            fake_time.sleep(timeout)
+            raise RuntimeError("forced test lock timeout")
+
+        _mod._lock_fd_exclusive = blocking_timeout
+        _mod.time = fake_time
+        _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = 0.2
+        _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 0.4
+        try:
+            ok = _mod._append_jsonl_safely(log_path, line)
+            elapsed = fake_time.monotonic()
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+            _mod.time = original_time
+            _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = original_budget
+            _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = original_cap
+
+        assert ok is False
+        assert elapsed < 0.3, (
+            "a single lock attempt must be clamped to the remaining shared "
+            f"budget (expected ~0.2s), got {elapsed:.4f}s - the per-attempt "
+            "cap is winning over the remaining-budget clamp"
+        )
+        print("PASS test_lock_retry_lock_timeout_clamped_to_remaining_budget")
+
+
+def test_lock_retry_backoff_sleep_clamped_to_remaining_budget():
+    """DS-158 round 3 Major 3: pins that the backoff sleep BETWEEN lock
+    retries is clamped to the REMAINING shared budget, not just to its own
+    linear-backoff cap. Mutation table (measured against this test):
+      - unmutated code                                    -> PASS
+      - drop the `remaining` term from the backoff sleep's
+        min(...) call (M2)                                 -> FAILS
+
+    Same deterministic fake-clock approach as
+    test_lock_retry_lock_timeout_clamped_to_remaining_budget. Here the
+    mocked lock call consumes ZERO fake time (an instantaneous EAGAIN-style
+    contention), isolating the backoff-sleep clamp from the lock-timeout
+    clamp covered by that sibling test - only the backoff `time.sleep(...)`
+    calls advance the fake clock.
+
+    Budget (0.12s) is tuned so the second attempt's linear-backoff term
+    (0.10s) exceeds the actual remaining budget at that point (0.06s):
+    with the clamp intact, that sleep is clipped to 0.06s and the loop
+    gives up on the third attempt; without it, the sleep overshoots to the
+    full 0.10s, pushing the total past what the clamp would allow.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "backoff-clamp-dev.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps({"session_uuid": "backoff-clamp"}, separators=(",", ":"))
+
+        original_lock = _mod._lock_fd_exclusive
+        original_time = _mod.time
+        original_budget = _mod.SESSION_LOG_LOCK_BUDGET_SECONDS
+        original_cap = _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS
+
+        fake_time = _FakeTimeModule(original_time)
+
+        def instant_timeout(fd, *, timeout):
+            # Zero fake-time cost: isolates the backoff-sleep clamp from
+            # the lock-timeout clamp (covered by the sibling test above).
+            raise RuntimeError("forced test lock timeout")
+
+        _mod._lock_fd_exclusive = instant_timeout
+        _mod.time = fake_time
+        _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = 0.12
+        _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 1.0
+        try:
+            ok = _mod._append_jsonl_safely(log_path, line)
+            elapsed = fake_time.monotonic()
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+            _mod.time = original_time
+            _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = original_budget
+            _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = original_cap
+
+        assert ok is False
+        assert elapsed < 0.15, (
+            "backoff sleeps must be clamped to the remaining shared budget "
+            f"(expected ~0.13s), got {elapsed:.4f}s - the linear-backoff cap "
+            "is winning over the remaining-budget clamp"
+        )
+        print("PASS test_lock_retry_backoff_sleep_clamped_to_remaining_budget")
+
+
+def test_write_hook_checkpoint_survives_sigkill_mid_global_append():
+    """DS-158 round 3 Major 2 regression: the --status-file checkpoint must
+    retain a CONFIRMED project outcome, and must NOT assert a global outcome
+    it never observed, when the write-hook subprocess is killed while the
+    global append is still contended.
+
+    This runs the real `bin/ds-identity write-hook` subcommand as an actual
+    subprocess (not an in-process call), holds a real flock on the global
+    session log from a second process so the global append genuinely
+    blocks/retries, waits for the checkpoint to confirm the project append
+    landed, then SIGKILLs the write-hook process mid-global-attempt - the
+    exact failure mode the round 3 Skeptic measured against round 2's code
+    (project landed on disk, health reported it as failed because the
+    process never got to print its final stdout status line).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        subprocess.run(
+            ["git", "init", "-q"], cwd=project_dir, check=True,
+            capture_output=True,
+        )
+
+        dev_id = "sigkill-dev"
+        global_identity = fake_home / ".agentic" / "identity.yml"
+        _write_identity_file(global_identity, dev_id, provisional=False)
+
+        global_log_path = fake_home / ".agentic" / "session-log" / f"{dev_id}.jsonl"
+        global_log_path.parent.mkdir(parents=True, exist_ok=True)
+        global_log_path.touch()
+
+        status_file = tmp_path / "status.json"
+
+        env = dict(os.environ)
+        env["HOME"] = str(fake_home)
+        for key in ("AGENTIC_CONFIG_DIR", "CLAUDE_CONFIG_DIR", "CODEX_HOME",
+                    "PI_CODING_AGENT_DIR", "AE_IDENTITY_DEBUG"):
+            env.pop(key, None)
+
+        locker_ready = tmp_path / "locker-ready"
+        locker_release = tmp_path / "locker-release"
+        locker_script = (
+            "import fcntl, os, sys, time\n"
+            f"fd = os.open({str(global_log_path)!r}, os.O_RDONLY)\n"
+            "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+            f"open({str(locker_ready)!r}, 'w').close()\n"
+            f"while not os.path.exists({str(locker_release)!r}):\n"
+            "    time.sleep(0.01)\n"
+            "os.close(fd)\n"
+        )
+        locker = subprocess.Popen([sys.executable, "-c", locker_script])
+        proc = None
+        try:
+            deadline = time.monotonic() + 5.0
+            while not locker_ready.exists():
+                assert time.monotonic() < deadline, "locker never acquired the global lock"
+                time.sleep(0.01)
+
+            request = json.dumps({
+                "identity": {
+                    "developer_id": dev_id,
+                    "provisional": False,
+                    "identity_scope": "global",
+                },
+                "session_uuid": "sigkill-session",
+                "branch": "main",
+                "data": {
+                    "wall_seconds": 1,
+                    "tokens": {"input": 1, "output": 1, "cache_creation": 0, "cache_read": 0},
+                    "spawn_count": 1,
+                    "by_agent": {},
+                },
+            })
+
+            proc = subprocess.Popen(
+                [
+                    sys.executable, str(_BIN_PATH), "write-hook",
+                    "--cwd", str(project_dir),
+                    "--status-file", str(status_file),
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                text=True,
+            )
+            proc.stdin.write(request)
+            proc.stdin.close()
+
+            checkpoint_deadline = time.monotonic() + 5.0
+            checkpoint_seen = False
+            while time.monotonic() < checkpoint_deadline:
+                if status_file.exists():
+                    try:
+                        data = json.loads(status_file.read_text(encoding="utf-8"))
+                    except (OSError, json.JSONDecodeError):
+                        data = None
+                    if isinstance(data, dict) and data.get("project") is True:
+                        checkpoint_seen = True
+                        break
+                time.sleep(0.02)
+
+            assert checkpoint_seen, (
+                "checkpoint must show project:true before the global append "
+                "contends against the held lock"
+            )
+
+            proc.kill()
+            proc.wait(timeout=5)
+        finally:
+            locker_release.touch()
+            locker.wait(timeout=5)
+            if proc is not None and proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        final = json.loads(status_file.read_text(encoding="utf-8"))
+        assert final.get("project") is True, (
+            f"checkpoint must retain the confirmed project outcome, got {final!r}"
+        )
+        assert "global" not in final, (
+            "checkpoint must NOT contain a global key while the global "
+            f"append was still interrupted mid-attempt, got {final!r}"
+        )
+
+        project_log = project_dir / ".agentic" / "session-log" / f"{dev_id}.jsonl"
+        project_rows = [
+            json.loads(line)
+            for line in project_log.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert [row["session_uuid"] for row in project_rows] == ["sigkill-session"], project_rows
+        print("PASS test_write_hook_checkpoint_survives_sigkill_mid_global_append")
 
 
 def test_missing_log_race_dedups_against_locked_append_fd():
@@ -3622,6 +3989,10 @@ if __name__ == "__main__":
     test_append_retries_when_canonical_parent_rotates_before_publication()
     test_lock_timeout_retries_with_backoff_and_succeeds()
     test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller()
+    test_hook_ceiling_matches_python_budget()
+    test_lock_retry_lock_timeout_clamped_to_remaining_budget()
+    test_lock_retry_backoff_sleep_clamped_to_remaining_budget()
+    test_write_hook_checkpoint_survives_sigkill_mid_global_append()
     test_missing_log_race_dedups_against_locked_append_fd()
     test_profile_confirmed_beats_confirmed_global()
     test_project_confirmed_beats_confirmed_profile()

--- a/bin/tests/test_agentic_identity.py
+++ b/bin/tests/test_agentic_identity.py
@@ -785,6 +785,113 @@ def test_append_retries_when_canonical_parent_rotates_before_publication():
         print("PASS test_append_retries_when_canonical_parent_rotates_before_publication")
 
 
+def test_lock_timeout_retries_with_backoff_and_succeeds():
+    """DS-158 round 2: a transient lock-timeout RuntimeError from
+    _lock_fd_exclusive must be retried by _write_jsonl_safely's attempt
+    loop, not swallowed after a single attempt. Round 1 only raised the
+    per-attempt timeout (2.0s -> 5.0s); that timeout still escaped the
+    loop's `except FileNotFoundError` entirely and was caught only by the
+    function's outer except, one shot, no retry - a bigger single wait does
+    not change that shape. This forces two consecutive lock-timeout raises
+    (matching what a real flock timeout raises, regardless of exact
+    exception subclass) before delegating to the real flock, and asserts
+    the record still lands durably and that more than one attempt occurred.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "lock-timeout-dev.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps(
+            {"session_uuid": "lock-timeout-retry", "data": {"tokens": {"total": 3}}},
+            separators=(",", ":"),
+        )
+
+        original_lock = _mod._lock_fd_exclusive
+        attempts = {"n": 0}
+
+        def flaky_lock(fd, *, timeout):
+            attempts["n"] += 1
+            if attempts["n"] <= 2:
+                # Same exception family a real flock timeout raises
+                # (RuntimeError); a plain RuntimeError here (rather than the
+                # production-only _LockTimeoutError subclass) keeps this
+                # test meaningful against a checkout that has not yet
+                # defined that subclass, since what must be proven is that
+                # the RETRY LOOP catches the timeout family, not that one
+                # specific subclass exists.
+                raise RuntimeError("forced test lock timeout")
+            return original_lock(fd, timeout=timeout)
+
+        _mod._lock_fd_exclusive = flaky_lock
+        try:
+            ok = _mod._append_jsonl_safely(log_path, line)
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+
+        assert ok is True, "a transient lock timeout must not drop the record"
+        assert attempts["n"] == 3, (
+            "expected exactly two forced timeouts before the real lock "
+            f"succeeded on the third attempt, got {attempts['n']}"
+        )
+        rows = [
+            json.loads(raw)
+            for raw in log_path.read_text(encoding="utf-8").splitlines()
+            if raw.strip()
+        ]
+        assert [row["session_uuid"] for row in rows] == ["lock-timeout-retry"], rows
+        print("PASS test_lock_timeout_retries_with_backoff_and_succeeds")
+
+
+def test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller():
+    """A permanently-contended lock must still fail closed: _append_jsonl_safely
+    returns False rather than raising to its caller, and the give-up path
+    terminates within a bounded window rather than hanging. Shrinks the
+    module's lock-retry budget/per-attempt cap for the duration of the test
+    so the exhaustion path resolves quickly and deterministically."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        log_path = root / "session-log" / "lock-timeout-exhausted.jsonl"
+        log_path.parent.mkdir(parents=True)
+        line = json.dumps({"session_uuid": "lock-timeout-exhausted"}, separators=(",", ":"))
+
+        original_lock = _mod._lock_fd_exclusive
+        original_budget = getattr(_mod, "SESSION_LOG_LOCK_BUDGET_SECONDS", None)
+        original_cap = getattr(
+            _mod, "SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS", None
+        )
+
+        def always_timeout(fd, *, timeout):
+            raise RuntimeError("forced permanent test lock timeout")
+
+        _mod._lock_fd_exclusive = always_timeout
+        # Shrink the budget (when present - round-1 code has no such
+        # constant, and the give-up path there is bounded by its own single
+        # 5.0s attempt regardless) so this resolves quickly under test.
+        if original_budget is not None:
+            _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = 0.2
+        if original_cap is not None:
+            _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = 0.05
+        try:
+            started = time.monotonic()
+            ok = _mod._append_jsonl_safely(log_path, line)
+            elapsed = time.monotonic() - started
+        finally:
+            _mod._lock_fd_exclusive = original_lock
+            if original_budget is not None:
+                _mod.SESSION_LOG_LOCK_BUDGET_SECONDS = original_budget
+            if original_cap is not None:
+                _mod.SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS = original_cap
+
+        assert ok is False, "a permanently-contended lock must fail closed, not raise"
+        assert elapsed < 5.0, (
+            f"give-up path must not exceed a bounded budget, took {elapsed:.2f}s"
+        )
+        assert log_path.read_text(encoding="utf-8") == ""
+        print(
+            "PASS test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller"
+        )
+
+
 def test_missing_log_race_dedups_against_locked_append_fd():
     """The first flush reads UUIDs only after opening and locking the log fd."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -3513,6 +3620,8 @@ if __name__ == "__main__":
     test_flush_replaces_attributed_total_published_immediately_after_claim()
     test_append_retries_when_canonical_log_rotates_before_flock()
     test_append_retries_when_canonical_parent_rotates_before_publication()
+    test_lock_timeout_retries_with_backoff_and_succeeds()
+    test_lock_timeout_gives_up_after_budget_exhausted_without_raising_to_caller()
     test_missing_log_race_dedups_against_locked_append_fd()
     test_profile_confirmed_beats_confirmed_global()
     test_project_confirmed_beats_confirmed_profile()

--- a/bin/tests/test_agentic_status.py
+++ b/bin/tests/test_agentic_status.py
@@ -676,6 +676,58 @@ def test_telemetry_health_block_empty_targets(monkeypatch, tmp_path):
     assert result == []
 
 
+def test_telemetry_health_block_unknown_entry(monkeypatch, tmp_path):
+    """DS-158 round 3 Major 2: a most-recent last_unknown_ts -> UNKNOWN
+    status, never asserted as a confirmed failure, even with failures == 0
+    and a prior last_success present."""
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeSessionLogGlobal": {
+                "failures": 0,
+                "last_success": "2026-01-01T11:00:00Z",
+                "last_error": None,
+                "last_error_ts": None,
+                "last_unknown": "write outcome indeterminate (helper killed before reporting)",
+                "last_unknown_ts": "2026-01-01T12:00:00Z",
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    joined = "\n".join(result)
+    assert "UNKNOWN" in joined
+    assert "writeSessionLogGlobal" in joined
+    assert "FAILING" not in joined
+    assert "indeterminate" in joined
+
+
+def test_telemetry_health_block_stale_unknown_does_not_override_ok(monkeypatch, tmp_path):
+    """An unknown outcome OLDER than the most recent success renders OK, not
+    UNKNOWN - the indeterminate state has since been resolved by a later
+    confirmed write."""
+    data = {
+        "updated_at": "2026-01-01T12:00:00Z",
+        "targets": {
+            "writeSessionLog": {
+                "failures": 0,
+                "last_success": "2026-01-01T12:00:00Z",
+                "last_error": None,
+                "last_error_ts": None,
+                "last_unknown": "stale indeterminate outcome",
+                "last_unknown_ts": "2026-01-01T11:00:00Z",
+            }
+        },
+    }
+    p = _write_health_file(tmp_path, data)
+    monkeypatch.setattr(_mod, "HEALTH_FILE_PATH", p)
+    result = _telemetry_health_block()
+    joined = "\n".join(result)
+    assert "OK" in joined
+    assert "UNKNOWN" not in joined
+
+
 def test_main_output_contains_telemetry_health(monkeypatch, tmp_path, capsys):
     """main() includes 'Telemetry health' when health file is present."""
     _clear_harness_env(monkeypatch)
@@ -838,6 +890,30 @@ def test_telemetry_health_line_malformed_json(tmp_path):
     p.write_text("{not valid json", encoding="utf-8")
     result = _telemetry_health_line(p)
     assert "OK" in result
+
+
+def test_telemetry_health_line_unknown_only_not_reported_ok(tmp_path):
+    """DS-158 round 3 Major 2: zero failures but a most-recent indeterminate
+    outcome must NOT summarize as plain OK - the operator needs to see that
+    something didn't confirm, not be told everything is fine."""
+    p = tmp_path / ".telemetry-health.json"
+    p.write_text(json.dumps({
+        "targets": {
+            "writeSessionLogGlobal": {
+                "failures": 0,
+                "last_success": None,
+                "last_error": None,
+                "last_error_ts": None,
+                "last_unknown": "killed before reporting",
+                "last_unknown_ts": "2026-06-01T12:00:00Z",
+            },
+        },
+        "updated_at": "2026-06-01T12:00:00Z",
+    }), encoding="utf-8")
+    result = _telemetry_health_line(p)
+    assert result != "telemetry-health: OK"
+    assert "indeterminate" in result
+    assert "writeSessionLogGlobal" in result
 
 
 def test_telemetry_health_line_default_path_absent(monkeypatch, tmp_path):

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -872,7 +872,12 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
     });
     const result = spawnSync(helper, ['write-hook', '--cwd', cwd], {
       encoding: 'utf8',
-      timeout: 3000,
+      // DS-158: bin/ds-identity's session-log append can wait up to 5000ms
+      // on its own flock (see the comment beside that timeout constant).
+      // This ceiling must stay above that budget with headroom, or a
+      // genuinely-contended write gets SIGKILLed here before it ever gets
+      // to report a graceful failure back to recordHealth().
+      timeout: 6000,
       maxBuffer: 64 * 1024,
       stdio: ['pipe', 'pipe', 'ignore'],
       input: request,

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -845,6 +845,17 @@ function generateUuid() {
  * Identity resolution is compared again in the helper before any write, so an
  * identity swap between resolution and persistence fails closed. The helper
  * independently reports project/global/pending outcomes for health telemetry.
+ *
+ * DS-158 round 2: this call is deliberately single-shot, not wrapped in its
+ * own retry. The Python helper already retries its flock acquisition with
+ * backoff across its own bounded wall-clock budget (see the spawnSync
+ * `timeout` comment below); a caller-side retry here would re-spawn the
+ * whole subprocess and could double the worst-case Stop-hook latency for no
+ * added chance of success, since a second attempt would race the same
+ * contention the first one just spent its full budget failing to clear.
+ * On a project/global write failure, status is surfaced through
+ * recordHealth() -> flushHealth() (unconditional, not debug-gated) rather
+ * than retried here.
  */
 function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
   const confirmed = Boolean(identity && !identity.provisional);
@@ -872,11 +883,22 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
     });
     const result = spawnSync(helper, ['write-hook', '--cwd', cwd], {
       encoding: 'utf8',
-      // DS-158: bin/ds-identity's session-log append can wait up to 5000ms
-      // on its own flock (see the comment beside that timeout constant).
-      // This ceiling must stay above that budget with headroom, or a
-      // genuinely-contended write gets SIGKILLed here before it ever gets
-      // to report a graceful failure back to recordHealth().
+      // DS-158 round 2: bin/ds-identity's session-log append now retries its
+      // flock with backoff across SESSION_LOG_LOCK_BUDGET_SECONDS (5.0s) of
+      // total wall clock, capped at SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS
+      // (1.0s) per attempt - the same total ceiling round 1 gave its single
+      // flat attempt (the fix is that a timeout now gets retried within that
+      // ceiling, not that the ceiling grew). Backoff sleeps are themselves
+      // capped by the remaining budget, so worst case is that budget plus a
+      // small (<=0.05s) floor overshoot on the final attempt, not the
+      // budget plus backoff on top of it. This ceiling is derived from that
+      // budget plus headroom for
+      // process startup, imports, and the surrounding read/render/write
+      // work, not chosen independently - raising the Python-side budget
+      // obliges raising this one to match, and vice versa. A genuinely
+      // contended write must exhaust its own retry budget and report a
+      // graceful failure back to recordHealth(), not get SIGKILLed here
+      // first.
       timeout: 6000,
       maxBuffer: 64 * 1024,
       stdio: ['pipe', 'pipe', 'ignore'],

--- a/hooks/stop-context.js
+++ b/hooks/stop-context.js
@@ -379,6 +379,38 @@ function recordHealth(target, success, errMsg) {
 }
 
 /**
+ * Record an INDETERMINATE outcome for a named write-path target - the
+ * write may or may not have landed, and this call deliberately does not
+ * touch `failures`, `last_success`, or `last_error` (DS-158 round 3
+ * Major 2). A write whose outcome cannot be confirmed must never be
+ * reported as a confirmed failure: the operator-facing telemetry-health
+ * surface (bin/ds-status) would then assert something untrue about data
+ * that may actually be on disk. Used when the write-hook subprocess is
+ * killed by its own timeout ceiling before it can checkpoint that
+ * specific target's result.
+ *
+ * @param {string} target - Stable label for the write path.
+ * @param {string|null} note - Human-readable reason it is unknown.
+ */
+function recordHealthUnknown(target, note) {
+  try {
+    if (!healthOutcomes[target]) {
+      healthOutcomes[target] = {
+        failures: 0,
+        last_success: null,
+        last_error: null,
+        last_error_ts: null,
+      };
+    }
+    healthOutcomes[target].last_unknown =
+      note || 'write outcome indeterminate (helper killed before reporting)';
+    healthOutcomes[target].last_unknown_ts = new Date().toISOString();
+  } catch (_) {
+    // Never throw from the health layer.
+  }
+}
+
+/**
  * Flush accumulated health outcomes to [cwd]/.agentic/.telemetry-health.json.
  * Single atomic read-merge-write: reads existing file (parse-fail or absent ->
  * start fresh), merges accumulated outcomes (cumulative failures, latest
@@ -434,6 +466,12 @@ function flushHealth(cwd) {
       if (outcome.last_error_ts) {
         stored.last_error = outcome.last_error;
         stored.last_error_ts = outcome.last_error_ts;
+      }
+      // DS-158 round 3 Major 2: an indeterminate outcome is tracked
+      // separately from confirmed failure - it never increments `failures`.
+      if (outcome.last_unknown_ts) {
+        stored.last_unknown = outcome.last_unknown;
+        stored.last_unknown_ts = outcome.last_unknown_ts;
       }
     }
     existing.updated_at = new Date().toISOString();
@@ -840,6 +878,42 @@ function generateUuid() {
   ].join('-');
 }
 
+// DS-158 round 3 Major 1: the JS-side spawnSync ceiling below must be
+// provably derived from bin/ds-identity's SESSION_LOG_LOCK_BUDGET_SECONDS,
+// not merely commented as such. SESSION_LOG_LOCK_BUDGET_MS mirrors that
+// Python constant (5.0s) and is now, as of round 3, the SHARED lock-retry
+// budget for the helper's WHOLE invocation - cmd_write_hook computes one
+// deadline and passes it to both the project and global appends, so a
+// permanently-contended lock on either target costs this budget once, not
+// twice (round 2's bug). HELPER_STARTUP_HEADROOM_MS covers process
+// startup/imports, the `git symbolic-ref` probe above, and the
+// read/render/write work outside the lock itself.
+// bin/tests/test_agentic_identity.py::test_hook_ceiling_matches_python_budget
+// parses this file and bin/ds-identity and fails the moment either value
+// changes without the other - this is enforced by that test, not by this
+// comment.
+const SESSION_LOG_LOCK_BUDGET_MS = 5000;
+const HELPER_STARTUP_HEADROOM_MS = 1000;
+const WRITE_HOOK_SPAWN_CEILING_MS = SESSION_LOG_LOCK_BUDGET_MS + HELPER_STARTUP_HEADROOM_MS;
+
+/**
+ * Best-effort read of the write-hook helper's partial-progress checkpoint
+ * (DS-158 round 3 Major 2). Returns `{}` on any absence/parse failure -
+ * the checkpoint is a diagnostic aid, never a correctness dependency.
+ *
+ * @param {string} statusFile - Path passed to the helper via --status-file.
+ * @returns {object}
+ */
+function readWriteHookCheckpoint(statusFile) {
+  try {
+    const raw = fs.readFileSync(statusFile, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_) {
+    return {};
+  }
+}
+
 /**
  * Persist one telemetry record through the descriptor-safe Python helper.
  * Identity resolution is compared again in the helper before any write, so an
@@ -856,9 +930,21 @@ function generateUuid() {
  * On a project/global write failure, status is surfaced through
  * recordHealth() -> flushHealth() (unconditional, not debug-gated) rather
  * than retried here.
+ *
+ * DS-158 round 3 Major 2: on a spawnSync error/timeout (no parseable
+ * stdout), this now consults the helper's --status-file checkpoint before
+ * concluding total failure. A target present in the checkpoint gets its
+ * confirmed outcome recorded normally; a target absent from it (never
+ * attempted, or killed mid-attempt) is recorded as indeterminate via
+ * recordHealthUnknown, never as a confirmed failure.
  */
 function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
   const confirmed = Boolean(identity && !identity.provisional);
+  const effectiveSessionId = sessionId || generateUuid();
+  const statusFile = path.join(
+    os.tmpdir(),
+    `ds-identity-write-hook-${process.pid}-${effectiveSessionId}.json`,
+  );
   try {
     const totals = computeSessionTotals(cwd, sessionId, cachedRaw);
     const data = totals || {
@@ -877,34 +963,38 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
     const helper = path.resolve(__dirname, '..', 'bin', 'ds-identity');
     const request = JSON.stringify({
       identity,
-      session_uuid: sessionId || generateUuid(),
+      session_uuid: effectiveSessionId,
       branch,
       data,
     });
-    const result = spawnSync(helper, ['write-hook', '--cwd', cwd], {
-      encoding: 'utf8',
-      // DS-158 round 2: bin/ds-identity's session-log append now retries its
-      // flock with backoff across SESSION_LOG_LOCK_BUDGET_SECONDS (5.0s) of
-      // total wall clock, capped at SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS
-      // (1.0s) per attempt - the same total ceiling round 1 gave its single
-      // flat attempt (the fix is that a timeout now gets retried within that
-      // ceiling, not that the ceiling grew). Backoff sleeps are themselves
-      // capped by the remaining budget, so worst case is that budget plus a
-      // small (<=0.05s) floor overshoot on the final attempt, not the
-      // budget plus backoff on top of it. This ceiling is derived from that
-      // budget plus headroom for
-      // process startup, imports, and the surrounding read/render/write
-      // work, not chosen independently - raising the Python-side budget
-      // obliges raising this one to match, and vice versa. A genuinely
-      // contended write must exhaust its own retry budget and report a
-      // graceful failure back to recordHealth(), not get SIGKILLed here
-      // first.
-      timeout: 6000,
-      maxBuffer: 64 * 1024,
-      stdio: ['pipe', 'pipe', 'ignore'],
-      input: request,
-      env: process.env,
-    });
+    const result = spawnSync(
+      helper,
+      ['write-hook', '--cwd', cwd, '--status-file', statusFile],
+      {
+        encoding: 'utf8',
+        // DS-158 round 2/3: bin/ds-identity's session-log append(s) retry
+        // their flock with backoff across a SESSION_LOG_LOCK_BUDGET_SECONDS
+        // (5.0s) wall-clock budget, capped at
+        // SESSION_LOG_LOCK_PER_ATTEMPT_CAP_SECONDS (1.0s) per attempt.
+        // As of round 3, that budget is SHARED across the whole helper
+        // invocation (both the project and global append below draw from
+        // one deadline computed once in cmd_write_hook), so this ceiling
+        // is WRITE_HOOK_SPAWN_CEILING_MS = SESSION_LOG_LOCK_BUDGET_MS +
+        // HELPER_STARTUP_HEADROOM_MS, not a multiple of the budget - see
+        // those constants' definitions above this function for the
+        // cross-file consistency test. A genuinely contended write must
+        // exhaust its own retry budget and report a graceful failure back
+        // to recordHealth(), not get SIGKILLed here first; if it IS
+        // SIGKILLed (e.g. real budget/headroom drift), the --status-file
+        // checkpoint below still lets us report per-target outcomes
+        // honestly instead of asserting uniform failure.
+        timeout: WRITE_HOOK_SPAWN_CEILING_MS,
+        maxBuffer: 64 * 1024,
+        stdio: ['pipe', 'pipe', 'ignore'],
+        input: request,
+        env: process.env,
+      },
+    );
     if (result.error || result.status !== 0 || typeof result.stdout !== 'string') {
       throw result.error || new Error('safe telemetry helper failed');
     }
@@ -919,12 +1009,31 @@ function writeTelemetrySafely(cwd, identity, sessionId, cachedRaw) {
       recordHealth('writePendingBuffer', status.pending === true, status.pending === true ? null : 'safe helper refused pending record');
     }
   } catch (_) {
+    // DS-158 round 3 Major 2: no parseable stdout - consult the helper's
+    // partial-progress checkpoint before asserting uniform failure. A
+    // target present in the checkpoint has a confirmed outcome; a target
+    // absent from it (never attempted, or interrupted mid-attempt) is
+    // reported as indeterminate, not as a confirmed failure.
+    const checkpoint = readWriteHookCheckpoint(statusFile);
+    const errMsg = _ && _.message;
     if (confirmed) {
-      recordHealth('writeSessionLog', false, _ && _.message);
-      recordHealth('writeSessionLogGlobal', false, _ && _.message);
+      if (typeof checkpoint.project === 'boolean') {
+        recordHealth('writeSessionLog', checkpoint.project, checkpoint.project ? null : 'safe helper refused project log');
+      } else {
+        recordHealthUnknown('writeSessionLog', errMsg);
+      }
+      if (typeof checkpoint.global === 'boolean') {
+        recordHealth('writeSessionLogGlobal', checkpoint.global, checkpoint.global ? null : 'safe helper refused global log');
+      } else {
+        recordHealthUnknown('writeSessionLogGlobal', errMsg);
+      }
+    } else if (typeof checkpoint.pending === 'boolean') {
+      recordHealth('writePendingBuffer', checkpoint.pending, checkpoint.pending ? null : 'safe helper refused pending record');
     } else {
-      recordHealth('writePendingBuffer', false, _ && _.message);
+      recordHealthUnknown('writePendingBuffer', errMsg);
     }
+  } finally {
+    try { fs.unlinkSync(statusFile); } catch (_e) { /* absent or never created */ }
   }
 }
 
@@ -1434,5 +1543,12 @@ run().catch(() => { try { process.exit(0); } catch (_) {} });
 // executing run(). stop-context.js has no production module.exports; this shim
 // is only reached when the test replaces `run();` before requiring.
 if (typeof module !== 'undefined') {
-  module.exports = { recordHealth, flushHealth, healthOutcomes, appendCaptureGapNoticeToContextMd };
+  module.exports = {
+    recordHealth,
+    recordHealthUnknown,
+    flushHealth,
+    healthOutcomes,
+    appendCaptureGapNoticeToContextMd,
+    readWriteHookCheckpoint,
+  };
 }

--- a/hooks/tests/test-stop-context-health.js
+++ b/hooks/tests/test-stop-context-health.js
@@ -69,7 +69,7 @@ try {
   try { fs.unlinkSync(tmpShimPath); } catch (_) { /* ignore */ }
 }
 
-const { recordHealth, flushHealth, healthOutcomes } = helpers;
+const { recordHealth, recordHealthUnknown, flushHealth, healthOutcomes, readWriteHookCheckpoint } = helpers;
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -361,6 +361,112 @@ console.log('\nM2: forced-failure (stub fs.writeFileSync to force failure branch
   assert(stubHit === true, '(b) failure branch was reached (stub was hit)');
   const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
   assert(!fs.existsSync(healthPath), '(c) health file NOT written when write fails');
+
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// N1: recordHealthUnknown-does-not-touch-failures (DS-158 round 3 Major 2)
+// ---------------------------------------------------------------------------
+console.log('\nN1: recordHealthUnknown-does-not-touch-failures');
+{
+  clearOutcomes();
+  recordHealthUnknown('writeSessionLogGlobal', 'killed before reporting');
+  const o = healthOutcomes['writeSessionLogGlobal'];
+  assert(o !== undefined, 'writeSessionLogGlobal entry created');
+  assert(o.failures === 0, `failures untouched by an unknown outcome (got: ${o && o.failures})`);
+  assert(o.last_success === null, `last_success untouched (got: ${o && o.last_success})`);
+  assert(o.last_error === null, `last_error untouched (got: ${o && o.last_error})`);
+  assert(o.last_unknown === 'killed before reporting',
+    `last_unknown set (got: ${o && o.last_unknown})`);
+  assert(typeof o.last_unknown_ts === 'string' && o.last_unknown_ts.length > 0,
+    `last_unknown_ts is a non-empty string (got: ${o && o.last_unknown_ts})`);
+}
+
+// ---------------------------------------------------------------------------
+// N2: recordHealthUnknown-never-throws
+// ---------------------------------------------------------------------------
+console.log('\nN2: recordHealthUnknown-never-throws');
+{
+  clearOutcomes();
+  let threw = false;
+  try {
+    recordHealthUnknown(null, undefined);
+    recordHealthUnknown(undefined, 'msg');
+  } catch (_) {
+    threw = true;
+  }
+  assert(!threw, 'recordHealthUnknown does not throw on pathological inputs');
+}
+
+// ---------------------------------------------------------------------------
+// N3: flushHealth-merges-last-unknown-without-incrementing-failures
+// ---------------------------------------------------------------------------
+console.log('\nN3: flushHealth-merges-last-unknown-without-incrementing-failures');
+{
+  clearOutcomes();
+  const tmpDir = makeTmpProject();
+  const healthPath = path.join(tmpDir, '.agentic', '.telemetry-health.json');
+
+  // Prior state: this target has been reliably succeeding.
+  const prior = {
+    updated_at: '2026-01-01T00:00:00Z',
+    targets: {
+      writeSessionLog: {
+        failures: 0,
+        last_success: '2026-01-01T00:00:00Z',
+        last_error: null,
+        last_error_ts: null,
+      },
+    },
+  };
+  fs.writeFileSync(healthPath, JSON.stringify(prior, null, 2), 'utf8');
+
+  recordHealthUnknown('writeSessionLog', 'helper killed mid-attempt');
+  flushHealth(tmpDir);
+
+  const parsed = JSON.parse(fs.readFileSync(healthPath, 'utf8'));
+  assert(parsed.targets.writeSessionLog.failures === 0,
+    `failures stays 0 - an indeterminate outcome is never a confirmed failure (got: ${parsed.targets.writeSessionLog.failures})`);
+  assert(parsed.targets.writeSessionLog.last_success === '2026-01-01T00:00:00Z',
+    `prior last_success preserved (got: ${parsed.targets.writeSessionLog.last_success})`);
+  assert(parsed.targets.writeSessionLog.last_unknown === 'helper killed mid-attempt',
+    `last_unknown merged onto the existing target (got: ${parsed.targets.writeSessionLog.last_unknown})`);
+  assert(typeof parsed.targets.writeSessionLog.last_unknown_ts === 'string',
+    'last_unknown_ts merged onto the existing target');
+
+  cleanup(tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// N4: readWriteHookCheckpoint-round-trips-partial-progress
+// ---------------------------------------------------------------------------
+console.log('\nN4: readWriteHookCheckpoint-round-trips-partial-progress');
+{
+  const tmpDir = makeTmpProject();
+  const statusFile = path.join(tmpDir, 'status.json');
+
+  // Absent file -> {} (never attempted; process killed before any checkpoint).
+  assert(JSON.stringify(readWriteHookCheckpoint(statusFile)) === '{}',
+    'absent checkpoint file reads as {} (no confirmed outcomes)');
+
+  // Partial checkpoint: only `project` has been reported so far.
+  fs.writeFileSync(statusFile, JSON.stringify({ project: true }), 'utf8');
+  const partial = readWriteHookCheckpoint(statusFile);
+  assert(partial.project === true, `partial checkpoint reports project:true (got: ${partial.project})`);
+  assert(!('global' in partial), 'partial checkpoint has no global key - never attempted or interrupted mid-attempt');
+
+  // Corrupted checkpoint -> {} (fail-open, never throws).
+  fs.writeFileSync(statusFile, '{ not valid json', 'utf8');
+  let threw = false;
+  let corrupted;
+  try {
+    corrupted = readWriteHookCheckpoint(statusFile);
+  } catch (_) {
+    threw = true;
+  }
+  assert(!threw, 'readWriteHookCheckpoint does not throw on corrupted checkpoint content');
+  assert(JSON.stringify(corrupted) === '{}', 'corrupted checkpoint reads as {}');
 
   cleanup(tmpDir);
 }

--- a/hooks/tests/test-stop-context-identity.js
+++ b/hooks/tests/test-stop-context-identity.js
@@ -936,6 +936,85 @@ console.log('\n[TELEMETRY] concurrent helper appends remain complete JSONL recor
   cleanup(tmpDir);
 }
 
+console.log('\n[CEILING] full Stop hook run stays bounded by the production write-hook ceiling when BOTH project and global logs are permanently contended');
+{
+  // DS-158 round 3 Minor 6: the other TELEMETRY/J-suite concurrency tests
+  // in this file invoke `bin/ds-identity write-hook` DIRECTLY (bypassing
+  // stop-context.js entirely) with a harness timeout (10000ms) more
+  // permissive than production's spawnSync ceiling - they cannot fail on a
+  // regression to that ceiling. This test runs the REAL Stop hook
+  // end-to-end against a permanently-held flock on BOTH the project and
+  // global session logs (not just global - locking only global leaves the
+  // project append uncontended and never exercises Major 1's shared-vs-
+  // doubled budget distinction, since only a target that ALSO genuinely
+  // contends can absorb a share of the budget) and measures the full run's
+  // wall clock from the JS side (not via in-script `date` arithmetic,
+  // which is non-portable across BSD/GNU `date`), asserting it stays
+  // bounded by the production ceiling plus a small margin - not the
+  // harness's own generous outer timeout. A regression to round 2's
+  // per-append budget (or an unshared JS ceiling) would let this run
+  // consume roughly double the shared budget before the JS-side spawnSync
+  // ceiling force-kills it.
+  const { tmpDir, fakeHome, projectDir, globalIdentityDir } = makeTmp('ae-id-ceiling-');
+  writeIdentity(globalIdentityDir, 'ceiling-dev', false);
+  execFileSync('git', ['init', '-q'], { cwd: projectDir });
+
+  const globalLog = sessionLogFor(fakeHome, 'ceiling-dev');
+  const projectLog = sessionLogFor(projectDir, 'ceiling-dev');
+  fs.mkdirSync(path.dirname(globalLog), { recursive: true });
+  fs.mkdirSync(path.dirname(projectLog), { recursive: true });
+  fs.writeFileSync(globalLog, '');
+  fs.writeFileSync(projectLog, '');
+
+  const ready = path.join(tmpDir, 'ready');
+  const release = path.join(tmpDir, 'release');
+  const payloadFile = path.join(tmpDir, 'payload.json');
+  fs.writeFileSync(payloadFile, JSON.stringify({
+    cwd: projectDir,
+    session_id: 'ceiling-uuid',
+    transcript: [],
+  }));
+
+  const script = [
+    // Locks BOTH targets from a single process before signaling ready, so
+    // the hook's project AND global appends are simultaneously contended
+    // for the entire run.
+    'python3 -c \'import fcntl,os,sys,time;',
+    'fd1=os.open(sys.argv[1], os.O_RDONLY); fcntl.flock(fd1, fcntl.LOCK_EX);',
+    'fd2=os.open(sys.argv[2], os.O_RDONLY); fcntl.flock(fd2, fcntl.LOCK_EX);',
+    'open(sys.argv[3],"w").close();',
+    'exec("while not os.path.exists(sys.argv[4]): time.sleep(0.002)");',
+    'os.close(fd1); os.close(fd2)\'',
+    '"$1" "$2" "$3" "$4" & locker=$!;',
+    'while [ ! -f "$3" ]; do sleep 0.002; done;',
+    '"$5" "$6" < "$7" >/dev/null 2>&1; hookrc=$?;',
+    'touch "$4"; wait "$locker";',
+    'exit "$hookrc"',
+  ].join(' ');
+
+  const started = Date.now();
+  const result = spawnSync('bash', [
+    '-c', script, 'bash', projectLog, globalLog, ready, release,
+    process.execPath, hookScript, payloadFile,
+  ], { env: buildEnv(fakeHome), encoding: 'utf8', timeout: 10000 });
+  const elapsedMs = Date.now() - started;
+
+  assert(!result.error && result.status === 0,
+    `Stop hook exits 0 even when both logs are permanently contended (status=${result.status}, error=${result.error && result.error.message})`);
+  // Measured: fixed (shared-deadline) code lands at ~5330-5370ms across
+  // repeated local runs; reverting to a separate 5s budget per append (the
+  // exact Major 1 regression) lands at ~6180-6200ms, because the JS-side
+  // spawnSync ceiling (unmutated, still 6000ms) force-kills the child
+  // before Python's own doubled budget would otherwise let it run to
+  // ~10s. 5800ms sits between the two with margin on both sides.
+  assert(elapsedMs < 5800,
+    `Stop hook run stays bounded by the production write-hook ceiling `
+    + `(~5300-5400ms observed for a shared budget; a reversion to a `
+    + `separate per-append budget lands at ~6200ms - the JS-side spawnSync `
+    + `ceiling still caps it below the theoretical ~10s), got ${elapsedMs}ms`);
+  cleanup(tmpDir);
+}
+
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

DS-158. A `hooks-js-tests` failure on an unrelated documentation-only PR (#657) turned out to expose a real production defect in telemetry writes, not just a flaky test.

**The defect.** `bin/ds-identity`'s session-log append acquires an exclusive `flock` with a bounded timeout. That call sits inside an 8-attempt retry loop whose `except` clause caught only `FileNotFoundError` (for log rotation), so a lock-timeout `RuntimeError` **escaped the loop entirely** and landed in the outer `except (OSError, RuntimeError): return False, False`. A timeout therefore got exactly one attempt, no retry, and was swallowed. `hooks/stop-context.js:writeTelemetrySafely` calls `write-hook` once and does not retry either.

Net effect: two genuine concurrent conductor sessions on the same project could permanently drop one session's telemetry record. Rare, silent, and exactly the soft-failing-telemetry pattern that has hidden real breakage in this repo before.

## The fix

- **The timeout is now retried, not dropped.** `_lock_fd_exclusive` raises a dedicated `_LockTimeoutError(RuntimeError)`, and `_write_jsonl_safely`'s attempt loop catches it alongside `FileNotFoundError` - caught by the base class rather than the subclass, so it stays correct against any RuntimeError-based lock helper including a test double.
- **Budget is bounded on both axes.** Attempts share the existing `max_attempts = 8`; wall-clock is bounded by `SESSION_LOG_LOCK_BUDGET_SECONDS` computed once at entry. Attempts alone cannot bound worst-case latency (which the JS subprocess ceiling depends on); wall-clock alone cannot guarantee a minimum number of tries. Backoff is linear-capped and itself bounded by the remaining budget, so it is spent *inside* the ceiling rather than added on top.
- **Total ceiling held at parity.** The per-attempt timeout was replaced by a total budget plus a per-attempt cap, deliberately keeping the overall ceiling where round 1 left it. The fix is that a timeout is now retried within the budget, not that the budget grew.

**Surfacing was already correct** - verified rather than assumed. `hooks/stop-context.js` already calls `recordHealth('writeSessionLog', status.project === true, ...)` on every invocation, and `flushHealth(cwd)` runs unconditionally (not gated on `AE_IDENTITY_DEBUG`), writing `.agentic/.telemetry-health.json`. Since `status.project` is exactly the append's return value, a give-up was already observable without a debug flag. No Python-side change needed.

**Caller-side retry judged not warranted**, documented inline: re-spawning the subprocess would double worst-case Stop-hook latency while racing the same contention the first attempt just spent its full budget failing to clear. The Python side is the right layer.

## Verification

A real forced-overlap subprocess race **cannot discriminate** the two versions - both bound total lock-wait to the same ceiling by construction, so a stall over it fails identically and a stall under it succeeds identically. The defect lives only in the narrow one-shot-vs-retry boundary, which a wall-clock race cannot reliably land inside without flakiness. That is stated plainly rather than papered over with a demonstration that proves nothing.

The deterministic equivalent was used instead: `_lock_fd_exclusive` monkeypatched to raise two forced timeouts before delegating to the real flock, run against the literal pre-fix commit via `git stash`.

- **Pre-fix:** `AssertionError: a transient lock timeout must not drop the record` - the defect reproduces.
- **Post-fix:** passes, with `attempts["n"] == 3` confirming the retry actually occurred and the record readable back from the log.

Plus an OS-level sanity check with a genuine `fcntl.flock` held for 2s by a second real process: the writer waited ~2.02s, acquired, and wrote.

Two regression tests added and wired into the runner - one pinning the retry path, one pinning that give-up stays soft-fail (returns `False`, never raises) and stays bounded.

`hooks/tests/test-stop-context-identity.js:891-937` is untouched and still asserts both the project-scoped and global-scoped logs receive both complete records.

## North Star alignment

**Pillar 2, verifiable outcomes** - the primary win. A silently dropped telemetry record produces no verifiable outcome at all, and the drop path is now retried and, on give-up, observable through the existing health record.

**Pillar 1, guard operator attention** - indirect but real: this class of flake reds CI on PRs that did not cause it, which costs an operator a diagnosis cycle each time.

**Pillar 3, low friction** - worst-case Stop-hook latency is unchanged; the ceiling was held at parity and backoff spends the budget rather than extending it.

**Pillar 4, universality** - neutral; no operator identity, tracker, or harness assumption introduced.

## Test plan

- `pytest bin/tests/` - 1157 → 1159 (two new regression tests)
- `node hooks/tests/test-stop-context-identity.js` × 20 clean and × 20 under full-core CPU saturation - 20/20 both
- Hooks JS suite, verbatim CI loop - 45 files, 0 failures
- `test-enforce-turn-shape.py` 157, `test-turn-charge-model.py` 18
- methodology-drift, resident-budget, skill-embed-budget, symlinks-relative, command-file-budget - all OK

Doc-sync: predicate not triggered - no doc states a concrete lock-timeout figure (re-checked), and both the retry behavior and the health-record surfacing are internal mechanisms with no documented user-facing contract.

---

## Round 3 (Skeptic BLOCK: 3 Major, 3 Minor - all measured by execution)

**The budget was per-append, not per-invocation.** `cmd_write_hook` makes two appends and each started a fresh 5s deadline, so worst case measured 10.019s against a 6000ms subprocess ceiling - the helper was SIGKILLed at 6.003s and the *global* append could never use the retry this ticket exists to add. Fixed by computing one shared deadline and passing it to both appends. The JS ceiling is now derived from the Python budget by construction via named constants, cross-checked by a test that parses both source files and reds on drift.

Measured after the fix: ~5.32-5.37s worst case under permanent dual-lock contention, against a 6000ms ceiling. Reverting to the per-append budget pushes it back to ~6.18-6.25s and reds the new end-to-end CEILING test.

**Partial success was reported as total failure.** With the project record on disk and the global append killed, health reported `failures:1, last_success:null` - a false negative reaching the operator through `ds-status`. Fixed with a `--status-file` checkpoint the child writes after each sub-write; on timeout the parent reports only confirmed outcomes and uses a new UNKNOWN state for anything the checkpoint does not cover. `ds-status` renders UNKNOWN distinctly from FAILING. Verified by SIGKILLing a real subprocess mid-global-append.

**The headline wall-clock bound was untested** - mutations dropping the backoff `remaining` cap and the per-attempt budget cap both survived the suite. Two deterministic tests added using a fake monotonic clock; both mutations now red.

| mutation | before | after |
|---|---|---|
| drop `except RuntimeError:` retry | red | red |
| drop backoff `remaining` cap | **passed** | **red** |
| drop per-attempt budget cap | **passed** | **red** |
| drop `remaining <= 0` give-up guard | red | red |

Also: the give-up test's docstring now states it is a version-agnostic invariant test rather than regression coverage; `bin/ds-identity`'s manifest documents the retry budget, shared-deadline behavior, give-up semantics and `--status-file`; and the end-to-end test now binds on production's real 6000ms ceiling rather than the harness's more permissive 10000ms.

`pytest bin/tests/` 1159 → 1166. 20/20 clean and 20/20 under full-core CPU saturation.
