### PR TITLE
fix(ds-branch-prune): report dry-run in the mode summary instead of 'live'

### DIFF
--- a/bin/ds-branch-prune
+++ b/bin/ds-branch-prune
@@ -664,7 +664,17 @@ def main(argv: Optional[List[str]] = None) -> int:
     delete_results = [r for r in results if r["outcome"] == "DELETE"]
     skip_counts = Counter(r["outcome"] for r in results if r["outcome"] != "DELETE")
 
-    mode = "degraded (gh unavailable)" if degraded else "live"
+    # `degraded` (gh unavailable) and `args.dry_run` are independent axes - a
+    # run can be both at once, and collapsing them into a single either/or
+    # chain would mask whichever fact loses the tiebreak. Both must remain
+    # visible when both hold, and a --dry-run invocation must never report
+    # the bare "live" an operator would read as "deletions already ran".
+    mode_parts = []
+    if degraded:
+        mode_parts.append("degraded (gh unavailable)")
+    if args.dry_run:
+        mode_parts.append("dry-run")
+    mode = ", ".join(mode_parts) if mode_parts else "live"
     print(
         f"ds-branch-prune: base={args.base} mode={mode} branches={len(results)} "
         f"deletions={len(delete_results)} skips={len(results) - len(delete_results)}"

--- a/bin/tests/test_branch_prune.py
+++ b/bin/tests/test_branch_prune.py
@@ -1004,5 +1004,34 @@ def test_ledger_write_failure_halts_further_deletions_but_exits_zero(tmp_path, m
     assert not (repo / ".agentic" / "branch-prune-ledger.txt").exists()
 
 
+# --------------------------------------------------------------------------
+# Mode-label reporting: `degraded` and `--dry-run` are independent axes, and
+# the summary line's `mode=` field must reflect both without collapsing them.
+# --------------------------------------------------------------------------
+
+
+def test_dry_run_summary_never_reports_mode_live(tmp_path):
+    repo, pr_path, _, _ = build_clean_squash(tmp_path)
+    proc = run_prune(repo, pr_data=pr_path, dry_run=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "mode=live" not in proc.stdout
+
+
+def test_normal_run_summary_reports_mode_live(tmp_path):
+    repo, pr_path, _, _ = build_clean_squash(tmp_path)
+    proc = run_prune(repo, pr_data=pr_path, dry_run=False)
+    assert proc.returncode == 0, proc.stderr
+    assert "mode=live" in proc.stdout
+
+
+def test_degraded_dry_run_summary_surfaces_both_facts(tmp_path):
+    repo, pr_path, _, _ = build_squash_then_main_diverges(tmp_path)
+    proc = run_prune(repo, no_gh=True, dry_run=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "degraded" in proc.stdout.lower()
+    assert "dry-run" in proc.stdout.lower()
+    assert "mode=live" not in proc.stdout
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/bin/tests/test_branch_prune.py
+++ b/bin/tests/test_branch_prune.py
@@ -1015,13 +1015,14 @@ def test_dry_run_summary_never_reports_mode_live(tmp_path):
     proc = run_prune(repo, pr_data=pr_path, dry_run=True)
     assert proc.returncode == 0, proc.stderr
     assert "mode=live" not in proc.stdout
+    assert "mode=dry-run branches=" in proc.stdout
 
 
 def test_normal_run_summary_reports_mode_live(tmp_path):
     repo, pr_path, _, _ = build_clean_squash(tmp_path)
     proc = run_prune(repo, pr_data=pr_path, dry_run=False)
     assert proc.returncode == 0, proc.stderr
-    assert "mode=live" in proc.stdout
+    assert "mode=live branches=" in proc.stdout
 
 
 def test_degraded_dry_run_summary_surfaces_both_facts(tmp_path):
@@ -1031,6 +1032,7 @@ def test_degraded_dry_run_summary_surfaces_both_facts(tmp_path):
     assert "degraded" in proc.stdout.lower()
     assert "dry-run" in proc.stdout.lower()
     assert "mode=live" not in proc.stdout
+    assert "mode=degraded (gh unavailable), dry-run branches=" in proc.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`bin/ds-branch-prune` reported `mode=live` on a `--dry-run` invocation.

The flag itself was always honored correctly - deletion is guarded at `:703` (`if not args.dry_run and delete_results:`), and a dry run provably deletes nothing. This was a reporting defect only, and the deletion guard is untouched.

The cause was that `mode` collapsed two independent axes into one either/or chain:

```python
mode = "degraded (gh unavailable)" if degraded else "live"
```

`degraded` and `dry_run` can both hold at once, so whichever lost the tiebreak was silently dropped - and `--dry-run` had no representation at all.

Now:

| run | reported |
|---|---|
| normal | `mode=live` (byte-identical to before) |
| dry-run | `mode=dry-run` |
| degraded | `mode=degraded (gh unavailable)` (unchanged) |
| degraded + dry-run | `mode=degraded (gh unavailable), dry-run` |

Why it matters on this tool specifically: an operator reading `mode=live` on a dry run can reasonably conclude deletions already happened - or skip a real dry run believing they already did one. On a tool whose entire job is deleting branches, that is the wrong thing to be ambiguous about. This was hit in practice during a cleanup pass and had to be disproved by counting local branches before and after.

## North Star alignment

- **Guard operator attention.** The whole value of `--dry-run` is letting an operator decide whether to proceed. A summary line that says `live` on a dry run inverts that signal at exactly the moment it is being relied on.
- **Produce verifiable outcomes autonomously.** All three new assertions are mutation-verified: the fix was reverted, each was confirmed red with its actual failure text, then restored and confirmed green. The normal-run assertion correctly stayed green under the mutation, which is what proves it is pinning the unchanged-string guarantee rather than duplicating the dry-run check.
- **Works for everyone (universality).** Rendering is computed from flags alone - no operator, path, or environment specifics. The `mode=live` string is preserved byte-identically so any existing log scraping keeps working.
- **No enforcement floor removed.** Reporting-only. The deletion guard and the four-layer subsumption predicate are untouched; nothing became deletable that was not before.

## Test plan

- [x] `test_dry_run_summary_never_reports_mode_live` - mutation-verified red: `'mode=live' is contained here: ...mode=live branches=2 deletions=1 skips=1`
- [x] `test_degraded_dry_run_summary_surfaces_both_facts` - mutation-verified red: the `dry-run` fact was absent from the degraded string
- [x] `test_normal_run_summary_reports_mode_live` - pins the unchanged-string guarantee
- [x] Scratch-fixture proof that `--dry-run` still deletes nothing: a squash-merged branch computed as a deletion candidate (`deletions=1`) and was still present after the run
- [x] `bin/tests/test_branch_prune.py`: 30 passed (was 27). Full `bin/tests/`: 1169 passed (was 1166)
- [x] `build-all.sh` + `git diff --exit-code` over the verbatim `adapter-sync.yml` pathspec: zero drift. `check-methodology-drift.sh` OK, baseline unchanged
