### PR TITLE
fix(DS-159): recognise a trailing bare completion declaration on the identity line

### DIFF
--- a/hooks/enforce-turn-shape.py
+++ b/hooks/enforce-turn-shape.py
@@ -960,13 +960,15 @@ def _has_continuing_work_signal(text: str) -> bool:
 # under this version - the former via `_has_continuing_work_signal`, the
 # latter because the `status: DONE` sentinel is deleted outright.
 #
-# Known residual gap, PARTIALLY closed by DS-157 (see
-# _has_body_completion_declaration below - that fix suppresses the
-# ADVISORY status-only nag for exactly this shape, but deliberately does
-# NOT extend this WARRANT-granting regex's own domain past the identity
-# line; see that function's docstring for why): a completion declared
-# under a markdown sub-heading (e.g. "## Done") several lines into the
-# body, rather than on the identity line, is still not recognised as a
+# Known residual gap, PARTIALLY closed by DS-157 and DS-159 (see
+# _has_body_completion_declaration below - those fixes suppress the
+# ADVISORY status-only nag for a completion declared in the body's first
+# paragraph (DS-157) or as the identity line's own trailing sentence
+# (DS-159), but deliberately do NOT extend this WARRANT-granting regex's
+# own domain past the identity line's first sentence; see that function's
+# docstring for why): a completion declared under a markdown sub-heading
+# (e.g. "## Done") several lines into the body, rather than in the first
+# body paragraph or on the identity line, is still not recognised as a
 # `completion` WARRANT - see
 # `hooks/tests/fixtures/turn-shape-completion-corpus.json` case A9.
 _LEADING_COMPLETION_RE = re.compile(
@@ -999,6 +1001,59 @@ _TALLY_HEADER_RE = re.compile(
     r"(?:is\s+|are\s+)?(?:done|complete|completed)\b",
     re.IGNORECASE,
 )
+
+# DS-159. A BARE trailing completion word as the identity line's OWN final
+# sentence - e.g. "All three shipped. Done." - deliberately narrow:
+# `_LEADING_COMPLETION_RE`'s `\A` anchor never scans past the identity
+# line's first sentence (see `_has_body_completion_declaration`'s
+# docstring for the DS-157 sibling gap this closes for the BODY case), so
+# a genuine completion declared as a SECOND sentence on the identity line
+# itself - rather than in the body's first paragraph - was equally
+# invisible. Consumed only by `_identity_line_trailing_completion` below,
+# itself only an ADVISORY-suppression input to
+# `_has_body_completion_declaration` - see that function's docstring for
+# why this never widens the BLOCKING `completion` WARRANT.
+#
+# Scoped to a single bare word (+ optional bold markers) precisely
+# because a general "match _LEADING_COMPLETION_RE against every later
+# sentence" was measured unsafe: against a ~12.8k-turn corpus
+# (`~/.claude/projects`, main-agent-only, isSidechain absent/false) it
+# produced 30 newly-granted matches, at least 2 confirmed false positives
+# ("Status while it completes:" - `_LEADING_COMPLETION_RE`'s optional
+# trailing-word group silently absorbed the "s" in "completes" via its
+# missing `\b`; "Both mechanical fixes are done. Now finalizing state
+# files..." - a genuine DS-156-round-1-class sub-item match on a MIDDLE
+# sentence of a still-in-progress turn). Restricting to only the FINAL
+# sentence removed the middle-sentence class but not "Will report when
+# done." (a future-tense promise, not a completion) or "Writing the file
+# complete." (extra words before "complete" reopening the same
+# `_LEADING_COMPLETION_RE` looseness). This closed-vocabulary bare-word
+# regex was re-measured against the same corpus at 3 newly-granted
+# matches, all 3 confirmed genuine ("Fix confirmed against live traffic.
+# Done.", "All three shipped. Done.", "All three PRs merged and verified
+# on `main`. Done."), 0 false positives, 0 losses.
+_BARE_TRAILING_COMPLETION_RE = re.compile(
+    r"\A\*{0,2}(?:done|complete|completed|finished)\*{0,2}[.!]\Z",
+    re.IGNORECASE,
+)
+
+# Splits a line into sentences on a terminal `.`/`!`/`:` followed by
+# whitespace - used only to isolate the identity line's OWN final
+# sentence for `_identity_line_trailing_completion` below. Deliberately
+# not fence-aware or otherwise general-purpose: the identity line is
+# always a single raw line by `_segment`'s construction.
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!:])\s+")
+
+
+def _identity_line_trailing_completion(identity_line: str) -> bool:
+    """True iff the identity line has more than one sentence AND its FINAL
+    sentence is a bare completion word (see `_BARE_TRAILING_COMPLETION_RE`).
+    See that constant's docstring for the corpus measurement behind the
+    narrow bare-word shape."""
+    sentences = _SENTENCE_BOUNDARY_RE.split(identity_line)
+    if len(sentences) < 2:
+        return False
+    return bool(_BARE_TRAILING_COMPLETION_RE.match(sentences[-1].strip()))
 
 # Best-effort "answer" warrant: a quoted fragment (>=8 chars inside the
 # quote marks) anywhere in the message. Deliberately loose - this is the
@@ -1302,12 +1357,26 @@ def _has_body_completion_declaration(text: str) -> bool:
     output, without granting the warrant, is the safe fix: it silences the
     nag on a genuine completion report without moving that report onto a
     structural shape check it was never written to satisfy.
+
+    DS-159 addendum: this function ALSO now returns True when the
+    completion declaration is the identity line's OWN final sentence
+    (`_identity_line_trailing_completion`) rather than the body's first
+    paragraph - see the reported symptom "All three shipped. Done.\\n\\n|
+    ticket | what landed |\\n..." (a markdown table, not prose, as the
+    first body paragraph). Same "why not widen the warrant" analysis
+    applies and was re-verified: synthetically granting `completion` for
+    this exact example still returns `_execution_prose_flag`'s blocking
+    finding (the table row is an unrecognized status-region line), so this
+    stays an advisory-only addition, same as the rest of this function.
     """
     identity_line, body = _segment(text)
     unfenced_lines = [ln for ln, is_fenced in body if not is_fenced]
     domain_text = identity_line + "\n" + "\n".join(unfenced_lines)
     if _has_continuing_work_signal(domain_text):
         return False
+
+    if _identity_line_trailing_completion(identity_line):
+        return True
 
     paragraphs = []
     current = []

--- a/hooks/tests/test-enforce-turn-shape.py
+++ b/hooks/tests/test-enforce-turn-shape.py
@@ -2490,6 +2490,120 @@ check(
 )
 
 # ---------------------------------------------------------------------------
+# z. DS-159: identity-line TRAILING bare completion sentence suppresses the
+#    status-only ADVISORY without granting the `completion` WARRANT (same
+#    posture as DS-157's y-block above, for the sibling gap where the
+#    completion is the identity line's own second sentence, not the body's
+#    first paragraph). See hooks/enforce-turn-shape.py's
+#    _identity_line_trailing_completion docstring for the corpus method.
+# ---------------------------------------------------------------------------
+
+# z1. The reported symptom, reproduced verbatim: identity line "All three
+# shipped. Done." does NOT match _LEADING_COMPLETION_RE at position 0 (the
+# `\A` anchor never scans past "All three shipped." to reach the second
+# sentence "Done."), and the first BODY paragraph is a markdown table, not
+# prose, so _has_body_completion_declaration's DS-157 body-paragraph check
+# also misses it. Must be QUIET (was ADVISORY pre-fix).
+z1_msg = (
+    "All three shipped. Done.\n"
+    "\n"
+    "| ticket | what landed |\n"
+    "|---|---|\n"
+    "| **DS-156** | Conductor turn shape bound to warrant. |\n"
+    "| **DS-157** | Body-paragraph completion detection. |\n"
+)
+rc, out, err = run_hook(make_payload(z1_msg))
+check(
+    "z1. DS-159 reported symptom - identity line's SECOND sentence is a "
+    "bare completion declaration, first body paragraph is a table -> "
+    "QUIET (was ADVISORY pre-fix)",
+    is_quiet(rc, out),
+)
+
+# z2. REGRESSION (measured false positive, non-bare trailing sentence):
+# "Both mechanical fixes are done." as a MIDDLE sentence followed by "Now
+# finalizing..." on the same identity line must NOT be recognised - the
+# bare-word-only shape (_BARE_TRAILING_COMPLETION_RE) requires the FINAL
+# sentence to be nothing but the completion word itself, and this sentence
+# both has extra leading words ("Both mechanical fixes are") and is not
+# the identity line's last sentence.
+z2_msg = (
+    "PR pushed successfully. Both mechanical fixes are done. Now "
+    "finalizing state files and the run summary.\n"
+    "\n"
+    "Extra detail line one.\n"
+    "Extra detail line two.\n"
+    "Extra detail line three.\n"
+)
+rc, out, err = run_hook(make_payload(z2_msg))
+check(
+    "z2. non-bare, non-final trailing sentence ('Both mechanical fixes "
+    "are done. Now finalizing...') is NOT suppressed -> ADVISORY "
+    "(status-only)",
+    is_advisory(rc, out, "status-only"),
+)
+
+# z3. REGRESSION (measured false positive, partial-word absorption): "Status
+# while it completes:" would match _LEADING_COMPLETION_RE.match (the regex's
+# optional trailing-word group silently absorbs the "s" in "completes"
+# before the terminal ":"), but _BARE_TRAILING_COMPLETION_RE's closed
+# single-word vocabulary correctly rejects it - "completes" is not
+# "complete"/"completed"/"done"/"finished".
+z3_msg = (
+    "Validation still running. Status while it completes:\n"
+    "\n"
+    "Wave 1 complete: 63 components authored.\n"
+    "Extra detail line one.\n"
+    "Extra detail line two.\n"
+)
+rc, out, err = run_hook(make_payload(z3_msg))
+check(
+    "z3. 'Status while it completes:' (partial-word, not a bare "
+    "completion token) is NOT suppressed -> ADVISORY (status-only)",
+    is_advisory(rc, out, "status-only"),
+)
+
+# z4. BLOCKING-PATH SAFETY REGRESSION (this ticket's central concern,
+# mirrors y6 above): the z1 shape must NEVER grant the `completion`
+# WARRANT, even though _has_body_completion_declaration is True for it -
+# only _status_only_flag may consume the DS-159 signal.
+_z1_warrants = _mod._classify_warrants(z1_msg)
+check(
+    "z4a. _has_body_completion_declaration is True for the z1 fixture "
+    "(precondition for z4b/z4c to be meaningful)",
+    _mod._has_body_completion_declaration(z1_msg) is True,
+)
+check(
+    "z4b. the `completion` warrant key is NOT granted for the z1 fixture",
+    _z1_warrants["completion"] is False,
+)
+# z4c. Directly verifies the blocking-path danger this ticket required be
+# analyzed: simulating the z1 warrant dict with `completion` forced True
+# trips _execution_prose_flag (BLOCKING) on this exact genuine-completion
+# turn (the table row is not a State:/Running:/Blocked:/Waiting: slot
+# line).
+_z1_warrants_if_granted = dict(_z1_warrants)
+_z1_warrants_if_granted["completion"] = True
+check(
+    "z4c. _execution_prose_flag BLOCKS the z1 fixture under a synthetic "
+    "completion=True warrant dict - shows why z4b's fix must NOT widen "
+    "the warrant",
+    _mod._execution_prose_flag(z1_msg, _z1_warrants_if_granted) is not None,
+)
+
+# z5. A single-sentence identity line ("Done.") must not be treated as a
+# TRAILING completion (there is no earlier sentence to trail) - this
+# shape is already covered by _LEADING_COMPLETION_RE's own `\A` match on
+# the identity line itself, so _identity_line_trailing_completion's
+# len(sentences) < 2 guard must return False here (not double-count).
+check(
+    "z5. a single-sentence identity line does not trigger "
+    "_identity_line_trailing_completion (already covered by the "
+    "leading-declaration path)",
+    _mod._identity_line_trailing_completion("Done.") is False,
+)
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The turn-shape guard fired its advisory status-only finding on a genuine completion report opening `All three shipped. Done.`

**Root cause.** Neither suspected path was at fault alone. `_LEADING_COMPLETION_RE` is `\A`-anchored, so it only tries position 0 of the identity line - but the actual declaration ("Done.") is that line's *second sentence*. `_has_body_completion_declaration` never fires either, not because of the markdown table but because the completion is not in the body at all. Confirmed by execution: `_LEADING_COMPLETION_RE.match(identity_line)` returns `None`.

**Fix.** `_BARE_TRAILING_COMPLETION_RE` + `_identity_line_trailing_completion()`, wired into `_has_body_completion_declaration` only - never into `_classify_warrants`. Same posture DS-157 established: advisory-only suppression of `_status_only_flag`, never the BLOCKING `completion` warrant.

## Measurement (~12.8k main-agent turns in `~/.claude/projects`)

A naive "scan every later sentence with the full regex" candidate produced **30 false positives**, including `Status while it completes:` (a missing `\b` absorbing the "s" in "completes") and `Both mechanical fixes are done. Now finalizing...` - the mid-sentence sub-item trap DS-156 round 1 already fell into.

Narrowed to a closed-vocabulary bare word (`Done.`/`Complete.`/`Completed.`/`Finished.`, optional bold) on only the identity line's **final** sentence: **3 gains, 0 false positives**, all three confirmed genuine by inspection.

Scoped to `_has_body_completion_declaration`: **1** status-only advisory newly suppressed (the reported symptom), **0** newly firing, **0** completion-warrant delta in either direction.

Blocking-path danger re-confirmed: synthetically granting `completion=True` on this shape still trips `_execution_prose_flag` on the table row, which is exactly why the signal stays advisory-only.

## North Star alignment

**Pillar 1** - a guard that fires on correct turns trains the conductor to ignore its own feedback channel, which the module docstring names as worse than no hook at all.
**Pillar 2** - measured against a 12.8k-turn corpus with false positives counted per candidate, not asserted.
**Pillar 3** - no blocking path touched; worst case is one fewer advisory line.
**Pillar 4** - neutral.

## Test plan

- `test-enforce-turn-shape.py` 157 -> 164. Mutation-verified: reverting only the hook (keeping the tests) reds `z1` and `z4a`; restoring passes both.
- `pytest bin/tests/` 1166; hooks JS suite 45/45; methodology-drift, resident-budget, skill-embed-budget, symlinks-relative all OK.

Doc-sync: predicate not triggered - internal hook-classifier fix, no public-facing claim affected.