### PR TITLE
docs(vision): add North Star pillars 5-6 - guard agent context, shorten wall-clock time

### DIFF
--- a/.codex/agents/skeptic.toml
+++ b/.codex/agents/skeptic.toml
@@ -76,7 +76,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.codex/agents/skeptic.toml
+++ b/.codex/agents/skeptic.toml
@@ -76,7 +76,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -77,7 +77,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -77,7 +77,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.github/ISSUE_TEMPLATE/protocol_change.yml
+++ b/.github/ISSUE_TEMPLATE/protocol_change.yml
@@ -40,7 +40,7 @@ body:
     id: north_star_alignment
     attributes:
       label: North Star alignment
-      description: Which pillar in docs/overview/vision.md does this advance (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone)? Note any pillar it could regress or trade off. (This RFC gate is issue-type-scoped per CONTRIBUTING.md's protocol-change definition - a narrower, distinct gate from the path-based trigger canonical in content/agents/skeptic.md step 3.6, not a duplicate of it.)
+      description: Which pillar in docs/overview/vision.md does this advance (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result)? Note any pillar it could regress or trade off. (This RFC gate is issue-type-scoped per CONTRIBUTING.md's protocol-change definition - a narrower, distinct gate from the path-based trigger canonical in content/agents/skeptic.md step 3.6, not a duplicate of it.)
     validations:
       required: true
   - type: textarea

--- a/.github/agents/skeptic.md
+++ b/.github/agents/skeptic.md
@@ -73,7 +73,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.github/agents/skeptic.md
+++ b/.github/agents/skeptic.md
@@ -73,7 +73,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12574,7 +12574,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -12574,7 +12574,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.openclaw/skills/agent-skeptic/SKILL.md
+++ b/.openclaw/skills/agent-skeptic/SKILL.md
@@ -73,7 +73,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.openclaw/skills/agent-skeptic/SKILL.md
+++ b/.openclaw/skills/agent-skeptic/SKILL.md
@@ -73,7 +73,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.opencode/agents/skeptic.md
+++ b/.opencode/agents/skeptic.md
@@ -78,7 +78,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/.opencode/agents/skeptic.md
+++ b/.opencode/agents/skeptic.md
@@ -78,7 +78,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Changes to the methodology itself - conductor rules, the Skeptic protocol, risk 
 - One concern per PR — don't bundle unrelated changes
 - Describe the *why* in the PR body, not just the *what*
 - Test locally before opening: re-run `install.sh`, open a Claude Code session, verify the change works as expected
-- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another, with operator attention as the tie-breaker. Fill in the PR template's '## North Star alignment' section - required for changes touching a methodology-shaping path (see content/agents/skeptic.md step 3.6); a trivial in-scope change may answer with a one-line N/A. Write "N/A" outright for out-of-scope PRs.
+- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another, with operator attention as the tie-breaker. Fill in the PR template's '## North Star alignment' section - required for changes touching a methodology-shaping path (see content/agents/skeptic.md step 3.6); a trivial in-scope change may answer with a one-line N/A. Write "N/A" outright for out-of-scope PRs.
 
 ### Adapter compatibility declaration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Changes to the methodology itself - conductor rules, the Skeptic protocol, risk 
 - One concern per PR — don't bundle unrelated changes
 - Describe the *why* in the PR body, not just the *what*
 - Test locally before opening: re-run `install.sh`, open a Claude Code session, verify the change works as expected
-- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another, with operator attention as the tie-breaker. Fill in the PR template's '## North Star alignment' section - required for changes touching a methodology-shaping path (see content/agents/skeptic.md step 3.6); a trivial in-scope change may answer with a one-line N/A. Write "N/A" outright for out-of-scope PRs.
+- Align changes with the North Star ([docs/overview/vision.md](docs/overview/vision.md)): a change is aligned if it advances one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another, with operator attention as the tie-breaker. Fill in the PR template's '## North Star alignment' section - required for changes touching a methodology-shaping path (see content/agents/skeptic.md step 3.6); a trivial in-scope change may answer with a one-line N/A. Write "N/A" outright for out-of-scope PRs.
 
 ### Adapter compatibility declaration
 

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -78,7 +78,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -78,7 +78,7 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
    For any diff touching none of these, skip this step entirely - do not manufacture a finding on a non-methodology change.
 
-   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context) without regressing another?
+   When applicable, read `docs/overview/vision.md` if it exists and apply its "How to use this for PR alignment" rubric: does the diff advance at least one North Star pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone, guard agent context, shorten wall-clock time to a finished, verified result) without regressing another?
 
    - **Trivial diffs stay trivial.** If the diff is typo-only, formatting-only, whitespace-only, or comment-only on an otherwise in-scope path, the check is satisfied by noting the triviality in your sign-off (e.g. "trivial formatting-only change, no pillar impact") - do not manufacture a Major or Minor finding demanding vision analysis on a diff with no behavioral surface. Proportionality applies inside scope, not just outside it.
    - If the diff writes to `docs/overview/vision.md` or `docs/overview/requirements.md` directly (as opposed to `docs/overview/_proposed/`): this is a **Critical** finding regardless of content - these files are operator-owned (see `content/references/planning-artifacts.md` §Product-intent layer) and no Worker or engineer may write them.

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -45,6 +45,24 @@ task and get back a verifiable outcome.
    what an agent must load or emit to do the same job at the same correctness? A single session
    once found 21 subagent return fields with no downstream consumer and 15 of 17 agent contracts
    with no output-length constraint - waste of exactly this shape.)
+6. **Shorten wall-clock time to a finished, verified result.** This is distinct from the other
+   two resource pillars: Pillar 1 is what the operator must read, Pillar 5 is what an agent must
+   load, this pillar is how long the operator waits. It can legitimately conflict with Pillar 5,
+   and this vision says so rather than pretending they always align: parallel fan-out spends more
+   total tokens to finish sooner, while a chain of small serial rounds spends fewer tokens and
+   takes far longer. When the two conflict, prefer the faster wall-clock outcome unless the token
+   cost is disproportionate - state that lean explicitly so an agent can act on it without asking.
+   Concretely: run independent units in parallel rather than serializing them, batch findings into
+   one rework round rather than one round per finding, do not block behavior work behind
+   infrastructure work, prefer same-PR rework over a fresh PR-and-CI cycle per round, and count CI
+   cycle time as part of the cost of an extra round. The same boundary as Pillar 5 applies just as
+   exactly here: speed is won only by removing serialization and waste, never by removing a gate,
+   a review round, a verification step, or an enforcement floor - shipping unverified work is not
+   fast, it defers the cost. (The "latency test": does this change shorten the path from request
+   to verified result without removing verification? A single session once took roughly 10 hours
+   and 15 review rounds on one change, with independent units run serially, one review round per
+   individual finding, and three units blocked behind an infrastructure-only unit that shipped no
+   user-visible behavior.)
 
 ## What it does
 
@@ -63,6 +81,8 @@ trust — escalating to the human only for genuine decisions.
 - **Not** a license to cut verification for token savings: a gate, review round, or enforcement
   floor removed to reduce context cost is a regression against verifiability, never a win for
   context efficiency.
+- **Not** speed at the cost of verification: a gate, review round, or enforcement floor removed
+  to finish sooner is a regression against verifiability, never a win for wall-clock time.
 
 ## How to use this for PR alignment
 
@@ -72,7 +92,10 @@ tax for little autonomy/verifiability gain, makes outcomes harder to verify, inc
 without justification, pulls the methodology toward "human must babysit," fails the
 portability test (works only for the author's identity, tracker, or setup), or grows
 always-loaded surface, duplicates binding prose, or adds an unconsumed output field without a
-proportional gain (fails the efficiency test). Symmetrically, a PR that cuts a gate, review
-round, verification step, or enforcement floor to save tokens is also misaligned, regardless of
-how it scores on the efficiency test - that trade-off is never on the table. Misalignment is a
-*direction* signal for the operator — not necessarily a request-changes verdict on correctness.
+proportional gain (fails the efficiency test), or needlessly serializes independent work, spends
+a full review cycle on a single non-blocking finding, or otherwise adds wall-clock delay without
+a proportional gain (fails the latency test). Symmetrically, a PR that cuts a gate, review round,
+verification step, or enforcement floor to save tokens or to finish sooner is also misaligned,
+regardless of how it scores on the efficiency or latency test - that trade-off is never on the
+table. Misalignment is a *direction* signal for the operator — not necessarily a request-changes
+verdict on correctness.

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -32,6 +32,19 @@ task and get back a verifiable outcome.
    capability isn't configured rather than breaking. A change that only works for its author's
    setup is a regression. (The "portability test": would this behave correctly for a teammate
    with different credentials, a different tracker, or a different harness?)
+5. **Guard agent context.** Agent context is a scarce resource, exactly the way operator
+   attention is - this pillar is the agent-facing counterpart to Pillar 1. Prefer changes that
+   reduce what an agent must load or emit to do the same job at equal or better quality: cut
+   duplicated prose, unconsumed return fields, always-loaded content that could be trigger-loaded
+   instead, and narration that surfaces no decision. That boundary is exact, not a matter of
+   degree: efficiency is won only by removing waste. It is never won by removing a gate, a review
+   round, a verification step, or an enforcement floor - an enforcement floor is not waste, and
+   trimming verification to save tokens is a regression against Pillar 2, not a win against this
+   one. This matches existing precedent: capability and efficiency changes move the risk-profile
+   dial, they never remove an enforcement floor. (The "efficiency test": does this change reduce
+   what an agent must load or emit to do the same job at the same correctness? A single session
+   once found 21 subagent return fields with no downstream consumer and 15 of 17 agent contracts
+   with no output-length constraint - waste of exactly this shape.)
 
 ## What it does
 
@@ -47,12 +60,19 @@ trust — escalating to the human only for genuine decisions.
 - **Not** a finished product — it is a living system meant to evolve as patterns improve.
 - **Not** single-operator software: behavior hardwired to one person's identity, tracker,
   workspace, or machine has no place in the shared rule set.
+- **Not** a license to cut verification for token savings: a gate, review round, or enforcement
+  floor removed to reduce context cost is a regression against verifiability, never a win for
+  context efficiency.
 
 ## How to use this for PR alignment
 
 A pull request is **aligned** if it advances at least one North Star pillar without regressing
 another (especially the attention test). A PR is **misaligned** if it adds operator attention
 tax for little autonomy/verifiability gain, makes outcomes harder to verify, increases friction
-without justification, pulls the methodology toward "human must babysit," or fails the
-portability test (works only for the author's identity, tracker, or setup). Misalignment is a
+without justification, pulls the methodology toward "human must babysit," fails the
+portability test (works only for the author's identity, tracker, or setup), or grows
+always-loaded surface, duplicates binding prose, or adds an unconsumed output field without a
+proportional gain (fails the efficiency test). Symmetrically, a PR that cuts a gate, review
+round, verification step, or enforcement floor to save tokens is also misaligned, regardless of
+how it scores on the efficiency test - that trade-off is never on the table. Misalignment is a
 *direction* signal for the operator — not necessarily a request-changes verdict on correctness.


### PR DESCRIPTION
## Summary

Operator-authored product intent (dictated directly by the operator; edited `docs/overview/vision.md` in place per the operator's explicit instruction not to stage a proposal). Adds two North Star pillars.

**Pillar 5 - Guard agent context** (first commit on this PR): makes agent context a scarce resource in the same way operator attention already is (Pillar 1's agent-facing counterpart). Efficiency is won only by removing waste (duplicated prose, unconsumed return fields, always-loaded content that could be trigger-loaded, narration that surfaces no decision) - never by removing a gate, review round, verification step, or enforcement floor. Names an "efficiency test" and cites concrete evidence (21 unconsumed return fields, 15/17 agent contracts with no output-length constraint).

**Pillar 6 - Shorten wall-clock time to a finished, verified result** (this commit): distinct from Pillar 1 (what the operator must read) and Pillar 5 (what an agent must load) - this is how long the operator waits. States explicitly that it can conflict with Pillar 5 rather than pretending they always align: parallel fan-out spends more tokens to finish sooner; serial rounds spend fewer tokens but take longer. When they conflict, prefer the faster wall-clock outcome unless the token cost is disproportionate. Names concrete levers: parallelize independent units, batch findings into one rework round instead of one per finding, don't block behavior work behind infra-only work, prefer same-PR rework over a fresh PR-and-CI cycle per round, count CI cycle time as a real cost of an extra round. Holds the same boundary as Pillar 5: speed comes only from removing serialization and waste, never from cutting a gate, review round, verification step, or enforcement floor - shipping unverified work is not fast, it defers the cost. Names a "latency test" parallel to the attention/portability/efficiency tests, with one grounding parenthetical (a session that took ~10 hours and ~15 review rounds on one change, with serial units, one review round per finding, and three units blocked behind an infra-only unit with no user-visible behavior).

Both pillars add a matching non-goal bullet and a symmetric "How to use this for PR alignment" clause. Syncs the derived sites that enumerate the pillar list by name: `content/agents/skeptic.md` step 3.6, `CONTRIBUTING.md`'s PR guidelines bullet, and `.github/ISSUE_TEMPLATE/protocol_change.yml` (plus regenerated adapter copies). No file asserts a numeric pillar count.

## North Star alignment

**This PR modifies the North Star itself** - it is not being measured against a pillar it introduces. Both pillars are additive and cohere with the existing set: Pillar 5 applies the "scarce resource, guard it, name a tie-break test" shape already used by Pillar 1, aimed at agent context. Pillar 6 applies the same shape to wall-clock time, and explicitly reconciles its tension with Pillar 5 rather than leaving a silent contradiction. Neither regresses Pillar 2 (verifiable outcomes): each has its own non-goal and PR-alignment clause stating that efficiency or speed gains may never come at the expense of a gate, review round, verification step, or enforcement floor. This restates, rather than contradicts, existing repo precedent that capability/efficiency changes move the risk-profile dial and never remove an enforcement floor.

## Test plan

- [x] `pytest bin/tests/ -q` - 1251 passed
- [x] hooks JS suite (quarantine re-derived from `.github/workflows/hooks-tests.yml` case arms: `test-wrap-acquire-lock.js`, `test-wrap-release-lock.js`) - 46 ran, 0 failed
- [x] `bash scripts/build-all.sh` then `git diff --exit-code` over the adapter-sync.yml pathspec - regenerated + staged adapter copies (`.codex/agents/skeptic.toml`, `.gemini/agents/skeptic.md`, `.github/agents/skeptic.md`, `.hermes/SKILL.md`, `.openclaw/skills/agent-skeptic/SKILL.md`, `.opencode/agents/skeptic.md`)
- [x] `.codex/skill-compatibility.yml` regenerated to a temp file and diffed - byte-identical, no change needed
- [x] `.claude/skills/dinostack/{agents,commands,references,rules}` symlinks re-checked relative (not absolutized) before staging, both commits
- [x] `scripts/check-resident-budget.sh` - OK, 391 B body / 600 B threshold, no delta (file untouched by this PR)
- [x] `scripts/check-skill-embed-budget.sh` - OK, 130015 B, no delta (`.claude/skills/dinostack/SKILL.md` does not embed per-agent files; the skeptic.md pillar-list change only propagates to `.hermes` and `.openclaw` generated copies)
- [x] No `content/sections/**` touched - `.methodology-baseline.sha256` regen not required
- [x] Own-diff em-dash check (`git diff -U0 -- <touched files> | grep '^+.*—'`) - the only match is the pre-existing em dash in the final PR-alignment sentence, reflowed by the paragraph edit, not new content; hyphens used throughout the new prose
- [x] Doc-sync: triggered (pillar prose enumerated in `content/agents/skeptic.md`, `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/protocol_change.yml`) -> updated all three plus their regenerated adapter copies. Swept README.md, docs/index.html, content/SKILL.md, docs/slides/*.md, content/references/**, content/sections/**, bin/tests/** for pillar-count/list assertions in all four surface forms (word, capitalized, hyphenated-compound, numeral) - none found beyond the sites updated.

Adapter compatibility: content/ change, all adapters affected (regenerated via build-all.sh).