### PR TITLE
fix(DS-return-contract): close final 23 violations, add 2 regression pins

### DIFF
--- a/.codex/agents/engineer.toml
+++ b/.codex/agents/engineer.toml
@@ -96,7 +96,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -109,11 +109,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -150,7 +150,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/.codex/agents/goal-condition-evaluator.toml
+++ b/.codex/agents/goal-condition-evaluator.toml
@@ -92,7 +92,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/.codex/agents/learning-extractor.toml
+++ b/.codex/agents/learning-extractor.toml
@@ -142,11 +142,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.codex/agents/learnings-agent.toml
+++ b/.codex/agents/learnings-agent.toml
@@ -199,12 +199,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.codex/agents/product-discovery.toml
+++ b/.codex/agents/product-discovery.toml
@@ -157,7 +157,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -180,7 +180,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/.codex/agents/wrap-ticket.toml
+++ b/.codex/agents/wrap-ticket.toml
@@ -236,17 +236,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/.copilot/references/subagent-return-contract.md
+++ b/.copilot/references/subagent-return-contract.md
@@ -267,69 +267,106 @@ now `bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`
 every `SHAPE_ASSIGNMENTS` file, asserted verbatim by
 `test_expected_violations_snapshot_matches_reality`. See
 `bin/tests/generate_agent_return_contract_snapshot.py` for the deliberate,
-reviewed update procedure (never a silent one-command refresh). Per-shape
-summary as of 2026-08-11 (Unit 1 of the DS return-contract migration):
+reviewed update procedure (never a silent one-command refresh).
 
-- **Shape 1** (tag every `###` field): `product-discovery.md` - not yet
-  migrated. `architect.md`, `debugger.md`, `investigator.md`,
-  `orchestration-planner.md`, and `security-auditor.md` are now fully
-  migrated and compliant: every `###` field is tagged
-  `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`, the boilerplate
-  "never omit any section" rule was deleted from each file's own Rules
-  section (where one existed), and each file's status/narration fields
-  (no decision or blocker payload under the attention test above) are
-  folded into a single `### Notes [ADVISORY]` block, present only when
-  non-empty.
-  `investigator.md` also gained a `coverage: complete | partial | blocked`
-  enum field; `security-auditor.md` gained a
+**The migration is complete as of the final unit (2026-08-11).** Every
+`SHAPE_ASSIGNMENTS` file has zero violations in the current snapshot -
+`test_fully_compliant_files_are_exactly_the_snapshot_empty_set` asserts
+this directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated list, so
+a future new agent file lands in the "compliant now" set automatically as
+soon as it is both shape-assigned and genuinely compliant. Per-shape
+summary:
+
+- **Shape 1** (tag every `###` field): `architect.md`, `debugger.md`,
+  `investigator.md`, `orchestration-planner.md`, `security-auditor.md`,
+  and `product-discovery.md` are all fully migrated and compliant: every
+  `###` field is tagged `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`,
+  the boilerplate "never omit any section" rule was deleted from each
+  file's own Rules section (where one existed), and each file's
+  status/narration fields (no decision or blocker payload under the
+  attention test above) are folded into a single `### Notes [ADVISORY]`
+  block, present only when non-empty. `investigator.md` also gained a
+  `coverage: complete | partial | blocked` enum field;
+  `security-auditor.md` gained a
   `dependency_scan: clean | cves_found | not_run` enum field.
+  `product-discovery.md`'s two `## Output templates` field headers
+  (`vision.md`/`requirements.md`) each carry an explicit
+  `[MECHANICAL, cap: <N> chars]` tag (final unit) - the file-artifact
+  templates themselves are unbounded by design (the operator edits the
+  staged proposal freely), but the header tag satisfies the shape's own
+  structural obligation the same way every other Shape-1 field does.
   `dependency-auditor.md` and `perf-analyst.md` migrated OUT of Shape 1
   entirely (Unit 4); `qa-engineer.md` migrated OUT of Shape 1 entirely
   (Unit 3) - see Shape 2 below.
 - **Shape 2** (schema-object): `engineer.md`, `learning-extractor.md`,
-  `learnings-agent.md`, `wrap-ticket.md` have a real structured return
-  (under a `### N. Return` workflow sub-step or a non-synonym `##` phase
-  heading) but are not yet migrated to this shape's enum/cap obligation.
-  `engineer.md` now carries FOUR genuine violations, not one - round 6's
-  Major-1 fix (a bare type declaration is not itself a bound) correctly
-  re-flags `task_id` (`<string or null>`) and `branch_name` (`<string, or
-  null>`), and round 6's Major-2 fix (schema/doc-pointer form deleted
-  outright) correctly re-flags `learnings_candidate`, alongside the
-  pre-existing `pr_description_body` gap. Round 5's `files_modified.path`
-  (`<repo-relative path>`) fix stands unchanged - it is a genuine
-  bounded-by-nature value literal and is still not flagged.
+  `learnings-agent.md`, `wrap-ticket.md`, `adr-drift-detector.md`,
+  `dependency-auditor.md`, `perf-analyst.md`, and `qa-engineer.md` are
+  all fully migrated and compliant. `engineer.md` (final unit) closed its
+  last four gaps: `task_id`/`branch_name` now use the nullable-type
+  placeholder form (`<id, or null>`/`<name, or null>`);
+  `pr_description_body` carries an explicit `capped at 2000 chars`
+  true-adjacent numeric cap (the architect plan's assigned bound -
+  decision-relevant PR body content read by a human reviewer, needing
+  headroom but not a changelog); `learnings_candidate` carries an
+  explicit `capped at 5 items` cap matching the canonical 5-entry cap in
+  `learnings-capture-instruction.md`, replacing the now-deleted
+  schema/doc-pointer form it previously (and incorrectly) passed through.
+  `files_modified.path` (`<repo-relative path>`) remains a genuine
+  bounded-by-nature value literal, unflagged. `learning-extractor.md` and
+  `learnings-agent.md` (final unit) each closed their four gaps
+  identically: `learnings_written[]`/`learning_ids[]`/`writer_actions[]`
+  each carry an inline `capped at 5 items` cap (matching each file's own
+  "cap at 5 entries per run/message" prose), and `skipped_reason` now
+  declares its closed enum directly as the field's own illustrative
+  value (`null | "zero-substance"`, matching the pipe-list-as-value
+  convention already used by `qa-engineer.md`'s `server_status`/`auth`
+  fields) rather than showing only one concrete literal per example
+  block - only the FIRST fenced return block in the `### N. Return`
+  section is checked, so the second ("if nothing was captured") block
+  keeps its concrete illustrative form unchanged. `wrap-ticket.md` (final
+  unit) closed all eight gaps the same way: `memory_md_appends`
+  (`capped at 3 items`), `decisions_md_appends` (`capped at 2 items`),
+  `writer_actions` (`capped at 6 items`), and `cluster_results`
+  (`capped at 5 items`) each carry an inline numeric cap;
+  `context_md_recent_focus_addition` and `size_advisory` each carry an
+  explicit `capped at 500 chars`/one-line-marker bound;
+  `skipped_reason` declares `null | "zero-substance" |
+  "wrap-lock-contention"` as its own value (the three reasons the agent
+  itself emits - `"trivial-no-brief"` is set by the conductor before
+  wrap-ticket is even spawned and is deliberately excluded from the
+  agent's own schema); `resolved_paths`'s two nested leaves each use the
+  unquoted `<path, or null>` nullable-type placeholder form (JSON-string
+  quoting around a `<...>` placeholder defeats the bracket-anchored bound
+  forms - `dependency-auditor.md`'s `<path>`/`<count>` fields were
+  already unquoted for this reason; `wrap-ticket.md`'s nested leaves
+  needed the same fix).
   `adr-drift-detector.md`, `dependency-auditor.md`, and `perf-analyst.md`
-  (Unit 4) are now fully migrated and compliant: each writes its full
-  human-readable report to a `.agentic/audit-reports/` file via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object - zero violations in the current snapshot for all three.
-  `qa-engineer.md` (Unit 3) is now fully migrated and compliant: it
-  writes its full human-readable report and a screenshot-evidence JSON
-  file to `/tmp/qa-reports/` (not `.agentic/qa-reports/` - this agent
-  always runs `isolation: "worktree"`, and a `.agentic/`-scoped write
-  would be sealed inside the throwaway worktree and never seen again;
-  `/tmp/` is host-level and shared across worktree checkouts) via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object (`result`, `criteria[]`, `blocking_count`, `blocking_issues[]`,
-  `server_status`, `auth`, `screenshot_evidence_json_path`,
-  `report_path`, `notes`) - zero violations in the current snapshot.
-- **Shape 3** (fixed literal-line template): `skeptic.md` is now fully
-  compliant - Unit 1 added one narrow, additive cap declaration on
-  finding-description length (300 chars) to the Calibration section,
-  without altering, retagging, or restructuring any of its six
-  conductor-validated Sign-off format lines. `goal-condition-evaluator.md`
-  was previously claimed
-  COMPLIANT NOW; round 5's `check_shape3` fix (now inspects every fenced
-  block in the section, not just the first) found it genuinely
-  non-compliant - its second template's Evidence value
-  (`"evaluator-error: <reason>"`) declares no bound. Its third template's
-  `BLOCKED` line, initially also flagged as "not a `Label: value` line",
-  is a round-5 over-strictness artifact corrected in round 6: a bare
-  closed-enum-shaped status token standing alone is a legitimate Shape-3
-  line (see "Shape 3" above) and is no longer flagged. Its Evidence-value
-  gap remains genuine and unmigrated - Unit 1 scoped `skeptic.md` only.
+  (Unit 4) write their full human-readable report to a
+  `.agentic/audit-reports/` file via a Bash heredoc and return only a
+  small, fully enum/cap-tagged pointer JSON object. `qa-engineer.md`
+  (Unit 3) writes its full human-readable report and a
+  screenshot-evidence JSON file to `/tmp/qa-reports/` (not
+  `.agentic/qa-reports/` - this agent always runs `isolation: "worktree"`,
+  and a `.agentic/`-scoped write would be sealed inside the throwaway
+  worktree and never seen again; `/tmp/` is host-level and shared across
+  worktree checkouts) via a Bash heredoc and returns only a small, fully
+  enum/cap-tagged pointer JSON object (`result`, `criteria[]`,
+  `blocking_count`, `blocking_issues[]`, `server_status`, `auth`,
+  `screenshot_evidence_json_path`, `report_path`, `notes`).
+- **Shape 3** (fixed literal-line template): `skeptic.md` and
+  `goal-condition-evaluator.md` are both fully compliant. `skeptic.md`:
+  Unit 1 added one narrow, additive cap declaration on finding-description
+  length (300 chars) to the Calibration section, without altering,
+  retagging, or restructuring any of its six conductor-validated Sign-off
+  format lines. `goal-condition-evaluator.md` (final unit): its second
+  template's Evidence value is now `"evaluator-error: <one-line reason>"`
+  - the one-line marker form (`SHAPE2_ONE_LINE_RE`, reused as-is by Shape
+  3) - closing the genuine gap round 5's `check_shape3` fix (inspects
+  every fenced block in the section, not just the first) found. Its third
+  template's bare `BLOCKED` line is a legitimate bare closed-enum-shaped
+  status token (see "Shape 3" above) and was never actually a violation.
 - **Shape 4** (markdown-sectioned flat report): `release-orchestrator.md`
-  is now fully compliant, zero violations (Unit 4 narrowed fix) - its
+  is fully compliant, zero violations (Unit 4 narrowed fix) - its
   previously-flagged `<message>` placeholder in the commit-listing lines
   under "What shipped" (appears twice) now carries an explicit cap,
   closing out the last of the three genuine violations from the prior

--- a/.cursor/references/subagent-return-contract.md
+++ b/.cursor/references/subagent-return-contract.md
@@ -267,69 +267,106 @@ now `bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`
 every `SHAPE_ASSIGNMENTS` file, asserted verbatim by
 `test_expected_violations_snapshot_matches_reality`. See
 `bin/tests/generate_agent_return_contract_snapshot.py` for the deliberate,
-reviewed update procedure (never a silent one-command refresh). Per-shape
-summary as of 2026-08-11 (Unit 1 of the DS return-contract migration):
+reviewed update procedure (never a silent one-command refresh).
 
-- **Shape 1** (tag every `###` field): `product-discovery.md` - not yet
-  migrated. `architect.md`, `debugger.md`, `investigator.md`,
-  `orchestration-planner.md`, and `security-auditor.md` are now fully
-  migrated and compliant: every `###` field is tagged
-  `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`, the boilerplate
-  "never omit any section" rule was deleted from each file's own Rules
-  section (where one existed), and each file's status/narration fields
-  (no decision or blocker payload under the attention test above) are
-  folded into a single `### Notes [ADVISORY]` block, present only when
-  non-empty.
-  `investigator.md` also gained a `coverage: complete | partial | blocked`
-  enum field; `security-auditor.md` gained a
+**The migration is complete as of the final unit (2026-08-11).** Every
+`SHAPE_ASSIGNMENTS` file has zero violations in the current snapshot -
+`test_fully_compliant_files_are_exactly_the_snapshot_empty_set` asserts
+this directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated list, so
+a future new agent file lands in the "compliant now" set automatically as
+soon as it is both shape-assigned and genuinely compliant. Per-shape
+summary:
+
+- **Shape 1** (tag every `###` field): `architect.md`, `debugger.md`,
+  `investigator.md`, `orchestration-planner.md`, `security-auditor.md`,
+  and `product-discovery.md` are all fully migrated and compliant: every
+  `###` field is tagged `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`,
+  the boilerplate "never omit any section" rule was deleted from each
+  file's own Rules section (where one existed), and each file's
+  status/narration fields (no decision or blocker payload under the
+  attention test above) are folded into a single `### Notes [ADVISORY]`
+  block, present only when non-empty. `investigator.md` also gained a
+  `coverage: complete | partial | blocked` enum field;
+  `security-auditor.md` gained a
   `dependency_scan: clean | cves_found | not_run` enum field.
+  `product-discovery.md`'s two `## Output templates` field headers
+  (`vision.md`/`requirements.md`) each carry an explicit
+  `[MECHANICAL, cap: <N> chars]` tag (final unit) - the file-artifact
+  templates themselves are unbounded by design (the operator edits the
+  staged proposal freely), but the header tag satisfies the shape's own
+  structural obligation the same way every other Shape-1 field does.
   `dependency-auditor.md` and `perf-analyst.md` migrated OUT of Shape 1
   entirely (Unit 4); `qa-engineer.md` migrated OUT of Shape 1 entirely
   (Unit 3) - see Shape 2 below.
 - **Shape 2** (schema-object): `engineer.md`, `learning-extractor.md`,
-  `learnings-agent.md`, `wrap-ticket.md` have a real structured return
-  (under a `### N. Return` workflow sub-step or a non-synonym `##` phase
-  heading) but are not yet migrated to this shape's enum/cap obligation.
-  `engineer.md` now carries FOUR genuine violations, not one - round 6's
-  Major-1 fix (a bare type declaration is not itself a bound) correctly
-  re-flags `task_id` (`<string or null>`) and `branch_name` (`<string, or
-  null>`), and round 6's Major-2 fix (schema/doc-pointer form deleted
-  outright) correctly re-flags `learnings_candidate`, alongside the
-  pre-existing `pr_description_body` gap. Round 5's `files_modified.path`
-  (`<repo-relative path>`) fix stands unchanged - it is a genuine
-  bounded-by-nature value literal and is still not flagged.
+  `learnings-agent.md`, `wrap-ticket.md`, `adr-drift-detector.md`,
+  `dependency-auditor.md`, `perf-analyst.md`, and `qa-engineer.md` are
+  all fully migrated and compliant. `engineer.md` (final unit) closed its
+  last four gaps: `task_id`/`branch_name` now use the nullable-type
+  placeholder form (`<id, or null>`/`<name, or null>`);
+  `pr_description_body` carries an explicit `capped at 2000 chars`
+  true-adjacent numeric cap (the architect plan's assigned bound -
+  decision-relevant PR body content read by a human reviewer, needing
+  headroom but not a changelog); `learnings_candidate` carries an
+  explicit `capped at 5 items` cap matching the canonical 5-entry cap in
+  `learnings-capture-instruction.md`, replacing the now-deleted
+  schema/doc-pointer form it previously (and incorrectly) passed through.
+  `files_modified.path` (`<repo-relative path>`) remains a genuine
+  bounded-by-nature value literal, unflagged. `learning-extractor.md` and
+  `learnings-agent.md` (final unit) each closed their four gaps
+  identically: `learnings_written[]`/`learning_ids[]`/`writer_actions[]`
+  each carry an inline `capped at 5 items` cap (matching each file's own
+  "cap at 5 entries per run/message" prose), and `skipped_reason` now
+  declares its closed enum directly as the field's own illustrative
+  value (`null | "zero-substance"`, matching the pipe-list-as-value
+  convention already used by `qa-engineer.md`'s `server_status`/`auth`
+  fields) rather than showing only one concrete literal per example
+  block - only the FIRST fenced return block in the `### N. Return`
+  section is checked, so the second ("if nothing was captured") block
+  keeps its concrete illustrative form unchanged. `wrap-ticket.md` (final
+  unit) closed all eight gaps the same way: `memory_md_appends`
+  (`capped at 3 items`), `decisions_md_appends` (`capped at 2 items`),
+  `writer_actions` (`capped at 6 items`), and `cluster_results`
+  (`capped at 5 items`) each carry an inline numeric cap;
+  `context_md_recent_focus_addition` and `size_advisory` each carry an
+  explicit `capped at 500 chars`/one-line-marker bound;
+  `skipped_reason` declares `null | "zero-substance" |
+  "wrap-lock-contention"` as its own value (the three reasons the agent
+  itself emits - `"trivial-no-brief"` is set by the conductor before
+  wrap-ticket is even spawned and is deliberately excluded from the
+  agent's own schema); `resolved_paths`'s two nested leaves each use the
+  unquoted `<path, or null>` nullable-type placeholder form (JSON-string
+  quoting around a `<...>` placeholder defeats the bracket-anchored bound
+  forms - `dependency-auditor.md`'s `<path>`/`<count>` fields were
+  already unquoted for this reason; `wrap-ticket.md`'s nested leaves
+  needed the same fix).
   `adr-drift-detector.md`, `dependency-auditor.md`, and `perf-analyst.md`
-  (Unit 4) are now fully migrated and compliant: each writes its full
-  human-readable report to a `.agentic/audit-reports/` file via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object - zero violations in the current snapshot for all three.
-  `qa-engineer.md` (Unit 3) is now fully migrated and compliant: it
-  writes its full human-readable report and a screenshot-evidence JSON
-  file to `/tmp/qa-reports/` (not `.agentic/qa-reports/` - this agent
-  always runs `isolation: "worktree"`, and a `.agentic/`-scoped write
-  would be sealed inside the throwaway worktree and never seen again;
-  `/tmp/` is host-level and shared across worktree checkouts) via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object (`result`, `criteria[]`, `blocking_count`, `blocking_issues[]`,
-  `server_status`, `auth`, `screenshot_evidence_json_path`,
-  `report_path`, `notes`) - zero violations in the current snapshot.
-- **Shape 3** (fixed literal-line template): `skeptic.md` is now fully
-  compliant - Unit 1 added one narrow, additive cap declaration on
-  finding-description length (300 chars) to the Calibration section,
-  without altering, retagging, or restructuring any of its six
-  conductor-validated Sign-off format lines. `goal-condition-evaluator.md`
-  was previously claimed
-  COMPLIANT NOW; round 5's `check_shape3` fix (now inspects every fenced
-  block in the section, not just the first) found it genuinely
-  non-compliant - its second template's Evidence value
-  (`"evaluator-error: <reason>"`) declares no bound. Its third template's
-  `BLOCKED` line, initially also flagged as "not a `Label: value` line",
-  is a round-5 over-strictness artifact corrected in round 6: a bare
-  closed-enum-shaped status token standing alone is a legitimate Shape-3
-  line (see "Shape 3" above) and is no longer flagged. Its Evidence-value
-  gap remains genuine and unmigrated - Unit 1 scoped `skeptic.md` only.
+  (Unit 4) write their full human-readable report to a
+  `.agentic/audit-reports/` file via a Bash heredoc and return only a
+  small, fully enum/cap-tagged pointer JSON object. `qa-engineer.md`
+  (Unit 3) writes its full human-readable report and a
+  screenshot-evidence JSON file to `/tmp/qa-reports/` (not
+  `.agentic/qa-reports/` - this agent always runs `isolation: "worktree"`,
+  and a `.agentic/`-scoped write would be sealed inside the throwaway
+  worktree and never seen again; `/tmp/` is host-level and shared across
+  worktree checkouts) via a Bash heredoc and returns only a small, fully
+  enum/cap-tagged pointer JSON object (`result`, `criteria[]`,
+  `blocking_count`, `blocking_issues[]`, `server_status`, `auth`,
+  `screenshot_evidence_json_path`, `report_path`, `notes`).
+- **Shape 3** (fixed literal-line template): `skeptic.md` and
+  `goal-condition-evaluator.md` are both fully compliant. `skeptic.md`:
+  Unit 1 added one narrow, additive cap declaration on finding-description
+  length (300 chars) to the Calibration section, without altering,
+  retagging, or restructuring any of its six conductor-validated Sign-off
+  format lines. `goal-condition-evaluator.md` (final unit): its second
+  template's Evidence value is now `"evaluator-error: <one-line reason>"`
+  - the one-line marker form (`SHAPE2_ONE_LINE_RE`, reused as-is by Shape
+  3) - closing the genuine gap round 5's `check_shape3` fix (inspects
+  every fenced block in the section, not just the first) found. Its third
+  template's bare `BLOCKED` line is a legitimate bare closed-enum-shaped
+  status token (see "Shape 3" above) and was never actually a violation.
 - **Shape 4** (markdown-sectioned flat report): `release-orchestrator.md`
-  is now fully compliant, zero violations (Unit 4 narrowed fix) - its
+  is fully compliant, zero violations (Unit 4 narrowed fix) - its
   previously-flagged `<message>` placeholder in the commit-listing lines
   under "What shipped" (appears twice) now carries an explicit cap,
   closing out the last of the three genuine violations from the prior

--- a/.gemini/agents/engineer.md
+++ b/.gemini/agents/engineer.md
@@ -97,7 +97,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -110,11 +110,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -151,7 +151,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/.gemini/agents/goal-condition-evaluator.md
+++ b/.gemini/agents/goal-condition-evaluator.md
@@ -93,7 +93,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/.gemini/agents/learning-extractor.md
+++ b/.gemini/agents/learning-extractor.md
@@ -143,11 +143,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.gemini/agents/learnings-agent.md
+++ b/.gemini/agents/learnings-agent.md
@@ -200,12 +200,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.gemini/agents/product-discovery.md
+++ b/.gemini/agents/product-discovery.md
@@ -158,7 +158,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -181,7 +181,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/.gemini/agents/wrap-ticket.md
+++ b/.gemini/agents/wrap-ticket.md
@@ -237,17 +237,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/.gemini/references/subagent-return-contract.md
+++ b/.gemini/references/subagent-return-contract.md
@@ -267,69 +267,106 @@ now `bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`
 every `SHAPE_ASSIGNMENTS` file, asserted verbatim by
 `test_expected_violations_snapshot_matches_reality`. See
 `bin/tests/generate_agent_return_contract_snapshot.py` for the deliberate,
-reviewed update procedure (never a silent one-command refresh). Per-shape
-summary as of 2026-08-11 (Unit 1 of the DS return-contract migration):
+reviewed update procedure (never a silent one-command refresh).
 
-- **Shape 1** (tag every `###` field): `product-discovery.md` - not yet
-  migrated. `architect.md`, `debugger.md`, `investigator.md`,
-  `orchestration-planner.md`, and `security-auditor.md` are now fully
-  migrated and compliant: every `###` field is tagged
-  `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`, the boilerplate
-  "never omit any section" rule was deleted from each file's own Rules
-  section (where one existed), and each file's status/narration fields
-  (no decision or blocker payload under the attention test above) are
-  folded into a single `### Notes [ADVISORY]` block, present only when
-  non-empty.
-  `investigator.md` also gained a `coverage: complete | partial | blocked`
-  enum field; `security-auditor.md` gained a
+**The migration is complete as of the final unit (2026-08-11).** Every
+`SHAPE_ASSIGNMENTS` file has zero violations in the current snapshot -
+`test_fully_compliant_files_are_exactly_the_snapshot_empty_set` asserts
+this directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated list, so
+a future new agent file lands in the "compliant now" set automatically as
+soon as it is both shape-assigned and genuinely compliant. Per-shape
+summary:
+
+- **Shape 1** (tag every `###` field): `architect.md`, `debugger.md`,
+  `investigator.md`, `orchestration-planner.md`, `security-auditor.md`,
+  and `product-discovery.md` are all fully migrated and compliant: every
+  `###` field is tagged `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`,
+  the boilerplate "never omit any section" rule was deleted from each
+  file's own Rules section (where one existed), and each file's
+  status/narration fields (no decision or blocker payload under the
+  attention test above) are folded into a single `### Notes [ADVISORY]`
+  block, present only when non-empty. `investigator.md` also gained a
+  `coverage: complete | partial | blocked` enum field;
+  `security-auditor.md` gained a
   `dependency_scan: clean | cves_found | not_run` enum field.
+  `product-discovery.md`'s two `## Output templates` field headers
+  (`vision.md`/`requirements.md`) each carry an explicit
+  `[MECHANICAL, cap: <N> chars]` tag (final unit) - the file-artifact
+  templates themselves are unbounded by design (the operator edits the
+  staged proposal freely), but the header tag satisfies the shape's own
+  structural obligation the same way every other Shape-1 field does.
   `dependency-auditor.md` and `perf-analyst.md` migrated OUT of Shape 1
   entirely (Unit 4); `qa-engineer.md` migrated OUT of Shape 1 entirely
   (Unit 3) - see Shape 2 below.
 - **Shape 2** (schema-object): `engineer.md`, `learning-extractor.md`,
-  `learnings-agent.md`, `wrap-ticket.md` have a real structured return
-  (under a `### N. Return` workflow sub-step or a non-synonym `##` phase
-  heading) but are not yet migrated to this shape's enum/cap obligation.
-  `engineer.md` now carries FOUR genuine violations, not one - round 6's
-  Major-1 fix (a bare type declaration is not itself a bound) correctly
-  re-flags `task_id` (`<string or null>`) and `branch_name` (`<string, or
-  null>`), and round 6's Major-2 fix (schema/doc-pointer form deleted
-  outright) correctly re-flags `learnings_candidate`, alongside the
-  pre-existing `pr_description_body` gap. Round 5's `files_modified.path`
-  (`<repo-relative path>`) fix stands unchanged - it is a genuine
-  bounded-by-nature value literal and is still not flagged.
+  `learnings-agent.md`, `wrap-ticket.md`, `adr-drift-detector.md`,
+  `dependency-auditor.md`, `perf-analyst.md`, and `qa-engineer.md` are
+  all fully migrated and compliant. `engineer.md` (final unit) closed its
+  last four gaps: `task_id`/`branch_name` now use the nullable-type
+  placeholder form (`<id, or null>`/`<name, or null>`);
+  `pr_description_body` carries an explicit `capped at 2000 chars`
+  true-adjacent numeric cap (the architect plan's assigned bound -
+  decision-relevant PR body content read by a human reviewer, needing
+  headroom but not a changelog); `learnings_candidate` carries an
+  explicit `capped at 5 items` cap matching the canonical 5-entry cap in
+  `learnings-capture-instruction.md`, replacing the now-deleted
+  schema/doc-pointer form it previously (and incorrectly) passed through.
+  `files_modified.path` (`<repo-relative path>`) remains a genuine
+  bounded-by-nature value literal, unflagged. `learning-extractor.md` and
+  `learnings-agent.md` (final unit) each closed their four gaps
+  identically: `learnings_written[]`/`learning_ids[]`/`writer_actions[]`
+  each carry an inline `capped at 5 items` cap (matching each file's own
+  "cap at 5 entries per run/message" prose), and `skipped_reason` now
+  declares its closed enum directly as the field's own illustrative
+  value (`null | "zero-substance"`, matching the pipe-list-as-value
+  convention already used by `qa-engineer.md`'s `server_status`/`auth`
+  fields) rather than showing only one concrete literal per example
+  block - only the FIRST fenced return block in the `### N. Return`
+  section is checked, so the second ("if nothing was captured") block
+  keeps its concrete illustrative form unchanged. `wrap-ticket.md` (final
+  unit) closed all eight gaps the same way: `memory_md_appends`
+  (`capped at 3 items`), `decisions_md_appends` (`capped at 2 items`),
+  `writer_actions` (`capped at 6 items`), and `cluster_results`
+  (`capped at 5 items`) each carry an inline numeric cap;
+  `context_md_recent_focus_addition` and `size_advisory` each carry an
+  explicit `capped at 500 chars`/one-line-marker bound;
+  `skipped_reason` declares `null | "zero-substance" |
+  "wrap-lock-contention"` as its own value (the three reasons the agent
+  itself emits - `"trivial-no-brief"` is set by the conductor before
+  wrap-ticket is even spawned and is deliberately excluded from the
+  agent's own schema); `resolved_paths`'s two nested leaves each use the
+  unquoted `<path, or null>` nullable-type placeholder form (JSON-string
+  quoting around a `<...>` placeholder defeats the bracket-anchored bound
+  forms - `dependency-auditor.md`'s `<path>`/`<count>` fields were
+  already unquoted for this reason; `wrap-ticket.md`'s nested leaves
+  needed the same fix).
   `adr-drift-detector.md`, `dependency-auditor.md`, and `perf-analyst.md`
-  (Unit 4) are now fully migrated and compliant: each writes its full
-  human-readable report to a `.agentic/audit-reports/` file via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object - zero violations in the current snapshot for all three.
-  `qa-engineer.md` (Unit 3) is now fully migrated and compliant: it
-  writes its full human-readable report and a screenshot-evidence JSON
-  file to `/tmp/qa-reports/` (not `.agentic/qa-reports/` - this agent
-  always runs `isolation: "worktree"`, and a `.agentic/`-scoped write
-  would be sealed inside the throwaway worktree and never seen again;
-  `/tmp/` is host-level and shared across worktree checkouts) via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object (`result`, `criteria[]`, `blocking_count`, `blocking_issues[]`,
-  `server_status`, `auth`, `screenshot_evidence_json_path`,
-  `report_path`, `notes`) - zero violations in the current snapshot.
-- **Shape 3** (fixed literal-line template): `skeptic.md` is now fully
-  compliant - Unit 1 added one narrow, additive cap declaration on
-  finding-description length (300 chars) to the Calibration section,
-  without altering, retagging, or restructuring any of its six
-  conductor-validated Sign-off format lines. `goal-condition-evaluator.md`
-  was previously claimed
-  COMPLIANT NOW; round 5's `check_shape3` fix (now inspects every fenced
-  block in the section, not just the first) found it genuinely
-  non-compliant - its second template's Evidence value
-  (`"evaluator-error: <reason>"`) declares no bound. Its third template's
-  `BLOCKED` line, initially also flagged as "not a `Label: value` line",
-  is a round-5 over-strictness artifact corrected in round 6: a bare
-  closed-enum-shaped status token standing alone is a legitimate Shape-3
-  line (see "Shape 3" above) and is no longer flagged. Its Evidence-value
-  gap remains genuine and unmigrated - Unit 1 scoped `skeptic.md` only.
+  (Unit 4) write their full human-readable report to a
+  `.agentic/audit-reports/` file via a Bash heredoc and return only a
+  small, fully enum/cap-tagged pointer JSON object. `qa-engineer.md`
+  (Unit 3) writes its full human-readable report and a
+  screenshot-evidence JSON file to `/tmp/qa-reports/` (not
+  `.agentic/qa-reports/` - this agent always runs `isolation: "worktree"`,
+  and a `.agentic/`-scoped write would be sealed inside the throwaway
+  worktree and never seen again; `/tmp/` is host-level and shared across
+  worktree checkouts) via a Bash heredoc and returns only a small, fully
+  enum/cap-tagged pointer JSON object (`result`, `criteria[]`,
+  `blocking_count`, `blocking_issues[]`, `server_status`, `auth`,
+  `screenshot_evidence_json_path`, `report_path`, `notes`).
+- **Shape 3** (fixed literal-line template): `skeptic.md` and
+  `goal-condition-evaluator.md` are both fully compliant. `skeptic.md`:
+  Unit 1 added one narrow, additive cap declaration on finding-description
+  length (300 chars) to the Calibration section, without altering,
+  retagging, or restructuring any of its six conductor-validated Sign-off
+  format lines. `goal-condition-evaluator.md` (final unit): its second
+  template's Evidence value is now `"evaluator-error: <one-line reason>"`
+  - the one-line marker form (`SHAPE2_ONE_LINE_RE`, reused as-is by Shape
+  3) - closing the genuine gap round 5's `check_shape3` fix (inspects
+  every fenced block in the section, not just the first) found. Its third
+  template's bare `BLOCKED` line is a legitimate bare closed-enum-shaped
+  status token (see "Shape 3" above) and was never actually a violation.
 - **Shape 4** (markdown-sectioned flat report): `release-orchestrator.md`
-  is now fully compliant, zero violations (Unit 4 narrowed fix) - its
+  is fully compliant, zero violations (Unit 4 narrowed fix) - its
   previously-flagged `<message>` placeholder in the commit-listing lines
   under "What shipped" (appears twice) now carries an explicit cap,
   closing out the last of the three genuine violations from the prior

--- a/.github/agents/engineer.md
+++ b/.github/agents/engineer.md
@@ -93,7 +93,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -106,11 +106,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -147,7 +147,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/.github/agents/goal-condition-evaluator.md
+++ b/.github/agents/goal-condition-evaluator.md
@@ -89,7 +89,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/.github/agents/learning-extractor.md
+++ b/.github/agents/learning-extractor.md
@@ -140,11 +140,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.github/agents/learnings-agent.md
+++ b/.github/agents/learnings-agent.md
@@ -197,12 +197,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.github/agents/product-discovery.md
+++ b/.github/agents/product-discovery.md
@@ -154,7 +154,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -177,7 +177,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/.github/agents/wrap-ticket.md
+++ b/.github/agents/wrap-ticket.md
@@ -233,17 +233,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -7379,69 +7379,106 @@ now `bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`
 every `SHAPE_ASSIGNMENTS` file, asserted verbatim by
 `test_expected_violations_snapshot_matches_reality`. See
 `bin/tests/generate_agent_return_contract_snapshot.py` for the deliberate,
-reviewed update procedure (never a silent one-command refresh). Per-shape
-summary as of 2026-08-11 (Unit 1 of the DS return-contract migration):
+reviewed update procedure (never a silent one-command refresh).
 
-- **Shape 1** (tag every `###` field): `product-discovery.md` - not yet
-  migrated. `architect.md`, `debugger.md`, `investigator.md`,
-  `orchestration-planner.md`, and `security-auditor.md` are now fully
-  migrated and compliant: every `###` field is tagged
-  `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`, the boilerplate
-  "never omit any section" rule was deleted from each file's own Rules
-  section (where one existed), and each file's status/narration fields
-  (no decision or blocker payload under the attention test above) are
-  folded into a single `### Notes [ADVISORY]` block, present only when
-  non-empty.
-  `investigator.md` also gained a `coverage: complete | partial | blocked`
-  enum field; `security-auditor.md` gained a
+**The migration is complete as of the final unit (2026-08-11).** Every
+`SHAPE_ASSIGNMENTS` file has zero violations in the current snapshot -
+`test_fully_compliant_files_are_exactly_the_snapshot_empty_set` asserts
+this directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated list, so
+a future new agent file lands in the "compliant now" set automatically as
+soon as it is both shape-assigned and genuinely compliant. Per-shape
+summary:
+
+- **Shape 1** (tag every `###` field): `architect.md`, `debugger.md`,
+  `investigator.md`, `orchestration-planner.md`, `security-auditor.md`,
+  and `product-discovery.md` are all fully migrated and compliant: every
+  `###` field is tagged `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`,
+  the boilerplate "never omit any section" rule was deleted from each
+  file's own Rules section (where one existed), and each file's
+  status/narration fields (no decision or blocker payload under the
+  attention test above) are folded into a single `### Notes [ADVISORY]`
+  block, present only when non-empty. `investigator.md` also gained a
+  `coverage: complete | partial | blocked` enum field;
+  `security-auditor.md` gained a
   `dependency_scan: clean | cves_found | not_run` enum field.
+  `product-discovery.md`'s two `## Output templates` field headers
+  (`vision.md`/`requirements.md`) each carry an explicit
+  `[MECHANICAL, cap: <N> chars]` tag (final unit) - the file-artifact
+  templates themselves are unbounded by design (the operator edits the
+  staged proposal freely), but the header tag satisfies the shape's own
+  structural obligation the same way every other Shape-1 field does.
   `dependency-auditor.md` and `perf-analyst.md` migrated OUT of Shape 1
   entirely (Unit 4); `qa-engineer.md` migrated OUT of Shape 1 entirely
   (Unit 3) - see Shape 2 below.
 - **Shape 2** (schema-object): `engineer.md`, `learning-extractor.md`,
-  `learnings-agent.md`, `wrap-ticket.md` have a real structured return
-  (under a `### N. Return` workflow sub-step or a non-synonym `##` phase
-  heading) but are not yet migrated to this shape's enum/cap obligation.
-  `engineer.md` now carries FOUR genuine violations, not one - round 6's
-  Major-1 fix (a bare type declaration is not itself a bound) correctly
-  re-flags `task_id` (`<string or null>`) and `branch_name` (`<string, or
-  null>`), and round 6's Major-2 fix (schema/doc-pointer form deleted
-  outright) correctly re-flags `learnings_candidate`, alongside the
-  pre-existing `pr_description_body` gap. Round 5's `files_modified.path`
-  (`<repo-relative path>`) fix stands unchanged - it is a genuine
-  bounded-by-nature value literal and is still not flagged.
+  `learnings-agent.md`, `wrap-ticket.md`, `adr-drift-detector.md`,
+  `dependency-auditor.md`, `perf-analyst.md`, and `qa-engineer.md` are
+  all fully migrated and compliant. `engineer.md` (final unit) closed its
+  last four gaps: `task_id`/`branch_name` now use the nullable-type
+  placeholder form (`<id, or null>`/`<name, or null>`);
+  `pr_description_body` carries an explicit `capped at 2000 chars`
+  true-adjacent numeric cap (the architect plan's assigned bound -
+  decision-relevant PR body content read by a human reviewer, needing
+  headroom but not a changelog); `learnings_candidate` carries an
+  explicit `capped at 5 items` cap matching the canonical 5-entry cap in
+  `learnings-capture-instruction.md`, replacing the now-deleted
+  schema/doc-pointer form it previously (and incorrectly) passed through.
+  `files_modified.path` (`<repo-relative path>`) remains a genuine
+  bounded-by-nature value literal, unflagged. `learning-extractor.md` and
+  `learnings-agent.md` (final unit) each closed their four gaps
+  identically: `learnings_written[]`/`learning_ids[]`/`writer_actions[]`
+  each carry an inline `capped at 5 items` cap (matching each file's own
+  "cap at 5 entries per run/message" prose), and `skipped_reason` now
+  declares its closed enum directly as the field's own illustrative
+  value (`null | "zero-substance"`, matching the pipe-list-as-value
+  convention already used by `qa-engineer.md`'s `server_status`/`auth`
+  fields) rather than showing only one concrete literal per example
+  block - only the FIRST fenced return block in the `### N. Return`
+  section is checked, so the second ("if nothing was captured") block
+  keeps its concrete illustrative form unchanged. `wrap-ticket.md` (final
+  unit) closed all eight gaps the same way: `memory_md_appends`
+  (`capped at 3 items`), `decisions_md_appends` (`capped at 2 items`),
+  `writer_actions` (`capped at 6 items`), and `cluster_results`
+  (`capped at 5 items`) each carry an inline numeric cap;
+  `context_md_recent_focus_addition` and `size_advisory` each carry an
+  explicit `capped at 500 chars`/one-line-marker bound;
+  `skipped_reason` declares `null | "zero-substance" |
+  "wrap-lock-contention"` as its own value (the three reasons the agent
+  itself emits - `"trivial-no-brief"` is set by the conductor before
+  wrap-ticket is even spawned and is deliberately excluded from the
+  agent's own schema); `resolved_paths`'s two nested leaves each use the
+  unquoted `<path, or null>` nullable-type placeholder form (JSON-string
+  quoting around a `<...>` placeholder defeats the bracket-anchored bound
+  forms - `dependency-auditor.md`'s `<path>`/`<count>` fields were
+  already unquoted for this reason; `wrap-ticket.md`'s nested leaves
+  needed the same fix).
   `adr-drift-detector.md`, `dependency-auditor.md`, and `perf-analyst.md`
-  (Unit 4) are now fully migrated and compliant: each writes its full
-  human-readable report to a `.agentic/audit-reports/` file via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object - zero violations in the current snapshot for all three.
-  `qa-engineer.md` (Unit 3) is now fully migrated and compliant: it
-  writes its full human-readable report and a screenshot-evidence JSON
-  file to `/tmp/qa-reports/` (not `.agentic/qa-reports/` - this agent
-  always runs `isolation: "worktree"`, and a `.agentic/`-scoped write
-  would be sealed inside the throwaway worktree and never seen again;
-  `/tmp/` is host-level and shared across worktree checkouts) via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object (`result`, `criteria[]`, `blocking_count`, `blocking_issues[]`,
-  `server_status`, `auth`, `screenshot_evidence_json_path`,
-  `report_path`, `notes`) - zero violations in the current snapshot.
-- **Shape 3** (fixed literal-line template): `skeptic.md` is now fully
-  compliant - Unit 1 added one narrow, additive cap declaration on
-  finding-description length (300 chars) to the Calibration section,
-  without altering, retagging, or restructuring any of its six
-  conductor-validated Sign-off format lines. `goal-condition-evaluator.md`
-  was previously claimed
-  COMPLIANT NOW; round 5's `check_shape3` fix (now inspects every fenced
-  block in the section, not just the first) found it genuinely
-  non-compliant - its second template's Evidence value
-  (`"evaluator-error: <reason>"`) declares no bound. Its third template's
-  `BLOCKED` line, initially also flagged as "not a `Label: value` line",
-  is a round-5 over-strictness artifact corrected in round 6: a bare
-  closed-enum-shaped status token standing alone is a legitimate Shape-3
-  line (see "Shape 3" above) and is no longer flagged. Its Evidence-value
-  gap remains genuine and unmigrated - Unit 1 scoped `skeptic.md` only.
+  (Unit 4) write their full human-readable report to a
+  `.agentic/audit-reports/` file via a Bash heredoc and return only a
+  small, fully enum/cap-tagged pointer JSON object. `qa-engineer.md`
+  (Unit 3) writes its full human-readable report and a
+  screenshot-evidence JSON file to `/tmp/qa-reports/` (not
+  `.agentic/qa-reports/` - this agent always runs `isolation: "worktree"`,
+  and a `.agentic/`-scoped write would be sealed inside the throwaway
+  worktree and never seen again; `/tmp/` is host-level and shared across
+  worktree checkouts) via a Bash heredoc and returns only a small, fully
+  enum/cap-tagged pointer JSON object (`result`, `criteria[]`,
+  `blocking_count`, `blocking_issues[]`, `server_status`, `auth`,
+  `screenshot_evidence_json_path`, `report_path`, `notes`).
+- **Shape 3** (fixed literal-line template): `skeptic.md` and
+  `goal-condition-evaluator.md` are both fully compliant. `skeptic.md`:
+  Unit 1 added one narrow, additive cap declaration on finding-description
+  length (300 chars) to the Calibration section, without altering,
+  retagging, or restructuring any of its six conductor-validated Sign-off
+  format lines. `goal-condition-evaluator.md` (final unit): its second
+  template's Evidence value is now `"evaluator-error: <one-line reason>"`
+  - the one-line marker form (`SHAPE2_ONE_LINE_RE`, reused as-is by Shape
+  3) - closing the genuine gap round 5's `check_shape3` fix (inspects
+  every fenced block in the section, not just the first) found. Its third
+  template's bare `BLOCKED` line is a legitimate bare closed-enum-shaped
+  status token (see "Shape 3" above) and was never actually a violation.
 - **Shape 4** (markdown-sectioned flat report): `release-orchestrator.md`
-  is now fully compliant, zero violations (Unit 4 narrowed fix) - its
+  is fully compliant, zero violations (Unit 4 narrowed fix) - its
   previously-flagged `<message>` placeholder in the commit-listing lines
   under "What shipped" (appears twice) now carries an explicit cap,
   closing out the last of the three genuine violations from the prior
@@ -9738,7 +9775,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -9751,11 +9788,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -9792,7 +9829,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```
@@ -9941,7 +9978,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.
@@ -10245,11 +10282,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 
@@ -10498,12 +10535,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 
@@ -11140,7 +11177,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -11163,7 +11200,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements
@@ -12883,17 +12920,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/.openclaw/skills/agent-engineer/SKILL.md
+++ b/.openclaw/skills/agent-engineer/SKILL.md
@@ -93,7 +93,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -106,11 +106,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -147,7 +147,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/.openclaw/skills/agent-goal-condition-evaluator/SKILL.md
+++ b/.openclaw/skills/agent-goal-condition-evaluator/SKILL.md
@@ -89,7 +89,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/.openclaw/skills/agent-learning-extractor/SKILL.md
+++ b/.openclaw/skills/agent-learning-extractor/SKILL.md
@@ -140,11 +140,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.openclaw/skills/agent-learnings-agent/SKILL.md
+++ b/.openclaw/skills/agent-learnings-agent/SKILL.md
@@ -197,12 +197,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.openclaw/skills/agent-product-discovery/SKILL.md
+++ b/.openclaw/skills/agent-product-discovery/SKILL.md
@@ -154,7 +154,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -177,7 +177,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/.openclaw/skills/agent-wrap-ticket/SKILL.md
+++ b/.openclaw/skills/agent-wrap-ticket/SKILL.md
@@ -234,17 +234,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/.opencode/agents/engineer.md
+++ b/.opencode/agents/engineer.md
@@ -94,7 +94,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -107,11 +107,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -148,7 +148,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/.opencode/agents/goal-condition-evaluator.md
+++ b/.opencode/agents/goal-condition-evaluator.md
@@ -94,7 +94,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/.opencode/agents/learning-extractor.md
+++ b/.opencode/agents/learning-extractor.md
@@ -141,11 +141,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.opencode/agents/learnings-agent.md
+++ b/.opencode/agents/learnings-agent.md
@@ -198,12 +198,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/.opencode/agents/product-discovery.md
+++ b/.opencode/agents/product-discovery.md
@@ -155,7 +155,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -178,7 +178,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/.opencode/agents/wrap-ticket.md
+++ b/.opencode/agents/wrap-ticket.md
@@ -235,17 +235,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json
+++ b/bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json
@@ -3,46 +3,17 @@
   "architect.md": [],
   "debugger.md": [],
   "dependency-auditor.md": [],
-  "engineer.md": [
-    "engineer.md: field 'task_id' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "engineer.md: field 'branch_name' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "engineer.md: field 'pr_description_body' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "engineer.md: field 'learnings_candidate' is capable of open-ended or repeated content but declares no cap or one-line marker"
-  ],
-  "goal-condition-evaluator.md": [
-    "goal-condition-evaluator.md: Shape-3 line 'Evidence:' (block 2) value '\"evaluator-error: <reason>\"' is neither a closed enum, a bare count, nor bounded to one line by its own placeholder text"
-  ],
+  "engineer.md": [],
+  "goal-condition-evaluator.md": [],
   "investigator.md": [],
-  "learning-extractor.md": [
-    "learning-extractor.md: field 'learnings_written' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learning-extractor.md: field 'learning_ids' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learning-extractor.md: field 'writer_actions' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learning-extractor.md: classification field 'skipped_reason' declares no closed enum (expected an inline 'X | Y | Z' value list or an adjacent JSON-Schema 'enum:')"
-  ],
-  "learnings-agent.md": [
-    "learnings-agent.md: field 'learnings_written' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learnings-agent.md: field 'learning_ids' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learnings-agent.md: field 'writer_actions' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "learnings-agent.md: classification field 'skipped_reason' declares no closed enum (expected an inline 'X | Y | Z' value list or an adjacent JSON-Schema 'enum:')"
-  ],
+  "learning-extractor.md": [],
+  "learnings-agent.md": [],
   "orchestration-planner.md": [],
   "perf-analyst.md": [],
-  "product-discovery.md": [
-    "product-discovery.md: field 'vision.md (one screen, narrative)' has no [MECHANICAL] or [ADVISORY] tag",
-    "product-discovery.md: field 'requirements.md (scoped, checkable)' has no [MECHANICAL] or [ADVISORY] tag"
-  ],
+  "product-discovery.md": [],
   "qa-engineer.md": [],
   "release-orchestrator.md": [],
   "security-auditor.md": [],
   "skeptic.md": [],
-  "wrap-ticket.md": [
-    "wrap-ticket.md: field 'memory_md_appends' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: field 'decisions_md_appends' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: field 'context_md_recent_focus_addition' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: field 'writer_actions' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: classification field 'skipped_reason' declares no closed enum (expected an inline 'X | Y | Z' value list or an adjacent JSON-Schema 'enum:')",
-    "wrap-ticket.md: field 'size_advisory' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: field 'cluster_results' is capable of open-ended or repeated content but declares no cap or one-line marker",
-    "wrap-ticket.md: field 'resolved_paths' is capable of open-ended or repeated content but declares no cap or one-line marker"
-  ]
+  "wrap-ticket.md": []
 }

--- a/bin/tests/test_agent_return_contract_spec.py
+++ b/bin/tests/test_agent_return_contract_spec.py
@@ -1553,72 +1553,27 @@ def test_shape2_missing_enum_and_cap_is_flagged():
     assert any("declares no cap" in v for v in violations)
 
 
-def test_shape2_engineer_is_not_yet_migrated():
-    """engineer.md is NOT compliant now (round-4 M1 fix): the
-    SHAPE2_PASSTHROUGH_EXEMPT_FIELDS exemption that previously manufactured
-    its compliant-now status is deleted, so pr_description_body's missing
-    cap is a real, genuine violation - independently confirmed by name
-    below, not merely 'the file has some violations'.
+def test_shape2_engineer_is_now_compliant():
+    """Final unit of the DS return-contract migration (2026-08-11) closes
+    engineer.md's last four violations: `task_id` and `branch_name` now use
+    the nullable-type placeholder form (`<id, or null>` / `<name, or null>`
+    - both TYPE words drawn from `_SHAPE_TYPE_WORDS`, not the deleted
+    'string' entry); `pr_description_body` carries an explicit
+    'capped at 2000 chars' true-adjacent numeric cap (the architect plan's
+    assigned bound - decision-relevant PR body content needs headroom but
+    not a changelog); `learnings_candidate` carries an explicit
+    'capped at 5 items' true-adjacent numeric cap (matching the canonical
+    5-entry cap in learnings-capture-instruction.md) rather than relying on
+    the now-deleted schema/doc-pointer form.
 
-    This also independently VERIFIES (rather than merely asserting, as the
-    pre-round-4 docstring did) that raw_output's 'truncated to 4000 chars'
-    bound is correctly recognized despite being nested inside the
-    quality_gate_results object - the M3 recursion fix walks into that
-    container instead of treating it as an unconditionally-bounded
-    structural field.
-
-    Round-5: files_modified.path (`<repo-relative path>`) must NOT be
-    flagged - it is a recognized bounded-by-nature form (round-5
-    over-strictness fix); prior to that fix, files_modified was flagged
-    SOLELY because of the 'path' leaf.
-
-    Round-6 Major-1/Major-2 fixes REVERSE two round-5 over-strictness
-    corrections that were themselves wrong: `task_id: <string or null>`
-    and `branch_name: <string, or null>` matched the round-5 nullable-type
-    form purely because 'string' was in the type vocabulary - a type
-    declaration is not a bound, so both are genuinely unbounded and are
-    now correctly flagged again (round-6 Major-1). `learnings_candidate`
-    was passing via the now-deleted schema/doc-pointer form (round-6
-    Major-2) and is now also correctly flagged - see the comment above
-    SHAPE_BOUNDED_VALUE_LITERALS for why that form was deleted rather than
-    narrowed."""
+    This also continues to VERIFY that raw_output's 'truncated to 4000
+    chars' bound is correctly recognized despite being nested inside the
+    quality_gate_results object, and that files_modified.path
+    (`<repo-relative path>`) is correctly recognized as a bounded-by-nature
+    value literal - neither regressed by this round's edits."""
     path = AGENTS_DIR / "engineer.md"
     violations = check_contract(path.read_text(), "engineer.md")
-    assert violations, (
-        "engineer.md is listed in NOT_YET_MIGRATED but its Shape-2 checker "
-        "found it fully compliant"
-    )
-    assert any("pr_description_body" in v for v in violations), violations
-    assert not any("raw_output" in v for v in violations), (
-        "raw_output declares an explicit 'truncated to 4000 chars' bound "
-        f"nested inside quality_gate_results - it must not be flagged: {violations}"
-    )
-    assert not any("files_modified" in v for v in violations), (
-        f"files_modified.path is '<repo-relative path>', a bounded-by-nature "
-        f"value literal - it must not be flagged: {violations}"
-    )
-    assert any("task_id" in v for v in violations), (
-        "task_id is '<string or null>' - a bare type declaration with no "
-        f"bound - it must be flagged (round-6 Major-1): {violations}"
-    )
-    assert any("branch_name" in v for v in violations), (
-        "branch_name is '<string, or null>' - a bare type declaration with "
-        f"no bound - it must be flagged (round-6 Major-1): {violations}"
-    )
-    assert any("learnings_candidate" in v for v in violations), (
-        "learnings_candidate previously passed only via the now-deleted "
-        f"schema/doc-pointer form - it must be flagged (round-6 Major-2): {violations}"
-    )
-    assert violations == [
-        "engineer.md: field 'task_id' is capable of open-ended or "
-        "repeated content but declares no cap or one-line marker",
-        "engineer.md: field 'branch_name' is capable of open-ended or "
-        "repeated content but declares no cap or one-line marker",
-        "engineer.md: field 'pr_description_body' is capable of open-ended "
-        "or repeated content but declares no cap or one-line marker",
-        "engineer.md: field 'learnings_candidate' is capable of open-ended "
-        "or repeated content but declares no cap or one-line marker",
-    ], violations
+    assert violations == [], violations
 
 
 # --- Shape 3 fixture tests ---
@@ -1636,30 +1591,26 @@ def test_shape3_missing_bound_is_flagged():
     assert violations, "expected a violation for an unbounded Evidence value"
 
 
-def test_shape3_goal_condition_evaluator_is_genuinely_not_yet_migrated():
+def test_shape3_goal_condition_evaluator_is_now_compliant():
     """Round-5 Minor fix: check_shape3 previously inspected only
     blocks[0] - goal-condition-evaluator.md has THREE fenced return
     templates (the two-line success/failure form, the evaluator-error
     escape hatch, and the no-confirmed-sign-off escape hatch), and the
-    second's Evidence value ('"evaluator-error: <reason>"') carries an
-    unbounded placeholder that was never inspected before this fix.
-    goal-condition-evaluator.md is therefore RECLASSIFIED here from
-    'compliant now' to genuinely non-compliant - it was never actually
-    fully compliant, only under-checked.
+    second's Evidence value ('"evaluator-error: <reason>"') carried an
+    unbounded placeholder that was never inspected before that fix.
 
     Round-6 Minor fix: the third block's bare 'BLOCKED' line (no colon)
-    is NO LONGER flagged - it is a legitimate bare closed-enum-shaped
-    status token (SHAPE3_BARE_STATUS_TOKEN_RE), and flagging it was gate
-    over-strictness, not a real gap. Only the genuine Evidence-value
-    violation remains."""
+    is NOT flagged - it is a legitimate bare closed-enum-shaped
+    status token (SHAPE3_BARE_STATUS_TOKEN_RE).
+
+    Final unit of the DS return-contract migration (2026-08-11) closes the
+    remaining genuine gap: the second block's Evidence value is now
+    '"evaluator-error: <one-line reason>"' - the one-line marker form
+    (SHAPE2_ONE_LINE_RE, reused as-is by Shape 3) - so
+    goal-condition-evaluator.md is now fully Shape-3 compliant."""
     path = AGENTS_DIR / "goal-condition-evaluator.md"
     violations = check_contract(path.read_text(), "goal-condition-evaluator.md")
-    assert violations == [
-        "goal-condition-evaluator.md: Shape-3 line 'Evidence:' (block 2) "
-        'value \'"evaluator-error: <reason>"\' is neither a closed enum, '
-        "a bare count, nor bounded to one line by its own placeholder "
-        "text",
-    ], violations
+    assert violations == [], violations
 
 
 def test_shape3_skeptic_is_now_compliant():
@@ -1944,40 +1895,138 @@ def test_fully_compliant_files_are_exactly_the_snapshot_empty_set():
     project's actual 'compliant now' set. As of round 5 this was the
     EMPTY set - goal-condition-evaluator.md, the only remaining
     candidate, was reclassified to genuinely non-compliant by the
-    check_shape3 all-blocks fix (see
-    test_shape3_goal_condition_evaluator_is_genuinely_not_yet_migrated).
-    Unit 1 of the DS return-contract migration (2026-08-11) grew this set
-    by six: architect.md, debugger.md, investigator.md,
-    orchestration-planner.md, security-auditor.md, skeptic.md - each
-    migrated to its shape's tagging/enum/cap obligation with the boilerplate
-    "never omit any section" rule deleted from its own Rules section (where
-    present) and folded ADVISORY content moved into a single `Notes` block.
-    Unit 4 (same migration) grew it by four more: dependency-auditor.md,
-    perf-analyst.md, and adr-drift-detector.md each retired a free-prose
-    report shape for the pointer-JSON Shape 2 return (report written to
-    .agentic/audit-reports/ via Bash heredoc - none of the three has a
-    Write/Edit grant); release-orchestrator.md added an explicit cap to
-    its three previously-unbounded Shape-4 placeholders. Unit 3 (same
-    migration) grew it by one more: qa-engineer.md moved from Shape 1 to
-    Shape 2, retiring its 6-near-duplicate free-prose report shape for
-    the pointer-JSON Shape 2 return (report + screenshot-evidence JSON
-    written to /tmp/qa-reports/ via Bash heredoc, deliberately not
-    .agentic/qa-reports/ since this agent always runs isolation:
-    "worktree" - no Write/Edit grant; SHAPE_ASSIGNMENTS updated to 2 in
-    the same change). A future
-    migration legitimately grows this set further; this test exists so
-    that growth is asserted explicitly rather than assumed."""
+    check_shape3 all-blocks fix. Unit 1 of the DS return-contract
+    migration (2026-08-11) grew this set by six: architect.md, debugger.md,
+    investigator.md, orchestration-planner.md, security-auditor.md,
+    skeptic.md - each migrated to its shape's tagging/enum/cap obligation
+    with the boilerplate "never omit any section" rule deleted from its own
+    Rules section (where present) and folded ADVISORY content moved into a
+    single `Notes` block. Unit 4 (same migration) grew it by four more:
+    dependency-auditor.md, perf-analyst.md, and adr-drift-detector.md each
+    retired a free-prose report shape for the pointer-JSON Shape 2 return
+    (report written to .agentic/audit-reports/ via Bash heredoc - none of
+    the three has a Write/Edit grant); release-orchestrator.md added an
+    explicit cap to its three previously-unbounded Shape-4 placeholders.
+    Unit 3 (same migration) grew it by one more: qa-engineer.md moved from
+    Shape 1 to Shape 2. The final unit of the migration (2026-08-11) closes
+    the remaining six files: engineer.md, goal-condition-evaluator.md,
+    learning-extractor.md, learnings-agent.md, product-discovery.md, and
+    wrap-ticket.md each cleared their last cap/enum/tag gaps. The
+    'compliant now' set is therefore now every SHAPE_ASSIGNMENTS file - the
+    migration is complete, and this test now asserts that directly against
+    SHAPE_ASSIGNMENTS rather than a hand-enumerated growing list, so a
+    future new agent file lands in this set automatically as soon as it is
+    both shape-assigned and genuinely compliant, with no list to remember
+    to extend."""
     compliant_now = {name for name, v in EXPECTED_VIOLATIONS.items() if v == []}
-    assert compliant_now == {
-        "architect.md",
-        "debugger.md",
-        "investigator.md",
-        "orchestration-planner.md",
-        "security-auditor.md",
-        "skeptic.md",
-        "dependency-auditor.md",
-        "perf-analyst.md",
-        "adr-drift-detector.md",
-        "release-orchestrator.md",
-        "qa-engineer.md",
-    }, f"unexpected 'compliant now' set: {sorted(compliant_now)}"
+    assert compliant_now == set(SHAPE_ASSIGNMENTS), (
+        f"unexpected 'compliant now' set: {sorted(compliant_now)} vs "
+        f"SHAPE_ASSIGNMENTS: {sorted(SHAPE_ASSIGNMENTS)}"
+    )
+
+
+# --- Final unit, Part B: two regression pins, accepted debt on the merged
+# Unit 3 PR. See content/references/subagent-return-contract.md's Unit 3
+# summary (qa-engineer.md) for the background this pins. ---
+
+# Generalized, not hardcoded to qa-engineer.md - matches any agent file
+# whose OWN prose asserts it always runs isolation: "worktree" (the exact
+# phrasing qa-engineer.md uses twice, both independently confirmed by
+# _find above). A future worktree-isolated writer is covered automatically
+# as soon as its own file states this, with no list to remember to extend.
+WORKTREE_MANDATORY_MARKER_RE = re.compile(
+    r'always runs\s*`?isolation:\s*"worktree"`?', re.IGNORECASE
+)
+# A Bash heredoc write target assigned to a repo-relative '.agentic/...'
+# path - either a shell variable assignment ('X_PATH=".agentic/foo"') or a
+# bare 'mkdir -p .agentic/foo' - inside a mandated-isolation agent's own
+# Bash block. Absolute paths ('/tmp/...') never match this pattern.
+REPO_RELATIVE_AGENTIC_WRITE_RE = re.compile(
+    r'(?:="|mkdir -p )(\.agentic/\S*)'
+)
+
+
+def test_worktree_mandatory_agents_write_artifacts_to_absolute_paths():
+    """Regression pin (final unit, Part B, pin 1) - accepted debt on the
+    merged Unit 3 PR: reverting every '/tmp/qa-reports' back to
+    '.agentic/qa-reports' in qa-engineer.md currently left all ~1251
+    bin/tests green, because nothing asserted that a mandatorily
+    worktree-isolated agent must write its machine-consumed artifacts to
+    an ABSOLUTE path rather than a repo-relative one - '.agentic/' is
+    gitignored and independent per worktree checkout, so a write there is
+    sealed inside the throwaway worktree and never seen again once it is
+    removed (qa-engineer.md's own rationale, content/agents/qa-engineer.md
+    §Report structure). This test discovers the mandated set from each
+    file's OWN prose (WORKTREE_MANDATORY_MARKER_RE) rather than a
+    hand-maintained list, so it generalizes to any future agent that gains
+    a mandatory isolation: "worktree" requirement, not only qa-engineer.md.
+
+    Mutation-proven: reverting qa-engineer.md's two '/tmp/qa-reports'
+    occurrences back to '.agentic/qa-reports' (the exact regression this
+    pin targets) turns this test RED; restoring them turns it GREEN. See
+    the four-observation report in the PR description for the live
+    RED/GREEN transcript."""
+    mandated_files = [
+        p for p in sorted(AGENTS_DIR.glob("*.md"))
+        if WORKTREE_MANDATORY_MARKER_RE.search(p.read_text())
+    ]
+    assert mandated_files, (
+        "expected at least one agent file whose own prose asserts "
+        "mandatory isolation: \"worktree\" (qa-engineer.md as of this "
+        "writing) - zero found; WORKTREE_MANDATORY_MARKER_RE may have "
+        "drifted from the live prose it is meant to match"
+    )
+    violations = []
+    for p in mandated_files:
+        text = p.read_text()
+        for block in _extract_fenced_blocks(text):
+            _lang, content = block
+            for m in REPO_RELATIVE_AGENTIC_WRITE_RE.finditer(content):
+                violations.append(
+                    f"{p.name}: writes machine-consumed artifact to "
+                    f"repo-relative '{m.group(1)}' despite this file's own "
+                    "prose asserting mandatory isolation: \"worktree\" - "
+                    "use an absolute path (e.g. /tmp/...) instead"
+                )
+    assert violations == [], violations
+
+
+def test_screenshot_evidence_json_path_producer_consumer_coupling():
+    """Regression pin (final unit, Part B, pin 2) - accepted debt on the
+    merged Unit 3 PR: nothing ties qa-engineer.md's emitted
+    `screenshot_evidence_json_path` field name to
+    content/commands/ds-implement-ticket.md Phase 8.5's reader of that
+    same field; a rename on either side yields dead evidence links with
+    nothing red. This pin asserts the exact field-name literal is present
+    in both the producer (qa-engineer.md's pointer-return schema) and the
+    consumer (ds-implement-ticket.md's Phase 8.5 QA screenshot evidence
+    capture step) - a rename on either side, without the matching rename
+    on the other, turns this test RED.
+
+    Mutation-proven: renaming the field in qa-engineer.md's schema line
+    (`screenshot_evidence_json_path: <path>`) alone, or renaming it in
+    ds-implement-ticket.md's Phase 8.5 read alone, each independently
+    turns this test RED; restoring either turns it GREEN. See the
+    four-observation report in the PR description for the live
+    RED/GREEN transcript."""
+    field_name = "screenshot_evidence_json_path"
+    producer_text = (AGENTS_DIR / "qa-engineer.md").read_text()
+    consumer_path = (
+        REPO_ROOT / "content" / "commands" / "ds-implement-ticket.md"
+    )
+    consumer_text = consumer_path.read_text()
+    assert f"{field_name}: <path>" in producer_text, (
+        f"qa-engineer.md no longer declares the '{field_name}' field in "
+        "its pointer-return schema - the producer side of this coupling "
+        "is broken"
+    )
+    assert field_name in consumer_text, (
+        f"ds-implement-ticket.md no longer references '{field_name}' - "
+        "the consumer side of this coupling is broken (Phase 8.5's QA "
+        "screenshot evidence read)"
+    )
+    assert "Phase 8.5" in consumer_text, (
+        "ds-implement-ticket.md's Phase 8.5 heading is gone or renamed - "
+        "re-anchor this pin's consumer-side check to wherever the "
+        "screenshot-evidence read step now lives"
+    )

--- a/content/agents/engineer.md
+++ b/content/agents/engineer.md
@@ -97,7 +97,7 @@ Schema (YAML shown; equivalent JSON is acceptable):
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
-task_id: <string or null>            # echoed from execution contract; null on single-unit
+task_id: <id, or null>                # echoed from execution contract; null on single-unit
 files_modified:
   - path: <repo-relative path>
     change: created | modified | deleted | renamed
@@ -110,11 +110,11 @@ quality_gate_results:
   raw_output: |
     <truncated to 4000 chars; tail-wins on truncation>
 commit_sha: <full 40-char SHA, or null if no commit was made>
-branch_name: <string, or null>
+branch_name: <name, or null>
 pr_description_body: |
-  <markdown body suitable for the PR; conductor may wrap with title/footer>
-learnings_candidate: []  # optional; entry shape, enum and cap are defined in
-                         # references/learnings-capture-instruction.md
+  <markdown body suitable for the PR, capped at 2000 chars; conductor may wrap with title/footer>
+learnings_candidate: []  # optional, capped at 5 items; entry shape, enum and
+                         # cap are defined in references/learnings-capture-instruction.md
 ```
 
 JSON-Schema fragment (informative; the conductor uses this to validate):
@@ -151,7 +151,7 @@ JSON-Schema fragment (informative; the conductor uses this to validate):
     },
     "commit_sha": { "type": ["string", "null"] },
     "branch_name": { "type": ["string", "null"] },
-    "pr_description_body": { "type": "string" }
+    "pr_description_body": { "type": "string", "maxLength": 2000 }
   }
 }
 ```

--- a/content/agents/goal-condition-evaluator.md
+++ b/content/agents/goal-condition-evaluator.md
@@ -94,7 +94,7 @@ On failure to determine confidently (read error, ambiguous condition, tool unava
 
 ```
 GOAL_MET: false
-Evidence: "evaluator-error: <reason>"
+Evidence: "evaluator-error: <one-line reason>"
 ```
 
 This fails closed - never guess `true`.

--- a/content/agents/learning-extractor.md
+++ b/content/agents/learning-extractor.md
@@ -143,11 +143,11 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-YYYYMMDD-XXX: <finding-title>", ...],
-  "learning_ids": ["LRN-YYYYMMDD-XXX", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-YYYYMMDD-XXX: <finding-title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-YYYYMMDD-XXX'", ...],
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [": appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/content/agents/learnings-agent.md
+++ b/content/agents/learnings-agent.md
@@ -200,12 +200,12 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "learnings_written": ["LRN-20260613-001: <title>", "KNW-20260613-001: <title>", ...],
-  "learning_ids": ["LRN-20260613-001", "KNW-20260613-001", ...],
+  "learnings_written": ["capped at 5 items: 'LRN-20260613-001: <title>'", ...],
+  "learning_ids": ["capped at 5 items: 'LRN-20260613-001'", ...],
   "memory_md_appended": true | false,
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": [".agentic/learnings.md: appended N entries", ...],
-  "skipped_reason": null
+  "writer_actions": ["capped at 5 items: '.agentic/learnings.md: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance"
 }
 ```
 

--- a/content/agents/product-discovery.md
+++ b/content/agents/product-discovery.md
@@ -158,7 +158,7 @@ Write the three files to `docs/overview/_proposed/` (`vision.md`, `requirements.
 
 Both templates open with the staged-proposal banner. Keep it verbatim on every pass, light or full - it is the operator-owned boundary made visible inside the file itself, so a reader who opens the draft directly (without the conversation) still knows it is not canonical and not yet ratified.
 
-### vision.md (one screen, narrative)
+### vision.md (one screen, narrative) [MECHANICAL, cap: 2000 chars]
 
 ```markdown
 # [Product / Feature] Vision
@@ -181,7 +181,7 @@ Both templates open with the staged-proposal banner. Keep it verbatim on every p
 [What this deliberately does not do. Naming non-goals is half of vision.]
 ```
 
-### requirements.md (scoped, checkable)
+### requirements.md (scoped, checkable) [MECHANICAL, cap: 3000 chars]
 
 ```markdown
 # [Product / Feature] Requirements

--- a/content/agents/wrap-ticket.md
+++ b/content/agents/wrap-ticket.md
@@ -237,17 +237,17 @@ Return the JSON object below as the agent's output. The conductor parses it and 
 
 ```json
 {
-  "memory_md_appends": ["<entry text>", ...],
-  "decisions_md_appends": ["<entry text>", ...],
-  "context_md_recent_focus_addition": "<paragraph text or null>",
+  "memory_md_appends": ["capped at 3 items: '<entry text>'", ...],
+  "decisions_md_appends": ["capped at 2 items: '<entry text>'", ...],
+  "context_md_recent_focus_addition": "<paragraph text, capped at 500 chars, or null>",
   "operator_summary": "<one-line human-readable summary of what was captured>",
-  "writer_actions": ["<file path>: appended <N> entries", ...],
-  "skipped_reason": null,
-  "size_advisory": null,
-  "cluster_results": [{"domain": "<slug>", "exampleNote": "<sentence>"}],
+  "writer_actions": ["capped at 6 items: '<file path>: appended <N> entries'", ...],
+  "skipped_reason": null | "zero-substance" | "wrap-lock-contention",
+  "size_advisory": "<one-line advisory text, or null>",
+  "cluster_results": ["capped at 5 items: {domain: <slug>, exampleNote: <one-line sentence>}", ...],
   "resolved_paths": {
-    "memory_md": "MEMORY.md",
-    "decisions_md": "<Step-4-resolved path, e.g. decisions.md or docs/adr/001-foo.md>"
+    "memory_md": <path, or null>
+    "decisions_md": <path, or null>
   }
 }
 ```

--- a/content/references/subagent-return-contract.md
+++ b/content/references/subagent-return-contract.md
@@ -267,69 +267,106 @@ now `bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`
 every `SHAPE_ASSIGNMENTS` file, asserted verbatim by
 `test_expected_violations_snapshot_matches_reality`. See
 `bin/tests/generate_agent_return_contract_snapshot.py` for the deliberate,
-reviewed update procedure (never a silent one-command refresh). Per-shape
-summary as of 2026-08-11 (Unit 1 of the DS return-contract migration):
+reviewed update procedure (never a silent one-command refresh).
 
-- **Shape 1** (tag every `###` field): `product-discovery.md` - not yet
-  migrated. `architect.md`, `debugger.md`, `investigator.md`,
-  `orchestration-planner.md`, and `security-auditor.md` are now fully
-  migrated and compliant: every `###` field is tagged
-  `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`, the boilerplate
-  "never omit any section" rule was deleted from each file's own Rules
-  section (where one existed), and each file's status/narration fields
-  (no decision or blocker payload under the attention test above) are
-  folded into a single `### Notes [ADVISORY]` block, present only when
-  non-empty.
-  `investigator.md` also gained a `coverage: complete | partial | blocked`
-  enum field; `security-auditor.md` gained a
+**The migration is complete as of the final unit (2026-08-11).** Every
+`SHAPE_ASSIGNMENTS` file has zero violations in the current snapshot -
+`test_fully_compliant_files_are_exactly_the_snapshot_empty_set` asserts
+this directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated list, so
+a future new agent file lands in the "compliant now" set automatically as
+soon as it is both shape-assigned and genuinely compliant. Per-shape
+summary:
+
+- **Shape 1** (tag every `###` field): `architect.md`, `debugger.md`,
+  `investigator.md`, `orchestration-planner.md`, `security-auditor.md`,
+  and `product-discovery.md` are all fully migrated and compliant: every
+  `###` field is tagged `[MECHANICAL, cap: <N> ...]`/`[MECHANICAL, enum]`,
+  the boilerplate "never omit any section" rule was deleted from each
+  file's own Rules section (where one existed), and each file's
+  status/narration fields (no decision or blocker payload under the
+  attention test above) are folded into a single `### Notes [ADVISORY]`
+  block, present only when non-empty. `investigator.md` also gained a
+  `coverage: complete | partial | blocked` enum field;
+  `security-auditor.md` gained a
   `dependency_scan: clean | cves_found | not_run` enum field.
+  `product-discovery.md`'s two `## Output templates` field headers
+  (`vision.md`/`requirements.md`) each carry an explicit
+  `[MECHANICAL, cap: <N> chars]` tag (final unit) - the file-artifact
+  templates themselves are unbounded by design (the operator edits the
+  staged proposal freely), but the header tag satisfies the shape's own
+  structural obligation the same way every other Shape-1 field does.
   `dependency-auditor.md` and `perf-analyst.md` migrated OUT of Shape 1
   entirely (Unit 4); `qa-engineer.md` migrated OUT of Shape 1 entirely
   (Unit 3) - see Shape 2 below.
 - **Shape 2** (schema-object): `engineer.md`, `learning-extractor.md`,
-  `learnings-agent.md`, `wrap-ticket.md` have a real structured return
-  (under a `### N. Return` workflow sub-step or a non-synonym `##` phase
-  heading) but are not yet migrated to this shape's enum/cap obligation.
-  `engineer.md` now carries FOUR genuine violations, not one - round 6's
-  Major-1 fix (a bare type declaration is not itself a bound) correctly
-  re-flags `task_id` (`<string or null>`) and `branch_name` (`<string, or
-  null>`), and round 6's Major-2 fix (schema/doc-pointer form deleted
-  outright) correctly re-flags `learnings_candidate`, alongside the
-  pre-existing `pr_description_body` gap. Round 5's `files_modified.path`
-  (`<repo-relative path>`) fix stands unchanged - it is a genuine
-  bounded-by-nature value literal and is still not flagged.
+  `learnings-agent.md`, `wrap-ticket.md`, `adr-drift-detector.md`,
+  `dependency-auditor.md`, `perf-analyst.md`, and `qa-engineer.md` are
+  all fully migrated and compliant. `engineer.md` (final unit) closed its
+  last four gaps: `task_id`/`branch_name` now use the nullable-type
+  placeholder form (`<id, or null>`/`<name, or null>`);
+  `pr_description_body` carries an explicit `capped at 2000 chars`
+  true-adjacent numeric cap (the architect plan's assigned bound -
+  decision-relevant PR body content read by a human reviewer, needing
+  headroom but not a changelog); `learnings_candidate` carries an
+  explicit `capped at 5 items` cap matching the canonical 5-entry cap in
+  `learnings-capture-instruction.md`, replacing the now-deleted
+  schema/doc-pointer form it previously (and incorrectly) passed through.
+  `files_modified.path` (`<repo-relative path>`) remains a genuine
+  bounded-by-nature value literal, unflagged. `learning-extractor.md` and
+  `learnings-agent.md` (final unit) each closed their four gaps
+  identically: `learnings_written[]`/`learning_ids[]`/`writer_actions[]`
+  each carry an inline `capped at 5 items` cap (matching each file's own
+  "cap at 5 entries per run/message" prose), and `skipped_reason` now
+  declares its closed enum directly as the field's own illustrative
+  value (`null | "zero-substance"`, matching the pipe-list-as-value
+  convention already used by `qa-engineer.md`'s `server_status`/`auth`
+  fields) rather than showing only one concrete literal per example
+  block - only the FIRST fenced return block in the `### N. Return`
+  section is checked, so the second ("if nothing was captured") block
+  keeps its concrete illustrative form unchanged. `wrap-ticket.md` (final
+  unit) closed all eight gaps the same way: `memory_md_appends`
+  (`capped at 3 items`), `decisions_md_appends` (`capped at 2 items`),
+  `writer_actions` (`capped at 6 items`), and `cluster_results`
+  (`capped at 5 items`) each carry an inline numeric cap;
+  `context_md_recent_focus_addition` and `size_advisory` each carry an
+  explicit `capped at 500 chars`/one-line-marker bound;
+  `skipped_reason` declares `null | "zero-substance" |
+  "wrap-lock-contention"` as its own value (the three reasons the agent
+  itself emits - `"trivial-no-brief"` is set by the conductor before
+  wrap-ticket is even spawned and is deliberately excluded from the
+  agent's own schema); `resolved_paths`'s two nested leaves each use the
+  unquoted `<path, or null>` nullable-type placeholder form (JSON-string
+  quoting around a `<...>` placeholder defeats the bracket-anchored bound
+  forms - `dependency-auditor.md`'s `<path>`/`<count>` fields were
+  already unquoted for this reason; `wrap-ticket.md`'s nested leaves
+  needed the same fix).
   `adr-drift-detector.md`, `dependency-auditor.md`, and `perf-analyst.md`
-  (Unit 4) are now fully migrated and compliant: each writes its full
-  human-readable report to a `.agentic/audit-reports/` file via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object - zero violations in the current snapshot for all three.
-  `qa-engineer.md` (Unit 3) is now fully migrated and compliant: it
-  writes its full human-readable report and a screenshot-evidence JSON
-  file to `/tmp/qa-reports/` (not `.agentic/qa-reports/` - this agent
-  always runs `isolation: "worktree"`, and a `.agentic/`-scoped write
-  would be sealed inside the throwaway worktree and never seen again;
-  `/tmp/` is host-level and shared across worktree checkouts) via a Bash
-  heredoc and returns only a small, fully enum/cap-tagged pointer JSON
-  object (`result`, `criteria[]`, `blocking_count`, `blocking_issues[]`,
-  `server_status`, `auth`, `screenshot_evidence_json_path`,
-  `report_path`, `notes`) - zero violations in the current snapshot.
-- **Shape 3** (fixed literal-line template): `skeptic.md` is now fully
-  compliant - Unit 1 added one narrow, additive cap declaration on
-  finding-description length (300 chars) to the Calibration section,
-  without altering, retagging, or restructuring any of its six
-  conductor-validated Sign-off format lines. `goal-condition-evaluator.md`
-  was previously claimed
-  COMPLIANT NOW; round 5's `check_shape3` fix (now inspects every fenced
-  block in the section, not just the first) found it genuinely
-  non-compliant - its second template's Evidence value
-  (`"evaluator-error: <reason>"`) declares no bound. Its third template's
-  `BLOCKED` line, initially also flagged as "not a `Label: value` line",
-  is a round-5 over-strictness artifact corrected in round 6: a bare
-  closed-enum-shaped status token standing alone is a legitimate Shape-3
-  line (see "Shape 3" above) and is no longer flagged. Its Evidence-value
-  gap remains genuine and unmigrated - Unit 1 scoped `skeptic.md` only.
+  (Unit 4) write their full human-readable report to a
+  `.agentic/audit-reports/` file via a Bash heredoc and return only a
+  small, fully enum/cap-tagged pointer JSON object. `qa-engineer.md`
+  (Unit 3) writes its full human-readable report and a
+  screenshot-evidence JSON file to `/tmp/qa-reports/` (not
+  `.agentic/qa-reports/` - this agent always runs `isolation: "worktree"`,
+  and a `.agentic/`-scoped write would be sealed inside the throwaway
+  worktree and never seen again; `/tmp/` is host-level and shared across
+  worktree checkouts) via a Bash heredoc and returns only a small, fully
+  enum/cap-tagged pointer JSON object (`result`, `criteria[]`,
+  `blocking_count`, `blocking_issues[]`, `server_status`, `auth`,
+  `screenshot_evidence_json_path`, `report_path`, `notes`).
+- **Shape 3** (fixed literal-line template): `skeptic.md` and
+  `goal-condition-evaluator.md` are both fully compliant. `skeptic.md`:
+  Unit 1 added one narrow, additive cap declaration on finding-description
+  length (300 chars) to the Calibration section, without altering,
+  retagging, or restructuring any of its six conductor-validated Sign-off
+  format lines. `goal-condition-evaluator.md` (final unit): its second
+  template's Evidence value is now `"evaluator-error: <one-line reason>"`
+  - the one-line marker form (`SHAPE2_ONE_LINE_RE`, reused as-is by Shape
+  3) - closing the genuine gap round 5's `check_shape3` fix (inspects
+  every fenced block in the section, not just the first) found. Its third
+  template's bare `BLOCKED` line is a legitimate bare closed-enum-shaped
+  status token (see "Shape 3" above) and was never actually a violation.
 - **Shape 4** (markdown-sectioned flat report): `release-orchestrator.md`
-  is now fully compliant, zero violations (Unit 4 narrowed fix) - its
+  is fully compliant, zero violations (Unit 4 narrowed fix) - its
   previously-flagged `<message>` placeholder in the commit-listing lines
   under "What shipped" (appears twice) now carries an explicit cap,
   closing out the last of the three genuine violations from the prior


### PR DESCRIPTION
## Summary

Final unit of the subagent return-contract migration. Clears the last 23 snapshot violations across `engineer.md` (4), `learning-extractor.md` (4), `learnings-agent.md` (4), `wrap-ticket.md` (8), `product-discovery.md` (2), and `goal-condition-evaluator.md` (1) - taking the migration to **zero violations** across every `SHAPE_ASSIGNMENTS` file (`bin/tests/fixtures/agent_return_contract/expected_violations_snapshot.json`).

- `engineer.md`: `task_id`/`branch_name` now use the nullable-type placeholder form (`<id, or null>`/`<name, or null>`); `pr_description_body` carries the architect-assigned `capped at 2000 chars` bound; `learnings_candidate` carries an explicit `capped at 5 items` cap (matching the canonical cap in `learnings-capture-instruction.md`) rather than the now-deleted schema/doc-pointer form.
- `learning-extractor.md` / `learnings-agent.md`: `learnings_written[]`/`learning_ids[]`/`writer_actions[]` each carry an inline numeric cap; `skipped_reason` declares its closed enum directly as the field's own value (`null | "zero-substance"`), matching the pipe-list-as-value convention `qa-engineer.md` already uses.
- `wrap-ticket.md`: all 8 fields capped/enum'd; `resolved_paths`'s two nested leaves use the unquoted `<path, or null>` form (a JSON-string-quoted `<...>` placeholder defeats the bracket-anchored bound forms - matches `dependency-auditor.md`'s existing unquoted `<path>` precedent).
- `product-discovery.md`: its two `## Output templates` field headers now carry `[MECHANICAL, cap: N chars]` tags.
- `goal-condition-evaluator.md`: its second template's Evidence value is now `"evaluator-error: <one-line reason>"` (one-line marker form).

Two mutation-proven regression pins (accepted debt from the merged Unit 3 PR), both added to `bin/tests/test_agent_return_contract_spec.py`:

1. `test_worktree_mandatory_agents_write_artifacts_to_absolute_paths` - generalized (discovers the mandated set from each file's own "always runs `isolation: \"worktree\"`" prose, not hardcoded to `qa-engineer.md`) assertion that a mandatorily worktree-isolated agent writes machine-consumed artifacts to an absolute path, never a repo-relative `.agentic/...` path.
2. `test_screenshot_evidence_json_path_producer_consumer_coupling` - pins the `screenshot_evidence_json_path` field-name literal in both `qa-engineer.md` (producer) and `content/commands/ds-implement-ticket.md` Phase 8.5 (consumer), so a rename on either side goes RED.

Both pins were proven by mutation: RED on the deliberate break, GREEN on restore (see Test plan).

`content/references/subagent-return-contract.md`'s migration-status section is rewritten to reflect completion - the "compliant now" set is now asserted directly against `SHAPE_ASSIGNMENTS`, not a hand-enumerated growing list.

## North Star alignment

This PR serves **Pillar 5: Guard agent context** directly. Quoting `docs/overview/vision.md` verbatim: *"Agent context is a scarce resource, exactly the way operator attention is - this pillar is the agent-facing counterpart to Pillar 1. Prefer changes that reduce what an agent must load or emit to do the same job at equal or better quality: cut duplicated prose, unconsumed return fields, always-loaded content that could be trigger-loaded instead, and narration that surfaces no decision."* The return-contract migration is the direct implementation of the pillar's own cited evidence - the same session referenced in the pillar text ("a single session once found 21 subagent return fields with no downstream consumer and 15 of 17 agent contracts with no output-length constraint") is what this migration closes out: every remaining agent file now declares an explicit cap or closed enum on every field capable of open-ended or repeated content, so a spawned subagent can no longer emit an unbounded field that inflates a downstream conductor's context for no decision-relevant reason. No gate, review round, or enforcement floor was removed to achieve this - the migration only tightens bounds and adds two regression pins (net addition of verification, consistent with the pillar's "never won by removing a gate" boundary).

## Test plan

- [x] `pytest bin/tests/ -q` - 1291 passed, 9 subtests passed
- [x] Snapshot regenerated via `python3 bin/tests/generate_agent_return_contract_snapshot.py --write` - confirmed only `-` (removed) violation lines, zero `+` (new) lines, across all 6 touched files
- [x] `python3 -m pytest bin/tests/test_agent_return_contract_spec.py -q` - 31 passed (includes the 3 updated tests reflecting migration completion and the 2 new pins)
- [x] Pin 1 mutation: reverted `qa-engineer.md`'s `/tmp/qa-reports` to `.agentic/qa-reports` -> RED (1 violation reported); restored -> GREEN
- [x] Pin 2 mutation: renamed `screenshot_evidence_json_path` in `qa-engineer.md`'s schema line -> RED (producer-side assertion failed); restored -> GREEN
- [x] hooks JS suite (46 files, quarantine of `test-wrap-acquire-lock.js`/`test-wrap-release-lock.js` re-derived from `.github/workflows/hooks-tests.yml` case arms) - all passed, exit 0
- [x] `bash scripts/build-all.sh` then `git diff --exit-code` over the verbatim adapter-sync.yml pathspec - drift staged and committed (agent .md/.toml/SKILL.md copies + reference copies across all adapters)
- [x] `scripts/check-symlinks-relative.sh` - all 4 `.claude/skills/dinostack/*` symlinks relative, OK
- [x] `pytest scripts/test/test_codex_skills.py -k test_referenced_content_reachable_from_codex_skills_has_no_new_unguarded_spawn_literal` - passed
- [x] `bash scripts/check-codex-skill-sync.sh` - OK (4 skills, 24 wrappers)
- [x] `.codex/skill-compatibility.yml` regenerated to a temp file and diffed - 0 diff, no update needed
- [x] `bash scripts/check-skill-embed-budget.sh` - OK (131045 B, floor 100000 B, ceiling 139160 B)
- [x] Em-dash check scoped to this diff only - zero matches
- [x] `content/sections/**` untouched - no baseline regen needed
- [x] `bin/tests/test_agent_write_capability_count_sync.py` - 3 passed (no tool-grant changes, unaffected)
- [x] Docs-currency: grepped `learnings_candidate`, `pr_description_body`, `skipped_reason`, `resolved_paths`, `screenshot_evidence_json_path`, `NOT_YET_MIGRATED`, `return-contract` across `docs/slides/*.md`, `docs/index.html`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` - only pre-existing, still-accurate mentions found; no stale count/list to update. `Doc-sync: predicate not triggered (no reality-asserting change to a documented count, path, convention, or public-facing behavior).`
