### PR TITLE
chore(ci): add honest routing reminder to vision-alignment-check (notice, not gate)

### DIFF
--- a/.github/workflows/vision-alignment-check.yml
+++ b/.github/workflows/vision-alignment-check.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Check North Star alignment section on methodology-affecting PRs
+        id: alignment-check
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           FILES="$(gh pr view "$PR_NUMBER" --json files -q '.files[].path')"
@@ -26,6 +27,8 @@ jobs:
                 ;;
             esac
           done <<< "$FILES"
+
+          echo "triggered=$TRIGGERED" >> "$GITHUB_OUTPUT"
 
           if [ "$TRIGGERED" != "true" ]; then
             echo "OK: no methodology-affecting paths changed - vision-alignment section not required."
@@ -47,3 +50,7 @@ jobs:
           fi
 
           echo "OK: North Star alignment section present."
+      - name: Reminder - route methodology-shaping work through /ds-update-agentic-engineering
+        if: always() && steps.alignment-check.outputs.triggered == 'true'
+        run: |
+          echo "::notice::This PR touches methodology-shaping paths. If this work was ad hoc rather than ticket-driven, confirm it was routed through /ds-update-agentic-engineering (git-sync, vision-alignment review, explicit human approval before commit). Ticket-driven work is expected to satisfy this via the Skeptic's step 3.6 instead. This notice is informational only and cannot verify which path was actually taken."

--- a/.github/workflows/vision-alignment-check.yml
+++ b/.github/workflows/vision-alignment-check.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Reminder - route methodology-shaping work through /ds-update-agentic-engineering
         if: always() && steps.alignment-check.outputs.triggered == 'true'
         run: |
-          echo "::notice::This PR touches methodology-shaping paths. If this work was ad hoc rather than ticket-driven, confirm it was routed through /ds-update-agentic-engineering (git-sync, vision-alignment review, explicit human approval before commit). Ticket-driven work is expected to satisfy this via the Skeptic's step 3.6 instead. This notice is informational only and cannot verify which path was actually taken."
+          echo "::notice::This PR touches methodology-shaping paths. If this work was ad hoc rather than ticket-driven, confirm it was routed through /ds-update-agentic-engineering (git-sync, vision-alignment review, explicit human approval before commit). Ticket-driven work is expected to satisfy the vision-alignment portion of this via the Skeptic's step 3.6 instead. This notice is informational only and cannot verify which path was actually taken."


### PR DESCRIPTION
## What

Adds a non-blocking `::notice::` step to the existing `check-vision-alignment` job. It fires whenever the job's `TRIGGERED` flag is true - in both the pass and the fail branch of the North Star body check - reminding a human reviewer that PRs touching methodology-shaping paths are expected to route through `/ds-update-agentic-engineering` when the work was ad hoc rather than ticket-driven.

7 lines, one file.

## Why this shape, and not a gate

This started as a proposed pass/fail CI gate keyed on a ticket-ID token or a `Routed-via:` commit trailer. That design was rejected: **both signals are freely fabricable by exactly the class of agent whose non-compliance the gate would exist to catch.** A bypassing agent writes conventional commit messages. Gating on one would have manufactured the appearance of enforcement without the substance, and would have left a named marker for someone to later wire a stronger gate to, trusting it.

An architect verified that no non-fabricable signal exists that a given PR ran the command. Mid-session hook enforcement was separately rejected: the violation is a session-level property invisible at every individual tool call, and a Write/Edit hook gated on a session sentinel would fire on essentially every `content/**` edit in the dominant ticket-driven workflow with no quieting mechanism - the same false-positive shape as an existing enforcement hook whose friction CI structurally cannot surface.

So this is deliberately a reminder surface, and it says so in its own text: *"This notice is informational only and cannot verify which path was actually taken."*

## Why the existing workflow rather than a new one

`vision-alignment-check.yml`'s trigger-path list is already a derived copy of the canonical list in `content/agents/skeptic.md` step 3.6. A new workflow would have needed a third copy of that list - a self-inflicted drift hazard on top of the evidentiary problem this change exists to avoid.

## Implementation note

`triggered=$TRIGGERED` is exported to `$GITHUB_OUTPUT` immediately after the trigger-detection loop, before both the `exit 0` and `exit 1` branches, so the value is always set. The notice step is gated on `always() && steps.alignment-check.outputs.triggered == 'true'`, which lets it fire regardless of the first step's exit code without touching that step's pass/fail logic at all.

## Verification

The job's inline bash was extracted and exercised locally in all three states, with exit codes compared against pre-change behavior:

| Scenario | Notice | Exit code | Matches prior |
|---|---|---|---|
| `TRIGGERED=true`, body filled | emitted | 0 | yes |
| `TRIGGERED=true`, body empty | emitted | 1 | yes |
| `TRIGGERED=false` | not emitted | 0 | yes |

Exit-code-neutral in every case. YAML validated via `yaml.safe_load`. Adapter drift checked with the pathspec copied verbatim from `adapter-sync.yml`: no drift (no `content/` path touched).

This PR exercises its own change: it modifies a methodology-shaping path, so the notice should appear in its own Checks tab.

## North Star alignment

**Advances Pillar 2 (produce verifiable outcomes autonomously)** in the honest direction: it declines to fabricate a verification signal. A check that reports fabricable evidence as proof is worse than no check, because it converts an open gap into a false assurance.

**Advances Pillar 1 (guard operator attention)** narrowly: it surfaces the routing question at review time on methodology PRs, where a human is already looking, rather than adding a new place to watch.

**Pillar 5 and 6 (guard agent context, shorten wall-clock):** neutral. No resident-set change, no new job, no added CI wall-clock beyond one `echo`.

**Pillar 4 (works for everyone):** unaffected. No operator-, tracker-, or harness-specific behavior.

**Named trade-off, stated plainly:** this does not close the gap it describes. It cannot detect a bypass. The only mechanism that would actually close it is requiring human approval before methodology-shaping PRs merge instead of auto-merging on green CI, which is a materially larger change and a separate operator decision.

## Doc-sync

`Doc-sync: predicate not triggered (no reality-asserting change). docs/changelog.html mentions vision-alignment-check only as a historical PR-record entry, not as current-state prose describing the workflow's behavior; nothing there is made stale by this addition.`
