### PR TITLE
feat(commands): DS-166 - surface engineer model attribution in PR body

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2685,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2694,8 +2710,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -2942,6 +2942,16 @@
       "source_token": "QA_STATUS"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "and",
+      "kind": "display-only",
+      "occurrence_hash": "0013f80b428698ceedf14444d6db9b169494464170086a24788a657f340ee184",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "and"
+    },
+    {
       "expected_target": ".agentic/loop-state-",
       "generated_token": "$AE_PROJECT_DIR/.agentic/loop-state-",
       "kind": "operational",
@@ -3652,6 +3662,16 @@
       "source_token": "-C"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "unique",
+      "kind": "display-only",
+      "occurrence_hash": "0e0f2ff53e6f635d214d507009c7e3b151a2ffb7e2f6ba358ef5ac0d27c95f30",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "unique"
+    },
+    {
       "expected_target": "bin/ds-codex-session-id",
       "generated_token": "$AE_SESSION_ID",
       "kind": "operational",
@@ -3680,6 +3700,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "then"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "the",
+      "kind": "display-only",
+      "occurrence_hash": "0e6516e79b1eb216973ac43fd28a48e831316668cdc6d4af81d78b8bab4e08f3",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "the"
     },
     {
       "expected_target": "gh",
@@ -3790,6 +3820,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "11731e9be033dbbd4a199480ec420343c4e84ebca133b48579560b25926f6e1d",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": ".agentic/loop-state-",
@@ -4716,6 +4756,16 @@
       "generated_token": "true",
       "kind": "operational",
       "occurrence_hash": "1ffcc6356a2118b9e8f93be13a94e18a0c297ac0a279dc1968b78726611dfd10",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "true"
+    },
+    {
+      "expected_target": "true",
+      "generated_token": "true",
+      "kind": "operational",
+      "occurrence_hash": "2035340de5fa9fdec17ddf0b78ee93655f891ad9ec43bb577922016e87ec1d24",
       "resolution_mode": "PATH-provided",
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
@@ -5810,6 +5860,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/qa.md"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "30d0ce3a0840cba53ca80c9466e62665c7ba9da8f116252064350341f31250ee",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -7152,6 +7212,16 @@
       "source_token": "if"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "join",
+      "kind": "display-only",
+      "occurrence_hash": "476889ed45ef3ed59cf99ae370420067402bd81fc6c81f575057925ea4eca677",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "join"
+    },
+    {
       "expected_target": "METHODOLOGY.md",
       "generated_token": "$AE_CORE_SKILL_ROOT/METHODOLOGY.md",
       "kind": "operational",
@@ -7600,6 +7670,26 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/loop-state-"
+    },
+    {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "4ec132c60944462000d01bdf8649f0a1846fb2fef63c6c6001b04f3d4b03de58",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
+    },
+    {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "4ec132c60944462000d01bdf8649f0a1846fb2fef63c6c6001b04f3d4b03de58",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
     },
     {
       "expected_target": "touch",
@@ -10432,6 +10522,16 @@
       "source_token": "pr"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "-sr",
+      "kind": "display-only",
+      "occurrence_hash": "7e8e1873e3ed2a1b540049764fecff4bf28a98b016f194f2e8b2b235512a3d70",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "-sr"
+    },
+    {
       "expected_target": ".agentic/tasks.jsonl",
       "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
       "kind": "operational",
@@ -11010,6 +11110,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "printf"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "/dev",
+      "kind": "display-only",
+      "occurrence_hash": "8a9ef7b235f2d21fd63d534a35f42a14b4615382b8c7159488a05d13b39fd963",
+      "resolution_mode": "display-only",
+      "scope": "display-only",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "/dev"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -16413,6 +16523,16 @@
     },
     {
       "expected_target": "hashed-source-occurrence",
+      "generated_token": "select",
+      "kind": "display-only",
+      "occurrence_hash": "de1155a1bdc56654d974fbcdce43203a13a84120810e2e990229f4212e8bc020",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "select"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
       "generated_token": "REVIEW_DECISION",
       "kind": "display-only",
       "occurrence_hash": "de1e1ba424c1166925e964d1b79c871c945ec89da94a320985c973e2fbc06d60",
@@ -17730,6 +17850,16 @@
       "scope": "display-only",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "/tmp"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": ".author_model",
+      "kind": "display-only",
+      "occurrence_hash": "f06bef1bbb2f1e328f2ce3cc9a14cfbb129d9e51ee0dc2fa0b9ccf4ed45f427e",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".author_model"
     },
     {
       "expected_target": "content/references/tracker-writeback.md",

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2663,7 +2663,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2679,6 +2679,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# $AE_PROJECT_DIR/.agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' $AE_PROJECT_DIR/.agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2726,6 +2741,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2750,8 +2766,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.copilot/references/task-state-file.md
+++ b/.copilot/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -100,4 +102,6 @@ a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
 of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+before selecting their own model. `/ds-implement-ticket` Phase 9 also reads the
+folded value to emit a `Model:` attribution line beside `Developer:` on the PR
+body, so a PR carries the model(s) that produced it.

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2679,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2704,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.cursor/references/task-state-file.md
+++ b/.cursor/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -100,4 +102,6 @@ a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
 of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+before selecting their own model. `/ds-implement-ticket` Phase 9 also reads the
+folded value to emit a `Model:` attribution line beside `Developer:` on the PR
+body, so a PR carries the model(s) that produced it.

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2685,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\
@@ -2694,8 +2710,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\

--- a/.gemini/references/task-state-file.md
+++ b/.gemini/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -100,4 +102,6 @@ a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
 of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+before selecting their own model. `/ds-implement-ticket` Phase 9 also reads the
+folded value to emit a `Model:` attribution line beside `Developer:` on the PR
+body, so a PR carries the model(s) that produced it.

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2604,7 +2604,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2620,6 +2620,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2667,6 +2682,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2691,8 +2707,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -7558,7 +7558,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -7628,7 +7630,9 @@ a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
 of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+before selecting their own model. `/ds-implement-ticket` Phase 9 also reads the
+folded value to emit a `Model:` attribution line beside `Developer:` on the PR
+body, so a PR carries the model(s) that produced it.
 
 ---
 
@@ -17498,7 +17502,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -17514,6 +17518,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -17561,6 +17580,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -17585,8 +17605,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2606,7 +2606,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2622,6 +2622,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2669,6 +2684,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2693,8 +2709,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2605,7 +2605,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2621,6 +2621,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2668,6 +2683,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2692,8 +2708,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,21 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# written once per engineer task at Phase 5 spawn, so the read survives context loss and a
+# resumed session (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe
+# distinct non-null values so a multi-unit PR lists every model that contributed; the line is
+# omitted (like Developer) when task state is absent (single-unit plans never write
+# tasks.jsonl), author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2679,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2704,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "Model: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/content/references/task-state-file.md
+++ b/content/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -100,4 +102,6 @@ a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
 of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+before selecting their own model. `/ds-implement-ticket` Phase 9 also reads the
+folded value to emit a `Model:` attribution line beside `Developer:` on the PR
+body, so a PR carries the model(s) that produced it.


### PR DESCRIPTION
## Summary

Adds a `Model:` attribution line beside `Developer:` in both Phase 9 PR-body paths of `/ds-implement-ticket`, so a PR names the model(s) that produced it. This is the DS-166 accountability idea (from Theo t3.gg "I Fixed Claude Without Touching Any Code"): naming the model + harness in the PR description so reviewers/operators get an accountability line and the data feeds per-model quality loops.

- Model value is read from `.agentic/tasks.jsonl` `author_model` (the durable per-engineer record written once at Phase 5 spawn) using the same jq idiom as the ticket-rework ledger; distinct non-null values are deduped and comma-joined, so a multi-unit PR lists every contributing model.
- Line is omitted (exactly like `Developer:`) when task state is absent, `author_model` is null, or `ticket_id` is empty.
- Source-of-truth decision documented inline (task state over a conductor-held variable - `author_model` survives context loss/resumed sessions).
- Doc-sync: `content/references/task-state-file.md` downstream-consumers and `author_model` field prose updated. All 11 adapter dirs regenerated; `.codex/skill-compatibility.yml` refreshed for the new jq tokens.

Note on scope: the pipeline records no per-task harness slug (verified: `tasks.jsonl` schema carries only `author_model`), so the line is `Model: <id>` - an honest no-new-field form. A "model + harness" claim would invent data.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Universality (documented workflow usable by any consumer) and Progressive self-improvement (per-PR model attribution feeds data-driven agent-config decisions).
- Trade-off or pillar this could regress, if any: None - additive PR-body line, no behavioral pipeline change, no new fields.

## Review rigor

- Brief / Plan path: ad-hoc (research synthesis), DS-166 ticket + engineer brief
- Skeptic rounds (tier): round 1 in flight
- Findings summary: pending

## Related issues

Closes DS-166

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Affected adapters declared
- [x] Before/after transcript included for agent-behavior changes
- [ ] `install.sh` re-run locally and behavior verified
- [x] Tests/lint passing
- [x] Docs updated if behavior changed

## Affected adapters

- [x] Claude Code
- [x] Cursor
- [x] Codex CLI
- [x] Gemini CLI
- [ ] Kimi Code
- [x] OpenCode
- [x] Pi coding agent
- [ ] Pi oh-my-pi
- [x] Hermes
- [x] OpenClaw
- [x] VS Code Copilot