### PR TITLE
feat(commands): DS-166 - surface engineer model attribution in PR body

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -1705,7 +1705,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2688,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2694,8 +2713,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -2942,6 +2942,16 @@
       "source_token": "QA_STATUS"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "and",
+      "kind": "display-only",
+      "occurrence_hash": "0013f80b428698ceedf14444d6db9b169494464170086a24788a657f340ee184",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "and"
+    },
+    {
       "expected_target": ".agentic/loop-state-",
       "generated_token": "$AE_PROJECT_DIR/.agentic/loop-state-",
       "kind": "operational",
@@ -3652,6 +3662,16 @@
       "source_token": "-C"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "unique",
+      "kind": "display-only",
+      "occurrence_hash": "0e0f2ff53e6f635d214d507009c7e3b151a2ffb7e2f6ba358ef5ac0d27c95f30",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "unique"
+    },
+    {
       "expected_target": "bin/ds-codex-session-id",
       "generated_token": "$AE_SESSION_ID",
       "kind": "operational",
@@ -3790,6 +3810,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "11731e9be033dbbd4a199480ec420343c4e84ebca133b48579560b25926f6e1d",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": ".agentic/loop-state-",
@@ -4722,6 +4752,16 @@
       "source_token": "true"
     },
     {
+      "expected_target": "true",
+      "generated_token": "true",
+      "kind": "operational",
+      "occurrence_hash": "2035340de5fa9fdec17ddf0b78ee93655f891ad9ec43bb577922016e87ec1d24",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "true"
+    },
+    {
       "expected_target": "content/references/base-branch-sync.md",
       "generated_token": "$AE_REPO_DIR/content/references/base-branch-sync.md",
       "kind": "operational",
@@ -5352,16 +5392,6 @@
       "source_token": "add"
     },
     {
-      "expected_target": "Task",
-      "generated_token": "Task",
-      "kind": "semantic-reference",
-      "occurrence_hash": "2b154cd0ba88ae2bcc7a01beff30a0343cfd7b1d7e461182789045074abd5390",
-      "resolution_mode": "canonical-prose",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": "Task"
-    },
-    {
       "expected_target": ".agentic/batch-state.json",
       "generated_token": "$AE_PROJECT_DIR/.agentic/batch-state.json",
       "kind": "operational",
@@ -5810,6 +5840,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/qa.md"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "30d0ce3a0840cba53ca80c9466e62665c7ba9da8f116252064350341f31250ee",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -6562,16 +6602,6 @@
       "source_token": "commit"
     },
     {
-      "expected_target": ".agentic/tasks.jsonl",
-      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
-      "kind": "operational",
-      "occurrence_hash": "3d380d1d2b94d5794e406bf09270728b3ad9dc864bc674bb766632d645e4bbd6",
-      "resolution_mode": "invoked-project-path",
-      "scope": "invoked-project",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": ".agentic/tasks.jsonl"
-    },
-    {
       "expected_target": ".agentic/*",
       "generated_token": "$AE_PROJECT_DIR/.agentic/*",
       "kind": "operational",
@@ -6850,6 +6880,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "then"
+    },
+    {
+      "expected_target": "Task",
+      "generated_token": "Task",
+      "kind": "semantic-reference",
+      "occurrence_hash": "4196f55d242b7c2fd87f47da3271ed7f8e8c4bc10da5ad2adca7ac7192a8ee20",
+      "resolution_mode": "canonical-prose",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "Task"
     },
     {
       "expected_target": "case",
@@ -7150,6 +7190,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "if"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "join",
+      "kind": "display-only",
+      "occurrence_hash": "476889ed45ef3ed59cf99ae370420067402bd81fc6c81f575057925ea4eca677",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "join"
     },
     {
       "expected_target": "METHODOLOGY.md",
@@ -9402,6 +9452,26 @@
       "source_token": "then"
     },
     {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "6b95723f305927583410e6caa16dabb3bf2aabc8e1258f6a0ccec1f11a753831",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
+    },
+    {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "6b95723f305927583410e6caa16dabb3bf2aabc8e1258f6a0ccec1f11a753831",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
+    },
+    {
       "expected_target": "then",
       "generated_token": "then",
       "kind": "operational",
@@ -10432,6 +10502,16 @@
       "source_token": "pr"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "-sr",
+      "kind": "display-only",
+      "occurrence_hash": "7e8e1873e3ed2a1b540049764fecff4bf28a98b016f194f2e8b2b235512a3d70",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "-sr"
+    },
+    {
       "expected_target": ".agentic/tasks.jsonl",
       "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
       "kind": "operational",
@@ -10952,6 +11032,16 @@
       "source_token": "PENDING"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "the",
+      "kind": "display-only",
+      "occurrence_hash": "8978206d5d7e249bafe022392b91aecbc2ca07474258082036c2fb10127e1b43",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "the"
+    },
+    {
       "expected_target": "git",
       "generated_token": "git",
       "kind": "operational",
@@ -11010,6 +11100,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "printf"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "/dev",
+      "kind": "display-only",
+      "occurrence_hash": "8a9ef7b235f2d21fd63d534a35f42a14b4615382b8c7159488a05d13b39fd963",
+      "resolution_mode": "display-only",
+      "scope": "display-only",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "/dev"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -13250,6 +13350,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/tracker-states.json"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "aafd311166bd9d2f4ecb253cbbd0e7f1ac917c25a1b18b41ebcd98c9b73fe856",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": "if",
@@ -16413,6 +16523,16 @@
     },
     {
       "expected_target": "hashed-source-occurrence",
+      "generated_token": "select",
+      "kind": "display-only",
+      "occurrence_hash": "de1155a1bdc56654d974fbcdce43203a13a84120810e2e990229f4212e8bc020",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "select"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
       "generated_token": "REVIEW_DECISION",
       "kind": "display-only",
       "occurrence_hash": "de1e1ba424c1166925e964d1b79c871c945ec89da94a320985c973e2fbc06d60",
@@ -17730,6 +17850,16 @@
       "scope": "display-only",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "/tmp"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": ".author_model",
+      "kind": "display-only",
+      "occurrence_hash": "f06bef1bbb2f1e328f2ce3cc9a14cfbb129d9e51ee0dc2fa0b9ccf4ed45f427e",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".author_model"
     },
     {
       "expected_target": "content/references/tracker-writeback.md",

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -1761,7 +1761,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `$AE_PROJECT_DIR/.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `$AE_PROJECT_DIR/.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `$AE_CORE_SKILL_ROOT/METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2663,7 +2663,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2679,6 +2679,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# $AE_PROJECT_DIR/.agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' $AE_PROJECT_DIR/.agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2726,6 +2744,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2750,8 +2769,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.copilot/references/task-state-file.md
+++ b/.copilot/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,8 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append (which also carries `ticket_id`, so Phase 9's
+`Model:` attribution read can scope to the current ticket), and reviewer spawns
+read the folded value before selecting their own model. `/ds-implement-ticket`
+Phase 9 also reads the folded value to emit a `Model:` attribution line beside
+`Developer:` on the PR body, so a PR carries the model(s) that produced it.

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -1699,7 +1699,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2682,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2707,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.cursor/references/task-state-file.md
+++ b/.cursor/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,8 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append (which also carries `ticket_id`, so Phase 9's
+`Model:` attribution read can scope to the current ticket), and reviewer spawns
+read the folded value before selecting their own model. `/ds-implement-ticket`
+Phase 9 also reads the folded value to emit a `Model:` attribution line beside
+`Developer:` on the PR body, so a PR carries the model(s) that produced it.

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -1705,7 +1705,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2688,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\\nModel: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\
@@ -2694,8 +2713,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\\nModel: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\

--- a/.gemini/references/task-state-file.md
+++ b/.gemini/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,8 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append (which also carries `ticket_id`, so Phase 9's
+`Model:` attribution read can scope to the current ticket), and reviewer spawns
+read the folded value before selecting their own model. `/ds-implement-ticket`
+Phase 9 also reads the folded value to emit a `Model:` attribution line beside
+`Developer:` on the PR body, so a PR carries the model(s) that produced it.

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -1702,7 +1702,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2604,7 +2604,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2620,6 +2620,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2667,6 +2685,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2691,8 +2710,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -7558,7 +7558,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -7627,8 +7629,11 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append (which also carries `ticket_id`, so Phase 9's
+`Model:` attribution read can scope to the current ticket), and reviewer spawns
+read the folded value before selecting their own model. `/ds-implement-ticket`
+Phase 9 also reads the folded value to emit a `Model:` attribution line beside
+`Developer:` on the PR body, so a PR carries the model(s) that produced it.
 
 ---
 
@@ -16596,7 +16601,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -17498,7 +17503,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -17514,6 +17519,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -17561,6 +17584,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -17585,8 +17609,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -1704,7 +1704,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2606,7 +2606,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2622,6 +2622,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2669,6 +2687,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2693,8 +2712,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -1703,7 +1703,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2605,7 +2605,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2621,6 +2621,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2668,6 +2686,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2692,8 +2711,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -1699,7 +1699,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH the single-engineer claim
+# (:1674, which writes nothing to disk - single-unit plans never create tasks.jsonl) and the
+# fan-out per-unit claim (:1702, which appends to tasks.jsonl and also carries ticket_id so
+# this read can scope by ticket), so the read survives context loss and a resumed session
+# (mirrors how DEVELOPER re-resolves from ds-identity at this point). Dedupe distinct non-null
+# values so a multi-unit PR lists every model that contributed; the line is omitted (like
+# Developer) when task state is absent, author_model is null (model unknown / routing off), or
+# ticket_id is empty (null-ticket projects). The pipeline records no per-task harness slug -
+# author_model is the only model identifier - so the attribution line is Model: carrying the
+# model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2682,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2707,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/content/references/task-state-file.md
+++ b/content/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,8 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append (which also carries `ticket_id`, so Phase 9's
+`Model:` attribution read can scope to the current ticket), and reviewer spawns
+read the folded value before selecting their own model. `/ds-implement-ticket`
+Phase 9 also reads the folded value to emit a `Model:` attribution line beside
+`Developer:` on the PR body, so a PR carries the model(s) that produced it.


### PR DESCRIPTION
## Summary

Adds a `Model:` attribution line beside `Developer:` in both Phase 9 PR-body paths of `/ds-implement-ticket`, so a PR names the model(s) that produced it. This is the DS-166 accountability idea (from Theo t3.gg "I Fixed Claude Without Touching Any Code").

This is a reworked branch (fix/ds-166-skeptic-m1-m2, 2c8eda35) superseding the original PR #709, resolving the Skeptic's round-1 findings:
- Major M1: the Model: line was inert - `ENGINEER_MODEL` was always empty because the fan-out ownership claim at ds-implement-ticket.md:1702 omitted `author_model` AND `ticket_id` (the jq scopes on `.ticket_id == $t`), so no `.agentic/tasks.jsonl` record matched. The fan-out claim now records both fields, and the diff comment states author_model is on both claim sites.
- Minor m2: both `Model:` printf calls now carry the leading newline Developer: has (no gluing to the Test-plan bullet when DEVELOPER is empty).

- Model value is read from `.agentic/tasks.jsonl` `author_model` (deduped, comma-joined across contributing units); line omitted when absent/null.
- Source-of-truth decision documented inline (task state over conductor-held variable).
- Doc-sync: task-state-file.md updated; all 11 adapters regenerated; .codex/skill-compatibility.yml refreshed.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Universality and Progressive self-improvement (per-PR model attribution feeds data-driven agent-config decisions).
- Trade-off or pillar this could regress, if any: None - additive PR-body line, no behavioral pipeline change, no new fields.

## Review rigor

- Brief / Plan path: ad-hoc (research synthesis), DS-166 ticket + engineer brief
- Skeptic rounds (tier): round 1 - 1 Major (inert Model: line, fixed) + 1 Minor (printf newline, fixed). Round 2 in flight on this reworked branch.
- Findings summary: M1 + m2 resolved in 2c8eda35; round-2 review pending.

## Related issues

Closes DS-166

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Affected adapters declared
- [x] Before/after transcript included for agent-behavior changes
- [ ] `install.sh` re-run locally and behavior verified
- [x] Tests/lint passing
- [x] Docs updated if behavior changed

## Affected adapters

- [x] Claude Code
- [x] Cursor
- [x] Codex CLI
- [x] Gemini CLI
- [ ] Kimi Code
- [x] OpenCode
- [x] Pi coding agent
- [ ] Pi oh-my-pi
- [x] Hermes
- [x] OpenClaw
- [x] VS Code Copilot