### PR TITLE
feat(commands): DS-166 - surface engineer model attribution in PR body

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -1677,7 +1677,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1705,7 +1705,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2688,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2694,8 +2713,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -2942,6 +2942,16 @@
       "source_token": "QA_STATUS"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "and",
+      "kind": "display-only",
+      "occurrence_hash": "0013f80b428698ceedf14444d6db9b169494464170086a24788a657f340ee184",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "and"
+    },
+    {
       "expected_target": ".agentic/loop-state-",
       "generated_token": "$AE_PROJECT_DIR/.agentic/loop-state-",
       "kind": "operational",
@@ -3652,6 +3662,16 @@
       "source_token": "-C"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "unique",
+      "kind": "display-only",
+      "occurrence_hash": "0e0f2ff53e6f635d214d507009c7e3b151a2ffb7e2f6ba358ef5ac0d27c95f30",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "unique"
+    },
+    {
       "expected_target": "bin/ds-codex-session-id",
       "generated_token": "$AE_SESSION_ID",
       "kind": "operational",
@@ -3790,6 +3810,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "11731e9be033dbbd4a199480ec420343c4e84ebca133b48579560b25926f6e1d",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": ".agentic/loop-state-",
@@ -4722,6 +4752,16 @@
       "source_token": "true"
     },
     {
+      "expected_target": "true",
+      "generated_token": "true",
+      "kind": "operational",
+      "occurrence_hash": "2035340de5fa9fdec17ddf0b78ee93655f891ad9ec43bb577922016e87ec1d24",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "true"
+    },
+    {
       "expected_target": "content/references/base-branch-sync.md",
       "generated_token": "$AE_REPO_DIR/content/references/base-branch-sync.md",
       "kind": "operational",
@@ -5352,16 +5392,6 @@
       "source_token": "add"
     },
     {
-      "expected_target": "Task",
-      "generated_token": "Task",
-      "kind": "semantic-reference",
-      "occurrence_hash": "2b154cd0ba88ae2bcc7a01beff30a0343cfd7b1d7e461182789045074abd5390",
-      "resolution_mode": "canonical-prose",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": "Task"
-    },
-    {
       "expected_target": ".agentic/batch-state.json",
       "generated_token": "$AE_PROJECT_DIR/.agentic/batch-state.json",
       "kind": "operational",
@@ -5810,6 +5840,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/qa.md"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "30d0ce3a0840cba53ca80c9466e62665c7ba9da8f116252064350341f31250ee",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -6562,16 +6602,6 @@
       "source_token": "commit"
     },
     {
-      "expected_target": ".agentic/tasks.jsonl",
-      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
-      "kind": "operational",
-      "occurrence_hash": "3d380d1d2b94d5794e406bf09270728b3ad9dc864bc674bb766632d645e4bbd6",
-      "resolution_mode": "invoked-project-path",
-      "scope": "invoked-project",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": ".agentic/tasks.jsonl"
-    },
-    {
       "expected_target": ".agentic/*",
       "generated_token": "$AE_PROJECT_DIR/.agentic/*",
       "kind": "operational",
@@ -6850,6 +6880,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "then"
+    },
+    {
+      "expected_target": "Task",
+      "generated_token": "Task",
+      "kind": "semantic-reference",
+      "occurrence_hash": "4196f55d242b7c2fd87f47da3271ed7f8e8c4bc10da5ad2adca7ac7192a8ee20",
+      "resolution_mode": "canonical-prose",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "Task"
     },
     {
       "expected_target": "case",
@@ -7152,6 +7192,16 @@
       "source_token": "if"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "join",
+      "kind": "display-only",
+      "occurrence_hash": "476889ed45ef3ed59cf99ae370420067402bd81fc6c81f575057925ea4eca677",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "join"
+    },
+    {
       "expected_target": "METHODOLOGY.md",
       "generated_token": "$AE_CORE_SKILL_ROOT/METHODOLOGY.md",
       "kind": "operational",
@@ -7422,6 +7472,16 @@
       "source_token": "/dev"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "the",
+      "kind": "display-only",
+      "occurrence_hash": "4b79b5ac991253018cd7339ccb9edbf9b77e27d3f34a1ae9a48c3bb5790bc631",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "the"
+    },
+    {
       "expected_target": "Task",
       "generated_token": "Task",
       "kind": "semantic-reference",
@@ -7470,16 +7530,6 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "cp"
-    },
-    {
-      "expected_target": "content/references/task-state-file.md",
-      "generated_token": "$AE_REPO_DIR/content/references/task-state-file.md",
-      "kind": "operational",
-      "occurrence_hash": "4c066e654ac97d8d7b32dc6fe135976b613043097fe40bc9d2f0e2839c8abd7d",
-      "resolution_mode": "validated-repository",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": "content/references/task-state-file.md"
     },
     {
       "expected_target": ".agentic/loop-state-",
@@ -9402,6 +9452,26 @@
       "source_token": "then"
     },
     {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "6b95723f305927583410e6caa16dabb3bf2aabc8e1258f6a0ccec1f11a753831",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
+    },
+    {
+      "expected_target": "printf",
+      "generated_token": "printf",
+      "kind": "operational",
+      "occurrence_hash": "6b95723f305927583410e6caa16dabb3bf2aabc8e1258f6a0ccec1f11a753831",
+      "resolution_mode": "PATH-provided",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "printf"
+    },
+    {
       "expected_target": "then",
       "generated_token": "then",
       "kind": "operational",
@@ -10432,6 +10502,16 @@
       "source_token": "pr"
     },
     {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "-sr",
+      "kind": "display-only",
+      "occurrence_hash": "7e8e1873e3ed2a1b540049764fecff4bf28a98b016f194f2e8b2b235512a3d70",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "-sr"
+    },
+    {
       "expected_target": ".agentic/tasks.jsonl",
       "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
       "kind": "operational",
@@ -10862,6 +10942,16 @@
       "source_token": "W1_REASON"
     },
     {
+      "expected_target": "content/references/task-state-file.md",
+      "generated_token": "$AE_REPO_DIR/content/references/task-state-file.md",
+      "kind": "operational",
+      "occurrence_hash": "8779908efe81979a06250b06726a2a9447cf6e8fe95b92c5efadcbe1f1428a68",
+      "resolution_mode": "validated-repository",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "content/references/task-state-file.md"
+    },
+    {
       "expected_target": "wrap",
       "generated_token": "$wrap",
       "kind": "operational",
@@ -11010,6 +11100,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "printf"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "/dev",
+      "kind": "display-only",
+      "occurrence_hash": "8a9ef7b235f2d21fd63d534a35f42a14b4615382b8c7159488a05d13b39fd963",
+      "resolution_mode": "display-only",
+      "scope": "display-only",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "/dev"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -13250,6 +13350,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": ".agentic/tracker-states.json"
+    },
+    {
+      "expected_target": ".agentic/tasks.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/tasks.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "aafd311166bd9d2f4ecb253cbbd0e7f1ac917c25a1b18b41ebcd98c9b73fe856",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".agentic/tasks.jsonl"
     },
     {
       "expected_target": "if",
@@ -16413,6 +16523,16 @@
     },
     {
       "expected_target": "hashed-source-occurrence",
+      "generated_token": "select",
+      "kind": "display-only",
+      "occurrence_hash": "de1155a1bdc56654d974fbcdce43203a13a84120810e2e990229f4212e8bc020",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "select"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
       "generated_token": "REVIEW_DECISION",
       "kind": "display-only",
       "occurrence_hash": "de1e1ba424c1166925e964d1b79c871c945ec89da94a320985c973e2fbc06d60",
@@ -17730,6 +17850,16 @@
       "scope": "display-only",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "/tmp"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": ".author_model",
+      "kind": "display-only",
+      "occurrence_hash": "f06bef1bbb2f1e328f2ce3cc9a14cfbb129d9e51ee0dc2fa0b9ccf4ed45f427e",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": ".author_model"
     },
     {
       "expected_target": "content/references/tracker-writeback.md",

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -1733,7 +1733,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `$AE_PROJECT_DIR/.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`$AE_REPO_DIR/content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`$AE_REPO_DIR/content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `$AE_PROJECT_DIR/.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`$AE_REPO_DIR/content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1761,7 +1761,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `$AE_PROJECT_DIR/.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `$AE_PROJECT_DIR/.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `$AE_CORE_SKILL_ROOT/METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2663,7 +2663,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2679,6 +2679,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# $AE_PROJECT_DIR/.agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' $AE_PROJECT_DIR/.agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2726,6 +2744,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2750,8 +2769,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.copilot/references/task-state-file.md
+++ b/.copilot/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,11 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append. Both Phase 5 claim sites - the sequential
+single-engineer claim and the parallel per-unit fan-out claim - carry
+`ticket_id` alongside `author_model`, so Phase 9's `Model:` attribution read
+can scope to the current ticket. Reviewer spawns read the folded value before
+selecting their own model. `/ds-implement-ticket` Phase 9 reads the raw claim
+records (filtered on raw `status` `in_progress`/`done`) to emit a `Model:`
+attribution line beside `Developer:` on the PR body, so a PR carries the
+model(s) that produced it.

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -1671,7 +1671,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1699,7 +1699,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2682,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2707,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.cursor/references/task-state-file.md
+++ b/.cursor/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,11 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append. Both Phase 5 claim sites - the sequential
+single-engineer claim and the parallel per-unit fan-out claim - carry
+`ticket_id` alongside `author_model`, so Phase 9's `Model:` attribution read
+can scope to the current ticket. Reviewer spawns read the folded value before
+selecting their own model. `/ds-implement-ticket` Phase 9 reads the raw claim
+records (filtered on raw `status` `in_progress`/`done`) to emit a `Model:`
+attribution line beside `Developer:` on the PR body, so a PR carries the
+model(s) that produced it.

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -1677,7 +1677,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1705,7 +1705,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2607,7 +2607,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2623,6 +2623,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2670,6 +2688,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\\nModel: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\
@@ -2694,8 +2713,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\\nDeveloper: %s\\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\\nModel: %s\\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \\
     --repo [GH_REPO] \\

--- a/.gemini/references/task-state-file.md
+++ b/.gemini/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,11 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append. Both Phase 5 claim sites - the sequential
+single-engineer claim and the parallel per-unit fan-out claim - carry
+`ticket_id` alongside `author_model`, so Phase 9's `Model:` attribution read
+can scope to the current ticket. Reviewer spawns read the folded value before
+selecting their own model. `/ds-implement-ticket` Phase 9 reads the raw claim
+records (filtered on raw `status` `in_progress`/`done`) to emit a `Model:`
+attribution line beside `Developer:` on the PR body, so a PR carries the
+model(s) that produced it.

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -1674,7 +1674,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1702,7 +1702,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2604,7 +2604,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2620,6 +2620,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2667,6 +2685,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2691,8 +2710,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -7558,7 +7558,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -7627,8 +7629,14 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append. Both Phase 5 claim sites - the sequential
+single-engineer claim and the parallel per-unit fan-out claim - carry
+`ticket_id` alongside `author_model`, so Phase 9's `Model:` attribution read
+can scope to the current ticket. Reviewer spawns read the folded value before
+selecting their own model. `/ds-implement-ticket` Phase 9 reads the raw claim
+records (filtered on raw `status` `in_progress`/`done`) to emit a `Model:`
+attribution line beside `Developer:` on the PR body, so a PR carries the
+model(s) that produced it.
 
 ---
 
@@ -16568,7 +16576,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -16596,7 +16604,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -17498,7 +17506,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -17514,6 +17522,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -17561,6 +17587,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -17585,8 +17612,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -1676,7 +1676,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1704,7 +1704,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2606,7 +2606,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2622,6 +2622,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2669,6 +2687,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2693,8 +2712,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -1675,7 +1675,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1703,7 +1703,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2605,7 +2605,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2621,6 +2621,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2668,6 +2686,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2692,8 +2711,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/bin/tests/test_ds166_model_claim_spec.sh
+++ b/bin/tests/test_ds166_model_claim_spec.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Purpose: DS-166 round-2 regression gate. Pins the Phase 5 ownership-claim
+#          include lists at BOTH claim sites in content/commands/ds-implement-ticket.md
+#          to carry `author_model` AND `ticket_id`, pins the Phase 9 ENGINEER_MODEL jq's
+#          ticket scoping and the Model: printf form, and empirically runs the exact jq
+#          against a sequential-style claim fixture.
+#
+#          WHY THIS TEST EXISTS: the DS-166 round-1 defect left the sequential
+#          single-engineer claim recording author_model WITHOUT ticket_id, so the
+#          ENGINEER_MODEL jq (which scopes `.ticket_id == $t`) never matched on the
+#          sequential-multi-unit path - the Model: attribution line stayed inert on
+#          sequential-multi-unit PRs while the round-1 comment falsely claimed the site
+#          "writes nothing to disk." A prose edit that removes ticket_id from either
+#          claim site (re-opening the inert-line bug), drops the jq's ticket scoping, or
+#          removes the Model: printf fails here.
+#
+# Public API: ./bin/tests/test_ds166_model_claim_spec.sh
+#             Exits 0 on all pass, 1 on any failure.
+#             Auto-wired into CI by the bin/tests/test_*.sh glob in
+#             .github/workflows/bin-tests.yml - no orphans entry needed.
+#
+# Upstream deps: bash, grep, jq. Reads content/commands/ds-implement-ticket.md
+#                from the checkout. Honors GATE_REPO to override the root.
+#
+# Downstream consumers: developer running locally before commit; CI
+#                       (.github/workflows/bin-tests.yml, bin-sh-tests job).
+#
+# Failure modes: jq missing -> hard _fail (never a silently-skipped assertion,
+#                indistinguishable from a passing one); no writes outside a
+#                mktemp scratch dir removed by an EXIT trap.
+#
+# Performance: < 1 s wall time (grep + two jq invocations; no network).
+
+set -uo pipefail
+
+REPO_DIR="${GATE_REPO:-$(cd "$(dirname "$0")/../.." 2>/dev/null && pwd)}"
+cd "$REPO_DIR" 2>/dev/null || { echo "FATAL: cannot cd to '$REPO_DIR'" >&2; exit 2; }
+if ! git rev-parse --show-toplevel >/dev/null 2>&1 \
+   || [ ! -f content/commands/ds-implement-ticket.md ]; then
+  echo "FATAL: '$REPO_DIR' is not a DinoStack repo root (expected content/commands/ds-implement-ticket.md). Set GATE_REPO." >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+DIT="$REPO_DIR/content/commands/ds-implement-ticket.md"
+
+# --- Prose-pin: both claim sites carry author_model AND ticket_id --------------
+# Sequential single-engineer claim (Phase 5 sequential multi-unit path): the
+# round-1 defect was this site recording author_model WITHOUT ticket_id.
+SEQ_CLAIM="$(grep -F "this append is the ownership claim." "$DIT" || true)"
+# Parallel fan-out per-unit claim (Phase 5 parallel path).
+FANOUT_CLAIM="$(grep -F "one \`in_progress\` claim record per unit" "$DIT" || true)"
+
+if [ -z "$SEQ_CLAIM" ]; then
+  _fail "sequential claim anchor 'this append is the ownership claim.' not found in $DIT"
+else
+  printf '%s' "$SEQ_CLAIM" | grep -qF 'author_model' \
+    && _pass "sequential claim include list carries author_model" \
+    || _fail "sequential claim include list lacks author_model"
+  printf '%s' "$SEQ_CLAIM" | grep -qF 'ticket_id' \
+    && _pass "sequential claim include list carries ticket_id" \
+    || _fail "sequential claim include list lacks ticket_id (round-1 inert-line defect)"
+fi
+
+if [ -z "$FANOUT_CLAIM" ]; then
+  _fail "fan-out claim anchor 'one \`in_progress\` claim record per unit' not found in $DIT"
+else
+  printf '%s' "$FANOUT_CLAIM" | grep -qF 'author_model' \
+    && _pass "fan-out claim include list carries author_model" \
+    || _fail "fan-out claim include list lacks author_model"
+  printf '%s' "$FANOUT_CLAIM" | grep -qF 'ticket_id' \
+    && _pass "fan-out claim include list carries ticket_id" \
+    || _fail "fan-out claim include list lacks ticket_id"
+fi
+
+# --- Prose-pin: ENGINEER_MODEL jq scopes on ticket_id; Model: printf survives ---
+grep -qF '.ticket_id == $t' "$DIT" \
+  && _pass "ENGINEER_MODEL jq scopes on .ticket_id == \$t" \
+  || _fail "ENGINEER_MODEL jq no longer scopes on .ticket_id == \$t"
+grep -qF 'printf "\nModel: %s\n" "$ENGINEER_MODEL"' "$DIT" \
+  && _pass "Model: printf form present" \
+  || _fail "Model: printf form missing"
+
+# --- Empirical: the exact ENGINEER_MODEL jq returns the model for a
+#     ticket_id+author_model sequential-style claim, and EMPTY for the
+#     round-1 defect shape (a claim that drops ticket_id) ----------------------
+if command -v jq >/dev/null 2>&1; then
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+
+  cat > "$TMP/tasks-with-ticket.jsonl" <<'EOF'
+{"task_id":"TASK-1-seq","session_id":"s1","ticket_id":"TICKET-1","unit_slug":"u1","status":"in_progress","depends_on":[],"created_at":"2026-08-12T00:00:00Z","updated_at":"2026-08-12T00:00:00Z","author_model":"claude-sonnet-4","assigned_agent":"engineer","worktree_path":"/wt","branch_name":"feature/ticket-1"}
+{"task_id":"TASK-2-seq","session_id":"s1","ticket_id":"TICKET-1","unit_slug":"u2","status":"done","depends_on":["TASK-1-seq"],"created_at":"2026-08-12T00:00:00Z","updated_at":"2026-08-12T00:00:00Z","author_model":"claude-sonnet-4","assigned_agent":"engineer","worktree_path":"/wt","branch_name":"feature/ticket-1"}
+EOF
+
+  cat > "$TMP/tasks-no-ticket.jsonl" <<'EOF'
+{"task_id":"TASK-1-seq","session_id":"s1","unit_slug":"u1","status":"in_progress","depends_on":[],"created_at":"2026-08-12T00:00:00Z","updated_at":"2026-08-12T00:00:00Z","author_model":"claude-sonnet-4","assigned_agent":"engineer","worktree_path":"/wt","branch_name":"feature/ticket-1"}
+EOF
+
+  ENGINEER_MODEL_JQ='[.[] | select(.ticket_id == $t and .assigned_agent == "engineer" and .author_model != null and (.status == "in_progress" or .status == "done")) | .author_model] | unique | join(", ")'
+
+  RESULT_POS="$(jq -sr --arg t "TICKET-1" "$ENGINEER_MODEL_JQ" "$TMP/tasks-with-ticket.jsonl" 2>/dev/null || true)"
+  if [ "$RESULT_POS" = "claude-sonnet-4" ]; then
+    _pass "ENGINEER_MODEL jq returns non-empty model for a sequential-style ticket_id+author_model claim"
+  else
+    _fail "ENGINEER_MODEL jq returned '$RESULT_POS' (expected 'claude-sonnet-4') for a ticket_id+author_model claim - the Model: attribution read would be inert"
+  fi
+
+  RESULT_NEG="$(jq -sr --arg t "TICKET-1" "$ENGINEER_MODEL_JQ" "$TMP/tasks-no-ticket.jsonl" 2>/dev/null || true)"
+  if [ -z "$RESULT_NEG" ]; then
+    _pass "ENGINEER_MODEL jq returns EMPTY for a claim that drops ticket_id (round-1 defect shape)"
+  else
+    _fail "ENGINEER_MODEL jq returned '$RESULT_NEG' for a claim that drops ticket_id (expected empty) - the round-1 defect shape would now silently attribute a model"
+  fi
+else
+  _fail "jq not found on PATH - ENGINEER_MODEL empirical check cannot run (a silently-skipped regression guard is indistinguishable from a passing one)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -1671,7 +1671,7 @@ The engineer return shape on the Elevated path now requires `quality_gate_result
 
 **Task-state reads (multi-unit only, when `.agentic/tasks.jsonl` is in use):**
 
-Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), and `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off).
+Before spawning each worker: apply the **task-state fold** (`content/references/task-state-file.md`) and check the task's `depends_on` field against the folded index. All dependency `task_id`s must have folded `status: done` before this task can start (rows 3/9 of the fold's row grid). Append a partial transition moving status from `pending` -> `in_progress` immediately before spawning - this append is the ownership claim. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path if using worktree isolation, null otherwise), `branch_name` (the branch the worker will operate on), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 After each worker returns: read the return summary, extract `worker_summary`, `commit_sha`, `files_modified`, and `quality_gate_passed`. Append an output-only entry to `.agentic/tasks.jsonl` with these output fields and **no `status` field** - an output append is never a claim and never a status transition (`content/references/task-state-file.md` §Task-state fold). "Status remains `in_progress`" is a statement about what the fold reports for this task until Skeptic sign-off or final determination, **not an instruction to re-emit the field**: re-emitting `status: in_progress` here would make this append a fresh ownership claim under the fold's state machine, letting a dispossessed session (rows 14/15) reclaim ownership merely by returning its engineer's outputs.
 
@@ -1699,7 +1699,7 @@ git -C $REPO worktree add ${REPO}/.agentic/worktrees/${FEATURE_BRANCH}-${unit_sl
   -b ${FEATURE_BRANCH}-${unit_slug} origin/$BASE_BRANCH
 ```
 
-**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), and `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`).
+**Task-state reads (when `.agentic/tasks.jsonl` is in use):** Before spawning, apply the **task-state fold** and verify all `depends_on` task_ids are folded `done`, then append a partial transition per unit moving status from `pending` -> `in_progress` - one `in_progress` claim record per unit. Include `assigned_agent` (the named agent type being spawned, e.g. 'engineer'), `worktree_path` (absolute path of the unit's worktree), `branch_name` (the unit's sub-branch `${FEATURE_BRANCH}-${unit_slug}`), `author_model` (the model id the engineer will run under, recorded so reviewer spawns - Skeptic, security-auditor - can select a different model when role-model routing is active; set to `null` when the model is unknown or role-model routing is off), and `ticket_id` (the ticket this unit belongs to - the Phase 9 Model: attribution read scopes on it).
 
 Spawn one `engineer` agent per worktree in a single message (parallel, background). Each engineer works in its assigned worktree path and commits to its own sub-branch. Each agent's prompt should include:
 - The execution contract block from `METHODOLOGY.md §Delegation > Worker preamble`, with fields filled in from the per-unit scope in the planner's JSONL block
@@ -2601,7 +2601,7 @@ Closes [[TICKET_PREFIX]-NNN]([JIRA_BASE_URL]/browse/[TICKET_PREFIX]-NNN)
 
 #### If TRACKER is `none`
 
-Omit the tracker reference block entirely. The PR body will have only Summary and Test plan, and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
+Omit the tracker reference block entirely. The PR body will have only Summary, Test plan, and the Developer/Model attribution lines (each appended only when its value is known), and the PR title should omit the `[TICKET_PREFIX]-NNN:` prefix.
 
 ---
 
@@ -2617,6 +2617,24 @@ Run:
 # Note: `show` (no --scope) resolves the project-local identity first per the 4-tier ordering.
 DEVELOPER=${DEVELOPER:-$(ds-identity show 2>/dev/null | awk '/^developer_id:/{print $2}')}
 if ds-identity show 2>/dev/null | grep -qE '^provisional:[[:space:]]+true'; then DEVELOPER=""; fi
+
+# Engineer model for the PR Model: attribution line (DS-166). Source-of-truth is
+# .agentic/tasks.jsonl, NOT a conductor-held variable: author_model is the durable record
+# appended on the Phase 5 ownership claim, recorded on BOTH claim sites - the sequential
+# single-engineer claim (:1674, which writes a claim record to tasks.jsonl whenever the plan
+# is multi-unit - single-unit plans never create the file) and the fan-out per-unit claim
+# (:1702, which appends to tasks.jsonl) - each also carrying ticket_id so this read can scope
+# by ticket, so the read survives context loss and a resumed session (mirrors how DEVELOPER
+# re-resolves from ds-identity at this point). Dedupe distinct non-null values so a multi-unit
+# PR lists every model that contributed; the line is omitted (like Developer) when task state
+# is absent, author_model is null (model unknown / routing off), or ticket_id is empty
+# (null-ticket projects). The pipeline records no per-task harness slug - author_model is the
+# only model identifier - so the attribution line is Model: carrying the model id(s).
+ENGINEER_MODEL=$(jq -sr --arg t "$TICKET_ID" '
+  [.[] | select(.ticket_id == $t and .assigned_agent == "engineer"
+    and .author_model != null and (.status == "in_progress" or .status == "done"))
+    | .author_model]
+  | unique | join(", ")' .agentic/tasks.jsonl 2>/dev/null || true)
 
 # UNIT_IS_BEHAVIOR_VISIBLE: true only when QA ran+passed, evidence URLs exist, AND risk class is
 # not security/auth/crypto/payments/Elevated-correctness (derived in-context from Phase 2/3
@@ -2664,6 +2682,7 @@ if [ "$UNIT_IS_BEHAVIOR_VISIBLE" = "true" ] && [ "${#QA_EVIDENCE_URLS[@]}" -gt 0
 - [ ] [step 2]
 PRBODY
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \
@@ -2688,8 +2707,9 @@ else
 - [ ] [step 1]
 - [ ] [step 2]
 PRBODY
-  # Append Developer: line when identity is confirmed (survives --squash via PR body).
+  # Append Developer:/Model: attribution lines when identity/model are known (survives --squash via PR body).
   [ -n "$DEVELOPER" ] && printf "\nDeveloper: %s\n" "$DEVELOPER" >> "$PR_BODY_FILE"
+  [ -n "$ENGINEER_MODEL" ] && printf "\nModel: %s\n" "$ENGINEER_MODEL" >> "$PR_BODY_FILE"
 
   gh pr create \
     --repo [GH_REPO] \

--- a/content/references/task-state-file.md
+++ b/content/references/task-state-file.md
@@ -30,7 +30,9 @@ Downstream consumers: conductor (/ds-implement-ticket multi-unit orchestration;
                       rewrites); engineer agents (receive task_id in
                       execution contract for identification only - never
                       write to tasks.jsonl); skeptic / security-auditor (read
-                      author_model before selecting their own model).
+                      author_model before selecting their own model);
+                      /ds-implement-ticket Phase 9 (reads author_model for the
+                      PR body Model: attribution line beside Developer:).
 
 Failure modes: tasks.jsonl IS gitignored, like other .agentic/ state files
                (see ds-init-project.md's scaffolded .gitignore block and
@@ -99,5 +101,11 @@ not recorded). Consumed by reviewer spawns (Skeptic, security-auditor) to pick
 a different model when role-model routing is active -- reviewer-diversity
 prose lives in `content/agents/skeptic.md` and `content/agents/security-auditor.md`.
 The conductor records `author_model` at engineer spawn time (Phase 5) as part
-of the ownership claim's append, and reviewer spawns read the folded value
-before selecting their own model.
+of the ownership claim's append. Both Phase 5 claim sites - the sequential
+single-engineer claim and the parallel per-unit fan-out claim - carry
+`ticket_id` alongside `author_model`, so Phase 9's `Model:` attribution read
+can scope to the current ticket. Reviewer spawns read the folded value before
+selecting their own model. `/ds-implement-ticket` Phase 9 reads the raw claim
+records (filtered on raw `status` `in_progress`/`done`) to emit a `Model:`
+attribution line beside `Developer:` on the PR body, so a PR carries the
+model(s) that produced it.


### PR DESCRIPTION
## Summary

Adds a `Model:` attribution line beside `Developer:` in both Phase 9 PR-body paths of `/ds-implement-ticket`, so a PR names the model(s) that produced it. This is the DS-166 accountability idea (from Theo t3.gg "I Fixed Claude Without Touching Any Code").

This is the round-2 rework (fix/ds-166-skeptic-r2, 783e8aa9), superseding PR #711 after round-2 Skeptic findings:
- R2-1 (Major): sequential-multi-unit :1674 claim lacked `ticket_id`, so the Model: line was still inert on that path; the :2624 comment falsely claimed ":1674 writes nothing to disk". Both claim sites (:1674 and :1702) now record `author_model` + `ticket_id`; comment corrected.
- R2-2 (Major): added regression test `bin/tests/test_ds166_model_claim_spec.sh` (8 assertions, prose-pin + empirical jq run) - proven to fail on the pre-fix code with the inert-line defect and pass on the fixed code. Wired into CI via the bin-sh-tests glob (no workflow change).
- R2-3 (Minor): task-state-file.md now states Phase 9 reads raw claim records (filtered on raw status), not the folded value.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Universality and Progressive self-improvement (per-PR model attribution feeds data-driven agent-config decisions).
- Trade-off or pillar this could regress, if any: None - additive PR-body line + regression test, no behavioral pipeline change.

## Review rigor

- Brief / Plan path: ad-hoc (research synthesis), DS-166 ticket + engineer brief
- Skeptic rounds (tier): round 1 (inert line + printf newline), round 2 (sequential ticket_id + regression test + wording). Round 3 in flight on this reworked branch.
- Findings summary: rounds 1-2 findings all resolved in 783e8aa9; round-3 review pending.

## Related issues

Closes DS-166

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Affected adapters declared
- [x] Before/after transcript included for agent-behavior changes
- [ ] `install.sh` re-run locally and behavior verified
- [x] Tests/lint passing
- [x] Docs updated if behavior changed

## Affected adapters

- [x] Claude Code
- [x] Cursor
- [x] Codex CLI
- [x] Gemini CLI
- [ ] Kimi Code
- [x] OpenCode
- [x] Pi coding agent
- [ ] Pi oh-my-pi
- [x] Hermes
- [x] OpenClaw
- [x] VS Code Copilot