### PR TITLE
fix(ds-update-agentic-engineering): Step 1.5 reads vision.md's own pillar list instead of a stale inline copy

### DIFF
--- a/.claude/commands/ds-update-agentic-engineering.md
+++ b/.claude/commands/ds-update-agentic-engineering.md
@@ -177,9 +177,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.cursor/commands/ds-update-agentic-engineering.md
+++ b/.cursor/commands/ds-update-agentic-engineering.md
@@ -171,9 +171,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.gemini/commands/ds-update-agentic-engineering.toml
+++ b/.gemini/commands/ds-update-agentic-engineering.toml
@@ -177,9 +177,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.github/prompts/ds-update-agentic-engineering.prompt.md
+++ b/.github/prompts/ds-update-agentic-engineering.prompt.md
@@ -174,9 +174,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -22137,9 +22137,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.openclaw/skills/ds-update-agentic-engineering/SKILL.md
+++ b/.openclaw/skills/ds-update-agentic-engineering/SKILL.md
@@ -176,9 +176,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/.opencode/commands/ds-update-agentic-engineering.md
+++ b/.opencode/commands/ds-update-agentic-engineering.md
@@ -175,9 +175,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.

--- a/bin/tests/test_ds_update_pillar_check_no_inline_list.py
+++ b/bin/tests/test_ds_update_pillar_check_no_inline_list.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Purpose: Regression guard for the defect fixed in
+         content/commands/ds-update-agentic-engineering.md Step 1.5 (the
+         vision-alignment check): that step used to hardcode an inline list
+         of North Star pillar names, which silently went stale the moment
+         docs/overview/vision.md grew from 4 pillars to 7. The fix replaced
+         the inline list with an instruction to read the pillar set from
+         vision.md itself. This test pins that fix as a durable invariant -
+         it derives the CURRENT pillar names from docs/overview/vision.md at
+         test time (not a hardcoded list of its own, which would reproduce
+         the exact defect it exists to catch) and asserts none of them
+         appear inside the Step 1.5 section specifically, plus that the
+         "read it from the file" instruction is still present.
+
+         Scope note (honest limitation, not engineered around): the
+         resilience here is to a pillar's WORDING changing or a NEW pillar
+         being appended - both are covered because the signature list is
+         derived from vision.md at test time. It is not resilient to
+         someone writing a differently-phrased summary of an existing
+         pillar that doesn't share a 4-word prefix with vision.md's bolded
+         name (e.g. paraphrasing "Guard operator attention" as "protect
+         operator focus"). A targeted prefix-substring check that is
+         resilient to the one thing that actually caused this defect
+         (pillar count growing) beats a fuzzier semantic check that risks
+         failing obscurely.
+
+Public API: pytest test module. Run with
+              python3 -m pytest bin/tests/test_ds_update_pillar_check_no_inline_list.py -q
+            (auto-discovered by `.github/workflows/bin-tests.yml`'s
+            `python3 -m pytest bin/tests/ -q` invocation - no separate CI
+            wiring required).
+
+Upstream deps: docs/overview/vision.md (pillar names, read live - never
+               hardcoded here); content/commands/ds-update-agentic-engineering.md
+               Step 1.5 section.
+
+Downstream consumers: none (leaf test module).
+
+Failure modes: a failure here means either Step 1.5 regressed back to an
+               inline pillar enumeration, or the "read the pillar set from
+               vision.md" instruction was removed/weakened.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+VISION_PATH = REPO_ROOT / "docs" / "overview" / "vision.md"
+COMMAND_PATH = REPO_ROOT / "content" / "commands" / "ds-update-agentic-engineering.md"
+
+# How many leading words of each pillar's bolded name to use as a
+# staleness signature. Short enough to survive minor rewording of the
+# rest of the sentence, long enough not to false-positive on common words.
+SIGNATURE_WORD_COUNT = 3
+
+PILLAR_HEADING_RE = re.compile(r"^\d+\.\s+\*\*(.+?)\.\*\*", re.MULTILINE)
+
+
+def _extract_pillar_signatures() -> list[str]:
+    """Derive lowercase word-prefix signatures for every pillar currently
+    listed in docs/overview/vision.md. Never hand-maintain this list - that
+    is precisely the staleness class this test exists to catch."""
+    text = VISION_PATH.read_text(encoding="utf-8")
+    names = PILLAR_HEADING_RE.findall(text)
+    assert names, (
+        "PILLAR_HEADING_RE matched zero pillar headings in vision.md - "
+        "the numbered-bold-heading format probably changed; update the "
+        "regex, don't skip this test."
+    )
+    signatures = []
+    for name in names:
+        # Drop a trailing parenthetical alias, e.g. "Works for everyone
+        # (universality)" -> "Works for everyone".
+        name = re.sub(r"\s*\(.*?\)\s*$", "", name)
+        words = name.lower().split()
+        signatures.append(" ".join(words[:SIGNATURE_WORD_COUNT]))
+    return signatures
+
+
+def _extract_step_1_5_section() -> str:
+    """Return the normalized (lowercased, whitespace-collapsed) text of
+    Step 1.5 only - bounded at the next '## ' heading - so a legitimate
+    pillar mention elsewhere in the file can't false-positive this test."""
+    text = COMMAND_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start = None
+    end = len(lines)
+    for i, line in enumerate(lines):
+        if line.startswith("## ") and "Step 1.5" in line:
+            start = i
+            continue
+        if start is not None and line.startswith("## "):
+            end = i
+            break
+    assert start is not None, (
+        "Could not locate the '## Step 1.5' heading in "
+        f"{COMMAND_PATH} - it may have been renamed or renumbered; "
+        "update this test's heading match if that was deliberate."
+    )
+    section = "\n".join(lines[start:end])
+    return " ".join(section.lower().split())
+
+
+def test_step_1_5_has_no_inline_pillar_enumeration():
+    signatures = _extract_pillar_signatures()
+    section = _extract_step_1_5_section()
+    hits = [sig for sig in signatures if sig in section]
+    assert not hits, (
+        "Step 1.5 of ds-update-agentic-engineering.md contains an inline "
+        f"pillar-name fragment ({hits}) derived from the CURRENT "
+        "docs/overview/vision.md pillar list. This reproduces the fixed "
+        "defect: hardcoding pillar names here goes stale the next time "
+        "vision.md's pillar set changes. Point the reader at vision.md's "
+        "own list instead of naming pillars inline."
+    )
+
+
+def test_step_1_5_still_instructs_reading_pillars_from_vision_file():
+    section = _extract_step_1_5_section()
+    assert "pillar set from the file itself" in section, (
+        "Step 1.5 no longer instructs the reader to take the pillar set "
+        "from docs/overview/vision.md itself. A test that only checks for "
+        "the ABSENCE of an inline list would pass even if this whole "
+        "instruction were deleted - this is the paired positive assertion."
+    )

--- a/content/commands/ds-update-agentic-engineering.md
+++ b/content/commands/ds-update-agentic-engineering.md
@@ -171,9 +171,9 @@ this check runs unconditionally, with no separate proportionality gate.
 
 Before presenting the diff in Step 2, read `docs/overview/vision.md` if it exists (it is the
 operator-owned North Star for this repo) and apply its "How to use this for PR alignment" rubric
-to the diff produced in Step 1: does the change advance at least one pillar (guard operator
-attention, produce verifiable outcomes autonomously, low friction, works for everyone) without
-regressing another?
+to the diff produced in Step 1: does the change advance at least one of the file's own listed
+pillars without regressing another? Take the pillar set from the file itself, not from memory or
+an inline list here - it changes over time and this step must never hardcode a stale copy.
 
 Write a short alignment note (2-4 sentences - this is a check, not a report):
 - Which pillar(s) the change advances, in one line each.


### PR DESCRIPTION
## Summary

`/ds-update-agentic-engineering` Step 1.5 is the vision-alignment check that runs unconditionally on every invocation that edits methodology-core files. It hardcoded an inline list of **four** pillar names:

> "does the change advance at least one pillar (guard operator attention, produce verifiable outcomes autonomously, low friction, works for everyone) without regressing another?"

`docs/overview/vision.md` now has **seven**. Pillars 5 (guard agent context) and 6 (shorten wall-clock time) were missing before today; 7 (prevent defects at the producing step) merged today in #703. So the check governing every methodology change has been grading against a stale subset - and the three omitted pillars are precisely the ones about agent context, latency, and defect prevention.

## The fix is a deletion, not an addition

Appending three names would have reproduced the defect exactly: a hand-maintained copy of a list that lives elsewhere, guaranteed to go stale on the next pillar. Step 1.5 already instructs the reader to open `vision.md`, so the list was removed and replaced with an instruction to take the pillar set from the file being read:

> "does the change advance at least one of the file's own listed pillars without regressing another? Take the pillar set from the file itself, not from memory or an inline list here - it changes over time and this step must never hardcode a stale copy."

Everything around it is untouched: the check still runs unconditionally, still produces the 2-4 sentence alignment note, still names any pillar the change plausibly regresses, still degrades gracefully when `vision.md` is absent, and remains a surface rather than a gate.

## Sweep

Grepped `content/`, `docs/`, `README.md`, `CONTRIBUTING.md`, `.github/`, `scripts/`, `bin/` for pillar-name fragments. No other stale enumeration found.

Three sites carry the full seven-name list and were updated earlier today, so they are current and deliberately untouched here: `content/agents/skeptic.md` step 3.6, `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/protocol_change.yml`. They are the same duplication class and are flagged for a separate decision rather than bundled into this PR.

Everything else is a legitimate single-pillar citation or a generic reference and was left alone, including `content/references/conductor-turn-format.md` (cites pillars by ordinal) and the unrelated "pillar" mentions in `docs/agentic-engineering-comparison.html` and `docs/slides/autonomy-slides.md`.

## North Star alignment

**Advances Pillar 7 (prevent defects at the producing step):** the stale-copy failure mode is removed at its source rather than corrected after the fact. There is no longer a second copy that can drift.

**Advances Pillar 2 (produce verifiable outcomes autonomously):** the alignment check now evaluates against the real, current pillar set instead of a subset that silently omitted three - including the two most relevant to how this repo actually spends its budget.

**Pillar 5 (guard agent context):** slightly positive. The replacement wording is close to the same length as the four-name list it removes, and the command file sits under a size ratchet with limited headroom.

**Pillar 4 (works for everyone):** unaffected. No operator- or harness-specific behavior.

**No pillar regressed.** The check's behavior, cadence, output format, and surface-not-gate framing are unchanged; only the source of its pillar list moved from an inline copy to the file it already reads.

## Verification

- `bash scripts/build-all.sh`: 11/11 adapters. Adapter drift over the 16-entry pathspec copied verbatim from `adapter-sync.yml`: only the expected 8 files, no unrelated reverts. `.hermes/SKILL.md` (aggregate) confirmed to be a single confined hunk.
- `pytest bin/tests/`: 1409 passed, 9 subtests. Hooks JS: 47/47 in `hooks-js-tests` plus 2/2 in `wrap-lock-tests`.
- Budget gates: command-file 370,420 B / 371,000 B; skill-embed 133,063 B within floor 100,000 and ceiling 139,160; resident 391 B / 600 B.
- No `content/sections/**` change, so no methodology-baseline regeneration.
- Skill symlinks clean; em-dash check on the diff empty.

## Doc-sync

`Doc-sync: predicate not triggered. Grepped docs/index.html and docs/slides/*.md by hand for pillar enumerations, pillar counts, and Step 1.5 prose - no hits. The only docs/index.html mention of /ds-update-agentic-engineering is a one-line command description with no pillar content and no count claim.`
