### PR TITLE
fix(protocol): DS-165/166/167 - apply 5 Skeptic Minor prose/test precision fixes

### DIFF
--- a/.claude/commands/ds-failure-audit.md
+++ b/.claude/commands/ds-failure-audit.md
@@ -58,7 +58,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -102,7 +102,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.claude/commands/ds-failure-audit.md
+++ b/.claude/commands/ds-failure-audit.md
@@ -58,7 +58,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -102,7 +102,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.claude/commands/ds-update-agentic-engineering.md
+++ b/.claude/commands/ds-update-agentic-engineering.md
@@ -39,7 +39,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.copilot/references/command-authoring.md
+++ b/.copilot/references/command-authoring.md
@@ -71,11 +71,11 @@ setting up projects, managing dependencies, writing scripts, or any task
 that involves reading, writing, or reasoning about code and systems.
 ```
 
-### Command files carry the same field
+### Command files use the same trigger principle
 
-Command files express the trigger as a "When to use" field. Every command file
-should answer "use when X, Y, or Z holds" before it explains what the command
-does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
+Where a command file needs a trigger, express it as a "When to use" field. Every
+command file should answer "use when X, Y, or Z holds" before it explains what
+the command does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
 
 ```
 **When to use - use whenever ANY of these hold:**
@@ -139,7 +139,9 @@ consumers, Failure modes, Performance).
 file with a complete manifest.
 
 A new command is not done when its file is written. It must also be wired in:
-registered in `bin/ds-help`, listed in `content/SKILL.md` (Commands section),
-and covered by the docs update check in `content/commands/ds-update-agentic-engineering.md`
-Step 3.5. The two principles above apply to the command's description during
-that wiring.
+registered in `bin/ds-help` (the full command inventory), and covered by the
+docs update check in `content/commands/ds-update-agentic-engineering.md`
+Step 3.5. `content/SKILL.md`'s Commands section is a curated subset - only a few
+commands warrant prominent placement there, so add a command to it only when
+that is the case. The two principles above apply to the command's description
+during that wiring.

--- a/.cursor/commands/ds-failure-audit.md
+++ b/.cursor/commands/ds-failure-audit.md
@@ -52,7 +52,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -96,7 +96,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.cursor/commands/ds-failure-audit.md
+++ b/.cursor/commands/ds-failure-audit.md
@@ -52,7 +52,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -96,7 +96,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.cursor/commands/ds-update-agentic-engineering.md
+++ b/.cursor/commands/ds-update-agentic-engineering.md
@@ -33,7 +33,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.cursor/references/command-authoring.md
+++ b/.cursor/references/command-authoring.md
@@ -71,11 +71,11 @@ setting up projects, managing dependencies, writing scripts, or any task
 that involves reading, writing, or reasoning about code and systems.
 ```
 
-### Command files carry the same field
+### Command files use the same trigger principle
 
-Command files express the trigger as a "When to use" field. Every command file
-should answer "use when X, Y, or Z holds" before it explains what the command
-does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
+Where a command file needs a trigger, express it as a "When to use" field. Every
+command file should answer "use when X, Y, or Z holds" before it explains what
+the command does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
 
 ```
 **When to use - use whenever ANY of these hold:**
@@ -139,7 +139,9 @@ consumers, Failure modes, Performance).
 file with a complete manifest.
 
 A new command is not done when its file is written. It must also be wired in:
-registered in `bin/ds-help`, listed in `content/SKILL.md` (Commands section),
-and covered by the docs update check in `content/commands/ds-update-agentic-engineering.md`
-Step 3.5. The two principles above apply to the command's description during
-that wiring.
+registered in `bin/ds-help` (the full command inventory), and covered by the
+docs update check in `content/commands/ds-update-agentic-engineering.md`
+Step 3.5. `content/SKILL.md`'s Commands section is a curated subset - only a few
+commands warrant prominent placement there, so add a command to it only when
+that is the case. The two principles above apply to the command's description
+during that wiring.

--- a/.gemini/commands/ds-failure-audit.toml
+++ b/.gemini/commands/ds-failure-audit.toml
@@ -58,7 +58,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -102,7 +102,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.gemini/commands/ds-failure-audit.toml
+++ b/.gemini/commands/ds-failure-audit.toml
@@ -58,7 +58,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -102,7 +102,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.gemini/commands/ds-update-agentic-engineering.toml
+++ b/.gemini/commands/ds-update-agentic-engineering.toml
@@ -39,7 +39,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.gemini/references/command-authoring.md
+++ b/.gemini/references/command-authoring.md
@@ -71,11 +71,11 @@ setting up projects, managing dependencies, writing scripts, or any task
 that involves reading, writing, or reasoning about code and systems.
 ```
 
-### Command files carry the same field
+### Command files use the same trigger principle
 
-Command files express the trigger as a "When to use" field. Every command file
-should answer "use when X, Y, or Z holds" before it explains what the command
-does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
+Where a command file needs a trigger, express it as a "When to use" field. Every
+command file should answer "use when X, Y, or Z holds" before it explains what
+the command does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
 
 ```
 **When to use - use whenever ANY of these hold:**
@@ -139,7 +139,9 @@ consumers, Failure modes, Performance).
 file with a complete manifest.
 
 A new command is not done when its file is written. It must also be wired in:
-registered in `bin/ds-help`, listed in `content/SKILL.md` (Commands section),
-and covered by the docs update check in `content/commands/ds-update-agentic-engineering.md`
-Step 3.5. The two principles above apply to the command's description during
-that wiring.
+registered in `bin/ds-help` (the full command inventory), and covered by the
+docs update check in `content/commands/ds-update-agentic-engineering.md`
+Step 3.5. `content/SKILL.md`'s Commands section is a curated subset - only a few
+commands warrant prominent placement there, so add a command to it only when
+that is the case. The two principles above apply to the command's description
+during that wiring.

--- a/.github/prompts/ds-failure-audit.prompt.md
+++ b/.github/prompts/ds-failure-audit.prompt.md
@@ -55,7 +55,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -99,7 +99,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.github/prompts/ds-failure-audit.prompt.md
+++ b/.github/prompts/ds-failure-audit.prompt.md
@@ -55,7 +55,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -99,7 +99,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.github/prompts/ds-update-agentic-engineering.prompt.md
+++ b/.github/prompts/ds-update-agentic-engineering.prompt.md
@@ -36,7 +36,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -1954,11 +1954,11 @@ setting up projects, managing dependencies, writing scripts, or any task
 that involves reading, writing, or reasoning about code and systems.
 ```
 
-### Command files carry the same field
+### Command files use the same trigger principle
 
-Command files express the trigger as a "When to use" field. Every command file
-should answer "use when X, Y, or Z holds" before it explains what the command
-does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
+Where a command file needs a trigger, express it as a "When to use" field. Every
+command file should answer "use when X, Y, or Z holds" before it explains what
+the command does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
 
 ```
 **When to use - use whenever ANY of these hold:**
@@ -2022,10 +2022,12 @@ consumers, Failure modes, Performance).
 file with a complete manifest.
 
 A new command is not done when its file is written. It must also be wired in:
-registered in `bin/ds-help`, listed in `content/SKILL.md` (Commands section),
-and covered by the docs update check in `content/commands/ds-update-agentic-engineering.md`
-Step 3.5. The two principles above apply to the command's description during
-that wiring.
+registered in `bin/ds-help` (the full command inventory), and covered by the
+docs update check in `content/commands/ds-update-agentic-engineering.md`
+Step 3.5. `content/SKILL.md`'s Commands section is a curated subset - only a few
+commands warrant prominent placement there, so add a command to it only when
+that is the case. The two principles above apply to the command's description
+during that wiring.
 
 ---
 
@@ -14363,7 +14365,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -14407,7 +14409,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.
@@ -21999,7 +22001,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14365,7 +14365,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -14409,7 +14409,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.openclaw/skills/ds-failure-audit/SKILL.md
+++ b/.openclaw/skills/ds-failure-audit/SKILL.md
@@ -57,7 +57,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -101,7 +101,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.openclaw/skills/ds-failure-audit/SKILL.md
+++ b/.openclaw/skills/ds-failure-audit/SKILL.md
@@ -57,7 +57,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -101,7 +101,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.openclaw/skills/ds-update-agentic-engineering/SKILL.md
+++ b/.openclaw/skills/ds-update-agentic-engineering/SKILL.md
@@ -38,7 +38,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/.opencode/commands/ds-failure-audit.md
+++ b/.opencode/commands/ds-failure-audit.md
@@ -56,7 +56,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -100,7 +100,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.opencode/commands/ds-failure-audit.md
+++ b/.opencode/commands/ds-failure-audit.md
@@ -56,7 +56,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -100,7 +100,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/.opencode/commands/ds-update-agentic-engineering.md
+++ b/.opencode/commands/ds-update-agentic-engineering.md
@@ -37,7 +37,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/bin/tests/test_ds166_model_claim_spec.sh
+++ b/bin/tests/test_ds166_model_claim_spec.sh
@@ -12,7 +12,11 @@
 #          sequential-multi-unit PRs while the round-1 comment falsely claimed the site
 #          "writes nothing to disk." A prose edit that removes ticket_id from either
 #          claim site (re-opening the inert-line bug), drops the jq's ticket scoping, or
-#          removes the Model: printf fails here.
+#          removes the Model: printf fails here. The jq-scoping pin is block-specific:
+#          it extracts the ENGINEER_MODEL jq block from the content file rather than
+#          grep-ing the whole file, because '.ticket_id == $t' also appears in unrelated
+#          jq (ds-implement-ticket.md:1048/2825/2834) and a whole-file grep would stay
+#          green if only the ENGINEER_MODEL jq lost its scoping.
 #
 # Public API: ./bin/tests/test_ds166_model_claim_spec.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -78,9 +82,25 @@ else
 fi
 
 # --- Prose-pin: ENGINEER_MODEL jq scopes on ticket_id; Model: printf survives ---
-grep -qF '.ticket_id == $t' "$DIT" \
-  && _pass "ENGINEER_MODEL jq scopes on .ticket_id == \$t" \
-  || _fail "ENGINEER_MODEL jq no longer scopes on .ticket_id == \$t"
+# Extract the ENGINEER_MODEL jq block from the content file itself (from the
+# ENGINEER_MODEL=$(jq assignment to the terminating '| unique | join(", ")' line)
+# and assert BOTH its ticket scoping and its engineer filter survive. A whole-file
+# grep for '.ticket_id == $t' would NOT trip on a scoping removal - that string
+# also appears in pre-existing jq at ds-implement-ticket.md:1048/2825/2834
+# (ticket-rework ledger / loop-state reads) - so the pin must be block-specific.
+JQ_START="$(grep -nF 'ENGINEER_MODEL=$(jq' "$DIT" | head -1 | cut -d: -f1)"
+JQ_END="$(grep -nF '| unique | join(", ")' "$DIT" | head -1 | cut -d: -f1)"
+if [ -z "$JQ_START" ] || [ -z "$JQ_END" ] || [ "$JQ_START" -gt "$JQ_END" ]; then
+  _fail "ENGINEER_MODEL jq block not locatable in $DIT (start line '$JQ_START', end line '$JQ_END')"
+else
+  ENGINEER_MODEL_BLOCK="$(sed -n "${JQ_START},${JQ_END}p" "$DIT")"
+  printf '%s' "$ENGINEER_MODEL_BLOCK" | grep -qF '.ticket_id == $t' \
+    && _pass "ENGINEER_MODEL jq block scopes on .ticket_id == \$t" \
+    || _fail "ENGINEER_MODEL jq block no longer scopes on .ticket_id == \$t (whole-file grep would miss this - .ticket_id == \$t survives at :1048/2825/2834)"
+  printf '%s' "$ENGINEER_MODEL_BLOCK" | grep -qF 'assigned_agent == "engineer"' \
+    && _pass "ENGINEER_MODEL jq block filters on assigned_agent == \"engineer\"" \
+    || _fail "ENGINEER_MODEL jq block no longer filters on assigned_agent == \"engineer\""
+fi
 grep -qF 'printf "\nModel: %s\n" "$ENGINEER_MODEL"' "$DIT" \
   && _pass "Model: printf form present" \
   || _fail "Model: printf form missing"

--- a/content/commands/ds-failure-audit.md
+++ b/content/commands/ds-failure-audit.md
@@ -52,7 +52,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -96,7 +96,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of the model/status/calibration fields by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/content/commands/ds-failure-audit.md
+++ b/content/commands/ds-failure-audit.md
@@ -52,7 +52,7 @@ The audit reuses the same telemetry the two siblings read - it is a new read pat
 
 The audit subagent reads three telemetry sources, plus one optional supplementary source if present:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, and `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - the global cross-project mirror of the same per-session schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL supplementary: the guardrail deny/advisory fire log written by `hooks/lib/enforcement_log.py`. Repo-wide cumulative, NOT session-scoped - any tally from it must state that scope. Consult it only for guardrail-fire failure modes; never treat it as a per-session count.
@@ -96,7 +96,7 @@ You are categorizing failure modes in an operator's own AI-assistant sessions, p
 
 Data sources and what each contains:
 
-1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`/`spawn_complete` (with `data.model`, `data.status`, `data.session_uuid`, Skeptic calibration fields `findings_count`/`iteration`/`signed_off`), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
+1. `.agentic/events.jsonl` - orchestration-boundary telemetry: `spawn_start`, `spawn_complete` (the conductor-emitted `spawn_complete` variant carries `data.model`, `data.status`, `data.session_uuid`, and Skeptic calibration fields `findings_count`/`iteration`/`signed_off`; the hook-emitted variant carries none of these by design - see Model axis), `session_total`, `tool_failure_workaround` (`data.tool`, `data.domain_tag`, `data.note`), `tracker_writeback`, `meta_review_complete`. Full schemas: `content/references/events-log.md`.
 2. `.agentic/session-log/*.jsonl` - per-session rollups: `ts`, `developer_id`, `session_uuid`, `project_slug`, `branch`, `data.by_agent`.
 3. `~/.agentic/session-log/*.jsonl` - global cross-project mirror, same schema.
 4. `.agentic/.enforcement-fires.jsonl` - OPTIONAL, only if present: guardrail deny/advisory log. REPO-WIDE cumulative, not session-scoped - any tally from it must state that scope explicitly.

--- a/content/commands/ds-update-agentic-engineering.md
+++ b/content/commands/ds-update-agentic-engineering.md
@@ -33,7 +33,7 @@ Out of scope (direct Edit/Write is fine; normal Trivial/Elevated tiers apply):
 
 Note: `.claude/skills/dinostack/**` files are symlinks into `content/` - editing them is functionally editing `content/`, so they remain IN scope via the `content/**` rule above. This is a clarification, not a separate scope.
 
-**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must also be registered in `bin/ds-help` and listed in `content/SKILL.md` (Commands section).
+**Command authoring:** when a Step 1 edit adds or rewrites a command file (`content/commands/*.md`), follow `content/references/command-authoring.md` - trigger-keyword "When to use" descriptions, bad/good example-pair seeding, and the module-manifest header. New commands must be registered in `bin/ds-help` (the full command inventory); `content/SKILL.md`'s Commands section is a curated subset, so list a command there only when it warrants prominent placement.
 
 ## Step 0a - Directory gate (run before Step 0)
 

--- a/content/references/command-authoring.md
+++ b/content/references/command-authoring.md
@@ -71,11 +71,11 @@ setting up projects, managing dependencies, writing scripts, or any task
 that involves reading, writing, or reasoning about code and systems.
 ```
 
-### Command files carry the same field
+### Command files use the same trigger principle
 
-Command files express the trigger as a "When to use" field. Every command file
-should answer "use when X, Y, or Z holds" before it explains what the command
-does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
+Where a command file needs a trigger, express it as a "When to use" field. Every
+command file should answer "use when X, Y, or Z holds" before it explains what
+the command does. Reference example (`content/commands/ds-update-agentic-engineering.md`):
 
 ```
 **When to use - use whenever ANY of these hold:**
@@ -139,7 +139,9 @@ consumers, Failure modes, Performance).
 file with a complete manifest.
 
 A new command is not done when its file is written. It must also be wired in:
-registered in `bin/ds-help`, listed in `content/SKILL.md` (Commands section),
-and covered by the docs update check in `content/commands/ds-update-agentic-engineering.md`
-Step 3.5. The two principles above apply to the command's description during
-that wiring.
+registered in `bin/ds-help` (the full command inventory), and covered by the
+docs update check in `content/commands/ds-update-agentic-engineering.md`
+Step 3.5. `content/SKILL.md`'s Commands section is a curated subset - only a few
+commands warrant prominent placement there, so add a command to it only when
+that is the case. The two principles above apply to the command's description
+during that wiring.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1291,6 +1291,7 @@
       <div class="node node-protocol">handoff-evaluation.md <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol">tracker-writeback.md <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol">subagent-return-contract.md <span class="load-badge on-demand">on demand</span></div>
+      <div class="node node-protocol">command-authoring.md <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="cross-harness-teams.md" target="_blank" rel="noopener">cross-harness-teams.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="role-model-routing.md" target="_blank" rel="noopener">role-model-routing.md</a> <span class="load-badge on-demand">on demand</span></div>
       <div class="node node-protocol"><a href="skill-candidates.md" target="_blank" rel="noopener">skill-candidates.md</a> <span class="load-badge on-demand">on demand</span></div>


### PR DESCRIPTION
## Summary

Bundled fix for the 5 Skeptic Minor findings across three merged tickets (DS-165/166/167), rebased onto current origin/main (444f225f) with the docs/index.html conflict resolved (kept both #719's doc-currency nodes and this branch's command-authoring.md node):

1. **DS-165** (/ds-failure-audit): telemetry-source lines now attribute `data.model`/`data.status`/Skeptic calibration fields to the conductor-emitted `spawn_complete` variant only; parenthetical reads "carries none of the model/status/calibration fields by design".
2. **DS-166** (model-attribution spec): the ENGINEER_MODEL jq prose-pin now block-extracts the actual jq (not a whole-file grep, which matched unrelated `.ticket_id == $t` sites).
3. **DS-167a**: both sites corrected - `bin/ds-help` is the full command inventory; content/SKILL.md Commands is a curated subset (4 of 26).
4. **DS-167b**: "Command files carry the same field" softened to recommended-pattern framing ("Command files use the same trigger principle"); prescriptive sentence intact.
5. **DS-167c**: added the command-authoring.md node to the docs/index.html Referenced Protocol Documents grid.

## North Star alignment

- Correctness/precision: fixes two telemetry-fact misstatements and a regression pin that could not detect the defect it guards. Universality: none of the changes bakes in operator-specific identity, workspace, or harness.

## Review rigor

- Brief / Plan path: ad-hoc (Skeptic Minor follow-up), engineer brief
- Skeptic rounds (tier): round 1 on PR #718 granted sign-off (0C/0M/1 Minor - the parenthetical, now fixed). Rebased twice; CI re-running on current base.
- Findings summary: original 5 Minors + follow-up Minor all resolved.

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Affected adapters declared
- [x] Before/after transcript included for agent-behavior changes
- [ ] `install.sh` re-run locally and behavior verified
- [x] Tests/lint passing
- [x] Docs updated if behavior changed

## Affected adapters

- [x] Claude Code
- [x] Cursor
- [x] Codex CLI
- [x] Gemini CLI
- [ ] Kimi Code
- [x] OpenCode
- [x] Pi coding agent
- [ ] Pi oh-my-pi
- [x] Hermes
- [x] OpenClaw
- [x] VS Code Copilot