### PR TITLE
fix(DS-136): bin/tests hang fixes, codex re-render cut, commit-time symlink gate

### DIFF
--- a/bin/tests/test_check_symlinks_relative.sh
+++ b/bin/tests/test_check_symlinks_relative.sh
@@ -1,18 +1,32 @@
 #!/usr/bin/env bash
-# Purpose: Regression guard for DS-104. scripts/check-symlinks-relative.sh is
-#          the CI gate that fails when any of the four
+# Purpose: Regression guard for DS-104 (ref mode) and DS-136 (--staged mode)
+#          of scripts/check-symlinks-relative.sh - the CI/pre-commit gate
+#          that fails when any of the four
 #          .claude/skills/dinostack/{agents,commands,references,rules}
-#          symlinks is absolutized in the committed tree. A gate that has
-#          only ever been observed passing has not been verified - this test
-#          exercises both directions: it must FAIL against a constructed
-#          commit with an absolutized symlink, and PASS against one with all
-#          four relative.
+#          symlinks are absolutized. A gate that has only ever been observed
+#          passing has not been verified - this test exercises both
+#          directions in both modes: it must FAIL against a constructed
+#          commit/index with an absolutized symlink, and PASS against one
+#          with all four relative. --staged mode additionally reproduces a
+#          Critical field-position bug that nearly shipped into
+#          hooks/pre-commit: `git ls-tree <ref>` emits <mode> <type> <sha>
+#          while `git ls-files -s` emits <mode> <sha> <stage> - sharing one
+#          awk parse across both modes crashes staged mode with
+#          `git cat-file -p 0` -> "fatal: Not a valid object name".
+#
+#          SKILL_DIR/LINKS in check-symlinks-relative.sh are cwd-relative
+#          (".claude/skills/dinostack", not tied to the real
+#          checkout's absolute path), so a synthetic fixture repo built at
+#          that same relative path under a throwaway git init exercises the
+#          gate identically to the real repo, in both ref and --staged
+#          mode - no clone of the live repo is required for either mode.
 #
 # Public API: ./bin/tests/test_check_symlinks_relative.sh
 #             Exits 0 on all pass, 1 on any failure.
 #
 # Upstream deps: bash, git, mktemp. Builds a throwaway git repo under a temp
-#                directory - never touches the real checkout's HEAD or refs.
+#                directory - never touches the real checkout's HEAD, refs,
+#                or index.
 #
 # Downstream consumers: developer running locally before commit; CI
 #                        (the bin-sh-tests job in
@@ -21,9 +35,12 @@
 #
 # Failure modes: gate script missing -> immediate FAIL. Gate does not exit 1
 #                on an absolutized fixture, or does not exit 0 on a relative
-#                fixture -> FAIL with the observed exit code.
+#                fixture (ref or --staged mode) -> FAIL with the observed
+#                exit code. --staged mode additionally FAILs if the
+#                field-position crash signature (fatal: / Not a valid
+#                object name) reappears on stderr.
 #
-# Performance: < 1 s wall time (pure git plumbing, no network).
+# Performance: < 1 s wall time (pure git plumbing, no network, no clone).
 
 set -uo pipefail
 
@@ -52,7 +69,7 @@ TMP_ROOT="$(mktemp -d)"
 _cleanup() {
   rm -rf "$TMP_ROOT"
 }
-trap _cleanup EXIT
+trap _cleanup EXIT INT TERM
 
 FIXTURE_REPO="$TMP_ROOT/fixture-repo"
 mkdir -p "$FIXTURE_REPO"
@@ -84,7 +101,24 @@ build_commit() {
   )
 }
 
-# --- Fixture 1: all four relative (must PASS) ---
+stage_change() {
+  # Same shape as build_commit but stages without committing - leaves the
+  # mutation in the index only, for exercising --staged mode against a
+  # dirty index.
+  shift # discard the unused message arg (kept for call-site symmetry)
+  (
+    cd "$FIXTURE_REPO" || exit 1
+    while [[ $# -gt 0 ]]; do
+      local name="$1" target="$2"
+      shift 2
+      rm -f ".claude/skills/dinostack/$name"
+      ln -s "$target" ".claude/skills/dinostack/$name"
+    done
+    git add -A .claude
+  )
+}
+
+# --- Fixture 1: all four relative (must PASS, ref mode) ---
 build_commit "all relative" \
   agents "../../../content/agents" \
   commands "../../../content/commands" \
@@ -100,7 +134,62 @@ else
   _fail "gate exited $rc against an all-relative commit (expected 0)"
 fi
 
-# --- Fixture 2: one absolutized (must FAIL) ---
+# ---------------------------------------------------------------------------
+# --staged Test A: a clean index (right after the GOOD_SHA commit above)
+# exits 0.
+# ---------------------------------------------------------------------------
+if (cd "$FIXTURE_REPO" && bash "$GATE_SCRIPT" --staged) >/dev/null 2>&1; then
+  _pass "--staged: clean index exits 0"
+else
+  rc=$?
+  _fail "--staged: clean index exited $rc (expected 0)"
+fi
+
+# ---------------------------------------------------------------------------
+# --staged Test B (Critical reproduction): stage an absolutized symlink
+# without committing, assert exit 1, AND assert stderr does NOT contain the
+# field-position crash signature. Asserting only on exit code would not
+# distinguish a crash from a correct rejection (both exit nonzero).
+# ---------------------------------------------------------------------------
+stage_change "stage absolutized rules (uncommitted)" \
+  rules "$FIXTURE_REPO/content/rules"
+
+set +e
+staged_out="$(cd "$FIXTURE_REPO" && bash "$GATE_SCRIPT" --staged 2>&1)"
+staged_rc=$?
+set -e
+
+if [[ "$staged_rc" -eq 1 ]]; then
+  _pass "--staged: absolutized symlink staged (uncommitted) exits 1"
+else
+  _fail "--staged: absolutized symlink staged (uncommitted) expected exit 1, got $staged_rc"
+fi
+
+if [[ "$staged_out" == *"fatal:"* || "$staged_out" == *"Not a valid object name"* ]]; then
+  _fail "--staged: field-position crash signature reappeared: $staged_out"
+else
+  _pass "--staged: no field-position crash signature"
+fi
+
+# Restore the index to the GOOD_SHA relative state before the next mutation.
+(cd "$FIXTURE_REPO" && git reset -q --hard "$GOOD_SHA")
+
+# ---------------------------------------------------------------------------
+# --staged Test C: staging a deletion of a watched symlink (uncommitted)
+# exits 0 - a legitimate removal must not block the commit that removes it.
+# ---------------------------------------------------------------------------
+(cd "$FIXTURE_REPO" && git rm -q ".claude/skills/dinostack/rules")
+
+if (cd "$FIXTURE_REPO" && bash "$GATE_SCRIPT" --staged) >/dev/null 2>&1; then
+  _pass "--staged: staged deletion of watched symlink exits 0"
+else
+  rc=$?
+  _fail "--staged: staged deletion of watched symlink exited $rc (expected 0)"
+fi
+
+(cd "$FIXTURE_REPO" && git reset -q --hard "$GOOD_SHA")
+
+# --- Fixture 2: one absolutized (must FAIL, ref mode) ---
 build_commit "rules absolutized" \
   rules "$FIXTURE_REPO/content/rules"
 

--- a/bin/tests/test_codex_hooks_resolve.sh
+++ b/bin/tests/test_codex_hooks_resolve.sh
@@ -24,7 +24,16 @@
 #                inside each command is evaluated (via bash command
 #                substitution) - the interpreter is never actually invoked,
 #                so this test has no side effects even if a resolved script
-#                has some.
+#                has some. On bash 3.2 (macOS default), the previous
+#                `mapfile -t COMMANDS < <(python3 -c "...")` form both failed
+#                (mapfile does not exist pre-4.0) and, once worked around,
+#                left COMMANDS unset when hooks.json had zero entries - an
+#                unguarded "${COMMANDS[@]}" expansion under `set -u` then
+#                raised "unbound variable" before this test's own empty-set
+#                diagnostic could print. Fixed by writing the extractor's
+#                output to a temp file and reading it back with a `while
+#                read` loop, and by guarding the loop expansion with
+#                "${COMMANDS[@]+"${COMMANDS[@]}"}".
 #
 # Performance: < 1 s wall time (pure shell + python3, no network).
 
@@ -65,9 +74,16 @@ mkdir -p "$FAKE_HOME/.codex"
 ln -s "$HOOKS_JSON" "$FAKE_HOME/.codex/hooks.json"
 
 # Extract every "command" string from hooks.json (order-independent walk).
-mapfile -t COMMANDS < <(python3 -c "
+# The path is passed as sys.argv[1] rather than interpolated into the Python
+# source string, so a checkout path containing a quote or $ cannot break the
+# script. bash 3.2 (macOS default) lacks `mapfile`, so the output is written
+# to a temp file and read back with a `while read` loop instead - see
+# bin/tests/test_tasks_jsonl_fold.sh:60-68 for why a pipe-fed `while read`
+# (subshell discards state) is also avoided.
+_CMDS_TMP="$TMP_ROOT/commands.txt"
+python3 -c "
 import json, sys
-with open('$HOOKS_JSON') as f:
+with open(sys.argv[1]) as f:
     data = json.load(f)
 
 def walk(node):
@@ -84,7 +100,12 @@ def walk(node):
     yield
 
 list(walk(data))
-")
+" "$HOOKS_JSON" > "$_CMDS_TMP"
+
+COMMANDS=()
+while IFS= read -r line; do
+  COMMANDS+=("$line")
+done < "$_CMDS_TMP"
 
 if [[ ${#COMMANDS[@]} -eq 0 ]]; then
   _fail "no 'command' entries found in $HOOKS_JSON - parser or fixture regressed"
@@ -92,7 +113,7 @@ else
   _pass "found ${#COMMANDS[@]} command entries in $HOOKS_JSON"
 fi
 
-for cmd in "${COMMANDS[@]}"; do
+for cmd in "${COMMANDS[@]+"${COMMANDS[@]}"}"; do
   # Each command has the shape:
   #   <interpreter> "<path-expression-with-$(...)-substitutions>"
   # Extract just the quoted path expression and evaluate it under FAKE_HOME

--- a/bin/tests/test_hooks_snapshot_migration.sh
+++ b/bin/tests/test_hooks_snapshot_migration.sh
@@ -53,11 +53,26 @@
 #                bin/tests/lib/precommit-hook-guard.sh (same guard used by
 #                bin/tests/test_uninstall_ds_prefix.sh); the guard does not
 #                cover the earlier install.sh pre-commit-hook writes above.
+#                This test previously could block on /dev/tty under
+#                ae_confirm when run with a real controlling terminal (not
+#                reproducible in GitHub-hosted CI, which has none), because
+#                the install.sh invocation exercised TWO separate /dev/tty
+#                prompt sites: ae_write_config's skill_auto_load prompt
+#                (gated on the key being absent from
+#                $fake_home/.claude/agentic-engineering.json - true on every
+#                run here) and _ae_setup_identity's identity prompt. Fixed by
+#                (1) seeding {"skill_auto_load": false} into that config
+#                file before every install.sh invocation in _run_install, so
+#                the key is never absent, and (2) passing --no-identity to
+#                suppress the identity block. Both fixes are required; either
+#                alone leaves the other /dev/tty site live.
 #
 # Performance: wall time scales with the `_run_install` call count (grep it
 #              for the live figure - see the NOTE above); each invocation
 #              includes a real build.sh pass, so expect tens of seconds
-#              rather than a fixed number.
+#              rather than a fixed number. This test could still block on
+#              /dev/tty under ae_confirm if a run omits --no-identity; see
+#              the identity-prompt fix noted above.
 
 set -uo pipefail
 
@@ -90,7 +105,17 @@ _run_install() {
   local install_sh="$1"
   local fake_home="$2"
   shift 2
-  HOME="$fake_home" bash "$install_sh" --mode=opt-out --profile=default "$@" \
+  # Seed 1: skill_auto_load key present -> suppresses the ae_write_config
+  # /dev/tty prompt (gated `if "skill_auto_load" not in config:`). All four
+  # in-scope adapters default AE_CONFIG_PATH to $fake_home/.claude/
+  # agentic-engineering.json (see bin/tests/test_install_stop_cadence.sh for
+  # the same pattern on .claude/install.sh alone). --no-identity below
+  # suppresses the SEPARATE _ae_setup_identity /dev/tty block.
+  mkdir -p "$fake_home/.claude"
+  cat > "$fake_home/.claude/agentic-engineering.json" <<'EOF'
+{"skill_auto_load": false}
+EOF
+  HOME="$fake_home" bash "$install_sh" --mode=opt-out --profile=default --no-identity "$@" \
     < /dev/null > "$fake_home/.install_out" 2>&1
   local rc=$?
   if [[ $rc -ne 0 ]]; then

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
-# Purpose: Enforce staged static-analysis, Codex native-skill drift, and adapter build gates.
+# Purpose: Enforce staged static-analysis, Codex native-skill drift, dinostack
+#          skill symlink absolutization, and adapter build gates.
 #
 # Public API: Git pre-commit hook invoked with no arguments from a DinoStack checkout.
 #
 # Upstream deps: the staged Git index, project lint/type tools when installed,
 #                native-skill and prompt-wrapper generators, their sync check,
+#                scripts/check-symlinks-relative.sh (run in --staged mode against
+#                the staged blob, not the working-tree copy),
 #                scripts/stamp-agent-fragments.sh (runs before the adapter
 #                builds so they see stamped content/agents/*.md), and all
 #                adapter build scripts.
 #
 # Downstream consumers: local Git commits and worktree-isolated engineer commits.
 #
-# Failure modes: exits non-zero on lint, type, native-skill drift, or adapter build
-#                failures; skips unavailable optional linters and worktree builds.
+# Failure modes: exits non-zero on lint, type, native-skill drift, symlink
+#                absolutization (staged skill symlink resolves to an absolute
+#                path), or adapter build failures; skips unavailable optional
+#                linters and worktree builds. The symlink-absolutization gate
+#                runs in every worktree, not just the primary checkout.
 #
 # Performance: staged-path scoped until canonical content requires full adapter builds.
 
@@ -148,6 +154,29 @@ if [[ "$CODEX_SKILL_SYNC_REQUIRED" == "true" ]]; then
   bash "$CODEX_SKILL_INDEX_SNAPSHOT/scripts/check-codex-skill-sync.sh"
   cleanup_codex_skill_snapshot
   trap - EXIT
+fi
+
+# ---------------------------------------------------------------------------
+# dinostack skill symlink absolutization gate (DS-104/DS-136)
+#
+# Runs the STAGED version of scripts/check-symlinks-relative.sh (via `git
+# show :path | bash -s --`) rather than the working-tree copy, so a locally
+# modified-but-unstaged checker cannot silently weaken this gate. Runs
+# before the worktree build-skip exit below so it fires in every linked
+# worktree, not just the primary checkout.
+# ---------------------------------------------------------------------------
+
+CHECK_SYMLINKS_STAGED_SRC="$(git show :scripts/check-symlinks-relative.sh 2>/dev/null)"
+if [[ -z "$CHECK_SYMLINKS_STAGED_SRC" ]]; then
+  echo "[pre-commit] ERROR: unable to read the staged scripts/check-symlinks-relative.sh (missing from the index, e.g. staged for deletion) - commit blocked. Restore or unstage it." >&2
+  exit 1
+fi
+# Success path is quiet: the checker's per-link "(relative, OK)" line goes to
+# stdout, which is silenced here on every passing commit. Failures still
+# surface - the checker writes all error/absolutization detail to stderr.
+if ! echo "$CHECK_SYMLINKS_STAGED_SRC" | bash -s -- --staged >/dev/null; then
+  echo "[pre-commit] ERROR: one or more dinostack skill symlinks are staged as absolute paths (expected relative) - commit blocked. Run 'git status' and re-link with a relative target." >&2
+  exit 1
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-symlinks-relative.sh
+++ b/scripts/check-symlinks-relative.sh
@@ -7,24 +7,74 @@
 #          Root cause is unconfirmed (DS-104) - this script is detection only.
 #
 # Public API: bash scripts/check-symlinks-relative.sh [ref]
-#             ref defaults to HEAD. Exits 0 when all four symlinks are
-#             relative (leading char != "/"), 1 when any is absolute or
+#             bash scripts/check-symlinks-relative.sh --staged
+#             ref defaults to HEAD when omitted. --staged checks the git
+#             index instead of a ref (used by the hooks/pre-commit gate to
+#             catch an absolutized symlink before it is committed); --staged
+#             and [ref] are mutually exclusive (exit 2 if both given). At
+#             most one positional [ref] argument is accepted in either mode
+#             - a second positional arg now exits 2 ("too many arguments"),
+#             tightened by DS-136: previously any extra positional args
+#             (e.g. `origin/main extra`) were silently ignored.
+#             Exits 0 when all four symlinks are relative (leading char !=
+#             "/") or staged for deletion, 1 when any is absolute or
 #             missing, 2 on usage/environment error.
 #
-# Upstream deps: git ls-tree, git cat-file. No working-tree filesystem access -
-#                operates purely on the git object database for the given ref.
+# Upstream deps: git ls-tree, git cat-file (ref mode); git ls-files -s and
+#                git diff --cached --diff-filter=D (staged mode). No
+#                working-tree filesystem access in either mode - the index
+#                is not the working tree.
 #
-# Downstream consumers: .github/workflows/adapter-sync.yml
+# Downstream consumers: .github/workflows/adapter-sync.yml (ref mode);
+#                        hooks/pre-commit (--staged mode).
 #
-# Failure modes: any of the four paths absent from the tree, not a symlink
-#                (mode != 120000), or resolving to an absolute path -> exit 1
-#                with the offending path(s) listed.
+# Failure modes: any of the four paths absent from the tree/index, not a
+#                symlink (mode != 120000), or resolving to an absolute path
+#                -> exit 1 with the offending path(s) listed. In --staged
+#                mode, a path staged for deletion is treated as a non-fatal
+#                skip rather than "missing" (a legitimate removal of one of
+#                these links must not block the commit that removes it) -
+#                this deletion-aware skip applies ONLY in --staged mode; ref
+#                mode's equivalent gap is pre-existing, CI-facing, and out
+#                of scope here.
 #
-# Performance: O(1) - four fixed git object lookups.
+# Performance: O(1) - four fixed git object/index lookups.
 
 set -euo pipefail
 
-REF="${1:-HEAD}"
+# --- MODE-SPECIFIC FIELD LAYOUT - DO NOT UNIFY ---
+# `git ls-tree <ref>` emits:  <mode> <type> <sha>    (sha is field 3)
+# `git ls-files -s`   emits:  <mode> <sha> <stage>   (sha is field 2)
+# Sharing one awk parse across both modes WILL silently break one of them.
+
+STAGED=0
+REF=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --staged)
+      STAGED=1
+      ;;
+    -*)
+      echo "check-symlinks-relative.sh: unknown option: $arg" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$REF" ]; then
+        echo "check-symlinks-relative.sh: too many arguments" >&2
+        exit 2
+      fi
+      REF="$arg"
+      ;;
+  esac
+done
+
+if [ "$STAGED" -eq 1 ] && [ -n "$REF" ]; then
+  echo "check-symlinks-relative.sh: --staged and [ref] are mutually exclusive" >&2
+  exit 2
+fi
+
+REF="${REF:-HEAD}"
 SKILL_DIR=".claude/skills/dinostack"
 LINKS="agents commands references rules"
 
@@ -32,19 +82,40 @@ fail=0
 
 for name in $LINKS; do
   path="$SKILL_DIR/$name"
-  entry="$(git ls-tree "$REF" -- "$path" 2>/dev/null || true)"
+
+  if [ "$STAGED" -eq 1 ]; then
+    entry="$(git ls-files -s -- "$path" 2>/dev/null || true)"
+  else
+    entry="$(git ls-tree "$REF" -- "$path" 2>/dev/null || true)"
+  fi
 
   if [ -z "$entry" ]; then
-    echo "check-symlinks-relative.sh: $path is missing from $REF" >&2
+    if [ "$STAGED" -eq 1 ] && git diff --cached --name-only --diff-filter=D -- "$path" | grep -qx "$path"; then
+      echo "check-symlinks-relative.sh: $path is staged for deletion - skipping" >&2
+      continue
+    fi
+    if [ "$STAGED" -eq 1 ]; then
+      echo "check-symlinks-relative.sh: $path is missing from the index" >&2
+    else
+      echo "check-symlinks-relative.sh: $path is missing from $REF" >&2
+    fi
     fail=1
     continue
   fi
 
   mode="$(echo "$entry" | awk '{print $1}')"
-  sha="$(echo "$entry" | awk '{print $3}')"
+  if [ "$STAGED" -eq 1 ]; then
+    sha="$(echo "$entry" | awk '{print $2}')"
+  else
+    sha="$(echo "$entry" | awk '{print $3}')"
+  fi
 
   if [ "$mode" != "120000" ]; then
-    echo "check-symlinks-relative.sh: $path is not a symlink in $REF (mode $mode)" >&2
+    if [ "$STAGED" -eq 1 ]; then
+      echo "check-symlinks-relative.sh: $path is not a symlink in the index (mode $mode)" >&2
+    else
+      echo "check-symlinks-relative.sh: $path is not a symlink in $REF (mode $mode)" >&2
+    fi
     fail=1
     continue
   fi
@@ -53,7 +124,11 @@ for name in $LINKS; do
 
   case "$target" in
     /*)
-      echo "check-symlinks-relative.sh: $path is ABSOLUTIZED in $REF -> $target" >&2
+      if [ "$STAGED" -eq 1 ]; then
+        echo "check-symlinks-relative.sh: $path is ABSOLUTIZED in the index -> $target" >&2
+      else
+        echo "check-symlinks-relative.sh: $path is ABSOLUTIZED in $REF -> $target" >&2
+      fi
       fail=1
       ;;
     *)
@@ -64,7 +139,11 @@ done
 
 if [ "$fail" -ne 0 ]; then
   echo "" >&2
-  echo "One or more dinostack skill symlinks are absolutized in $REF." >&2
+  if [ "$STAGED" -eq 1 ]; then
+    echo "One or more dinostack skill symlinks are staged as absolutized paths." >&2
+  else
+    echo "One or more dinostack skill symlinks are absolutized in $REF." >&2
+  fi
   echo "Restore them to relative form (e.g. ../../../content/<name>) before merging." >&2
   exit 1
 fi

--- a/scripts/codex-skills.py
+++ b/scripts/codex-skills.py
@@ -1955,23 +1955,24 @@ def build(repo: Path, output: Path) -> None:
             assert isinstance(nonce, str)
             set_registry_binding(repo, output, nonce)
         sync_tree(staging, output, ownership_marker)
-    check(repo, output)
+    _check(repo, output, revalidate_render=False)
 
 
-def check(repo: Path, output: Path) -> None:
+def _check(repo: Path, output: Path, *, revalidate_render: bool) -> None:
     load_compatibility(repo)
     validate_adapter_mirrors(repo)
     ownership_marker, _ = prepare_root_ownership(repo, output, required=True)
-    with tempfile.TemporaryDirectory(prefix="codex-skills-check-") as temp:
-        expected_root = Path(temp)
-        render_tree(repo, output, expected_root, ownership_marker)
-        expected = scan_tree(expected_root)
-        actual = scan_tree(output)
-        if expected != actual:
-            missing = sorted(set(expected) - set(actual))
-            unexpected = sorted(set(actual) - set(expected))
-            changed = sorted(rel for rel in set(actual) & set(expected) if actual[rel] != expected[rel])
-            raise SkillError(f"generated skill drift: missing={missing}, unexpected={unexpected}, changed={changed}")
+    if revalidate_render:
+        with tempfile.TemporaryDirectory(prefix="codex-skills-check-") as temp:
+            expected_root = Path(temp)
+            render_tree(repo, output, expected_root, ownership_marker)
+            expected = scan_tree(expected_root)
+            actual = scan_tree(output)
+            if expected != actual:
+                missing = sorted(set(expected) - set(actual))
+                unexpected = sorted(set(actual) - set(expected))
+                changed = sorted(rel for rel in set(actual) & set(expected) if actual[rel] != expected[rel])
+                raise SkillError(f"generated skill drift: missing={missing}, unexpected={unexpected}, changed={changed}")
     validate_resources(output)
     with tempfile.TemporaryDirectory(prefix="codex-skill-home-") as home, tempfile.TemporaryDirectory(prefix="codex-skill-cwd-") as cwd:
         install = Path(home) / ".agents/skills"
@@ -1984,6 +1985,10 @@ def check(repo: Path, output: Path) -> None:
             validate_resources(install)
         finally:
             os.chdir(previous)
+
+
+def check(repo: Path, output: Path) -> None:
+    _check(repo, output, revalidate_render=True)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Supersedes #571 (same verified content, signed history). #571 was functionally
complete and CI-green (26 checks passed), but three of its commits
(`35077960`, `dbda3b6f`, `39aa37df`) were authored by
`admin@fullmetalblanket.com` with no `Signed-off-by` trailer, and force-push
is denied in this repo so they could not be amended in place. This PR
recreates the identical end-state tree from `origin/fix/ds-136-bin-tests-hangs`
(tip `e32e7ce8`) as a single fully DCO-signed commit on top of current
`origin/main`. Verified via `git diff` against the original branch on all six
touched paths: empty.

## Changes

- `test_hooks_snapshot_migration.sh`: pass `--no-identity` and seed
  `skill_auto_load: false` so the `install.sh` identity/skill-auto-load
  prompts cannot block on `/dev/tty` with a real controlling terminal
  (`ae_confirm` reads `/dev/tty`; never fires in CI, which has no TTY).
- `test_codex_hooks_resolve.sh`: replace `mapfile` with a `while read` loop
  reading from a temp file (bash 3.2 on macOS has no `mapfile` builtin, and
  an empty command set previously left `COMMANDS` unset, tripping `set -u`).
- `codex-skills.py`: drop the redundant re-render in `build()`'s self-check;
  standalone `check()` keeps full re-render validation.
- `check-symlinks-relative.sh`: add a `--staged` index mode with a
  deletion-aware skip, so a legitimate removal of a watched symlink does not
  block the commit that removes it.
- `hooks/pre-commit`: wire the staged symlink-absolutization gate
  (DS-104/DS-136) so an absolutized dinostack skill symlink is caught before
  commit, not just in CI.

The job-level timeout bump from the original PR is dropped: main's per-step
timeout policy supersedes it.

The two comment-only files from the original branch
(`bin/tests/test_install_profiles.sh`, `bin/tests/test_install_profile_config_dir.sh`)
were reverted to main's content - they were functionally empty and carried
hardcoded perf figures that main's own policy forbids.


## North Star alignment

**Pillar 2 (verifiable outcomes autonomously) - advanced.** The commit-time symlink gate turns a
failure class that has shipped twice (DS-96, DS-104) into a mechanically-caught one at the
earliest possible point. That class is specifically invisible to normal review: an absolutized
symlink still resolves on the machine that produced it, so CI stays green while the skill breaks
for every other clone. The gate is verified in both directions (blocks an absolutized staged
link, passes a relative one) rather than only observed passing - the failure mode this repo
documents as a vacuous gate.

**Pillar 3 (low friction) - advanced, with one accepted cost.** `--no-identity` removes a real
local-dev hang: `install.sh` calls `_ae_setup_identity` unconditionally, which reaches
`ae_confirm` reading `/dev/tty`, so the test blocks on a real terminal (never in CI, which has
no TTY). The `mapfile` -> `while read` change fixes a test that fails outright on macOS bash 3.2,
reproducible on current `main` today. The codex re-render cut removes a provably redundant second
render+compare in `build()`'s self-check; standalone `check()` keeps full validation.

The accepted cost is the pre-commit gate itself, which runs on every commit forever. It is
proportionate: four O(1) git object lookups, against a failure this repo has actually shipped.
Its honest incremental value over the existing CI check in `adapter-sync.yml` is earlier feedback
and defense-in-depth against `--admin` merges - not new coverage.

**Attention test - neutral.** Nothing here adds status output or anything the operator must watch.
The gate speaks only when it fires.

**Scope discipline.** Two changes from the original PR were deliberately dropped rather than
carried forward: the job-level `timeout-minutes` bump (superseded by main's per-step timeout
policy, whose own comment warns against raising the job timeout alone), and two comment-only
hunks that were functionally empty and carried hardcoded perf figures that main's policy in
`test_hooks_snapshot_migration.sh` explicitly forbids.
