### PR TITLE
chore(docs): mechanically pin docs-currency drift sites via bin/tests

### DIFF
--- a/bin/tests/test_docs_currency_sync.py
+++ b/bin/tests/test_docs_currency_sync.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Cross-site consistency pins for docs-currency drift classes that PR #719's
+manual sweep found but did not mechanically close. Each assertion derives the
+expected value from live repo state (a glob or a grep of hooks/), never a
+hardcoded literal, so a future change that updates one site and forgets its
+sibling now fails here instead of silently drifting.
+
+Drift classes covered:
+  - docs/components.md "**Agents** (<N>)"          vs len(content/agents/*.md)
+  - docs/components.md "**Commands** (<N>)"        vs len(content/commands/ds-*.md)
+  - docs/index.html "Guard kill-switches" card     vs the AE_*_DISABLE env vars
+                                                    referenced in hooks/ (the
+                                                    card omitted 3 of the 8
+                                                    hooks-defined kill-switches)
+  - docs/configuration-reference.md section 4      vs the same hooks-derived
+    "Environment kill-switches" table              AE_*_DISABLE set
+  - README.md deck inventory                       vs docs/slides/*-slides.md
+                                                    (the list drifted to ~9 of
+                                                    18 decks before #719)
+  - docs/index.html "N named agents" claims        vs len(content/agents/*.md)
+
+docs/index.html's Referenced Protocol Documents grid is intentionally NOT
+covered here: it is a curated subset, not a full enumeration (see
+test_reference_doc_count_sync.py's docstring). The kill-switch card and the
+"named agents" claims ARE full assertions of derivable facts, so they are
+pinned exactly.
+
+docs/overview/requirements.md is gitignored/absent and is never asserted
+against; docs/slides/*.md decks are enumerated from the `*-slides.md` glob
+(docs/slides/AGENTS.md is a directory guide, not a deck).
+
+Run with: python3 -m pytest bin/tests/test_docs_currency_sync.py -q
+CI wiring: .github/workflows/bin-tests.yml's python-bin-tests job runs
+`python3 -m pytest bin/tests/ -q` - full-directory glob discovery, no
+per-file wiring required for a new test_*.py file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+AGENTS_DIR = REPO_ROOT / "content" / "agents"
+COMMANDS_DIR = REPO_ROOT / "content" / "commands"
+HOOKS_DIR = REPO_ROOT / "hooks"
+SLIDES_DIR = REPO_ROOT / "docs" / "slides"
+COMPONENTS_PATH = REPO_ROOT / "docs" / "components.md"
+INDEX_PATH = REPO_ROOT / "docs" / "index.html"
+CONFIG_REF_PATH = REPO_ROOT / "docs" / "configuration-reference.md"
+README_PATH = REPO_ROOT / "README.md"
+
+# Every AE_*_DISABLE token is a guard kill-switch env var. Tokens are derived
+# from hooks/ source, never a hand-typed literal, so adding a new kill-switch
+# to a hook fails the pinning tests until every documented enumeration catches
+# up - the exact drift class PR #719 fixed by hand.
+_HOOK_KILL_SWITCH_RE = re.compile(r"\b(AE_[A-Z_]+_DISABLE)\b")
+
+
+@pytest.fixture(scope="module")
+def hooks_kill_switches() -> set[str]:
+    """Live set of guard kill-switch env vars referenced in hooks/."""
+    hook_paths = sorted(HOOKS_DIR.glob("*.py")) + sorted(HOOKS_DIR.glob("*.sh"))
+    return {
+        name
+        for path in hook_paths
+        for name in _HOOK_KILL_SWITCH_RE.findall(path.read_text(encoding="utf-8"))
+    }
+
+
+@pytest.fixture(scope="module")
+def agent_count() -> int:
+    return len(list(AGENTS_DIR.glob("*.md")))
+
+
+@pytest.fixture(scope="module")
+def deck_stems() -> list[str]:
+    """Live set of slide-deck basenames (without .md). The `*-slides.md` glob
+    excludes docs/slides/AGENTS.md, which is a directory guide, not a deck."""
+    return sorted(p.stem for p in SLIDES_DIR.glob("*-slides.md"))
+
+
+def test_hooks_kill_switch_set_is_plausible(hooks_kill_switches):
+    # Sanity floor: the derived set is the ground truth this spec enforces.
+    # A collapse below this floor means hooks/ itself lost its kill-switches.
+    assert len(hooks_kill_switches) >= 5, (
+        f"derived hooks kill-switch set {sorted(hooks_kill_switches)} is "
+        "implausibly small"
+    )
+
+
+def test_components_md_agent_count_matches(agent_count):
+    text = COMPONENTS_PATH.read_text(encoding="utf-8")
+    match = re.search(r"\*\*Agents\*\* \((\d+)\)", text)
+    assert match, (
+        "docs/components.md must state the agent count as '**Agents** (<N>)'"
+    )
+    stated = int(match.group(1))
+    assert stated == agent_count, (
+        f"docs/components.md states {stated} agents, expected {agent_count} "
+        "(one per content/agents/*.md file)"
+    )
+
+
+def test_components_md_command_count_matches():
+    live = len(list(COMMANDS_DIR.glob("ds-*.md")))
+    text = COMPONENTS_PATH.read_text(encoding="utf-8")
+    match = re.search(r"\*\*Commands\*\* \((\d+)\)", text)
+    assert match, (
+        "docs/components.md must state the command count as "
+        "'**Commands** (<N>)'"
+    )
+    stated = int(match.group(1))
+    assert stated == live, (
+        f"docs/components.md states {stated} commands, expected {live} "
+        "(one per content/commands/ds-*.md file)"
+    )
+
+
+def _kill_switch_region(text: str, start_marker: str, end_marker: str) -> str:
+    """Substring of `text` that documents a kill-switch enumeration."""
+    start = text.index(start_marker)
+    nxt = text.find(end_marker, start + len(start_marker))
+    if nxt == -1:
+        nxt = len(text)
+    return text[start:nxt]
+
+
+def test_index_html_kill_switch_card_matches(hooks_kill_switches):
+    text = INDEX_PATH.read_text(encoding="utf-8")
+    card = _kill_switch_region(text, "Guard kill-switches", "<h4>")
+    card_vars = set(_HOOK_KILL_SWITCH_RE.findall(card))
+    assert card_vars == hooks_kill_switches, (
+        "docs/index.html 'Guard kill-switches' card disagrees with the "
+        "AE_*_DISABLE kill-switches referenced in hooks/.\n"
+        f"  missing from card: {sorted(hooks_kill_switches - card_vars)}\n"
+        f"  extra in card: {sorted(card_vars - hooks_kill_switches)}"
+    )
+
+
+def test_config_reference_env_kill_switch_table_matches(hooks_kill_switches):
+    text = CONFIG_REF_PATH.read_text(encoding="utf-8")
+    section = _kill_switch_region(text, "## 4. Environment kill-switches", "\n## ")
+    section_vars = set(_HOOK_KILL_SWITCH_RE.findall(section))
+    assert section_vars == hooks_kill_switches, (
+        "docs/configuration-reference.md 'Environment kill-switches' table "
+        "disagrees with the AE_*_DISABLE kill-switches referenced in hooks/.\n"
+        f"  missing from table: {sorted(hooks_kill_switches - section_vars)}\n"
+        f"  extra in table: {sorted(section_vars - hooks_kill_switches)}"
+    )
+
+
+def test_readme_deck_inventory_matches(deck_stems):
+    text = README_PATH.read_text(encoding="utf-8")
+    listed = sorted(set(re.findall(r"docs/slides/([a-z0-9-]+)\.html", text)))
+    assert listed, "README.md must list slide decks as docs/slides/<deck>.html"
+    missing = [stem for stem in deck_stems if stem not in listed]
+    assert not missing, (
+        f"README.md deck inventory is missing decks: {missing}"
+    )
+    extra = [stem for stem in listed if stem not in deck_stems]
+    assert not extra, (
+        f"README.md deck inventory names non-existent decks: {extra}"
+    )
+
+
+def test_index_html_named_agents_claims_match(agent_count):
+    text = INDEX_PATH.read_text(encoding="utf-8")
+    claims = [int(m) for m in re.findall(r"(\d+) named agents", text)]
+    assert claims, (
+        "docs/index.html must state the agent-team size as '<N> named agents'"
+    )
+    assert all(c == agent_count for c in claims), (
+        f"docs/index.html states {claims} named agents, expected {agent_count} "
+        "(one per content/agents/*.md file)"
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/bin/tests/test_reference_doc_count_sync.py
+++ b/bin/tests/test_reference_doc_count_sync.py
@@ -23,6 +23,12 @@ Count sites covered:
                                          triggered this drift) is listed
   - docs/index.html                    : the evidence-on-disk.md node is in the
                                          Referenced Protocol Documents grid
+  - docs/components.md                 : "**Reference docs** (<N> .md docs
+                                         plus <M> example .yml files" against
+                                         the live content/references/ counts
+                                         for both extensions (PR #719 fixed a
+                                         33 -> 39 drift here; the site was
+                                         previously unpinned)
 
 docs/index.html's grid is a curated subset, not a full enumeration - it lists
 a fraction of the files and carries pre-existing stale names (e.g. graphify.md,
@@ -49,6 +55,7 @@ CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
 SLIDES_PATH = REPO_ROOT / "docs" / "slides" / "contributing-slides.md"
 SKILL_PATH = REPO_ROOT / "content" / "SKILL.md"
 INDEX_PATH = REPO_ROOT / "docs" / "index.html"
+COMPONENTS_PATH = REPO_ROOT / "docs" / "components.md"
 
 # The doc whose addition bumped the count 33 -> 34 and triggered this finding.
 DRIFT_TRIGGER_DOC = "evidence-on-disk"
@@ -138,6 +145,32 @@ def test_slides_count_matches_at_all_sites(reference_count):
     assert all(c == reference_count for c in counts), (
         f"contributing-slides.md states {counts} reference docs, "
         f"expected {reference_count} at every site"
+    )
+
+
+def test_components_md_counts_match(reference_count, reference_stems):
+    text = COMPONENTS_PATH.read_text(encoding="utf-8")
+    md_match = re.search(r"\*\*Reference docs\*\* \((\d+) \.md docs", text)
+    assert md_match, (
+        "docs/components.md must state the count as "
+        "'**Reference docs** (<N> .md docs ...'"
+    )
+    stated_md = int(md_match.group(1))
+    assert stated_md == reference_count, (
+        f"docs/components.md states {stated_md} reference-doc .md files, "
+        f"expected {reference_count}"
+    )
+
+    yml_match = re.search(r"plus (\d+) example \.yml files", text)
+    assert yml_match, (
+        "docs/components.md must state the example .yml count as "
+        "'plus <M> example .yml files'"
+    )
+    live_yml = len(list(REFERENCES_DIR.glob("*.yml")))
+    stated_yml = int(yml_match.group(1))
+    assert stated_yml == live_yml, (
+        f"docs/components.md states {stated_yml} example .yml files, "
+        f"expected {live_yml}"
     )
 
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -108,7 +108,10 @@ Unset by default. Set to `1` to disable the named guard for a session.
 | Variable | Default (unset) | What it disables |
 |---|---|---|
 | `AE_ABDICATION_GUARD_DISABLE=1` | guard active | Abdication guard Stop hook (only relevant when `abdication_guard_enabled: true`) |
+| `AE_PLANNING_GUARD_DISABLE=1` | guard active | Planning-artifact spawn advisory hook (`hooks/enforce-planning-artifact-spawn.py`) |
+| `AE_SHIPPABLE_GUARD_DISABLE=1` | guard active | Shippable-edit guard denying conductor-direct shippable edits (`hooks/enforce-shippable-edit.py`) |
 | `AE_SINGULARITY_GUARD_DISABLE=1` | guard active | Orchestrator-singularity hook (prevents subagents from spawning subagents) |
+| `AE_TEAM_ROUTING_DISABLE=1` | guard active | Cross-harness team-routing branch of the background-spawn guard (`hooks/enforce-background-spawn.py`) |
 | `AE_TIER_GUARD_DISABLE=1` | guard active | Tier-enforcement hook (prevents sub-Opus on mandated Tier-3 spawns) |
 | `AE_TURN_SHAPE_GUARD_DISABLE=1` | guard active | Turn-shape guard - both the blocking structural check and the advisory phrasing check (only relevant when `turn_shape_guard_enabled: true`) |
 | `AE_WORKTREE_READ_GUARD_DISABLE=1` | guard active | Worktree-isolation Read guard (`hooks/enforce-worktree-read.py`) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1159,8 +1159,8 @@
   <!-- Env kill-switches -->
   <div class="rel-card" style="margin-bottom: 10px;">
     <h4>Guard kill-switches</h4>
-    <p style="font-size: 13px; color: var(--text-secondary); margin-bottom: 6px;">Per-session env vars that disable individual enforcement hooks or silence activation output.</p>
-    <p style="font-size: 12px; margin-bottom: 2px;"><strong>Vars:</strong> <code>AE_SINGULARITY_GUARD_DISABLE</code> / <code>AE_TIER_GUARD_DISABLE</code> / <code>AE_WORKTREE_READ_GUARD_DISABLE</code> / <code>AE_ABDICATION_GUARD_DISABLE</code> / <code>AE_TURN_SHAPE_GUARD_DISABLE</code> / <code>AGENTIC_QUIET</code> &nbsp; <strong>Default:</strong> unset</p>
+    <p style="font-size: 13px; color: var(--text-secondary); margin-bottom: 6px;">Per-session env vars that disable or narrow individual enforcement hooks or silence activation output.</p>
+    <p style="font-size: 12px; margin-bottom: 2px;"><strong>Vars:</strong> <code>AE_SINGULARITY_GUARD_DISABLE</code> / <code>AE_TIER_GUARD_DISABLE</code> / <code>AE_WORKTREE_READ_GUARD_DISABLE</code> / <code>AE_ABDICATION_GUARD_DISABLE</code> / <code>AE_TURN_SHAPE_GUARD_DISABLE</code> / <code>AE_SHIPPABLE_GUARD_DISABLE</code> / <code>AE_PLANNING_GUARD_DISABLE</code> / <code>AE_TEAM_ROUTING_DISABLE</code> / <code>AGENTIC_QUIET</code> &nbsp; <strong>Default:</strong> unset</p>
     <p style="font-size: 12px; color: var(--text-secondary); margin: 0;"><strong>Set:</strong> in-session - <code>export &lt;VAR&gt;=1</code> before launching</p>
   </div>
 


### PR DESCRIPTION
## Summary

PR #719 fixed 19 stale docs assertions by hand but left no mechanical guard behind. The docs-sync mechanism is prose-enforced and reactive per `/ds-update-agentic-engineering` run, and the one existing count-sync detector omitted `docs/components.md` - the exact site that drifted 33 -> 39. This PR extends the derived-claim pattern in `bin/tests/` so that drift class fails CI on every PR/push instead of a manual sweep, and fixes the residual drift the new assertions surface.

Assertions added (all derive the expected value from live repo state, never a hardcoded literal):
- `test_reference_doc_count_sync.py`: `docs/components.md` reference-doc `.md` count and example `.yml` count.
- `test_docs_currency_sync.py` (new): `docs/components.md` agent and command counts; the `docs/index.html` Guard kill-switches card and the `docs/configuration-reference.md` section 4 env kill-switch table, both pinned to the `AE_*_DISABLE` vars actually referenced in `hooks/`; the README deck inventory vs `docs/slides/*-slides.md`; and the `docs/index.html` "N named agents" claims.

Every new assertion was mutation-verified to redden on the drift it targets. Wired automatically: `bin-tests.yml`'s `python-bin-tests` job runs `pytest bin/tests/ -q`, so the new test file needs no workflow edit.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Pillar 2 (produce verifiable outcomes autonomously) - docs currency becomes CI-enforced rather than prose-reliant, so a stale count is a red build instead of intent debt; Pillar 3 (low friction) - the drift class PR #719 caught by hand now fails `bin-tests` automatically, with no operator sweep and no new hook or workflow.
- Trade-off or pillar this could regress, if any: None. The gate is additive derived-claim assertions over `bin/tests/`; it makes no methodology-behavior change and adds no enforcement hook or CI workflow.

## Review rigor

- Brief / Plan path: N/A - Trivial risk, single Worker, no Skeptic per AE risk classification
- Skeptic rounds (tier): N/A
- Findings summary: N/A

## Doc-sync

Doc-sync: clause 1 (enumerable set) triggered -> updated `docs/index.html` (Guard kill-switches card) and `docs/configuration-reference.md` (section 4 env kill-switch table): added `AE_PLANNING_GUARD_DISABLE`, `AE_SHIPPABLE_GUARD_DISABLE`, `AE_TEAM_ROUTING_DISABLE` so both enumerations match the `AE_*_DISABLE` kill-switches referenced in `hooks/`. No `content/`, `README.md`, `CONTRIBUTING.md`, or `content/SKILL.md` count site changed.

## Related issues

None (follow-up to PR #719).

## Checklist

- [x] DCO sign-off on every commit (`git commit -s`)
- [x] Tests/lint passing (`pytest bin/tests/` green: 1442 passed, 25 subtests passed)
- [x] Docs updated if behavior changed

## Affected adapters

- [ ] Claude Code
- [ ] Cursor
- [ ] Codex CLI
- [ ] Gemini CLI
- [ ] Kimi Code
- [ ] OpenCode
- [ ] Pi coding agent
- [ ] Pi oh-my-pi
- [ ] Hermes
- [ ] OpenClaw
- [ ] VS Code Copilot
- [x] None (methodology / docs only)
