### PR TITLE
vision: Pillar 2 orchestration tenet - the conductor does not do the work

### DIFF
--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -20,7 +20,13 @@ task and get back a verifiable outcome.
 2. **Produce verifiable outcomes autonomously.** Agents should drive work to a checkable result
    — tests/lints/gates passing, an adversarial Skeptic sign-off, a clear `ok | needs_human |
    blocked` exit — without a human in the loop for routine steps. Verifiability is what makes
-   autonomy safe to trust.
+   autonomy safe to trust. The conductor does not do the work - it orchestrates agents that do. A
+   conductor that investigates, diagnoses, or asserts unverified conclusions has substituted its
+   own unchecked judgment for the adversarial verification this pillar exists to guarantee, and
+   the correction round that follows costs strictly more than delegation would have. (The
+   "orchestration test": did this claim/artifact come from a subagent return or a conductor read
+   verified against `origin/main`, or did the conductor manufacture it directly? The latter is not
+   ready to spawn on.)
 3. **Low friction.** Sensible defaults, minimal setup, global-default/per-project-override
    everywhere. The protocol should reduce ceremony, not add it.
 4. **Works for everyone (universality).** The protocol is a shared, portable package — every
@@ -116,7 +122,9 @@ proportional gain (fails the efficiency test), or needlessly serializes independ
 a full review cycle on a single non-blocking finding, or otherwise adds wall-clock delay without
 a proportional gain (fails the latency test), or leaves a mechanical review check unmoved to the
 producing step when it could catch the defect earlier without weakening the review (fails the
-prevention test). Symmetrically, a PR that cuts a gate, review round, verification step, or
+prevention test), or asserts a conclusion/value in a spawn brief that came from neither a
+subagent return nor a conductor read verified against `origin/main` (fails the orchestration
+test). Symmetrically, a PR that cuts a gate, review round, verification step, or
 enforcement floor to save tokens or to finish sooner - or that removes a reviewer's mechanical
 check because the producer now runs it too - is also misaligned, regardless of how it scores on
 the efficiency, latency, or prevention test - that trade-off is never on the table. Misalignment is


### PR DESCRIPTION
## North Star alignment

This is a North Star change: it sharpens Pillar 2 (produce verifiable outcomes autonomously) by adding an explicit orchestration tenet - the conductor does not do the work, it orchestrates agents that do - plus a gradeable "orchestration test." The test is also wired into the "How to use this for PR alignment" misalignment list, so a spawn brief asserting an unverified conclusion is now checkable against the vision document, not just against prose scattered across `content/`. No pillar regresses: this is additive text within Pillar 2's existing scope, and the misalignment-list addition follows the file's existing enumerated `or ...` style with zero other semantic changes.

Text operator-adopted and the edit operator-authorized in-session; landing is mechanical.

## Summary

- Append to Pillar 2: the conductor-does-not-do-the-work tenet and the "orchestration test" (did this claim/artifact come from a subagent return or a conductor read verified against `origin/main`, or did the conductor manufacture it directly?).
- Append a matching clause to the PR-alignment misalignment list so the test is gradeable against PRs.

## Gate evidence

- `git diff -U0 origin/main...HEAD -- docs/overview/vision.md | grep '^+.*—'` -> no match (no em dashes introduced).
- `grep -c "Pillar" docs/index.html` -> 0. Doc-sync: predicate not triggered (no reality-asserting change elsewhere; docs/index.html does not mirror pillar text).
- `bash scripts/build-all.sh` -> all 11 adapters built successfully; `git status --short` shows only `docs/overview/vision.md` modified (no adapter drift, since vision.md is outside `content/`).
- `bash scripts/check-symlinks-relative.sh` -> all 4 dinostack skill symlinks OK (relative, unabsolutized).
- DCO: `git log -1 --format=%ae` -> `tyson@solara6.com`; `Signed-off-by: Tyson Hummel <tyson@solara6.com>` present.

## Test plan

- [x] Verify diff is scoped to `docs/overview/vision.md` only
- [x] Verify no em dashes introduced
- [x] Verify docs/index.html has no stale pillar-mirroring text to sync
- [x] Verify adapter build produces no drift
- [x] Verify symlinks remain relative
