### PR TITLE
fix(adapter-hooks): anchor .agentic writes in Cursor, Copilot, and OpenCode hooks

### DIFF
--- a/.copilot/hooks/session-start-copilot.sh
+++ b/.copilot/hooks/session-start-copilot.sh
@@ -8,13 +8,26 @@
 # Output: JSON on stdout with hookSpecificOutput.additionalContext (or empty object).
 #
 # Reference: VS Code Copilot Extensibility - hooks reference (SessionStart output format).
+#
+# The .agentic/ read is anchored at the nearest .git ancestor of the payload
+# cwd via hooks/lib/repo-root.sh's resolve_agentic_root, not the payload cwd
+# verbatim, and NEVER falls back to `pwd` - a stray cd or a drifted
+# harness-supplied cwd could otherwise point this hook at a phantom
+# .agentic/ tree wherever the process happens to be. On resolution failure
+# (payload has no cwd, or no .git ancestor is found), the hook SKIPS the
+# lookup entirely and emits {}.
 
 set -euo pipefail
 
-# Resolve workspace root from stdin JSON (cwd field), fall back to pwd
-CWD=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../hooks/lib/repo-root.sh
+source "$SCRIPT_DIR/../../hooks/lib/repo-root.sh"
+
+# Resolve workspace root from stdin JSON (cwd field). Never falls back to
+# `pwd` - see the header comment above.
+PAYLOAD_CWD=""
 if command -v python3 >/dev/null 2>&1; then
-  CWD="$(python3 -c "
+  PAYLOAD_CWD="$(python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -24,8 +37,14 @@ except Exception:
 " 2>/dev/null || true)"
 fi
 
+CWD=""
+if [[ -n "$PAYLOAD_CWD" ]]; then
+  CWD="$(resolve_agentic_root "$PAYLOAD_CWD")"
+fi
+
 if [[ -z "$CWD" ]]; then
-  CWD="$(pwd)"
+  printf '{}\n'
+  exit 0
 fi
 
 CONTEXT_FILE="$CWD/.agentic/context.md"

--- a/.copilot/hooks/stop-context-copilot.js
+++ b/.copilot/hooks/stop-context-copilot.js
@@ -24,6 +24,13 @@
  * reader with a first-byte timeout and a re-armed inactivity timeout) instead
  * of a blocking fs.readFileSync('/dev/stdin'), so this hook cannot hang
  * Copilot's shutdown path when the spawning process never closes stdin.
+ *
+ * The .agentic/ write is anchored at the nearest .git ancestor of the
+ * payload cwd via hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics,
+ * not the payload cwd verbatim - a stray cd or a drifted harness-supplied
+ * cwd could otherwise write a phantom .agentic/ tree wherever the process
+ * happens to be. On resolution failure (no .git ancestor found), the write
+ * is SKIPPED entirely rather than falling back to the unresolved cwd.
  */
 
 'use strict';
@@ -31,6 +38,7 @@
 const fs = require('fs');
 const path = require('path');
 const { readStdinGuarded } = require('../../hooks/lib/stdin-guard.js');
+const { resolveAgenticCwdWithDiagnostics } = require('../../hooks/lib/repo-root.js');
 
 // Always exit with valid JSON for Copilot Stop hook compliance. Hoisted to
 // module scope so both run()'s internal paths and the top-level run().catch()
@@ -66,6 +74,17 @@ async function run() {
     process.exit(0);
   }
 
+  // --- 3b. Resolve the repo root anchoring the .agentic/ write, instead of
+  // trusting the payload-supplied cwd verbatim. On resolution failure (no
+  // .git ancestor found), SKIP the write entirely - never fall back to the
+  // unresolved cwd, which would silently reproduce the phantom-tree bug
+  // this resolver exists to prevent.
+  const { root: agenticRoot, foundGitAncestor } = resolveAgenticCwdWithDiagnostics(cwd);
+  if (!foundGitAncestor) {
+    process.stdout.write(successOutput);
+    process.exit(0);
+  }
+
   const sessionId = typeof payload.session_id === 'string'
     ? payload.session_id
     : '(unknown)';
@@ -79,7 +98,7 @@ async function run() {
     : '(unknown)';
 
   // --- 4. Compute output path ---
-  const agenticDir = path.join(cwd, '.agentic');
+  const agenticDir = path.join(agenticRoot, '.agentic');
   const outputPath = path.join(agenticDir, 'context.md');
 
   // --- 5. Format content ---

--- a/.cursor/hooks/stop-context-cursor.js
+++ b/.cursor/hooks/stop-context-cursor.js
@@ -23,7 +23,11 @@
  * Upstream deps: Node built-ins only (fs, path) plus
  *                ../../hooks/lib/stdin-guard.js (readStdinGuarded - the
  *                shared bounded-stdin reader; see that module's manifest for
- *                the first-byte/inactivity timer contract). No npm
+ *                the first-byte/inactivity timer contract) and
+ *                ../../hooks/lib/repo-root.js (resolveAgenticCwdWithDiagnostics
+ *                - anchors the .agentic/ write at the nearest .git ancestor
+ *                instead of trusting the payload cwd verbatim; write is
+ *                skipped entirely when no .git ancestor is found). No npm
  *                dependencies. Reads process.env.CURSOR_PROJECT_DIR,
  *                process.env.CLAUDE_PROJECT_DIR, and
  *                process.env.CURSOR_TRANSCRIPT_PATH as fallbacks when the
@@ -106,6 +110,7 @@
 const fs = require('fs');
 const path = require('path');
 const { readStdinGuarded } = require('../../hooks/lib/stdin-guard.js');
+const { resolveAgenticCwdWithDiagnostics } = require('../../hooks/lib/repo-root.js');
 
 const TRANSCRIPT_MAX_BYTES = 256 * 1024;
 const TRANSCRIPT_TAIL_CHARS = 2000;
@@ -224,6 +229,15 @@ async function run() {
   // for a reject branch to have protected that this does not already close.
   cwd = path.resolve(cwd);
 
+  // --- 3b. Resolve the repo root anchoring the .agentic/ write, instead of
+  // trusting the payload-supplied cwd verbatim (a stray cd or a drifted
+  // harness-supplied cwd can otherwise write a phantom .agentic/ tree
+  // wherever the process happens to be). On resolution failure (no .git
+  // ancestor found), SKIP the write entirely rather than falling back to
+  // the unresolved cwd - see hooks/lib/repo-root.js's manifest.
+  const { root: agenticRoot, foundGitAncestor } = resolveAgenticCwdWithDiagnostics(cwd);
+  if (!foundGitAncestor) return exitOk();
+
   // --- 4. Extract remaining fields (all optional, all defensive) ---
   const sessionId = (typeof payload.conversation_id === 'string' && payload.conversation_id.trim())
     ? payload.conversation_id.trim()
@@ -250,7 +264,7 @@ async function run() {
   const lastActivity = readTranscriptExcerpt(transcriptPath);
 
   // --- 5. Compute output path ---
-  const agenticDir = path.join(cwd, '.agentic');
+  const agenticDir = path.join(agenticRoot, '.agentic');
   const outputPath = path.join(agenticDir, 'context.md');
 
   // --- 6. Format content (same shape as the Codex/Copilot ports) ---

--- a/.github/hooks/session-start-copilot.sh
+++ b/.github/hooks/session-start-copilot.sh
@@ -8,13 +8,26 @@
 # Output: JSON on stdout with hookSpecificOutput.additionalContext (or empty object).
 #
 # Reference: VS Code Copilot Extensibility - hooks reference (SessionStart output format).
+#
+# The .agentic/ read is anchored at the nearest .git ancestor of the payload
+# cwd via hooks/lib/repo-root.sh's resolve_agentic_root, not the payload cwd
+# verbatim, and NEVER falls back to `pwd` - a stray cd or a drifted
+# harness-supplied cwd could otherwise point this hook at a phantom
+# .agentic/ tree wherever the process happens to be. On resolution failure
+# (payload has no cwd, or no .git ancestor is found), the hook SKIPS the
+# lookup entirely and emits {}.
 
 set -euo pipefail
 
-# Resolve workspace root from stdin JSON (cwd field), fall back to pwd
-CWD=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../hooks/lib/repo-root.sh
+source "$SCRIPT_DIR/../../hooks/lib/repo-root.sh"
+
+# Resolve workspace root from stdin JSON (cwd field). Never falls back to
+# `pwd` - see the header comment above.
+PAYLOAD_CWD=""
 if command -v python3 >/dev/null 2>&1; then
-  CWD="$(python3 -c "
+  PAYLOAD_CWD="$(python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -24,8 +37,14 @@ except Exception:
 " 2>/dev/null || true)"
 fi
 
+CWD=""
+if [[ -n "$PAYLOAD_CWD" ]]; then
+  CWD="$(resolve_agentic_root "$PAYLOAD_CWD")"
+fi
+
 if [[ -z "$CWD" ]]; then
-  CWD="$(pwd)"
+  printf '{}\n'
+  exit 0
 fi
 
 CONTEXT_FILE="$CWD/.agentic/context.md"

--- a/.github/hooks/stop-context-copilot.js
+++ b/.github/hooks/stop-context-copilot.js
@@ -24,6 +24,13 @@
  * reader with a first-byte timeout and a re-armed inactivity timeout) instead
  * of a blocking fs.readFileSync('/dev/stdin'), so this hook cannot hang
  * Copilot's shutdown path when the spawning process never closes stdin.
+ *
+ * The .agentic/ write is anchored at the nearest .git ancestor of the
+ * payload cwd via hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics,
+ * not the payload cwd verbatim - a stray cd or a drifted harness-supplied
+ * cwd could otherwise write a phantom .agentic/ tree wherever the process
+ * happens to be. On resolution failure (no .git ancestor found), the write
+ * is SKIPPED entirely rather than falling back to the unresolved cwd.
  */
 
 'use strict';
@@ -31,6 +38,7 @@
 const fs = require('fs');
 const path = require('path');
 const { readStdinGuarded } = require('../../hooks/lib/stdin-guard.js');
+const { resolveAgenticCwdWithDiagnostics } = require('../../hooks/lib/repo-root.js');
 
 // Always exit with valid JSON for Copilot Stop hook compliance. Hoisted to
 // module scope so both run()'s internal paths and the top-level run().catch()
@@ -66,6 +74,17 @@ async function run() {
     process.exit(0);
   }
 
+  // --- 3b. Resolve the repo root anchoring the .agentic/ write, instead of
+  // trusting the payload-supplied cwd verbatim. On resolution failure (no
+  // .git ancestor found), SKIP the write entirely - never fall back to the
+  // unresolved cwd, which would silently reproduce the phantom-tree bug
+  // this resolver exists to prevent.
+  const { root: agenticRoot, foundGitAncestor } = resolveAgenticCwdWithDiagnostics(cwd);
+  if (!foundGitAncestor) {
+    process.stdout.write(successOutput);
+    process.exit(0);
+  }
+
   const sessionId = typeof payload.session_id === 'string'
     ? payload.session_id
     : '(unknown)';
@@ -79,7 +98,7 @@ async function run() {
     : '(unknown)';
 
   // --- 4. Compute output path ---
-  const agenticDir = path.join(cwd, '.agentic');
+  const agenticDir = path.join(agenticRoot, '.agentic');
   const outputPath = path.join(agenticDir, 'context.md');
 
   // --- 5. Format content ---

--- a/.opencode/plugins/session-context.ts
+++ b/.opencode/plugins/session-context.ts
@@ -11,8 +11,9 @@
  * Public API: SessionContextPlugin — exported plugin function for OpenCode.
  *
  * Upstream deps: Bun runtime APIs ($, Bun.file, Bun.write). Node built-in
- *                path. Node fs/promises (appendFile, rename). OpenCode SDK
- *                client (client.app.log, client.session.prompt).
+ *                path. Node fs/promises (appendFile, rename). Node fs
+ *                (existsSync, realpathSync - DS-176's resolveAgenticRoot).
+ *                OpenCode SDK client (client.app.log, client.session.prompt).
  *
  * Downstream consumers: OpenCode plugin system (loaded from
  *                        ~/.config/opencode/plugins/ or .opencode/plugins/).

--- a/.opencode/plugins/session-context.ts
+++ b/.opencode/plugins/session-context.ts
@@ -123,12 +123,69 @@
 
 import path from 'path';
 import { appendFile, rename, readdir, stat } from 'fs/promises';
+import { existsSync, realpathSync } from 'fs';
 import type { Plugin } from "@opencode-ai/plugin";
 
 interface ToolExecuteArgs {
   file_path?: string;
   path?: string;
   command?: string;
+}
+
+/** Mirrors hooks/lib/repo-root.js's MAX_DEPTH - see resolveAgenticRoot below. */
+const AGENTIC_ROOT_MAX_DEPTH = 64;
+
+/**
+ * Resolve the repo root anchoring `.agentic/` writes, instead of trusting
+ * `directory || process.cwd()` verbatim. Realpath-pins the start dir, then
+ * walks up looking for a `.git` entry (file OR directory - EXISTENCE ONLY,
+ * never isDirectory()/isFile(): a linked git worktree's `.git` is a FILE,
+ * not a directory, so a dir-only check fails in the most common execution
+ * environment here). Never throws.
+ *
+ * INTENTIONAL PARALLEL IMPLEMENTATION of
+ * hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics - duplicated
+ * inline rather than required, because this is a standalone Bun plugin
+ * loaded from ~/.config/opencode/plugins/ where the repo's hooks/ tree is
+ * not reachable (same constraint already documented above for
+ * resolveLoopStateCandidates and the shard/rollup composer).
+ * THE TWO MUST CHANGE TOGETHER IN THE SAME PR; nothing mechanical enforces
+ * it, and check-adapter-sync cannot see this file at all.
+ *
+ * Unlike most `hooks/lib/repo-root.js` JS consumers (which use the
+ * returned path unconditionally and treat a false foundGitAncestor as a
+ * degraded-but-tolerable advisory write), every call site in THIS file
+ * belongs to the stricter category: it checks foundGitAncestor explicitly
+ * and SKIPS the write entirely when it is false, matching
+ * hooks/session-start-wrap.sh and hooks/enforce-skeptic-round-cap.py.
+ * Falling back to the unresolved start dir would silently reproduce the
+ * exact phantom-`.agentic`-tree bug this resolver exists to prevent.
+ */
+function resolveAgenticRoot(startDir: string): { root: string; foundGitAncestor: boolean } {
+  let real: string;
+  try {
+    real = realpathSync(startDir);
+  } catch (_err) {
+    real = startDir;
+  }
+
+  let current = real;
+  for (let i = 0; i <= AGENTIC_ROOT_MAX_DEPTH; i += 1) {
+    let hasGit = false;
+    try {
+      hasGit = existsSync(path.join(current, '.git'));
+    } catch (_err) {
+      hasGit = false;
+    }
+    if (hasGit) {
+      return { root: current, foundGitAncestor: true };
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return { root: real, foundGitAncestor: false };
 }
 
 const ACTIVITY_SENTINEL = '\n\n---\n\n## Session Activity\n';
@@ -1074,7 +1131,16 @@ ${toolsLine}
         await log("info", "session.idle event handler entered");
 
         try {
-          const cwd = directory || process.cwd();
+          const startDir = directory || process.cwd();
+          const { root: cwd, foundGitAncestor } = resolveAgenticRoot(startDir);
+          if (!foundGitAncestor) {
+            await log(
+              "warn",
+              "Skipping session.idle .agentic write: no .git ancestor found",
+              { startDir },
+            );
+            return;
+          }
           const dateStr = new Date().toISOString().slice(0, 10);
           const idleSessionID: string | null = props.sessionID ?? null;
           await log("info", "session.idle event fired", { cwd, date: dateStr });
@@ -1123,7 +1189,16 @@ ${toolsLine}
         );
 
         try {
-          const cwd = directory || process.cwd();
+          const startDir = directory || process.cwd();
+          const { root: cwd, foundGitAncestor } = resolveAgenticRoot(startDir);
+          if (!foundGitAncestor) {
+            await log(
+              "warn",
+              "Skipping /ds-wrap finalization writes: no .git ancestor found",
+              { startDir },
+            );
+            return;
+          }
           const dateStr = new Date().toISOString().slice(0, 10);
 
           // Best-effort: write this session's shard and recompose the rollup.

--- a/bin/tests/test_agentic_site_inventory_coverage.py
+++ b/bin/tests/test_agentic_site_inventory_coverage.py
@@ -12,26 +12,66 @@ Purpose: Coverage-diff gate for DS-171's repo-root anchoring fix. Re-derives
     write with no gate ever noticing.
 
     DS-176 REWORK (adapter-hooks-agentic-root): SCAN_DIRS now also covers
-    the hand-authored, non-build-generated adapter hook/plugin surfaces -
-    ".cursor/hooks", ".copilot/hooks", ".github/hooks", ".gemini/hooks",
-    ".kimi/hooks", ".opencode/plugins" - which were the LAST remaining path
-    to the phantom-.agentic-tree bug class this gate exists to close (the
-    original DS-171 pass covered hooks/**, bin/**, and the Claude Code Bash
-    hook, but explicitly NOT the adapter dirs, because build.sh does not
-    regenerate them and check-adapter-sync cannot see them). Deliberately
-    scoped to each adapter's `hooks/` (or `.opencode/plugins/`)
-    SUBDIRECTORY, never the adapter's full top-level tree: every adapter
-    directory also holds a build-generated, verbatim copy of content/**
-    (references/, commands/, agents/, skills/, templates/ - including, for
-    .cursor and .gemini, a templates/.agentic/ SCAFFOLD directory whose
-    files are literal `/ds-init-project` templates, not executable code)
-    - scanning those would flood candidates with prose matches on the
-    literal string ".agentic" inside markdown, none of which are path-
-    construction sites. The `hooks/`-or-`plugins/`-only subdirectory is the
-    narrowest rule that still catches every adapter's actual executable
-    surface: verified empirically (see this file's own git history) that
-    each of the six new SCAN_DIRS entries currently holds ONLY hook
-    scripts/plugins, zero generated markdown.
+    the hand-authored, non-build-generated adapter hook/plugin/extension
+    surfaces - ".cursor/hooks", ".copilot/hooks", ".github/hooks",
+    ".gemini/hooks", ".kimi/hooks", ".opencode/plugins", ".codex/hooks",
+    ".pi/extensions/dinostack" - which close the phantom-.agentic-tree bug
+    class this gate exists to catch (the original DS-171 pass covered
+    hooks/**, bin/**, and the Claude Code Bash hook, but explicitly NOT the
+    adapter dirs, because build.sh does not regenerate them and
+    check-adapter-sync cannot see them). Deliberately scoped to each
+    adapter's hand-authored hook/plugin/extension SUBDIRECTORY, never the
+    adapter's full top-level tree: every adapter directory also holds a
+    build-generated, verbatim copy of content/** (references/, commands/,
+    agents/, skills/, templates/ - including, for .cursor and .gemini, a
+    templates/.agentic/ SCAFFOLD directory whose files are literal
+    `/ds-init-project` templates, not executable code) - scanning those
+    would flood candidates with prose matches on the literal string
+    ".agentic" inside markdown, none of which are path-construction sites.
+
+    DS-176 ROUND-2 REWORK (Major 1: the six-entry list above was confirm-only -
+    each dir was individually verified to hold hooks and nothing else, but
+    the set itself was never independently derived, so it silently omitted
+    ".codex/hooks" (3 files: risk-reminder.sh, stop-context-codex.js, and a
+    symlinked skill-auto-load-check.sh -> ../../hooks/skill-auto-load-
+    check.sh that the scanner's is_symlink() skip already handles) and
+    ".pi/extensions/dinostack" (index.ts) entirely): the eight SCAN_DIRS
+    adapter entries above were derived by enumerating the FULL set of
+    adapter roots this repo builds (the 11-entry pathspec asserted by
+    ".github/workflows/adapter-sync.yml"'s "Verify adapter-sync pathspec
+    entries exist" step: .claude .codex .cursor .gemini .kimi .opencode
+    .omp .pi .hermes .openclaw .copilot, plus the .github/* subpaths),
+    then running `find <each-root> -maxdepth 2 -type d` over all 11 and
+    keeping every directory name matching hook/plugin/extension/script.
+    That surfaced exactly eight hits: .copilot/hooks, .github/hooks,
+    .kimi/hooks, .opencode/plugins, .pi/extensions (containing the single
+    dinostack/ subdir, scanned directly rather than its parent so the scan
+    stays scoped to hand-authored code, not a future sibling extension
+    directory of unknown shape), .codex/hooks, .cursor/hooks, .gemini/hooks
+    - .claude, .omp, .hermes, and .openclaw have no such directory at this
+    depth (Claude Code's hooks are wired via settings.json, not a
+    hooks/-shaped directory in the adapter tree). Each of the eight
+    SCAN_DIRS adapter entries was then individually verified (as before) to
+    hold only hook/plugin/extension code, zero generated markdown - but
+    that per-entry confirmation is no longer the sole method establishing
+    the set is complete.
+
+    The same `find`-derived sweep also surfaced ".codex/lib/prompt-
+    wrappers.py", which builds two ".agentic"-shaped paths (RUNTIME_REL at
+    module scope, and `paths.repo / ".agentic"`) but sits under ".codex/lib"
+    (not ".codex/hooks"), i.e. it is not, and never was, inside SCAN_DIRS -
+    it is out of scope by directory selection, not by an EXCLUDED_FILES
+    entry. Decision: it stays out of scope, deliberately not added to
+    SCAN_DIRS or EXCLUDED_FILES. Every `.agentic` site in that module
+    derives from `paths.repo`, which comes from its parser's `--repo`
+    argument (argparse `required=True`, no cwd default,
+    ".codex/lib/prompt-wrappers.py:3052,3056") - the same explicit-required-
+    argument exemption rationale already applied to bin/ds-doctor,
+    bin/ds-evaluate, bin/ds-migrate, and bin/ds-team above, not the bare-
+    cwd-fallback drift-prone class this gate exists to catch. It is a
+    build-time prompt-generation tool invoked by ".codex/build.sh" and by a
+    human operator, never by a live hooks/*.js or hooks/*.py call site
+    reading a harness-payload cwd.
 
     NAMING NOTE: the originating spec named this file with hyphens
     (bin/tests/test-agentic-site-inventory-coverage.py). bin/tests/ is
@@ -111,10 +151,13 @@ INVENTORY_PATH = REPO_ROOT / "hooks" / "tests" / "fixtures" / "agentic-write-sit
 # directory. bin/ has no subdirectories today but is walked recursively
 # too for the same forward-looking reason "hooks" is.
 #
-# DS-176: the six adapter hook/plugin subdirectories below are scanned in
-# addition - see the DS-176 REWORK paragraph in this file's module
-# docstring for why each is scoped to exactly `hooks/` (or
-# `.opencode/plugins/`) and not its adapter's full top-level tree.
+# DS-176: the eight adapter hook/plugin/extension subdirectories below are
+# scanned in addition - see the DS-176 REWORK and DS-176 ROUND-2 REWORK
+# paragraphs in this file's module docstring for how the set was derived
+# (enumerated from all 11 adapter roots, not confirmed against a
+# pre-picked list) and why each is scoped to its adapter's hand-authored
+# hooks/plugins/extension subdirectory, never the adapter's full top-level
+# tree.
 SCAN_DIRS = [
     "hooks",
     "bin",
@@ -124,11 +167,13 @@ SCAN_DIRS = [
     ".gemini/hooks",
     ".kimi/hooks",
     ".opencode/plugins",
+    ".codex/hooks",
+    ".pi/extensions/dinostack",
 ]
 
 # File extensions considered ("" covers extension-less bin/ CLIs; ".ts" is
-# DS-176's addition, needed solely for .opencode/plugins/session-context.ts -
-# no other SCAN_DIRS entry contains a .ts file today).
+# DS-176's addition, needed for .opencode/plugins/session-context.ts and
+# .pi/extensions/dinostack/index.ts).
 CANDIDATE_EXTENSIONS = {".js", ".py", ".sh", ".ts", ""}
 
 # The resolver modules themselves are what DOES the resolving, not a site

--- a/bin/tests/test_agentic_site_inventory_coverage.py
+++ b/bin/tests/test_agentic_site_inventory_coverage.py
@@ -11,6 +11,28 @@ Purpose: Coverage-diff gate for DS-171's repo-root anchoring fix. Re-derives
     silently reintroduce a cwd-relative (non-repo-root-anchored) .agentic/
     write with no gate ever noticing.
 
+    DS-176 REWORK (adapter-hooks-agentic-root): SCAN_DIRS now also covers
+    the hand-authored, non-build-generated adapter hook/plugin surfaces -
+    ".cursor/hooks", ".copilot/hooks", ".github/hooks", ".gemini/hooks",
+    ".kimi/hooks", ".opencode/plugins" - which were the LAST remaining path
+    to the phantom-.agentic-tree bug class this gate exists to close (the
+    original DS-171 pass covered hooks/**, bin/**, and the Claude Code Bash
+    hook, but explicitly NOT the adapter dirs, because build.sh does not
+    regenerate them and check-adapter-sync cannot see them). Deliberately
+    scoped to each adapter's `hooks/` (or `.opencode/plugins/`)
+    SUBDIRECTORY, never the adapter's full top-level tree: every adapter
+    directory also holds a build-generated, verbatim copy of content/**
+    (references/, commands/, agents/, skills/, templates/ - including, for
+    .cursor and .gemini, a templates/.agentic/ SCAFFOLD directory whose
+    files are literal `/ds-init-project` templates, not executable code)
+    - scanning those would flood candidates with prose matches on the
+    literal string ".agentic" inside markdown, none of which are path-
+    construction sites. The `hooks/`-or-`plugins/`-only subdirectory is the
+    narrowest rule that still catches every adapter's actual executable
+    surface: verified empirically (see this file's own git history) that
+    each of the six new SCAN_DIRS entries currently holds ONLY hook
+    scripts/plugins, zero generated markdown.
+
     NAMING NOTE: the originating spec named this file with hyphens
     (bin/tests/test-agentic-site-inventory-coverage.py). bin/tests/ is
     discovered by `pytest bin/tests/ -q` (see .github/workflows/
@@ -88,10 +110,26 @@ INVENTORY_PATH = REPO_ROOT / "hooks" / "tests" / "fixtures" / "agentic-write-sit
 # once as a descendant of "hooks"), duplicating every candidate in that
 # directory. bin/ has no subdirectories today but is walked recursively
 # too for the same forward-looking reason "hooks" is.
-SCAN_DIRS = ["hooks", "bin"]
+#
+# DS-176: the six adapter hook/plugin subdirectories below are scanned in
+# addition - see the DS-176 REWORK paragraph in this file's module
+# docstring for why each is scoped to exactly `hooks/` (or
+# `.opencode/plugins/`) and not its adapter's full top-level tree.
+SCAN_DIRS = [
+    "hooks",
+    "bin",
+    ".cursor/hooks",
+    ".copilot/hooks",
+    ".github/hooks",
+    ".gemini/hooks",
+    ".kimi/hooks",
+    ".opencode/plugins",
+]
 
-# File extensions considered ("" covers extension-less bin/ CLIs).
-CANDIDATE_EXTENSIONS = {".js", ".py", ".sh", ""}
+# File extensions considered ("" covers extension-less bin/ CLIs; ".ts" is
+# DS-176's addition, needed solely for .opencode/plugins/session-context.ts -
+# no other SCAN_DIRS entry contains a .ts file today).
+CANDIDATE_EXTENSIONS = {".js", ".py", ".sh", ".ts", ""}
 
 # The resolver modules themselves are what DOES the resolving, not a site
 # to be resolved - excluded from candidate scanning. Also excluded: files

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -6,8 +6,8 @@ below (12 Python PreToolUse/Stop enforcers, 7 Node lifecycle handlers, 3 Bash he
 `pre-commit` is also present but is a git hook, not a Claude Code lifecycle
 hook, and is out of scope for this table. `lib/` holds shared utilities;
 the repo-root resolver trio specifically (`lib/repo_root.py`/
-`lib/repo-root.js`/`lib/repo-root.sh`, added by DS-171) is consumed by 7 JS
-hooks, 5 Python hooks, 1 Bash hook, and 6 `bin/` scripts respectively - see
+`lib/repo-root.js`/`lib/repo-root.sh`, added by DS-171) is consumed by 10 JS
+hooks, 5 Python hooks, 3 Bash hooks, and 6 `bin/` scripts respectively - see
 the `lib/` table below for the three new rows and their exact consumer
 lists. Other `lib/` modules have their own, different consumer counts
 (round-3 rework, Major 5: this previously said "the JS hooks and one bin
@@ -15,7 +15,21 @@ script", stale since the trio was added; round-4 rework, Minor 1: the
 "5/1/6" figures scoped this sentence to the trio only, since the same
 sentence used to read as a `lib/`-wide claim and contradicted
 `lib/enforcement_log.py`'s own row, which is consumed by all twelve
-enforce-*.py hooks, not five). Each script ships with a
+enforce-*.py hooks, not five; DS-176 round-2 rework: bumped 7 JS -> 10 JS
+and 1 Bash -> 3 Bash for the 3 new adapter hook consumers added by
+DS-176's stop-context and session-start ports; this trio's 7/5/1/6 counts
+have now drifted twice (once before this rework, once during it) with no
+mechanical gate catching either. `_ENFORCER_SUBCOUNT_SITES` in
+`bin/tests/test_tracker_writeback_ranking_spec.py` explicitly excludes
+this trio by name ("a DIFFERENT fact about a different module... are
+deliberately not derived here") because it derives its counts from a
+uniform `hooks/enforce-*.py` glob, whereas this trio's consumers are
+scattered across `hooks/`, `bin/`, and per-adapter directories with no
+single glob or `require`/`source`/`import` discovery helper today - adding
+one is a real, separate unit of work, not a cheap extension of the
+existing sweep. Deferred, not silently dropped: counts corrected by hand
+in this rework, mechanical enforcement left as a named gap). Each script
+ships with a
 module-manifest docstring; read the script for full detail. This file is the
 module-group map.
 
@@ -60,8 +74,8 @@ module-group map.
 | `lib/enforcement_log.py` | Shared fire-logging helper: appends one line to `.agentic/.enforcement-fires.jsonl`. Dynamically imported (best-effort, fails open to a no-op), lazily from inside each caller's logging branch, by all twelve enforce-*.py hooks. Two caller postures: ACTION-ONLY (eleven hooks) logs only a non-passthrough action - a deny, or an allow-with-advisory-reason - and a silent allow never calls it; EVERY-VERDICT (`enforce-no-abdication.py` alone) also logs plain `"allow"` rows for every verdict path reached after its enablement gate, because action-only logging leaves "this guard never fires" unfalsifiable. The every-verdict posture is safe only for a Stop hook (once per conductor turn); do not copy it to a PreToolUse hook, which runs at tool-call volume. Accepts an optional keyword-only `detail` dict for structured discriminators, omitted from the line entirely when absent so every action-only caller's row stays byte-identical to the canonical 4-field schema. `enforce-no-abdication.py` additionally keeps its own pre-existing `.abdication-guard-fire-count` counter file, which this module never touches. |
 | `lib/git_worktree.py` | Shared `is_git_worktree(caller_root)` discriminator: True only when `caller_root`'s `.git` entry is a FILE whose gitdir pointer contains `/worktrees/` (a genuine linked git worktree), False for an ordinary subdirectory, a submodule (`/modules/` gitdir), an independent nested clone (`.git` as a real directory), or any unparseable/unreadable `.git`. Fails to False on every ambiguity - only ever narrows a caller's deny path, never widens it. Dynamically imported (best-effort, fails open to `False`) by both `enforce-worktree-read.py` and `enforce-worktree-write.py`. Not an `enforce-*.py` hook itself - no `main()`, never registered in `~/.claude/settings.json`, not subject to `bin/ds-doctor`'s `MANAGED_HOOK_BASENAMES` or any enforcer subcount. |
 | `lib/repo_root.py` | DS-171: resolves the repo-root directory to anchor `.agentic/` state writes/reads instead of trusting a harness-payload `cwd` verbatim (`.git`-ancestor walk, existence-only, file-or-dir). `resolve_agentic_cwd_with_diagnostics(start_dir)` returns `{root, drift_levels, found_git_ancestor}`; `resolve_agentic_cwd(start_dir)` returns just `root`. Consumed via a lazy `importlib.util` dynamic loader (best-effort, fails open to `None`/raw cwd depending on caller) by 5 Python hooks (`enforce-no-abdication.py`, `enforce-shippable-edit.py`, `enforce-planning-artifact-spawn.py`, `enforce-skeptic-round-cap.py`, `enforce-turn-shape.py`), 2 sibling `lib/` modules (`lib/enforcement_log.py`, `lib/loop_guard.py`), and 6 `bin/` scripts (`bin/ds-status`, `bin/ds-cost`, `bin/ds-memory`, `bin/ds-identity`, `bin/ds-codex-dispatch`, `bin/ds-reap-worktrees`). Most callers use the plain `.git`-only result and never fall back further; two callers (`enforce-skeptic-round-cap.py`'s round-counter state path and `bin/ds-identity`'s Stop-hook session-log `write-hook`/`resolve-hook`) genuinely SKIP the write/read entirely when `found_git_ancestor` is False, since a write at the wrong location would corrupt cross-session state - see the module's own Failure modes docstring section for the full caller-tier rationale. |
-| `lib/repo-root.js` | Node port of `lib/repo_root.py` (same `.git`-ancestor walk, same `{root, drift_levels, found_git_ancestor}` diagnostics shape). Consumed by 7 JS hooks: `session-end-wrap.js`, `post-tool-use-capture-nudge.js`, `conductor-overreach-nudge.js`, `pre-tool-use-spawn-emit.js`, `subagent-stop-spawn-emit.js`, `stop-context.js`, `wrap-daemon.js`. |
-| `lib/repo-root.sh` | Bash port of `lib/repo_root.py`/`lib/repo-root.js` for the one Bash hook that needs it, `session-start-wrap.sh`; every `.agentic/` write it guards is conditioned on `-n "$resolved_root"` (zero fallback on resolution failure - the strict-skip tier, same discipline as `enforce-skeptic-round-cap.py` and `bin/ds-identity`'s write-hook above). |
+| `lib/repo-root.js` | Node port of `lib/repo_root.py` (same `.git`-ancestor walk, same `{root, drift_levels, found_git_ancestor}` diagnostics shape). Consumed by 10 JS hooks: `session-end-wrap.js`, `post-tool-use-capture-nudge.js`, `conductor-overreach-nudge.js`, `pre-tool-use-spawn-emit.js`, `subagent-stop-spawn-emit.js`, `stop-context.js`, `wrap-daemon.js`, plus DS-176's `.copilot/hooks/stop-context-copilot.js`, `.github/hooks/stop-context-copilot.js`, and `.cursor/hooks/stop-context-cursor.js` (`.opencode/plugins/session-context.ts` is NOT a consumer - a standalone TS reimplementation, not a `require()` of this file; see this file's own module docstring). |
+| `lib/repo-root.sh` | Bash port of `lib/repo_root.py`/`lib/repo-root.js`, consumed by 3 Bash hooks: `session-start-wrap.sh`, plus DS-176's `.copilot/hooks/session-start-copilot.sh` and `.github/hooks/session-start-copilot.sh`; every `.agentic/` write it guards is conditioned on `-n "$resolved_root"`/`-n "$CWD"` (zero fallback on resolution failure - the strict-skip tier, same discipline as `enforce-skeptic-round-cap.py` and `bin/ds-identity`'s write-hook above). |
 | `lib/loop_guard.py` | Shared two-layer loop-guard machinery for the two Stop hooks that act on the conductor's final message (`enforce-no-abdication.py` and `enforce-turn-shape.py`): the `stop_hook_active` primary guard is checked by the hooks themselves, and this module supplies the Layer-2 counter-cap backstop (CC bug #54360) - per-hook counter filename + cap, `read_counter`/`write_counter`/`reset_counter` (pid-suffixed tmp + atomic replace, fail-open toward allow), and `count_user_messages`/`is_genuine_user_turn`/`last_genuine_user_text` (filters out tool_result, meta, and harness-injected lines; `last_genuine_user_text` added DS-155 for `enforce-turn-shape.py`'s answer-warrant detector). Counter files: `.abdication-guard-fire-count` (cap 2) and `.turn-shape-guard-fire-count` (cap 2), both under `.agentic/`. |
 
 ## Upstream dependencies

--- a/hooks/lib/repo-root.js
+++ b/hooks/lib/repo-root.js
@@ -16,7 +16,15 @@
  *   hooks/session-end-wrap.js, hooks/wrap-daemon.js,
  *   hooks/lib/skill-candidate-detector.js, hooks/lib/state-mark.js,
  *   hooks/lib/capture-gap.js, hooks/lib/context-rollup.js,
- *   bin/ds-wrap-acquire-lock, bin/ds-wrap-release-lock
+ *   bin/ds-wrap-acquire-lock, bin/ds-wrap-release-lock,
+ *   .copilot/hooks/stop-context-copilot.js,
+ *   .github/hooks/stop-context-copilot.js,
+ *   .cursor/hooks/stop-context-cursor.js (DS-176, adapter-hooks-agentic-root
+ *   - 3 new adapter JS consumers, each requiring
+ *   resolveAgenticCwdWithDiagnostics; .opencode/plugins/session-context.ts
+ *   is NOT a consumer here - it is a verbatim, standalone TS
+ *   reimplementation of the same algorithm, not a `require()` of this
+ *   module, see hooks/tests/test-opencode-agentic-root.js)
  *
  * Failure modes: never throws. EACCES/ENOENT at any level along the walk is
  *   treated as "not found here, keep walking". If no `.git` ancestor is
@@ -60,7 +68,18 @@
  *   added to this stricter category in the same round-2 rework: telemetry
  *   misattributed to a phantom non-repo `.agentic/session-log/` is a
  *   correctness bug (wrong developer_id/project_slug), not a merely
- *   degraded advisory. Callers needing the SKIP discipline must consult
+ *   degraded advisory.
+ *
+ *   DS-176 (adapter-hooks-agentic-root): the 3 adapter JS consumers listed
+ *   above - `.copilot/hooks/stop-context-copilot.js`,
+ *   `.github/hooks/stop-context-copilot.js`, and
+ *   `.cursor/hooks/stop-context-cursor.js` - also belong in this stricter
+ *   SKIP category: each calls `resolveAgenticCwdWithDiagnostics` and
+ *   returns/no-ops when `foundGitAncestor` is false, rather than writing at
+ *   the fallback root. They are NOT part of the "12 JS consumers ...
+ *   discards foundGitAncestor" count two paragraphs above.
+ *
+ *   Callers needing the SKIP discipline must consult
  *   `foundGitAncestor` explicitly via `resolveAgenticCwdWithDiagnostics`
  *   and refuse the write themselves when it is false - this module never
  *   enforces that policy on a caller's behalf.

--- a/hooks/lib/repo-root.sh
+++ b/hooks/lib/repo-root.sh
@@ -1,5 +1,5 @@
 # Purpose: Resolves the repo-root directory to anchor `.agentic/` state
-#          writes for session-start-wrap.sh, instead of trusting the
+#          reads/writes for shell hooks, instead of trusting the
 #          harness-supplied payload cwd verbatim. No python3 or node
 #          dependency - shells out to `git rev-parse --show-toplevel`.
 #
@@ -8,7 +8,10 @@
 #
 # Upstream deps: git (rev-parse --show-toplevel)
 #
-# Downstream consumers: hooks/session-start-wrap.sh
+# Downstream consumers: hooks/session-start-wrap.sh,
+#   .copilot/hooks/session-start-copilot.sh, .github/hooks/session-start-copilot.sh
+#   (the latter two are hand-duplicated copies of each other, not
+#   build-generated - keep them in sync by hand on any future edit)
 #
 # Failure modes: on any failure (start dir does not exist, not inside a
 #   git repo, git not on PATH) prints an EMPTY STRING. Callers MUST skip
@@ -22,19 +25,19 @@
 #   `.git` directory itself and requires `git` on PATH, where the JS/Py
 #   walk is existence-only (checks for a `.git` entry at each level) and
 #   has no external dependency. This divergence is DELIBERATE, not an
-#   unfixed bug: this file's sole consumer, hooks/session-start-wrap.sh,
-#   is a plain POSIX shell hook with no python3/node guarantee at the
-#   point it runs (SessionStart, before any harness-specific runtime
-#   assumption is safe to make) - `git` is the one dependency that
-#   invocation environment can actually assume, since the hook is already
-#   operating on a git checkout by construction. Re-implementing the
-#   existence-only walk in bash would add real complexity (directory
-#   traversal, symlink-safe realpath) to remove a dependency that is
-#   already guaranteed present, for a resolver with exactly one caller
-#   that already fails safe (empty-string skip, `-n "$resolved_root"`
-#   guard, zero `|| echo "$cwd"` fallback - verified correct and
-#   unchanged by this rework). If a second, non-git-guaranteed caller of
-#   this file is ever added, revisit this decision.
+#   unfixed bug: this file's consumers are all plain POSIX shell hooks with
+#   no python3/node guarantee at the point they run (SessionStart, before
+#   any harness-specific runtime assumption is safe to make) - `git` is the
+#   one dependency that invocation environment can actually assume, since
+#   the hook is already operating on a git checkout by construction.
+#   Re-implementing the existence-only walk in bash would add real
+#   complexity (directory traversal, symlink-safe realpath) to remove a
+#   dependency that is already guaranteed present. Every consumer already
+#   fails safe (empty-string skip, `-n "$resolved_root"` guard or
+#   equivalent, zero `|| echo "$cwd"`/`|| echo "$(pwd)"` fallback -
+#   verified correct for all three at last audit). If a caller of this
+#   file that CANNOT assume git-on-PATH is ever added, revisit this
+#   decision for that caller specifically.
 #
 # Performance: one `git rev-parse` subprocess call per invocation.
 

--- a/hooks/tests/fixtures/agentic-write-sites.txt
+++ b/hooks/tests/fixtures/agentic-write-sites.txt
@@ -43,6 +43,10 @@
 .cursor/hooks/stop-context-cursor.js::const agenticDir = path.join(agenticRoot, '.agentic');
 .github/hooks/session-start-copilot.sh::CONTEXT_FILE="$CWD/.agentic/context.md"
 .github/hooks/stop-context-copilot.js::const agenticDir = path.join(agenticRoot, '.agentic');
+# Reviewed, confirmed harmless: message-string concatenation (rollup
+# footer text), not a path-construction site - the same category as
+# hooks/lib/context-rollup.js's near-identical "*Derived from
+# .agentic/context.d/ - " line below.
 .opencode/plugins/session-context.ts::"\n*Derived from .agentic/context.d/ - " +
 .opencode/plugins/session-context.ts::agenticDir: path.join(cwd, ".agentic"),
 .opencode/plugins/session-context.ts::const agenticDir = path.join(cwd, ".agentic");

--- a/hooks/tests/fixtures/agentic-write-sites.txt
+++ b/hooks/tests/fixtures/agentic-write-sites.txt
@@ -38,6 +38,18 @@
 # been reviewed and confirmed harmless (not a real path-construction
 # site), not silently accepted.
 
+.copilot/hooks/session-start-copilot.sh::CONTEXT_FILE="$CWD/.agentic/context.md"
+.copilot/hooks/stop-context-copilot.js::const agenticDir = path.join(agenticRoot, '.agentic');
+.cursor/hooks/stop-context-cursor.js::const agenticDir = path.join(agenticRoot, '.agentic');
+.github/hooks/session-start-copilot.sh::CONTEXT_FILE="$CWD/.agentic/context.md"
+.github/hooks/stop-context-copilot.js::const agenticDir = path.join(agenticRoot, '.agentic');
+.opencode/plugins/session-context.ts::"\n*Derived from .agentic/context.d/ - " +
+.opencode/plugins/session-context.ts::agenticDir: path.join(cwd, ".agentic"),
+.opencode/plugins/session-context.ts::const agenticDir = path.join(cwd, ".agentic");
+.opencode/plugins/session-context.ts::const batchStatePath = path.join(cwd, ".agentic", "batch-state.json");
+.opencode/plugins/session-context.ts::const eventsPath = path.join(cwd, ".agentic", "events.jsonl");
+.opencode/plugins/session-context.ts::const projectDir = path.join(cwd, ".agentic");
+.opencode/plugins/session-context.ts::const shardDir = path.join(cwd, ".agentic", "context.d");
 bin/ds-cost::EVENTS_PATH = _agentic_root() / ".agentic" / "events.jsonl"
 bin/ds-cost::Path(".agentic/..."). Constants, not functions, so
 bin/ds-cost::SESSION_LOG_DIR = _agentic_root() / ".agentic" / "session-log"

--- a/hooks/tests/test-opencode-agentic-root.js
+++ b/hooks/tests/test-opencode-agentic-root.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Behavioral test: .opencode/plugins/session-context.ts's resolveAgenticRoot
+ * (DS-176, adapter-hooks-agentic-root) and its two call sites (session.idle,
+ * command.executed), which anchor every `.agentic/` write at the nearest
+ * `.git` ancestor of `directory || process.cwd()` instead of trusting that
+ * value verbatim, and SKIP the write entirely (never fall back to the
+ * unresolved start dir) when no `.git` ancestor is found.
+ *
+ * WHY THIS TEST EXTRACTS RATHER THAN SPAWNS. This is a standalone Bun
+ * plugin (Bun.file, Bun.write, the `$` shell tag) loaded from
+ * ~/.config/opencode/plugins/ - there is no OpenCode runtime in CI to
+ * execute it against, and `bun` itself is not installed in this repo's CI
+ * (see .github/workflows/hooks-tests.yml - no bun setup step), so a real
+ * end-to-end spawn is not an option here, unlike the Cursor/Copilot JS
+ * hooks. hooks/tests/test-opencode-rollup-parity.js established the
+ * accepted precedent for this file: a STRUCTURAL regex-based check that
+ * fails loudly on drift.
+ *
+ * This test goes one step further where it can: resolveAgenticRoot itself
+ * uses ONLY Node built-ins (fs.existsSync, fs.realpathSync, path) - no
+ * Bun-specific API - so its source is extracted verbatim from the .ts file,
+ * has its known TS type annotations stripped (targeted string replacement,
+ * not a general TS-to-JS transpile - adequate because this test controls
+ * exactly which annotations it expects: the function signature's parameter
+ * type + return type, and the one `let real: string;` local declaration -
+ * and asserts all were found), and is `new Function`-evaluated in-process.
+ * This gives REAL behavioral
+ * coverage of the resolver logic itself (not just a regex match), while
+ * the two call-site checks below (skip-on-no-git-ancestor wiring) remain
+ * structural, same as the rest of this file's sibling parity test.
+ *
+ * If this extraction ever breaks (e.g. the function gains a third TS
+ * annotation, or starts using a Bun-only API), the STRIP assertion below
+ * fails loudly rather than silently testing nothing - see the
+ * "extraction succeeded" assertion.
+ *
+ * Run with: node hooks/tests/test-opencode-agentic-root.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO = path.resolve(__dirname, '..', '..');
+const TS_PATH = path.join(REPO, '.opencode', 'plugins', 'session-context.ts');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+const ts = fs.readFileSync(TS_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// Extract resolveAgenticRoot's source (balanced-brace scan from the
+// function keyword) and strip its two TS type annotations.
+// ---------------------------------------------------------------------------
+
+// NOTE: `signature` must END in the function body's OPENING brace. A naive
+// `src.indexOf('{', start)` search for that opening brace is unsafe here
+// because resolveAgenticRoot's TS return-type annotation
+// (`: { root: string; foundGitAncestor: boolean }`) contains its OWN
+// balanced brace pair BEFORE the body even starts - the first `{` after
+// `start` belongs to the return type, not the function body. Using the
+// known signature's own length to locate the body-opening brace sidesteps
+// that entirely.
+function extractFunctionSource(src, signature) {
+  const start = src.indexOf(signature);
+  if (start === -1) return null;
+  const braceOpen = start + signature.length - 1;
+  if (src[braceOpen] !== '{') return null;
+  let depth = 0;
+  for (let i = braceOpen; i < src.length; i += 1) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+const TS_SIGNATURE = 'function resolveAgenticRoot(startDir: string): { root: string; foundGitAncestor: boolean } {';
+const JS_SIGNATURE = 'function resolveAgenticRoot(startDir) {';
+const TS_LOCAL = 'let real: string;';
+const JS_LOCAL = 'let real;';
+
+let fnSource = extractFunctionSource(ts, TS_SIGNATURE);
+let stripped = false;
+if (fnSource && fnSource.startsWith(TS_SIGNATURE) && fnSource.includes(TS_LOCAL)) {
+  fnSource = JS_SIGNATURE + fnSource.slice(TS_SIGNATURE.length);
+  fnSource = fnSource.replace(TS_LOCAL, JS_LOCAL);
+  stripped = true;
+}
+
+assert(
+  !!fnSource && stripped,
+  'extraction succeeded: resolveAgenticRoot found in session-context.ts with its expected TS signature and local, both stripped cleanly'
+);
+
+const maxDepthMatch = ts.match(/const AGENTIC_ROOT_MAX_DEPTH = (\d+);/);
+assert(!!maxDepthMatch, 'AGENTIC_ROOT_MAX_DEPTH constant found');
+assert(
+  !!maxDepthMatch && maxDepthMatch[1] === '64',
+  `AGENTIC_ROOT_MAX_DEPTH is 64, matching hooks/lib/repo-root.js's MAX_DEPTH (got: ${maxDepthMatch && maxDepthMatch[1]})`
+);
+
+// ---------------------------------------------------------------------------
+// Behavioral: evaluate the extracted function against real fixture trees.
+// ---------------------------------------------------------------------------
+
+if (fnSource && stripped && maxDepthMatch) {
+  // eslint-disable-next-line no-new-func
+  const resolveAgenticRoot = new Function(
+    'existsSync', 'realpathSync', 'path', 'AGENTIC_ROOT_MAX_DEPTH',
+    `${fnSource}\nreturn resolveAgenticRoot;`
+  )(fs.existsSync, fs.realpathSync, path, Number(maxDepthMatch[1]));
+
+  function makeTmp(prefix) {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  }
+  function cleanup(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  }
+
+  // (a) start dir IS the repo root -> foundGitAncestor true, root unchanged.
+  {
+    const repoRoot = makeTmp('ae-opencode-agentic-root-a-');
+    fs.mkdirSync(path.join(repoRoot, '.git'));
+    try {
+      const { root, foundGitAncestor } = resolveAgenticRoot(repoRoot);
+      assert(foundGitAncestor === true, '(a) foundGitAncestor is true when start dir has a .git entry');
+      assert(root === fs.realpathSync(repoRoot), '(a) root is the realpath of the start dir itself');
+    } finally {
+      cleanup(repoRoot);
+    }
+  }
+
+  // (b) drifted subdirectory -> walks up to the repo root, not the drifted dir.
+  {
+    const repoRoot = makeTmp('ae-opencode-agentic-root-b-');
+    fs.mkdirSync(path.join(repoRoot, '.git'));
+    const driftedDir = path.join(repoRoot, 'sub', 'nested', 'drift');
+    fs.mkdirSync(driftedDir, { recursive: true });
+    try {
+      const { root, foundGitAncestor } = resolveAgenticRoot(driftedDir);
+      assert(foundGitAncestor === true, '(b) foundGitAncestor is true for a drifted subdirectory of a real repo');
+      assert(
+        root === fs.realpathSync(repoRoot),
+        `(b) root walks up to the REPO ROOT, not the drifted subdirectory (got: ${root})`
+      );
+    } finally {
+      cleanup(repoRoot);
+    }
+  }
+
+  // (c) no .git ancestor anywhere -> foundGitAncestor false.
+  {
+    const noGitDir = makeTmp('ae-opencode-agentic-root-c-');
+    try {
+      const { foundGitAncestor } = resolveAgenticRoot(noGitDir);
+      assert(foundGitAncestor === false, '(c) foundGitAncestor is false when no .git ancestor exists');
+    } finally {
+      cleanup(noGitDir);
+    }
+  }
+
+  // (d) linked-worktree .git is a FILE, not a directory - existence-only
+  // check must still find it (a .isDirectory() test would fail here).
+  {
+    const repoRoot = makeTmp('ae-opencode-agentic-root-d-');
+    fs.writeFileSync(path.join(repoRoot, '.git'), 'gitdir: ../.git/worktrees/x\n', 'utf8');
+    try {
+      const { foundGitAncestor } = resolveAgenticRoot(repoRoot);
+      assert(
+        foundGitAncestor === true,
+        '(d) a FILE .git entry (linked worktree) is recognized - existence-only, not isDirectory()'
+      );
+    } finally {
+      cleanup(repoRoot);
+    }
+  }
+} else {
+  console.error('  SKIP: behavioral cases skipped - extraction failed (see the "extraction succeeded" assertion above)');
+}
+
+// ---------------------------------------------------------------------------
+// Structural: both event-handler call sites must check foundGitAncestor and
+// SKIP (return early) rather than falling back to the unresolved start dir.
+//
+// Reddening mutation: reverting either `const { root: cwd, foundGitAncestor }
+// = resolveAgenticRoot(startDir); if (!foundGitAncestor) { ...; return; }`
+// block back to the pre-fix `const cwd = directory || process.cwd();` makes
+// these assertions fail - the call site would no longer anchor the write or
+// skip on resolution failure.
+// ---------------------------------------------------------------------------
+
+console.log('\n--- call-site wiring ---');
+{
+  assert(
+    !/const cwd = directory \|\| process\.cwd\(\);/.test(ts),
+    'the pre-fix unresolved `directory || process.cwd()` assignment to cwd is gone'
+  );
+
+  const idleSite = ts.match(/if \(type === "session\.idle"\) \{[\s\S]{0,600}?resolveAgenticRoot\(startDir\)[\s\S]{0,300}?if \(!foundGitAncestor\) \{[\s\S]{0,200}?return;/);
+  assert(!!idleSite, 'session.idle handler resolves via resolveAgenticRoot and skips (return) when foundGitAncestor is false');
+
+  const wrapSite = ts.match(/if \(type === "command\.executed"\) \{[\s\S]{0,1200}?resolveAgenticRoot\(startDir\)[\s\S]{0,300}?if \(!foundGitAncestor\) \{[\s\S]{0,200}?return;/);
+  assert(!!wrapSite, 'command.executed (/ds-wrap) handler resolves via resolveAgenticRoot and skips (return) when foundGitAncestor is false');
+}
+
+console.log(`\n${passed} passed, ${failed} failed.`);
+process.exit(failed > 0 ? 1 : 0);

--- a/hooks/tests/test-opencode-agentic-root.js
+++ b/hooks/tests/test-opencode-agentic-root.js
@@ -37,12 +37,20 @@
  * fails loudly rather than silently testing nothing - see the
  * "extraction succeeded" assertion.
  *
+ * Round-2 rework: each of the four behavioral fixtures (a)-(d) below also
+ * runs through hooks/lib/repo-root.js's own
+ * resolveAgenticCwdWithDiagnostics and asserts an identical {root,
+ * foundGitAncestor} result - a mechanical parity check binding the inline
+ * TS reimplementation to the canonical JS resolver, closing the gap where
+ * MAX_DEPTH === 64 alone was the only thing tying them together.
+ *
  * Run with: node hooks/tests/test-opencode-agentic-root.js
  */
 
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { resolveAgenticCwdWithDiagnostics } = require('../lib/repo-root.js');
 
 const REPO = path.resolve(__dirname, '..', '..');
 const TS_PATH = path.join(REPO, '.opencode', 'plugins', 'session-context.ts');
@@ -142,6 +150,11 @@ if (fnSource && stripped && maxDepthMatch) {
       const { root, foundGitAncestor } = resolveAgenticRoot(repoRoot);
       assert(foundGitAncestor === true, '(a) foundGitAncestor is true when start dir has a .git entry');
       assert(root === fs.realpathSync(repoRoot), '(a) root is the realpath of the start dir itself');
+      const parity = resolveAgenticCwdWithDiagnostics(repoRoot);
+      assert(
+        parity.root === root && parity.foundGitAncestor === foundGitAncestor,
+        `(a) matches hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics (got ts:${JSON.stringify({ root, foundGitAncestor })} vs js:${JSON.stringify({ root: parity.root, foundGitAncestor: parity.foundGitAncestor })})`
+      );
     } finally {
       cleanup(repoRoot);
     }
@@ -160,6 +173,11 @@ if (fnSource && stripped && maxDepthMatch) {
         root === fs.realpathSync(repoRoot),
         `(b) root walks up to the REPO ROOT, not the drifted subdirectory (got: ${root})`
       );
+      const parity = resolveAgenticCwdWithDiagnostics(driftedDir);
+      assert(
+        parity.root === root && parity.foundGitAncestor === foundGitAncestor,
+        `(b) matches hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics (got ts:${JSON.stringify({ root, foundGitAncestor })} vs js:${JSON.stringify({ root: parity.root, foundGitAncestor: parity.foundGitAncestor })})`
+      );
     } finally {
       cleanup(repoRoot);
     }
@@ -169,8 +187,13 @@ if (fnSource && stripped && maxDepthMatch) {
   {
     const noGitDir = makeTmp('ae-opencode-agentic-root-c-');
     try {
-      const { foundGitAncestor } = resolveAgenticRoot(noGitDir);
+      const { root, foundGitAncestor } = resolveAgenticRoot(noGitDir);
       assert(foundGitAncestor === false, '(c) foundGitAncestor is false when no .git ancestor exists');
+      const parity = resolveAgenticCwdWithDiagnostics(noGitDir);
+      assert(
+        parity.root === root && parity.foundGitAncestor === foundGitAncestor,
+        `(c) matches hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics (got ts:${JSON.stringify({ root, foundGitAncestor })} vs js:${JSON.stringify({ root: parity.root, foundGitAncestor: parity.foundGitAncestor })})`
+      );
     } finally {
       cleanup(noGitDir);
     }
@@ -182,10 +205,15 @@ if (fnSource && stripped && maxDepthMatch) {
     const repoRoot = makeTmp('ae-opencode-agentic-root-d-');
     fs.writeFileSync(path.join(repoRoot, '.git'), 'gitdir: ../.git/worktrees/x\n', 'utf8');
     try {
-      const { foundGitAncestor } = resolveAgenticRoot(repoRoot);
+      const { root, foundGitAncestor } = resolveAgenticRoot(repoRoot);
       assert(
         foundGitAncestor === true,
         '(d) a FILE .git entry (linked worktree) is recognized - existence-only, not isDirectory()'
+      );
+      const parity = resolveAgenticCwdWithDiagnostics(repoRoot);
+      assert(
+        parity.root === root && parity.foundGitAncestor === foundGitAncestor,
+        `(d) matches hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics (got ts:${JSON.stringify({ root, foundGitAncestor })} vs js:${JSON.stringify({ root: parity.root, foundGitAncestor: parity.foundGitAncestor })})`
       );
     } finally {
       cleanup(repoRoot);

--- a/hooks/tests/test-session-start-copilot.js
+++ b/hooks/tests/test-session-start-copilot.js
@@ -23,12 +23,26 @@
  *       reflects the ROOT's context.md, not a (nonexistent) one at the
  *       drifted subdirectory.
  *   (b) payload cwd has no .git ancestor anywhere -> {} (no additionalContext),
- *       even when an unrelated context.md exists at the hook's own process
+ *       even when an unrelated context.md exists at the hook PROCESS's own
  *       cwd (proves there is no `pwd` fallback reading the wrong file).
  *   (c) payload carries no cwd field at all -> {} (guarded no-op), same
  *       proof as (b) for the empty-payload path.
  *   (d) payload cwd resolves to a real repo root with NO context.md yet ->
  *       {} (file legitimately absent, not a resolution failure).
+ *
+ * Round-2 rework (Major 2): (b) and (c) previously relied on runHook's
+ * process cwd defaulting to `process.cwd()` - i.e. this test file's own
+ * repo checkout - as the "unrelated context.md" that a restored `pwd`
+ * fallback would leak. That is non-deterministic: `.agentic/` is
+ * categorically gitignored, so a fresh clone, a worktree, or CI has no
+ * `.agentic/context.md` there at all, and the mutation that removes the
+ * `pwd`-fallback-removal fix silently passed (`18 passed, 0 failed`)
+ * instead of reddening. Fixed: runHook now defaults its process cwd to
+ * SENTINEL_CWD, a fixture directory seeded once at module load with a
+ * `.agentic/context.md` containing a known sentinel string. If the `pwd`
+ * fallback is ever restored, (b)/(c) deterministically observe that
+ * sentinel leak into additionalContext, regardless of what the test
+ * runner's own working directory happens to contain.
  *
  * Run with: node hooks/tests/test-session-start-copilot.js
  */
@@ -86,14 +100,28 @@ function cleanup(tmpDir) {
   try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
 }
 
+// Sentinel string a restored `pwd` fallback would leak into
+// additionalContext - deterministic stand-in for "this test's own process
+// cwd happens to have a .agentic/context.md", replacing that
+// non-deterministic assumption (see Round-2 rework note above).
+const SENTINEL_CONTEXT = 'LEAKED-PHANTOM-CONTEXT';
+const SENTINEL_CWD = makeTmp('ae-session-start-copilot-sentinel-cwd-');
+fs.mkdirSync(path.join(SENTINEL_CWD, '.agentic'), { recursive: true });
+fs.writeFileSync(path.join(SENTINEL_CWD, '.agentic', 'context.md'), SENTINEL_CONTEXT, 'utf8');
+process.once('exit', () => cleanup(SENTINEL_CWD));
+
 /**
  * Run the hook with a JSON payload on stdin. execFileSync closes stdin
  * after writing `input`, so the hook's stdin-reading python3 subprocess
  * sees EOF and returns promptly - no stdin-guard machinery needed here
  * (these session-start hooks are synchronous, unlike the stop hooks).
+ *
+ * The hook PROCESS's own cwd (as opposed to the payload's `cwd` field)
+ * defaults to SENTINEL_CWD, not process.cwd() - see Round-2 rework note
+ * above.
  */
 function runHook(hookScript, payload, opts) {
-  const cwd = (opts && opts.cwd) || process.cwd();
+  const cwd = (opts && opts.cwd) || SENTINEL_CWD;
   try {
     const stdout = execFileSync('bash', [hookScript], {
       input: JSON.stringify(payload),

--- a/hooks/tests/test-session-start-copilot.js
+++ b/hooks/tests/test-session-start-copilot.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Integration tests: .copilot/hooks/session-start-copilot.sh and its
+ * hand-duplicated mirror .github/hooks/session-start-copilot.sh (DS-176,
+ * adapter-hooks-agentic-root). Neither script had any test coverage before
+ * this unit.
+ *
+ * Both scripts read the payload's `cwd` field from stdin and, pre-fix,
+ * fell back to `pwd` when the payload carried none - the same
+ * phantom-.agentic-tree bug class fixed for hooks/**\/bin/** in PR #745.
+ * Post-fix, the workspace root is resolved via hooks/lib/repo-root.sh's
+ * resolve_agentic_root (walks up to the nearest ACTUAL git repo via
+ * `git rev-parse --show-toplevel` - unlike the JS/Py resolvers, a bare
+ * `mkdir .git` does NOT satisfy this; fixtures below use `git init`), and
+ * the `pwd` fallback is removed entirely: an unresolvable cwd now emits
+ * `{}` rather than reading (or worse, phantom-creating) an unrelated
+ * .agentic/context.md whichever directory the hook process happens to be
+ * running in.
+ *
+ * Test cases (each run once per entry in HOOK_SCRIPTS):
+ *   (a) payload cwd is a DRIFTED subdirectory of a real git repo whose
+ *       ROOT holds a real context.md -> the injected additionalContext
+ *       reflects the ROOT's context.md, not a (nonexistent) one at the
+ *       drifted subdirectory.
+ *   (b) payload cwd has no .git ancestor anywhere -> {} (no additionalContext),
+ *       even when an unrelated context.md exists at the hook's own process
+ *       cwd (proves there is no `pwd` fallback reading the wrong file).
+ *   (c) payload carries no cwd field at all -> {} (guarded no-op), same
+ *       proof as (b) for the empty-payload path.
+ *   (d) payload cwd resolves to a real repo root with NO context.md yet ->
+ *       {} (file legitimately absent, not a resolution failure).
+ *
+ * Run with: node hooks/tests/test-session-start-copilot.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  PASS: ${message}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${message}`);
+    failed++;
+  }
+}
+
+const HOOK_SCRIPTS = [
+  { label: '.copilot', path: path.resolve(__dirname, '..', '..', '.copilot', 'hooks', 'session-start-copilot.sh') },
+  { label: '.github', path: path.resolve(__dirname, '..', '..', '.github', 'hooks', 'session-start-copilot.sh') },
+];
+
+for (const { label, path: hookScript } of HOOK_SCRIPTS) {
+  if (!fs.existsSync(hookScript)) {
+    console.error(`FAIL: ${label} hook not found at ${hookScript}`);
+    process.exit(1);
+  }
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Creates a tmp dir and `git init`s it - the bash resolver shells out to
+ * `git rev-parse --show-toplevel`, which (unlike the JS/Py existence-only
+ * walk) requires an ACTUAL git repository, not merely a `.git` directory
+ * entry. Verified empirically: a bare `mkdir .git` makes
+ * `git rev-parse --show-toplevel` fail with "not a git repository".
+ */
+function makeGitFixture(prefix) {
+  const dir = makeTmp(prefix);
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  return dir;
+}
+
+function cleanup(tmpDir) {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+/**
+ * Run the hook with a JSON payload on stdin. execFileSync closes stdin
+ * after writing `input`, so the hook's stdin-reading python3 subprocess
+ * sees EOF and returns promptly - no stdin-guard machinery needed here
+ * (these session-start hooks are synchronous, unlike the stop hooks).
+ */
+function runHook(hookScript, payload, opts) {
+  const cwd = (opts && opts.cwd) || process.cwd();
+  try {
+    const stdout = execFileSync('bash', [hookScript], {
+      input: JSON.stringify(payload),
+      cwd,
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status, stdout: err.stdout ? err.stdout.toString() : '', stderr: err.stderr ? err.stderr.toString() : '' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (a) drifted cwd -> additionalContext reflects the REPO ROOT's context.md
+//
+// Reddening mutation: reverting the resolve_agentic_root sourcing back to
+// the pre-fix `CWD="$PAYLOAD_CWD"` / `[[ -z "$CWD" ]] && CWD="$(pwd)"`
+// shape makes this test fail for the wrong reason it was written to catch
+// - CONTEXT_FILE would point at the drifted subdirectory (which has no
+// context.md) instead of the repo root, so additionalContext would never
+// appear at all.
+// ---------------------------------------------------------------------------
+
+function testDriftedCwdReadsRootContext(hookScript, label) {
+  const repoRoot = makeGitFixture('ae-session-start-copilot-a-');
+  try {
+    const driftedDir = path.join(repoRoot, 'sub', 'nested', 'drift');
+    fs.mkdirSync(driftedDir, { recursive: true });
+    fs.mkdirSync(path.join(repoRoot, '.agentic'), { recursive: true });
+    fs.writeFileSync(path.join(repoRoot, '.agentic', 'context.md'), 'ROOT-CONTEXT-DS176', 'utf8');
+
+    const result = runHook(hookScript, { cwd: driftedDir, session_id: 'drift-a' });
+
+    assert(result.code === 0, `(a ${label}) hook exits 0`);
+    let parsed = null;
+    try { parsed = JSON.parse(result.stdout); } catch (_) { /* leave null */ }
+    assert(parsed !== null, `(a ${label}) stdout parses as JSON (got: ${JSON.stringify(result.stdout)})`);
+    const injected = parsed && parsed.hookSpecificOutput && parsed.hookSpecificOutput.additionalContext;
+    assert(
+      typeof injected === 'string' && injected.includes('ROOT-CONTEXT-DS176'),
+      `(a ${label}) additionalContext reflects the REPO ROOT's context.md, not the drifted subdirectory (got: ${JSON.stringify(result.stdout)})`
+    );
+  } finally {
+    cleanup(repoRoot);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (b) no .git ancestor -> {} even though an unrelated context.md exists at
+// the hook's own process cwd. Proves there is no `pwd` fallback: if the
+// pre-fix `CWD="$(pwd)"` fallback still fired, this test's own process cwd
+// (the repo checkout, which of course has a .agentic/context.md-shaped
+// dir) would leak into the output.
+// ---------------------------------------------------------------------------
+
+function testNoGitAncestorSkipsLookup(hookScript, label) {
+  const noGitDir = makeTmp('ae-session-start-copilot-b-');
+  try {
+    const result = runHook(hookScript, { cwd: noGitDir, session_id: 'no-git-b' });
+
+    assert(result.code === 0, `(b ${label}) hook exits 0`);
+    assert(
+      result.stdout.trim() === '{}',
+      `(b ${label}) stdout is exactly {} - no .git ancestor, lookup skipped, no pwd fallback (got: ${JSON.stringify(result.stdout)})`
+    );
+  } finally {
+    cleanup(noGitDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (c) no cwd field at all -> {} (guarded no-op)
+// ---------------------------------------------------------------------------
+
+function testMissingCwdField(hookScript, label) {
+  const result = runHook(hookScript, { session_id: 'no-cwd-c' });
+
+  assert(result.code === 0, `(c ${label}) hook exits 0`);
+  assert(
+    result.stdout.trim() === '{}',
+    `(c ${label}) stdout is exactly {} when the payload has no cwd field (got: ${JSON.stringify(result.stdout)})`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// (d) real repo root, no context.md yet -> {} (legitimately absent file,
+// not a resolution failure)
+// ---------------------------------------------------------------------------
+
+function testResolvedRootNoContextFile(hookScript, label) {
+  const repoRoot = makeGitFixture('ae-session-start-copilot-d-');
+  try {
+    const result = runHook(hookScript, { cwd: repoRoot, session_id: 'no-context-d' });
+
+    assert(result.code === 0, `(d ${label}) hook exits 0`);
+    assert(
+      result.stdout.trim() === '{}',
+      `(d ${label}) stdout is exactly {} when the resolved root has no context.md yet (got: ${JSON.stringify(result.stdout)})`
+    );
+  } finally {
+    cleanup(repoRoot);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+function main() {
+  for (const { label, path: hookScript } of HOOK_SCRIPTS) {
+    console.log(`\n=== ${label} ===`);
+
+    console.log('(a) drifted cwd -> additionalContext reflects the repo root');
+    testDriftedCwdReadsRootContext(hookScript, label);
+
+    console.log('(b) no .git ancestor -> {} (no pwd fallback)');
+    testNoGitAncestorSkipsLookup(hookScript, label);
+
+    console.log('(c) missing cwd field -> {} (guarded no-op)');
+    testMissingCwdField(hookScript, label);
+
+    console.log('(d) resolved root, no context.md yet -> {}');
+    testResolvedRootNoContextFile(hookScript, label);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();

--- a/hooks/tests/test-stop-context-copilot-stdin-guard.js
+++ b/hooks/tests/test-stop-context-copilot-stdin-guard.js
@@ -1,15 +1,27 @@
 #!/usr/bin/env node
 /**
- * Integration tests: .copilot/hooks/stop-context-copilot.js bounded-stdin-
- * guard swap (docs/planning/cursor-stop-hook-plan.md Unit A item 8). This
- * port had zero existing test coverage before this unit.
+ * Integration tests: .copilot/hooks/stop-context-copilot.js and its
+ * hand-duplicated mirror .github/hooks/stop-context-copilot.js bounded-
+ * stdin-guard swap (docs/planning/cursor-stop-hook-plan.md Unit A item 8).
+ * This port had zero existing test coverage before this unit.
  *
- * Test cases:
+ * DS-176: both scripts are hand-duplicated copies of each other (not
+ * build-generated), so every case below runs against BOTH hook paths -
+ * see HOOK_SCRIPTS.
+ *
+ * Test cases (each run once per entry in HOOK_SCRIPTS):
  *   (a) open-but-silent stdin -> exit 0, elapsed <1200ms (CI slack over the
  *       1000ms production-defaults bar asserted at the shared-helper level
  *       in test-stdin-guard.js).
  *   (b) one normal-payload smoke -> context.md written at the port's
- *       existing output path (<cwd>/.agentic/context.md).
+ *       existing output path (<repo root>/.agentic/context.md).
+ *   (c) DS-176 regression: a drifted payload cwd deep inside a real repo
+ *       writes .agentic/context.md at the REPO ROOT, not the drifted
+ *       subdirectory - the .agentic/ write is anchored via
+ *       hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics, not the
+ *       payload cwd verbatim.
+ *   (d) DS-176 regression: no .git ancestor anywhere -> the write is
+ *       SKIPPED entirely, never falls back to the unresolved payload cwd.
  *
  * Run with: node hooks/tests/test-stop-context-copilot-stdin-guard.js
  */
@@ -35,15 +47,32 @@ function assert(condition, message) {
   }
 }
 
-const hookScript = path.resolve(__dirname, '..', '..', '.copilot', 'hooks', 'stop-context-copilot.js');
-if (!fs.existsSync(hookScript)) {
-  console.error(`FAIL: hook not found at ${hookScript}`);
-  process.exit(1);
+const HOOK_SCRIPTS = [
+  { label: '.copilot', path: path.resolve(__dirname, '..', '..', '.copilot', 'hooks', 'stop-context-copilot.js') },
+  { label: '.github', path: path.resolve(__dirname, '..', '..', '.github', 'hooks', 'stop-context-copilot.js') },
+];
+
+for (const { label, path: hookScript } of HOOK_SCRIPTS) {
+  if (!fs.existsSync(hookScript)) {
+    console.error(`FAIL: ${label} hook not found at ${hookScript}`);
+    process.exit(1);
+  }
 }
 
 function makeTmp(prefix) {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  return tmpDir;
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Creates a tmp fixture dir with a `.git` entry so it resolves as a repo
+ * root under the DS-176 repo-root anchoring fix (the hook now walks up
+ * from the payload cwd to the nearest `.git` ancestor and SKIPS the write
+ * entirely when none is found).
+ */
+function makeGitFixture(prefix) {
+  const dir = makeTmp(prefix);
+  fs.mkdirSync(path.join(dir, '.git'));
+  return dir;
 }
 
 function cleanup(tmpDir) {
@@ -54,7 +83,7 @@ function cleanup(tmpDir) {
 // (a) open-but-silent stdin -> bounded exit
 // ---------------------------------------------------------------------------
 
-async function testOpenButSilentStdin() {
+async function testOpenButSilentStdin(hookScript, label) {
   const tmpDir = makeTmp('ae-copilot-stdinguard-a-');
   try {
     const result = await spawnSilentStdin({
@@ -63,30 +92,27 @@ async function testOpenButSilentStdin() {
       env: process.env,
       maxWaitMs: 3000,
     });
-    assert(!result.timedOut, '(a) hook exits on its own (not force-killed by the test harness)');
-    assert(result.code === 0, `(a) hook exits 0 (got: ${result.code})`);
+    assert(!result.timedOut, `(a ${label}) hook exits on its own (not force-killed by the test harness)`);
+    assert(result.code === 0, `(a ${label}) hook exits 0 (got: ${result.code})`);
     assert(
       result.elapsedMs < 1200,
-      `(a) hook exits with bounded elapsed time under CI slack (${result.elapsedMs}ms, must be < 1200ms)`
+      `(a ${label}) hook exits with bounded elapsed time under CI slack (${result.elapsedMs}ms, must be < 1200ms)`
     );
-    assert(result.stdout.trim() === '{}', `(a) stdout is the empty-object success contract (got: ${JSON.stringify(result.stdout)})`);
+    assert(result.stdout.trim() === '{}', `(a ${label}) stdout is the empty-object success contract (got: ${JSON.stringify(result.stdout)})`);
   } finally {
     cleanup(tmpDir);
   }
 }
 
 // ---------------------------------------------------------------------------
-// (b) normal-payload smoke -> context.md written at <cwd>/.agentic/
+// (b) normal-payload smoke -> context.md written at <repo root>/.agentic/
 // ---------------------------------------------------------------------------
 
-async function testNormalPayloadWritesContext() {
-  const tmpDir = makeTmp('ae-copilot-stdinguard-b-');
+async function testNormalPayloadWritesContext(hookScript, label) {
+  const repoRoot = makeGitFixture('ae-copilot-stdinguard-b-');
   try {
-    const projectDir = path.join(tmpDir, 'project');
-    fs.mkdirSync(projectDir, { recursive: true });
-
     const payload = JSON.stringify({
-      cwd: projectDir,
+      cwd: repoRoot,
       session_id: 'copilot-stdin-guard-smoke-session',
       last_assistant_message: 'copilot stdin-guard smoke test assistant message',
       model: 'copilot-test',
@@ -102,19 +128,105 @@ async function testNormalPayloadWritesContext() {
       maxWaitMs: 5000,
     });
 
-    assert(!result.timedOut, '(b) hook exits on its own (not force-killed by the test harness)');
-    assert(result.code === 0, `(b) hook exits 0 (got: ${result.code})`);
-    assert(result.stdout.trim() === '{}', `(b) stdout is the empty-object success contract (got: ${JSON.stringify(result.stdout)})`);
+    assert(!result.timedOut, `(b ${label}) hook exits on its own (not force-killed by the test harness)`);
+    assert(result.code === 0, `(b ${label}) hook exits 0 (got: ${result.code})`);
+    assert(result.stdout.trim() === '{}', `(b ${label}) stdout is the empty-object success contract (got: ${JSON.stringify(result.stdout)})`);
 
-    const contextPath = path.join(projectDir, '.agentic', 'context.md');
-    assert(fs.existsSync(contextPath), `(b) context.md written at ${contextPath}`);
+    const contextPath = path.join(repoRoot, '.agentic', 'context.md');
+    assert(fs.existsSync(contextPath), `(b ${label}) context.md written at ${contextPath}`);
     if (fs.existsSync(contextPath)) {
       const content = fs.readFileSync(contextPath, 'utf8');
       assert(content.includes('copilot stdin-guard smoke test assistant message'),
-        '(b) context.md contains the delivered last_assistant_message');
+        `(b ${label}) context.md contains the delivered last_assistant_message`);
     }
   } finally {
-    cleanup(tmpDir);
+    cleanup(repoRoot);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (c) DS-176 regression: drifted payload cwd -> write lands at repo root
+//
+// Reddening mutation: reverting the resolveAgenticCwdWithDiagnostics call
+// back to using the payload cwd directly (the pre-fix state) makes this
+// test fail for the wrong reason it was written to catch - context.md
+// would be written at the DRIFTED subdirectory instead of the repo root.
+// ---------------------------------------------------------------------------
+
+async function testDriftedCwdWritesAtRepoRoot(hookScript, label) {
+  const repoRoot = makeGitFixture('ae-copilot-stdinguard-c-');
+  try {
+    const driftedDir = path.join(repoRoot, 'sub', 'nested', 'drift');
+    fs.mkdirSync(driftedDir, { recursive: true });
+
+    const payload = JSON.stringify({
+      cwd: driftedDir,
+      session_id: 'copilot-drifted-cwd-session',
+      last_assistant_message: 'drifted cwd regression',
+      model: 'copilot-test',
+    });
+
+    const result = await spawnDelayedChunks({
+      cmd: process.execPath,
+      args: [hookScript],
+      env: process.env,
+      chunks: [payload],
+      gapMs: 0,
+      holdOpenMs: 0,
+      maxWaitMs: 5000,
+    });
+
+    assert(result.code === 0, `(c ${label}) hook exits 0`);
+
+    const rootContextPath = path.join(repoRoot, '.agentic', 'context.md');
+    const driftedContextPath = path.join(driftedDir, '.agentic', 'context.md');
+    assert(
+      fs.existsSync(rootContextPath),
+      `(c ${label}) .agentic/context.md written at the REPO ROOT, not the drifted subdirectory`
+    );
+    assert(
+      !fs.existsSync(driftedContextPath),
+      `(c ${label}) no phantom .agentic tree written at the drifted subdirectory`
+    );
+  } finally {
+    cleanup(repoRoot);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (d) DS-176 regression: no .git ancestor anywhere -> write is SKIPPED
+// entirely, never falls back to the unresolved cwd.
+// ---------------------------------------------------------------------------
+
+async function testNoGitAncestorSkipsWrite(hookScript, label) {
+  const noGitDir = makeTmp('ae-copilot-stdinguard-d-');
+  try {
+    const payload = JSON.stringify({
+      cwd: noGitDir,
+      session_id: 'copilot-no-git-ancestor-session',
+      last_assistant_message: 'no git ancestor regression',
+      model: 'copilot-test',
+    });
+
+    const result = await spawnDelayedChunks({
+      cmd: process.execPath,
+      args: [hookScript],
+      env: process.env,
+      chunks: [payload],
+      gapMs: 0,
+      holdOpenMs: 0,
+      maxWaitMs: 5000,
+    });
+
+    assert(result.code === 0, `(d ${label}) hook exits 0`);
+
+    const contextPath = path.join(noGitDir, '.agentic', 'context.md');
+    assert(
+      !fs.existsSync(contextPath),
+      `(d ${label}) write is SKIPPED, no .agentic tree created`
+    );
+  } finally {
+    cleanup(noGitDir);
   }
 }
 
@@ -123,11 +235,21 @@ async function testNormalPayloadWritesContext() {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  console.log('(a) open-but-silent stdin -> bounded exit');
-  await testOpenButSilentStdin();
+  for (const { label, path: hookScript } of HOOK_SCRIPTS) {
+    console.log(`\n=== ${label} ===`);
 
-  console.log('\n(b) normal-payload smoke -> context.md written');
-  await testNormalPayloadWritesContext();
+    console.log('(a) open-but-silent stdin -> bounded exit');
+    await testOpenButSilentStdin(hookScript, label);
+
+    console.log('\n(b) normal-payload smoke -> context.md written');
+    await testNormalPayloadWritesContext(hookScript, label);
+
+    console.log('\n(c) DS-176 regression: drifted cwd writes at repo root');
+    await testDriftedCwdWritesAtRepoRoot(hookScript, label);
+
+    console.log('\n(d) DS-176 regression: no .git ancestor skips the write');
+    await testNoGitAncestorSkipsWrite(hookScript, label);
+  }
 
   console.log(`\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);

--- a/hooks/tests/test-stop-context-cursor.js
+++ b/hooks/tests/test-stop-context-cursor.js
@@ -107,8 +107,17 @@ function assertStdoutShape(rawStdout, label) {
   }
 }
 
+/**
+ * Creates a tmp fixture dir with a `.git` entry so it resolves as a repo
+ * root under the DS-176 repo-root anchoring fix (the hook now walks up
+ * from the payload cwd to the nearest `.git` ancestor and SKIPS the write
+ * entirely when none is found - a bare mkdtempSync fixture with no `.git`
+ * would silently no-op every pre-existing test in this file otherwise).
+ */
 function mkFixtureDir(prefix) {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.mkdirSync(path.join(dir, '.git'));
+  return dir;
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +227,100 @@ async function testContingencyNoWorkspaceRoot() {
 
   const contextPath = path.join(fixtureCwd, '.agentic', 'context.md');
   assert(!fs.existsSync(contextPath), 'case c: guarded safe no-op - no context.md created');
+}
+
+// ---------------------------------------------------------------------------
+// Regression (DS-176, adapter-hooks-agentic-root): the .agentic/ write must
+// be anchored at the nearest .git ancestor of the payload workspace root,
+// not the payload value verbatim - a drifted/stray-cd cwd deep inside a
+// real repo must still land .agentic/context.md at the REPO ROOT.
+//
+// Reddening mutation: reverting the "--- 3b. Resolve the repo root..."
+// block back to using `cwd` directly (the pre-fix state) makes this test
+// fail for the wrong reason it was written to catch - context.md would be
+// written at the DRIFTED subdirectory instead of the repo root.
+// ---------------------------------------------------------------------------
+
+async function testDriftedCwdWritesAtRepoRoot() {
+  const repoRoot = mkFixtureDir('cursor-stop-test-drift-');
+  const driftedDir = path.join(repoRoot, 'sub', 'nested', 'drift');
+  fs.mkdirSync(driftedDir, { recursive: true });
+
+  const payload = {
+    status: 'completed',
+    loop_count: 1,
+    conversation_id: 'conv-drifted-cwd',
+    model: 'claude-sonnet-4.5',
+    hook_event_name: 'stop',
+    cursor_version: '1.4.0',
+    workspace_roots: [driftedDir],
+    user_email: null,
+    transcript_path: null,
+  };
+
+  const result = await spawnDelayedChunks({
+    cmd: process.execPath,
+    args: [HOOK_PATH],
+    chunks: [JSON.stringify(payload)],
+    gapMs: 0,
+    holdOpenMs: 0,
+  });
+
+  assert(result.code === 0, 'regression (drifted cwd): exits 0');
+  assertStdoutShape(result.stdout, 'regression (drifted cwd)');
+
+  const rootContextPath = path.join(repoRoot, '.agentic', 'context.md');
+  const driftedContextPath = path.join(driftedDir, '.agentic', 'context.md');
+  assert(
+    fs.existsSync(rootContextPath),
+    'regression (drifted cwd): .agentic/context.md written at the REPO ROOT, not the drifted subdirectory'
+  );
+  assert(
+    !fs.existsSync(driftedContextPath),
+    'regression (drifted cwd): no phantom .agentic tree written at the drifted subdirectory'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Regression (DS-176): resolution failure (no .git ancestor anywhere up to
+// the filesystem root) must SKIP the write entirely - never fall back to
+// the unresolved cwd, which would silently reproduce the phantom-tree bug.
+// Uses a bare mkdtempSync dir (deliberately WITHOUT mkFixtureDir's `.git`)
+// under os.tmpdir(), which has no .git ancestor on any supported CI/dev
+// environment.
+// ---------------------------------------------------------------------------
+
+async function testNoGitAncestorSkipsWrite() {
+  const noGitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-stop-test-nogit-'));
+
+  const payload = {
+    status: 'completed',
+    loop_count: 1,
+    conversation_id: 'conv-no-git-ancestor',
+    model: 'claude-sonnet-4.5',
+    hook_event_name: 'stop',
+    cursor_version: '1.4.0',
+    workspace_roots: [noGitDir],
+    user_email: null,
+    transcript_path: null,
+  };
+
+  const result = await spawnDelayedChunks({
+    cmd: process.execPath,
+    args: [HOOK_PATH],
+    chunks: [JSON.stringify(payload)],
+    gapMs: 0,
+    holdOpenMs: 0,
+  });
+
+  assert(result.code === 0, 'regression (no .git ancestor): exits 0');
+  assertStdoutShape(result.stdout, 'regression (no .git ancestor)');
+
+  const contextPath = path.join(noGitDir, '.agentic', 'context.md');
+  assert(
+    !fs.existsSync(contextPath),
+    'regression (no .git ancestor): write is SKIPPED, no .agentic tree created'
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -585,6 +688,12 @@ async function main() {
 
   console.log('Case c: contingency - no workspace_roots, env scrubbed');
   await testContingencyNoWorkspaceRoot();
+
+  console.log('Regression (DS-176): drifted cwd writes .agentic at the repo root');
+  await testDriftedCwdWritesAtRepoRoot();
+
+  console.log('Regression (DS-176): no .git ancestor skips the write entirely');
+  await testNoGitAncestorSkipsWrite();
 
   console.log('Regression: trailing-slash workspace root (Skeptic Major)');
   await testTrailingSlashWorkspaceRoot();

--- a/hooks/tests/test-stop-context-cursor.js
+++ b/hooks/tests/test-stop-context-cursor.js
@@ -316,10 +316,31 @@ async function testNoGitAncestorSkipsWrite() {
   assert(result.code === 0, 'regression (no .git ancestor): exits 0');
   assertStdoutShape(result.stdout, 'regression (no .git ancestor)');
 
-  const contextPath = path.join(noGitDir, '.agentic', 'context.md');
+  // Round-2 rework (Minor): asserting only against `noGitDir` cannot
+  // distinguish "skipped" from "written somewhere else" - on macOS,
+  // os.tmpdir() typically resolves through a symlink (/var ->
+  // /private/var), so the resolver's own fallback root (realpath'd, per
+  // hooks/lib/repo-root.js's resolveAgenticCwdWithDiagnostics) differs
+  // from the raw `noGitDir` string. If the hook's `!foundGitAncestor`
+  // guard were ever removed, it would write at the REALPATH'D fallback
+  // root, not at `noGitDir` verbatim - a check scoped only to `noGitDir`
+  // would silently pass while a phantom .agentic tree appeared one path
+  // segment away. Pin the check to the resolver's own decision instead:
+  // confirm foundGitAncestor is actually false for this fixture (proves
+  // the SKIP branch is the one under test), then check both the raw and
+  // realpath'd candidate paths for the absent write.
+  const { resolveAgenticCwdWithDiagnostics } = require('../lib/repo-root.js');
+  const diag = resolveAgenticCwdWithDiagnostics(noGitDir);
   assert(
-    !fs.existsSync(contextPath),
-    'regression (no .git ancestor): write is SKIPPED, no .agentic tree created'
+    diag.foundGitAncestor === false,
+    'regression (no .git ancestor): fixture genuinely has no .git ancestor (resolver confirms foundGitAncestor:false)'
+  );
+
+  const rawContextPath = path.join(noGitDir, '.agentic', 'context.md');
+  const realContextPath = path.join(diag.root, '.agentic', 'context.md');
+  assert(
+    !fs.existsSync(rawContextPath) && !fs.existsSync(realContextPath),
+    'regression (no .git ancestor): write is SKIPPED, no .agentic tree created at the raw or realpath\'d fallback location'
   );
 }
 


### PR DESCRIPTION
Closes the last remaining path to the phantom-`.agentic/` bug.

## Why this exists

PR #745 anchored every `.agentic/` write to the resolved repo root, and #750 added the tool that cleaned up the damage (39 phantom trees, 430 recovered telemetry records in one consumer repo). Neither covered the adapter hook copies: they are hand-authored and `build.sh` does not regenerate them, so they inherited nothing.

Concretely, Claude Code users were protected and Cursor, Copilot, and OpenCode users were not. The same stray `cd` still produced phantom trees under those harnesses.

## What changed - 11 sites across 6 files

**JS (3 files)** - `.cursor/hooks/stop-context-cursor.js`, `.copilot/hooks/stop-context-copilot.js`, `.github/hooks/stop-context-copilot.js` now `require('../../hooks/lib/repo-root.js')` and skip the write when no `.git` ancestor is found. These files already required `stdin-guard.js` from the same shared lib dir, so this follows the established pattern.

**Bash (2 files)** - `.copilot/hooks/session-start-copilot.sh` and `.github/hooks/session-start-copilot.sh` now source `hooks/lib/repo-root.sh`. Their `CWD="$(pwd)"` fallback was itself a second instance of the bug, not merely the join beneath it - the same shape as `enforcement_log.py`'s `os.getcwd()` fallback that needed its own fix in #745. Neither falls back to `pwd` any more.

**TypeScript (6 sites in 1 file)** - `.opencode/plugins/session-context.ts`. The drift-injection point was `directory || process.cwd()` at the `session.idle` and `command.executed` handlers, feeding all six write sites downstream.

`.copilot/` and `.github/` are hand-duplicated byte-identical copies, not generated. Both fixed; verified identical before and after each edit. Not deduplicated here - that is a separate decision.

## OpenCode: inline, not shared

`session-context.ts` is a standalone Bun plugin loaded from `~/.config/opencode/plugins/` with no access to the repo's `hooks/` tree, so it carries an inline `resolveAgenticRoot` rather than requiring the shared module. Semantics mirror `hooks/lib/repo-root.js` exactly: realpath-pinned, walk up to the nearest `.git`, **existence-only** check (a linked worktree's `.git` is a FILE - an `isDirectory()` test fails in the most common execution environment here), MAX_DEPTH 64, never throws.

Written with Node built-ins only rather than Bun APIs specifically so it can be executed under test instead of only regex-matched. `hooks/tests/test-opencode-agentic-root.js` extracts and runs the real function, including the linked-worktree case.

## The durable half

The coverage gate that prevents a new unanchored writer from being added silently did not scan adapter dirs. That omission is precisely why these 11 sites survived #745. `SCAN_DIRS` now includes `.cursor/hooks`, `.copilot/hooks`, `.github/hooks`, `.gemini/hooks`, `.kimi/hooks`, `.opencode/plugins`, and `.ts` was added to the candidate extensions.

Scoped to each adapter's hook/plugin subdirectory, never the adapter's full tree - those hold a generated verbatim `content/**` copy including two literal `templates/.agentic/` scaffold dirs, which would flood the scan with prose matches. Each of the six directories was verified to hold only executable hook code today.

Inventory regenerated mechanically via the scanner's own `_find_candidates()`: exactly 12 new lines, nothing else. `.gemini` and `.kimi` hooks correctly produced zero candidates (HOME-scoped or unrelated).

**Reddening mutation proven:** appended an uninventoried `.agentic` construction to `.kimi/hooks/session-start.sh`, confirmed the gate failed naming the exact line, removed it, confirmed green.

## Tests

Each fixed site has a regression test firing the write from a drifted cwd inside a fixture repo, asserting `.agentic` lands at the fixture root. Each was confirmed failing pre-fix by mutating the fix back to its original shape. Fixtures create `<fixture>/.git` explicitly - without it the resolver fail-opens and a pre-fix assertion fails for the wrong reason, reading as a false reproduction.

`hooks/tests/test-session-start-copilot.js` is new: that script had zero prior coverage. The shared `mkFixtureDir` helper in the cursor test file gained `.git` creation, because every pre-existing test there would otherwise have silently no-opped after this change.

## North Star alignment

**Pillar: mechanical enforcement over remembered rules.** The gate extension matters more than the 11 fixes. Those sites were missed because they sat outside the scanner's scope, not because anyone forgot them - and a hand-maintained list of write sites has now been wrong four separate times in this work.

**Pillar: works for everyone.** The methodology ships six harness adapters; fixing only the one the maintainer happens to use leaves every other user exposed to a bug we have already diagnosed.

**Cuts against: single-sourcing.** OpenCode gets an inline resolver duplicating the shared contract, which can drift. Accepted because the plugin genuinely cannot reach the repo's `hooks/` tree; mitigated by testing the real function behaviorally rather than trusting the copy.

## Gates

`pytest bin/tests/` 1606 passed + 25 subtests; `hooks/tests/test-*.js` loop 54 files all pass; `hooks/tests/test-*.sh` loop passes; `test-repo-root.py` 45 passed; em-dash check clean; `check-resident-budget.sh` OK.

Doc-sync: predicate not triggered - no reality-asserting change to README, CONTRIBUTING, or `content/SKILL.md`; adapter hook internals are not documented there.

## Review rigor

**Brief / Plan path:** none on disk; the site inventory is the committed `hooks/tests/fixtures/agentic-write-sites.txt`.

**Skeptic rounds (tier):** 2 at Tier 2 (round 1: 0C/4M/5Mi, all four Majors reproduced by execution; round 2 closed all four). Original PR #752 was closed and reopened here after a concurrent session pushed an unsigned commit onto the branch - force-push is denied, so the branch was rebuilt clean.

**Findings summary:** this is the fourth PR in a sequence where every hand-built inventory of `.agentic` write sites proved incomplete (4 sites, then 39, then 47, then 57, then these 11). The gate extension is the response to that pattern rather than a fifth list.
