### PR TITLE
fix(bin): close five deferred discovery-guard defects, including a fail-closed regression (DS-177)

### DIFF
--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -19,16 +19,17 @@ Public API: pytest test functions only. `_normalized_scan`, `_site_label`,
          hand-typed - DS-177 Fix 5).
 Upstream deps: `git ls-files` (repo-relative, tracked-only discovery -
          this checkout's `.claude/worktrees/agent-*` count fluctuates
-         session-to-session as isolation worktrees are created and reaped
-         (measured 35-36 across two checks in one review), each a full
-         copy of every guard site; an unfiltered `rglob()` from the repo
-         root would
+         session-to-session as isolation worktrees are created and reaped,
+         each a full copy of every guard site; an unfiltered `rglob()`
+         from the repo root would
          multiply every LIVE_GUARD_SITES entry by (1 + worktree count) and
          either mask the problem under bare-basename keys or redden this
-         gate locally while CI, a clean checkout, stays green - see
-         `_tracked_relative_paths()` in
-         bin/tests/test_ticket_offer_gate_trigger_wording_spec.py:110-133
-         for the identical precedent this reuses). `LIVE_GUARD_SITES` keys
+         gate locally while CI, a clean checkout, stays green - see the
+         `_tracked_relative_paths()` function in
+         bin/tests/test_ticket_offer_gate_trigger_wording_spec.py (grep
+         for that function name - a raw line-number citation here has
+         already drifted twice) for the identical precedent this reuses).
+         `LIVE_GUARD_SITES` keys
          are `(repo_relative_path, derived_label)` pairs; the label is
          content-derived (AST scope resolution for .py, nearest enclosing
          `jobs:` job name for .yml), never hand-typed, so a 3-guards-to-2
@@ -86,10 +87,11 @@ GUARD_PHRASE = "discovery is broken, not clean"
 
 SEARCH_SUFFIXES = {".py", ".yml", ".yaml"}
 
-# Content-derived, never hand-typed (DS-176 Round-2 Critical fix). The 6
-# pre-existing entries plus this file's own vacuous-pass guard (7th entry,
-# added because this file's own discovery guard carries the same literal
-# phrase and is therefore itself discoverable by the mechanism it tests).
+# Content-derived, never hand-typed (DS-176 Round-2 Critical fix). All but
+# the last entry below pre-date this file; the last entry is this file's
+# own vacuous-pass guard, added because this file's own discovery guard
+# carries the same literal phrase and is therefore itself discoverable by
+# the mechanism it tests.
 LIVE_GUARD_SITES = frozenset(
     {
         (".github/workflows/bin-tests.yml", "hooks-python-tests"),
@@ -112,8 +114,8 @@ def _tracked_relative_paths() -> list[pathlib.Path]:
     unfiltered directory walk) matters because this checkout carries a
     fluctuating number of `.claude/worktrees/agent-*` copies of the whole
     tree - created and reaped session-to-session as isolation worktrees
-    spin up and down (measured 35-36 across two checks in one review; see
-    the module docstring's Upstream deps note) - none of which are part of
+    spin up and down (fluctuating count, see the module docstring's
+    Upstream deps note) - none of which are part of
     the primary worktree's git index. DS-177 Fix 4: no cardinal is
     asserted here, since one would go stale independently of this
     function's own behavior."""
@@ -176,10 +178,20 @@ def _line_start_offsets(text: str) -> list[int]:
     """`starts[i]` is the absolute character offset of the start of
     (1-indexed) line `i + 1`. Used to convert an AST node's
     `lineno`/`col_offset` into an absolute character offset comparable
-    against `_normalized_scan_positions`' output."""
+    against `_normalized_scan_positions`' output. Splits ONLY on `\\n` -
+    NOT `str.splitlines()`'s broader break set (`\\x0b`, `\\x0c`, U+2028,
+    U+2029, U+0085, ...), which CPython's tokenizer (and therefore AST
+    `lineno`) does not treat as a line boundary. A `str.splitlines()` split
+    diverges from AST line numbering the moment one of those characters
+    appears earlier in the file, misaligning every subsequent offset
+    (DS-177 rework Minor 1 fix; `_check_form_c`'s `text_lines` has the
+    matching fix - see `test_form_c_form_feed_does_not_misalign_offsets`)."""
     starts = [0]
-    for line in text.splitlines(keepends=True):
-        starts.append(starts[-1] + len(line))
+    offset = 0
+    for ch in text:
+        offset += 1
+        if ch == "\n":
+            starts.append(offset)
     return starts
 
 
@@ -366,7 +378,12 @@ def _check_form_c(text: str, line_range: tuple[int, int]) -> bool:
         return False
 
     line_starts = _line_start_offsets(text)
-    text_lines = text.splitlines()
+    # Split ONLY on "\n" - see `_line_start_offsets`' docstring (DS-177
+    # rework Minor 1 fix). `str.splitlines()` here would misalign
+    # `text_lines[msg.lineno - 1]` against AST `lineno` the moment a
+    # non-`\n` line-break character (form feed, U+2028, ...) appears
+    # earlier in the file.
+    text_lines = text.split("\n")
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
             continue
@@ -486,15 +503,17 @@ def test_live_guard_sites_bidirectional_set_equality() -> None:
     )
     assert not only_pinned, (
         "LIVE_GUARD_SITES pin(s) not found on disk (phantom entry, deleted "
-        "guard, or - most likely for this file's own 7th entry - this "
-        "test file itself is not yet `git add`ed and so invisible to the "
+        "guard, or - most likely for this file's own vacuous-pass-guard "
+        "entry - this test file itself is not yet `git add`ed and so "
+        "invisible to the "
         f"`git ls-files`-scoped discovery in an uncommitted checkout): {sorted(only_pinned)}"
     )
 
 
 def test_bidirectional_comparison_reddens_on_phantom_pin(monkeypatch) -> None:
     """Minor 3 (DS-176 rework-2): on the real, synced tree there is no
-    phantom pin, so `only_pinned = LIVE_GUARD_SITES - disk_live` at :424
+    phantom pin, so the `only_pinned = LIVE_GUARD_SITES - disk_live` line
+    inside test_live_guard_sites_bidirectional_set_equality above
     and a neutered `only_pinned = frozenset()` both report zero difference
     - nothing in the suite would catch that line being neutered. This
     injects a genuine phantom entry into LIVE_GUARD_SITES via monkeypatch,
@@ -516,6 +535,39 @@ def test_bidirectional_comparison_reddens_on_phantom_pin(monkeypatch) -> None:
             "expected test_live_guard_sites_bidirectional_set_equality to "
             "raise AssertionError on a phantom LIVE_GUARD_SITES entry, but "
             "it passed - the only_pinned comparison is not discriminating"
+        )
+
+
+def test_bidirectional_comparison_reddens_on_unpinned_disk_site(monkeypatch) -> None:
+    """DS-177 rework Minor 2 regression test - mirror direction of
+    test_bidirectional_comparison_reddens_on_phantom_pin above. `only_on_disk
+    = disk_live - LIVE_GUARD_SITES` catches an unpinned real site; a
+    neutered `only_on_disk = frozenset()` would report zero difference no
+    matter what disk contains, and nothing else in the suite would catch
+    it. This injects a genuine extra site into the LIVE result via
+    monkeypatching `_discover_live_sites` (never a hardcoded stub), then
+    calls the real production test function - which executes the actual
+    `disk_live - LIVE_GUARD_SITES` subtraction against that live-computed
+    set - and asserts it raises."""
+    extra_site = ("bin/tests/this-file-does-not-exist.py", "phantom_disk_guard")
+    real_discover_live_sites = _discover_live_sites
+
+    def _discover_with_extra_site(*args, **kwargs):
+        return real_discover_live_sites(*args, **kwargs) | {extra_site}
+
+    monkeypatch.setattr(
+        sys.modules[__name__], "_discover_live_sites", _discover_with_extra_site
+    )
+    try:
+        test_live_guard_sites_bidirectional_set_equality()
+    except AssertionError:
+        pass
+    else:
+        pytest.fail(
+            "expected test_live_guard_sites_bidirectional_set_equality to "
+            "raise AssertionError on an unpinned disk-only site, but it "
+            "passed - the only_on_disk comparison is not discriminating "
+            "(e.g. neutered to a hardcoded `frozenset()`)"
         )
 
 
@@ -701,6 +753,73 @@ def test_form_c_rejects_hit_straddling_condition_message_boundary() -> None:
         f"a phrase hit straddling the assert's test/msg boundary should "
         f"NOT conform (the message alone does not carry the phrase), got "
         f"({ok}, {form})"
+    )
+
+
+def test_form_c_form_feed_does_not_misalign_offsets() -> None:
+    """DS-177 rework Minor 1 regression test. `_line_start_offsets` and
+    `_check_form_c`'s `text_lines` used to split on `str.splitlines()`'s
+    broader break set (form feed `\\x0c` among them), which CPython's
+    tokenizer - and therefore AST `lineno` - does NOT treat as a line
+    boundary. A form feed appearing on an earlier physical line inserts an
+    extra phantom "line" into the `splitlines()`-derived list/offset
+    array, so `text_lines[msg.lineno - 1]` (indexed by the true, `\\n`-only
+    AST line number) grabs the WRONG line's content and the resulting
+    character-offset comparison misses - misclassifying a genuinely
+    conforming guard as non-conforming. Fixture: a form feed sits inside a
+    string literal on the line BEFORE the assert, so `str.splitlines()`
+    over-splits by one entry ahead of the assert's own (`\\n`-only) AST
+    line number. Confirmed failing pre-fix against the parent commit's
+    module (returned `(False, 'NONE')`); this fixture must classify Form
+    C."""
+    fixture = (
+        "def check_files(hook_files):\n"
+        '    marker = "a\x0cb"\n'
+        f'    assert hook_files, "{GUARD_PHRASE}"\n'
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert ok and form == "C", (
+        f"a form feed on an earlier line should not misalign line "
+        f"numbering and cause a conforming guard to misclassify, got "
+        f"({ok}, {form})"
+    )
+
+
+def test_form_a_rejects_stdout_only_with_exit() -> None:
+    """DS-177 rework Minor 2 regression test. `_check_form_a`'s `>&2`
+    check can be silently deleted, leaving only the `exit 1` search, and
+    nothing in the suite would catch it. A guard that logs to STDOUT
+    (no `>&2`) and then exits is not the mandated Form A shape - the
+    message must be stderr-directed - and must NOT conform."""
+    fixture = f'echo "ERROR: zero matched - {GUARD_PHRASE}"\nexit 1\n'
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".yml", fixture, matches[0])
+    assert not ok, (
+        f"stdout-only (no >&2) message followed by exit 1 should NOT "
+        f"conform, got ({ok}, {form})"
+    )
+
+
+def test_form_b_rejects_stderr_write_without_exit() -> None:
+    """DS-177 rework Minor 2 regression test. `_check_form_b`'s
+    `sys.exit(1)`/`raise SystemExit` check can be silently neutered to
+    `return True`, and nothing in the suite would catch it. A Form B
+    guard that writes to stderr but never exits is the classic
+    'log but don't fail' vacuous-pass shape and must NOT conform."""
+    fixture = (
+        "def check_files(hook_files):\n"
+        f'    print("ERROR: zero matched - {GUARD_PHRASE}", file=sys.stderr)\n'
+        "    pass\n"
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert not ok, (
+        f"stderr write without sys.exit(1)/raise SystemExit should NOT "
+        f"conform, got ({ok}, {form})"
     )
 
 

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -90,6 +90,16 @@ GUARD_PHRASE = "discovery is broken, not clean"
 
 SEARCH_SUFFIXES = {".py", ".yml", ".yaml"}
 
+# Single source of truth for the module docstring's "False-positive
+# reasoning" cardinal (DS-177 rework3 Minor fix). The docstring's prose
+# ("currently 2") and test_docstring_reference_not_flagged_as_violation's
+# assertion both read this constant instead of carrying independent
+# hand-typed copies; test_module_docstring_cites_current_reference_count
+# below proves the coupling by asserting the docstring text itself embeds
+# this constant's live value, so a divergence (constant changed, prose
+# not) reddens rather than passing silently.
+DOCSTRING_REFERENCE_COUNT = 2
+
 # Content-derived, never hand-typed (DS-176 Round-2 Critical fix). All but
 # the last entry below pre-date this file; the last entry is this file's
 # own vacuous-pass guard, added because this file's own discovery guard
@@ -847,6 +857,71 @@ def test_form_a_form_feed_does_not_misalign_offsets() -> None:
     )
 
 
+def test_site_label_python_form_feed_does_not_misalign() -> None:
+    """DS-177 rework3 Major regression test. `_site_label_python`'s
+    module-level fallback branch (`if not <ident>:` guard scan) used to
+    split on `str.splitlines()`'s broader break set before this rework's
+    `text.split("\\n")` fix (:305) - the same sibling-site defect class
+    `_line_start_offsets`, `_check_form_c`'s `text_lines`, and
+    `_conforms_to_mandated_form`'s `lines` were already fixed for. Fixture:
+    two form feeds earlier in the file insert two phantom
+    `splitlines()`-only entries, misaligning the reverse index scan so it
+    lands on `DECOY1`'s guard line instead of the nearer, correct
+    `RIGHT_IDENT` guard - both `if not <ident>:` lines exist so a reverted
+    site returns a WRONG label, not merely a missing one. Confirmed RED
+    against a reverted (`splitlines()`) site during this rework: returned
+    'DECOY1' instead of 'RIGHT_IDENT'."""
+    fixture = (
+        "x = 1\x0c\n"
+        "y = 2\x0c\n"
+        "if not DECOY1:\n"
+        "    pass\n"
+        "if not RIGHT_IDENT:\n"
+        f'    print("ERROR - {GUARD_PHRASE}")\n'
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    label = _site_label_python(fixture, matches[0])
+    assert label == "RIGHT_IDENT", (
+        f"a form feed earlier in the file should not misalign the reverse "
+        f"`if not <ident>:` scan and cause it to return the wrong guard's "
+        f"identifier, got {label!r}"
+    )
+
+
+def test_site_label_yaml_form_feed_does_not_misalign() -> None:
+    """DS-177 rework3 Major regression test, mirroring
+    test_site_label_python_form_feed_does_not_misalign above. `_site_label`'s
+    yaml branch (:323) used to split on `str.splitlines()`'s broader break
+    set before this rework's `text.split("\\n")` fix - the same
+    sibling-site defect class. Fixture: two form feeds packed into one
+    line earlier in the file insert two phantom `splitlines()`-only
+    entries, misaligning the reverse upward job-name scan so it lands on
+    the decoy job `decoy1` instead of the nearer, correct job `right-job` -
+    both job-name lines exist so a reverted site returns a WRONG label,
+    not merely a missing one. Confirmed RED against a reverted
+    (`splitlines()`) site during this rework: returned 'decoy1' instead of
+    'right-job'."""
+    fixture = (
+        "jobs:\n"
+        "  filler-job:\n"
+        "    steps:\n"
+        "      - run: ff\x0c\x0cend\n"
+        "    more: stuff\n"
+        "  decoy1:\n"
+        "  right-job:\n"
+        f'      - run: echo "ERROR - {GUARD_PHRASE}" >&2; exit 1\n'
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    label = _site_label(".yml", fixture, matches[0])
+    assert label == "right-job", (
+        f"a form feed earlier in the file should not misalign the reverse "
+        f"job-name scan and cause it to return the wrong job's name, got "
+        f"{label!r}"
+    )
+
+
 def test_form_a_rejects_stdout_only_with_exit() -> None:
     """DS-177 rework Minor 2 regression test. `_check_form_a`'s `>&2`
     check can be silently deleted, leaving only the `exit 1` search, and
@@ -975,14 +1050,18 @@ def test_docstring_reference_not_flagged_as_violation() -> None:
     exact equality, not a `>= 2` lower bound - a lower bound stays green
     if a third occurrence appears on disk, silently going stale exactly
     like the word-form-cardinal class this fix closes in the module
-    docstring above."""
+    docstring above. DS-177 rework3 Minor fix: compares against
+    DOCSTRING_REFERENCE_COUNT, the same module constant this file's own
+    docstring prose is pinned against by
+    test_module_docstring_cites_current_reference_count below - not an
+    independent hand-typed `2` literal."""
     target = REPO_ROOT / "bin" / "tests" / "test_ticket_offer_gate_trigger_wording_spec.py"
     text = target.read_text(encoding="utf-8")
     matches = _normalized_scan(text)
-    assert len(matches) == 2, (
-        f"expected exactly 2 phrase occurrences in {target}, found "
-        f"{len(matches)} - re-derive the module docstring's False-positive "
-        "reasoning citation if this count has changed"
+    assert len(matches) == DOCSTRING_REFERENCE_COUNT, (
+        f"expected exactly {DOCSTRING_REFERENCE_COUNT} phrase occurrences in "
+        f"{target}, found {len(matches)} - re-derive the module docstring's "
+        "False-positive reasoning citation if this count has changed"
     )
     for line_range in matches:
         assert _is_docstring_hit(text, line_range), (
@@ -993,3 +1072,23 @@ def test_docstring_reference_not_flagged_as_violation() -> None:
         assert ok and form == "DOCUMENTATION", (
             f"{target}:{line_range} expected DOCUMENTATION classification, got ({ok}, {form})"
         )
+
+
+def test_module_docstring_cites_current_reference_count() -> None:
+    """DS-177 rework3 Minor regression test. Proves the coupling between
+    DOCSTRING_REFERENCE_COUNT and this module's own docstring prose
+    ("The exact count (currently 2) is asserted with `==`..."): asserts
+    the docstring literally embeds the constant's live value. If the
+    constant is ever changed without updating the prose (or vice versa),
+    this test reddens instead of the two hand-typed copies silently
+    diverging - the exact class Minor 3 (DS-176 rework-2) and the word-
+    form-cardinal class closed above (test_docstring_reference_not_
+    flagged_as_violation's own docstring, three paragraphs up) already
+    describe for other counts in this file."""
+    assert __doc__ is not None
+    needle = f"currently {DOCSTRING_REFERENCE_COUNT}"
+    assert needle in __doc__, (
+        f"module docstring does not contain {needle!r} - DOCSTRING_REFERENCE_COUNT "
+        f"is {DOCSTRING_REFERENCE_COUNT} but the docstring prose was not updated "
+        "to match (or the constant was changed without updating the prose)"
+    )

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -22,8 +22,10 @@ Public API: pytest test functions only. `_ast_derived_helper_call_set`,
          `test_manifest_public_api_matches_ast_derived_call_set` below,
          which walks every `test_*` function's AST call sites against this
          module's own `_`-prefixed defs and asserts bidirectional set
-         equality against this sentence's own backtick-quoted names - a
-         hand-edit that omits or phantom-adds a name reddens that test
+         equality against the enumerated, comma/and-joined run of backtick-
+         quoted names immediately above (not the surrounding rationale
+         prose in this field) - a hand-edit that omits or phantom-adds a
+         name reddens that test
          (DS-177 Fix 5, re-pinned rework4 after a helper name was added to
          a test without a matching manifest update and went undetected by
          hand-reconciliation alone).
@@ -1209,6 +1211,43 @@ def test_manifest_public_api_matches_ast_derived_call_set() -> None:
         "AST-derived set of `_`-prefixed helpers called directly from "
         f"test_* functions - missing from manifest: {sorted(missing_from_manifest)}; "
         f"phantom in manifest (no test calls this name): {sorted(phantom_in_manifest)}"
+    )
+
+
+def test_manifest_public_api_parses_enumerated_list_not_whole_field(monkeypatch) -> None:
+    """DS-177 rework6 Minor 1 pin. `_manifest_public_api_names` used to
+    slice the WHOLE `Public API:` field with a bare `` `(_name)` `` findall
+    - a name mentioned only in the field's rationale prose (outside the
+    enumerated list) counted as declared even if it had been removed from
+    the actual list. Rework5 fixed this by anchoring `_PUBLIC_API_LIST_RE`
+    on the contiguous, comma/and-joined backtick-name run immediately
+    preceding "are internal helpers". This test pins that fix permanently:
+    it builds an in-memory fixture docstring where `_phantom_name` appears
+    ONLY in the rationale prose (never in the enumerated list) and asserts
+    `_manifest_public_api_names` does not return it. The fixture is
+    installed via monkeypatch onto this module's `__doc__` for the
+    duration of the test only - the real docstring stays the thing
+    `test_manifest_public_api_matches_ast_derived_call_set` above pins, per
+    this test's own scope. Confirmed RED against a field-wide
+    `` `(_name)` `` findall (reverted `_manifest_public_api_names`), GREEN
+    against the list-scoped regex."""
+    fixture_doc = (
+        "Purpose: fixture only, not the real module docstring.\n"
+        "Public API: `_real_helper` are internal helpers (as discussed for "
+        "`_phantom_name` above, which is mentioned only in this field's "
+        "rationale prose, not in the enumerated list).\n"
+        "Upstream deps: none.\n"
+    )
+    monkeypatch.setattr(sys.modules[__name__], "__doc__", fixture_doc)
+    manifest = _manifest_public_api_names()
+    assert manifest == frozenset({"_real_helper"}), (
+        f"expected only the enumerated-list name in the fixture, got {sorted(manifest)}"
+    )
+    assert "_phantom_name" not in manifest, (
+        "a name mentioned only in the field's rationale prose (not the "
+        "enumerated list) must not count as declared - this is the exact "
+        "blind spot rework5's Minor 1 fix closed, and a regression back to "
+        "a field-wide findall would silently restore it"
     )
 
 

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -1106,21 +1106,54 @@ def test_module_docstring_cites_current_reference_count() -> None:
 
 _FIELD_HEADER_RE = re.compile(r"^([A-Z][\w \-]*):", re.MULTILINE)
 
+# Matches ONLY the contiguous, comma/and-joined run of backtick-quoted
+# `_`-prefixed names that sits immediately before the "are internal
+# helpers" clause - i.e. the enumerated list itself, not the surrounding
+# rationale prose in the same field. DS-177 rework5 Minor 1 fix: the prior
+# version slurped the whole `Public API:` field with a bare
+# `` `(_name)` `` findall, so a name mentioned only in passing in the
+# rationale (e.g. "as discussed for `_site_label_python` above") counted
+# as declared even if it had been removed from the actual list - a false
+# negative demonstrated by deleting a name from the list while adding one
+# rationale mention of it in the same field, which left the pin GREEN.
+# Anchoring on "are\b" is what makes this narrower than the field slice:
+# the enumeration is always immediately followed by "are internal
+# helpers" in this module's docstring convention (see the sentence this
+# regex targets), so nothing after that word can be mistaken for a list
+# member no matter how many more `_name` backticks appear later in the
+# same field's rationale.
+_PUBLIC_API_LIST_RE = re.compile(
+    r"((?:(?:and\s+)?`_[A-Za-z0-9_]+`,\s*)*(?:and\s+)?`_[A-Za-z0-9_]+`)\s+are\b"
+)
+
 
 def _manifest_public_api_names() -> frozenset[str]:
     """Parse THIS module's own docstring's `Public API:` field and return
-    every backtick-quoted `_`-prefixed name it lists. Field boundaries are
-    located structurally (the next unindented `Header:` line, matching the
-    module docstring's own field layout - see the raw-line audit in this
-    ticket's rework), not by a hand-typed line range, so a later field
-    reorder or insertion does not silently widen or narrow the slice."""
+    every backtick-quoted `_`-prefixed name in its enumerated LIST -
+    specifically the comma/and-joined run of names that sits directly
+    before "are internal helpers", located by `_PUBLIC_API_LIST_RE` - not
+    every backtick-quoted name anywhere in the field's text. A name
+    mentioned only in the field's rationale prose (outside that list) does
+    NOT count as declared. Field boundaries are located structurally (the
+    next unindented `Header:` line, matching the module docstring's own
+    field layout - see the raw-line audit in this ticket's rework), not by
+    a hand-typed line range, so a later field reorder or insertion does
+    not silently widen or narrow the slice fed to the list regex."""
     assert __doc__ is not None
     headers = list(_FIELD_HEADER_RE.finditer(__doc__))
     start = next(m for m in headers if m.group(1) == "Public API")
     later = [m for m in headers if m.start() > start.start()]
     end = later[0].start() if later else len(__doc__)
     field_text = __doc__[start.start():end]
-    return frozenset(re.findall(r"`(_[A-Za-z0-9_]+)`", field_text))
+    list_match = _PUBLIC_API_LIST_RE.search(field_text)
+    assert list_match is not None, (
+        "could not locate the enumerated name list (the backtick-name run "
+        "immediately preceding 'are internal helpers') inside this "
+        "module's docstring 'Public API:' field - the field's prose no "
+        "longer matches the expected list-then-'are' shape; fix the "
+        "docstring or `_PUBLIC_API_LIST_RE` before trusting this pin"
+    )
+    return frozenset(re.findall(r"`(_[A-Za-z0-9_]+)`", list_match.group(1)))
 
 
 def _ast_derived_helper_call_set() -> frozenset[str]:
@@ -1134,7 +1167,7 @@ def _ast_derived_helper_call_set() -> frozenset[str]:
     tree = ast.parse(source)
     helper_defs = {
         node.name
-        for node in ast.walk(tree)
+        for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name.startswith("_")
     }
     called: set[str] = set()
@@ -1177,3 +1210,23 @@ def test_manifest_public_api_matches_ast_derived_call_set() -> None:
         f"test_* functions - missing from manifest: {sorted(missing_from_manifest)}; "
         f"phantom in manifest (no test calls this name): {sorted(phantom_in_manifest)}"
     )
+
+
+def test_nested_local_helper_does_not_pressure_manifest_pin() -> None:
+    """DS-177 rework5 Minor 2 regression test. Defines and calls a purely
+    local, NESTED `_`-prefixed helper (not module-level) to prove
+    `_ast_derived_helper_call_set`'s `helper_defs` set is built from
+    `tree.body` (module-level defs only), not `ast.walk(tree)` (which
+    would also pick up nested defs). Before this fix, `ast.walk` pulled
+    `_helper` into `helper_defs`, and this test's own call to it made it
+    show up as "missing from manifest" in
+    `test_manifest_public_api_matches_ast_derived_call_set` - pressuring
+    an author to add a non-API local name to the docstring `Public API:`
+    field to silence a false positive, which would have made that field
+    false. Confirmed failing pre-fix by temporarily reverting the
+    `tree.body` change back to `ast.walk(tree)`."""
+
+    def _helper() -> int:
+        return 1
+
+    assert _helper() == 1

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -40,27 +40,30 @@ Downstream consumers: bin-tests.yml python-bin-tests job
 Failure modes: (a) a live guard site is deleted or weakened to a fourth,
          undetectable idiom (log-only, no `exit 1` / `sys.exit(1)` /
          assert) - caught by `test_each_live_guard_conforms_to_mandated_form`
-         and the two mutation tests; (b) `LIVE_GUARD_SITES` drifts from the
+         and the mutation tests below; (b) `LIVE_GUARD_SITES` drifts from the
          live tree (a site added or removed without updating the pin) -
          caught by the bidirectional set-equality test, in BOTH directions
          (a phantom entry naming something nonexistent is caught by
          `LIVE_GUARD_SITES - disk_live`, not just an omission); (c) phrase
          discovery itself finds nothing (this file's own vacuous-pass
          guard, `test_discovery_finds_phrase_occurrences`).
-False-positive reasoning: two prose references to the guard phrase exist
+False-positive reasoning: prose references to the guard phrase exist
          purely as documentation - bin/tests/test_ticket_offer_gate_trigger_
          wording_spec.py:36 (module docstring, explaining this file's own
          discipline by citation) and :164-165 (a FUNCTION docstring
          explaining a *different*, non-phrase-carrying guard's rationale).
-         Both are classified DOCUMENTATION by AST (first-statement string
-         constant of a Module/FunctionDef), out of scope, not a violation -
-         see `test_docstring_reference_not_flagged_as_violation`.
+         The exact count (currently 2) is asserted with `==`, never
+         hand-typed here, by `test_docstring_reference_not_flagged_as_violation`
+         - re-derive fresh at PR time, never trust a cited cardinal. Both
+         are classified DOCUMENTATION by AST (first-statement string
+         constant of a Module/FunctionDef), out of scope, not a violation.
 AC-5 scope justification (re-derive fresh at PR time, never trust a cited
          cardinal): as of this file's introduction, 29-of-77 files matched
          by the flat (non-recursive) `bin/tests/*.py` glob use a discovery
          pattern (`.glob(`, `.rglob(`, `os.walk(`, or `git ls-files`),
-         against 7 live guards (this file's own guard plus the 6
-         documented above) carrying the mandated-form phrase, across 4
+         against 7 live guards (this file's own vacuous-pass guard - the
+         last entry in `LIVE_GUARD_SITES` below - plus the pre-existing
+         entries above it) carrying the mandated-form phrase, across 4
          files. (The recursive `bin/tests/**/*.py` glob yields 80, not 77
          - a different method with a different denominator; this
          justification cites the flat glob because that is the method
@@ -179,13 +182,25 @@ def _line_start_offsets(text: str) -> list[int]:
     (1-indexed) line `i + 1`. Used to convert an AST node's
     `lineno`/`col_offset` into an absolute character offset comparable
     against `_normalized_scan_positions`' output. Splits ONLY on `\\n` -
-    NOT `str.splitlines()`'s broader break set (`\\x0b`, `\\x0c`, U+2028,
-    U+2029, U+0085, ...), which CPython's tokenizer (and therefore AST
-    `lineno`) does not treat as a line boundary. A `str.splitlines()` split
-    diverges from AST line numbering the moment one of those characters
-    appears earlier in the file, misaligning every subsequent offset
-    (DS-177 rework Minor 1 fix; `_check_form_c`'s `text_lines` has the
-    matching fix - see `test_form_c_form_feed_does_not_misalign_offsets`)."""
+    deliberately NOT `str.splitlines()`'s broader break set (`\\x0b`,
+    `\\x0c`, U+2028, U+2029, U+0085, ...), none of which CPython's
+    tokenizer (and therefore AST `lineno`) treats as a line boundary; a
+    `str.splitlines()` split diverges from AST line numbering the moment
+    one of those characters appears earlier in the file, misaligning every
+    subsequent offset (DS-177 rework Minor 1 fix; `_check_form_c`'s
+    `text_lines` has the matching fix - see
+    `test_form_c_form_feed_does_not_misalign_offsets`). This is NOT a
+    claim that `\\n`-only splitting is exactly equivalent to tokenizer line
+    boundaries in general: a lone `\\r` (old Mac line ending) IS also a
+    tokenizer/AST line boundary that `\\n`-only splitting would miss,
+    causing the same class of misalignment. That residual case is
+    unreachable via this file's real discovery path (never via an
+    in-memory mutation-test fixture, which controls its own bytes)
+    because every real file is read with `pathlib.Path.read_text()`,
+    which applies universal-newline translation - `\\r` and `\\r\\n` are
+    already collapsed to `\\n` before the text ever reaches this function
+    (verified: a CRLF fixture read via `read_text()` contains no `\\r` and
+    classifies (True, 'C'))."""
     starts = [0]
     offset = 0
     for ch in text:
@@ -282,7 +297,12 @@ def _site_label_python(text: str, line_range: tuple[int, int]) -> str | None:
         candidates.sort(key=lambda t: t[0])
         return candidates[0][1]
 
-    lines = text.splitlines()
+    # Split ONLY on "\n" - see `_line_start_offsets`' docstring (DS-177
+    # rework2 Major fix). `line_range` is derived from `_normalized_scan`,
+    # which counts `\n` only; `str.splitlines()` here would misalign
+    # `lines[i]` against that line number the moment a non-`\n` line-break
+    # character (form feed, U+2028, ...) appears earlier in the file.
+    lines = text.split("\n")
     lower_bound = max(-1, hit_line - 16)
     for i in range(hit_line - 1, lower_bound, -1):
         m = _MODULE_GUARD_RE.match(lines[i])
@@ -295,7 +315,12 @@ def _site_label(
     suffix: str, text: str, line_range: tuple[int, int]
 ) -> str | None:
     if suffix in (".yml", ".yaml"):
-        return _site_label_yaml(text.splitlines(), line_range)
+        # Split ONLY on "\n" - see `_line_start_offsets`' docstring
+        # (DS-177 rework2 Major fix). `line_range` is `\n`-counted by
+        # `_normalized_scan`; `str.splitlines()` here would misalign the
+        # indexed line the moment a non-`\n` line-break character appears
+        # earlier in the file.
+        return _site_label_yaml(text.split("\n"), line_range)
     if suffix == ".py":
         return _site_label_python(text, line_range)
     return None
@@ -419,7 +444,15 @@ def _conforms_to_mandated_form(
     whole-statement line-span containment. For .py files, a phrase
     occurring inside a docstring is classified DOCUMENTATION - out of
     scope, not a violation, not a guard."""
-    lines = text.splitlines()
+    # Split ONLY on "\n" - see `_line_start_offsets`' docstring (DS-177
+    # rework2 Major fix). `line_range` is `\n`-counted by
+    # `_normalized_scan`; `str.splitlines()` here would misalign
+    # `lines[i]` against that line number the moment a non-`\n` line-break
+    # character (form feed, U+2028, ...) appears earlier in the file -
+    # this is the exact sibling-site defect `_line_start_offsets` and
+    # `_check_form_c`'s `text_lines` were already fixed for in the DS-177
+    # rework, and that fix's reviewer measured this site as unfixed.
+    lines = text.split("\n")
     if suffix in (".yml", ".yaml"):
         ok = _check_form_a(lines, line_range)
         return (ok, "A" if ok else "NONE")
@@ -787,6 +820,33 @@ def test_form_c_form_feed_does_not_misalign_offsets() -> None:
     )
 
 
+def test_form_a_form_feed_does_not_misalign_offsets() -> None:
+    """DS-177 rework2 Major regression test, mirroring
+    test_form_c_form_feed_does_not_misalign_offsets above. The declined
+    sibling site: `_conforms_to_mandated_form` used to split on
+    `str.splitlines()`'s broader break set (form feed among them) before
+    handing `lines` to `_check_form_a`, so a form feed on an earlier
+    physical line inserted a phantom extra "line" into the list -
+    misaligning the `>&2`/`exit 1` window against the `\\n`-only
+    `line_range` `_normalized_scan` produces, and misclassifying a
+    genuinely conforming Form A guard as non-conforming. Confirmed failing
+    pre-fix against the parent commit's module (returned `(False,
+    'NONE')`); this fixture must classify Form A."""
+    fixture = (
+        'echo "a\x0cb"\n'
+        f'echo "ERROR: zero matched - {GUARD_PHRASE}" >&2\n'
+        "exit 1\n"
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".yml", fixture, matches[0])
+    assert ok and form == "A", (
+        f"a form feed on an earlier line should not misalign line "
+        f"numbering and cause a conforming Form A guard to misclassify, "
+        f"got ({ok}, {form})"
+    )
+
+
 def test_form_a_rejects_stdout_only_with_exit() -> None:
     """DS-177 rework Minor 2 regression test. `_check_form_a`'s `>&2`
     check can be silently deleted, leaving only the `exit 1` search, and
@@ -820,6 +880,31 @@ def test_form_b_rejects_stderr_write_without_exit() -> None:
     assert not ok, (
         f"stderr write without sys.exit(1)/raise SystemExit should NOT "
         f"conform, got ({ok}, {form})"
+    )
+
+
+def test_form_b_rejects_stdout_only_with_exit() -> None:
+    """DS-177 rework2 Minor 1 regression test, mirroring
+    test_form_a_rejects_stdout_only_with_exit above. `_check_form_b`'s
+    stderr-direction check (`"file=sys.stderr" not in joined_nearby and
+    "sys.stderr.write" not in joined_nearby`) can be silently deleted,
+    leaving only the `sys.exit(1)`/`raise SystemExit` search - and, unlike
+    Form A (which already had both halves guarded), nothing in the suite
+    caught it: all pre-existing tests still passed with that check
+    removed. A guard that logs to STDOUT (no stderr direction) and then
+    exits is not the mandated Form B shape - the message must be
+    stderr-directed - and must NOT conform."""
+    fixture = (
+        "def check_files(hook_files):\n"
+        f'    print("ERROR: zero matched - {GUARD_PHRASE}")\n'
+        "    sys.exit(1)\n"
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert not ok, (
+        f"stdout-only (no stderr direction) message followed by "
+        f"sys.exit(1) should NOT conform, got ({ok}, {form})"
     )
 
 
@@ -886,12 +971,18 @@ def test_mutation_guard_entirely_removed_reddens(tmp_path: pathlib.Path) -> None
 def test_docstring_reference_not_flagged_as_violation() -> None:
     """test_ticket_offer_gate_trigger_wording_spec.py:36 (module docstring)
     and :164-165 (function docstring) both classify as DOCUMENTATION
-    (AST-confirmed), not NON-CONFORMING."""
+    (AST-confirmed), not NON-CONFORMING. DS-177 rework2 Minor 2 fix:
+    exact equality, not a `>= 2` lower bound - a lower bound stays green
+    if a third occurrence appears on disk, silently going stale exactly
+    like the word-form-cardinal class this fix closes in the module
+    docstring above."""
     target = REPO_ROOT / "bin" / "tests" / "test_ticket_offer_gate_trigger_wording_spec.py"
     text = target.read_text(encoding="utf-8")
     matches = _normalized_scan(text)
-    assert len(matches) >= 2, (
-        f"expected at least 2 phrase occurrences in {target}, found {len(matches)}"
+    assert len(matches) == 2, (
+        f"expected exactly 2 phrase occurrences in {target}, found "
+        f"{len(matches)} - re-derive the module docstring's False-positive "
+        "reasoning citation if this count has changed"
     )
     for line_range in matches:
         assert _is_docstring_hit(text, line_range), (

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -12,8 +12,11 @@ Purpose: Regression guard for DS-176 (the vacuous-pass check class): every
          weakening edit (e.g. dropping the `exit 1`, or turning the guard
          into a bare log statement) reddens this suite.
 Public API: pytest test functions only. `_normalized_scan`, `_site_label`,
-         `_conforms_to_mandated_form`, and `_discover_live_sites` are
-         internal helpers exercised directly by the mutation tests below.
+         `_conforms_to_mandated_form`, `_discover_live_sites`, and
+         `_is_docstring_hit` are internal helpers exercised directly by the
+         mutation tests below (derived by walking every `test_*` function's
+         AST call sites against this module's own `_`-prefixed defs, not
+         hand-typed - DS-177 Fix 5).
 Upstream deps: `git ls-files` (repo-relative, tracked-only discovery -
          this checkout's `.claude/worktrees/agent-*` count fluctuates
          session-to-session as isolation worktrees are created and reaped
@@ -106,9 +109,14 @@ LIVE_GUARD_SITES = frozenset(
 def _tracked_relative_paths() -> list[pathlib.Path]:
     """Git-tracked paths with a SEARCH_SUFFIXES extension, resolved
     relative to REPO_ROOT. Scoping via `git ls-files` (rather than an
-    unfiltered directory walk) matters because this checkout carries 40+
-    `.claude/worktrees/agent-*` copies of the whole tree, none of which are
-    part of the primary worktree's git index."""
+    unfiltered directory walk) matters because this checkout carries a
+    fluctuating number of `.claude/worktrees/agent-*` copies of the whole
+    tree - created and reaped session-to-session as isolation worktrees
+    spin up and down (measured 35-36 across two checks in one review; see
+    the module docstring's Upstream deps note) - none of which are part of
+    the primary worktree's git index. DS-177 Fix 4: no cardinal is
+    asserted here, since one would go stale independently of this
+    function's own behavior."""
     result = subprocess.run(
         ["git", "-C", str(REPO_ROOT), "ls-files"],
         capture_output=True,
@@ -299,51 +307,83 @@ def _check_form_b(lines: list[str], line_range: tuple[int, int]) -> bool:
     return "sys.exit(1)" in joined_after or "raise SystemExit" in joined_after
 
 
+def _byte_col_to_char_col(line: str, byte_col: int) -> int:
+    """`ast` node `col_offset`/`end_col_offset` values are UTF-8 BYTE
+    offsets into their line (the `ast` module's documented contract),
+    while `_line_start_offsets` and `_normalized_scan_positions` both
+    count CHARACTERS. Comparing the two directly without this conversion
+    shifts the comparison by one position per multi-byte character
+    preceding the offset on that line (DS-177 Fix 2 - measured: 20
+    multi-byte characters earlier on the line made a conforming Form C
+    guard misclassify as NONE). Converts by encoding `line` to UTF-8,
+    slicing the first `byte_col` bytes, decoding back to str, and taking
+    the resulting character length - AST byte offsets always land on a
+    UTF-8 boundary (token boundaries in valid source), so this slice never
+    splits a multi-byte sequence."""
+    return len(line.encode("utf-8")[:byte_col].decode("utf-8"))
+
+
 def _check_form_c(text: str, line_range: tuple[int, int]) -> bool:
     """AST-based, at CHARACTER-OFFSET precision, not proximity regex or
     line-span containment (DS-176 rework-2 Major fix, then re-fixed to
-    column granularity in the same round). Line-range containment on
-    `node.msg` alone is still not sufficient: a one-liner assert's
-    CONDITION and MESSAGE share the same physical line number
-    (`assert "<phrase>" not in out, "unexpected"` - phrase in the
+    column granularity in the same round; DS-177 fixed three further
+    defects in this same comparison - see Fix 1/2/3 notes below). Line-
+    range containment on `node.msg` alone is still not sufficient: a
+    one-liner assert's CONDITION and MESSAGE share the same physical line
+    number (`assert "<phrase>" not in out, "unexpected"` - phrase in the
     condition, "unexpected" the message, both on line N), so line-level
-    comparison cannot tell them apart. This re-locates the phrase hit's
-    exact character-offset span (via `_normalized_scan_positions`, not
-    just its line range) and requires that span to fall inside `node.msg`'s
-    own character-offset span (from `lineno`/`col_offset` to
-    `end_lineno`/`end_col_offset`) - never the whole assert statement, and
-    never `node.test`. Also still catches the earlier same-line
-    `print("...phrase"); assert True` shape: `assert True` has no `msg` at
-    all, so it is skipped outright."""
+    comparison cannot tell them apart. This re-locates every phrase hit
+    whose (start_line, end_line) equals `line_range` (DS-177 Fix 1: ALL
+    such hits, not just the first found - a one-liner where the phrase
+    appears in both the condition AND the message, e.g. `assert "<p>" in
+    out, "bad - <p>"`, has two same-line-range hits, and testing only the
+    leftmost one rejected a genuinely conforming guard) at exact
+    character-offset precision (via `_normalized_scan_positions`, DS-177
+    Fix 2: `node.msg`'s AST col_offset/end_col_offset are UTF-8 BYTE
+    offsets and must be converted to character offsets via
+    `_byte_col_to_char_col` before comparison against the character-offset
+    hit spans, or a multi-byte character earlier on the line shifts every
+    downstream comparison) and requires the hit span to fall FULLY INSIDE
+    `node.msg`'s own character-offset span (DS-177 Fix 3: containment, not
+    overlap - a straddling hit like `assert discovery is broken, not
+    clean` (phrase spanning the test/msg comma boundary) overlaps
+    `node.msg`'s span without being contained in it and must NOT conform)
+    - never the whole assert statement, and never `node.test`. Also still
+    catches the earlier same-line `print("...phrase"); assert True` shape:
+    `assert True` has no `msg` at all, so it is skipped outright."""
     try:
         tree = ast.parse(text)
     except SyntaxError:
         return False
 
-    hit_start_offset: int | None = None
-    hit_end_offset: int | None = None
+    hit_offsets: list[tuple[int, int]] = []
     for orig_start, orig_end in _normalized_scan_positions(text):
         start_line = text.count("\n", 0, orig_start) + 1
         end_line = text.count("\n", 0, orig_end) + 1
         if (start_line, end_line) == line_range:
-            hit_start_offset, hit_end_offset = orig_start, orig_end
-            break
-    if hit_start_offset is None:
+            hit_offsets.append((orig_start, orig_end))
+    if not hit_offsets:
         return False
 
     line_starts = _line_start_offsets(text)
+    text_lines = text.splitlines()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
             continue
         msg = node.msg
         if msg is None:
             continue
-        msg_start_offset = line_starts[msg.lineno - 1] + msg.col_offset
+        msg_start_line_text = text_lines[msg.lineno - 1]
+        msg_start_char_col = _byte_col_to_char_col(msg_start_line_text, msg.col_offset)
+        msg_start_offset = line_starts[msg.lineno - 1] + msg_start_char_col
         msg_end_lineno = getattr(msg, "end_lineno", msg.lineno)
         msg_end_col = getattr(msg, "end_col_offset", msg.col_offset)
-        msg_end_offset = line_starts[msg_end_lineno - 1] + msg_end_col - 1
-        if msg_start_offset <= hit_end_offset and hit_start_offset <= msg_end_offset:
-            return True
+        msg_end_line_text = text_lines[msg_end_lineno - 1]
+        msg_end_char_col = _byte_col_to_char_col(msg_end_line_text, msg_end_col)
+        msg_end_offset = line_starts[msg_end_lineno - 1] + msg_end_char_col - 1
+        for hit_start_offset, hit_end_offset in hit_offsets:
+            if msg_start_offset <= hit_start_offset and hit_end_offset <= msg_end_offset:
+                return True
     return False
 
 
@@ -585,6 +625,83 @@ def test_form_c_accepts_assert_that_itself_carries_the_phrase() -> None:
     assert matches
     ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
     assert ok and form == "C", f"expected Form C, got ({ok}, {form})"
+
+
+def test_form_c_accepts_phrase_in_both_condition_and_message() -> None:
+    """DS-177 Fix 1 regression test. `_check_form_c` used to re-locate the
+    phrase hit's character-offset span by BREAKing on the first
+    `line_range` match it found. When the phrase appears in BOTH the
+    assert's CONDITION and its MESSAGE on one line
+    (`assert "<phrase>" in out, "bad - <phrase>"`), both occurrences share
+    the same (start_line, end_line), and the leftmost (condition) offset
+    won the break - so a genuinely conforming guard (the message DOES
+    carry the phrase) was rejected. Must conform: at least one of the two
+    same-line-range hits (the message one) falls inside `node.msg`'s
+    span."""
+    fixture = (
+        "def check_output(out):\n"
+        f'    assert "{GUARD_PHRASE}" in out, "bad - {GUARD_PHRASE}"\n'
+    )
+    matches = _normalized_scan(fixture)
+    assert len(matches) == 2, f"expected 2 same-line-range hits, got {matches}"
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert ok and form == "C", (
+        f"phrase present in the message (as well as the condition) should "
+        f"still conform via the message occurrence, got ({ok}, {form})"
+    )
+
+
+def test_form_c_multibyte_characters_before_message_do_not_misalign() -> None:
+    """DS-177 Fix 2 regression test. `ast` node `col_offset`/
+    `end_col_offset` are UTF-8 BYTE offsets, while `_line_start_offsets`
+    and `_normalized_scan_positions` both count CHARACTERS; comparing them
+    directly shifted the comparison by one position per multi-byte
+    character preceding the assert's message on the same line. 20 CJK
+    characters (3 bytes each in UTF-8, so +2 bytes per character over a
+    naive 1-byte-per-char assumption = 40 bytes of drift) in the
+    condition, immediately before a message that IS just the phrase, push
+    the mis-derived message-start offset past the phrase's true end
+    offset - reddening a genuinely conforming guard. (A non-em-dash
+    multi-byte character is used deliberately; this repo bans authored
+    em dashes and the point under test is multi-byte width, not the exact
+    character.)"""
+    multibyte_padding = "日" * 20  # CJK "day/sun" character, 3 UTF-8 bytes
+    fixture = (
+        "def check_files(hook_files):\n"
+        f'    assert hook_files == "{multibyte_padding}", "{GUARD_PHRASE}"\n'
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert ok and form == "C", (
+        f"multi-byte padding earlier on the line should not affect Form C "
+        f"classification, got ({ok}, {form})"
+    )
+
+
+def test_form_c_rejects_hit_straddling_condition_message_boundary() -> None:
+    """DS-177 Fix 3 regression test. `_check_form_c` used to test interval
+    OVERLAP between the phrase hit and `node.msg`'s span, not containment,
+    despite its own docstring promising containment ("fall inside"). A
+    phrase hit that STRADDLES the test/msg comma boundary -
+    `assert discovery is broken, not clean` has `node.test` = `discovery
+    is broken` and `node.msg` = `not clean`, and the phrase spans both -
+    overlapped `node.msg`'s span without being contained in it, and the
+    old overlap check wrongly accepted it. Must NOT conform: the assert's
+    message here is `not clean`, which says nothing about discovery being
+    broken."""
+    fixture = (
+        "def check():\n"
+        f"    assert {GUARD_PHRASE}\n"
+    )
+    matches = _normalized_scan(fixture)
+    assert matches
+    ok, form = _conforms_to_mandated_form(".py", fixture, matches[0])
+    assert not ok, (
+        f"a phrase hit straddling the assert's test/msg boundary should "
+        f"NOT conform (the message alone does not carry the phrase), got "
+        f"({ok}, {form})"
+    )
 
 
 def test_mutation_weakened_to_log_only_reddens() -> None:

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -11,12 +11,22 @@ Purpose: Regression guard for DS-176 (the vacuous-pass check class): every
          derived classification table, so an accidental deletion or a
          weakening edit (e.g. dropping the `exit 1`, or turning the guard
          into a bare log statement) reddens this suite.
-Public API: pytest test functions only. `_normalized_scan`, `_site_label`,
-         `_conforms_to_mandated_form`, `_discover_live_sites`, and
-         `_is_docstring_hit` are internal helpers exercised directly by the
-         mutation tests below (derived by walking every `test_*` function's
-         AST call sites against this module's own `_`-prefixed defs, not
-         hand-typed - DS-177 Fix 5).
+Public API: pytest test functions only. `_ast_derived_helper_call_set`,
+         `_conforms_to_mandated_form`, `_discover_live_sites`,
+         `_is_docstring_hit`, `_manifest_public_api_names`,
+         `_normalized_scan`, `_site_label`, and `_site_label_python` are
+         internal helpers exercised directly by test functions below (the
+         two helpers backing the pin test itself are self-covering - the
+         same AST walk that pins this field also scans the pin test's own
+         body). This list is no longer hand-reconciled: it is PINNED by
+         `test_manifest_public_api_matches_ast_derived_call_set` below,
+         which walks every `test_*` function's AST call sites against this
+         module's own `_`-prefixed defs and asserts bidirectional set
+         equality against this sentence's own backtick-quoted names - a
+         hand-edit that omits or phantom-adds a name reddens that test
+         (DS-177 Fix 5, re-pinned rework4 after a helper name was added to
+         a test without a matching manifest update and went undetected by
+         hand-reconciliation alone).
 Upstream deps: `git ls-files` (repo-relative, tracked-only discovery -
          this checkout's `.claude/worktrees/agent-*` count fluctuates
          session-to-session as isolation worktrees are created and reaped,
@@ -1091,4 +1101,79 @@ def test_module_docstring_cites_current_reference_count() -> None:
         f"module docstring does not contain {needle!r} - DOCSTRING_REFERENCE_COUNT "
         f"is {DOCSTRING_REFERENCE_COUNT} but the docstring prose was not updated "
         "to match (or the constant was changed without updating the prose)"
+    )
+
+
+_FIELD_HEADER_RE = re.compile(r"^([A-Z][\w \-]*):", re.MULTILINE)
+
+
+def _manifest_public_api_names() -> frozenset[str]:
+    """Parse THIS module's own docstring's `Public API:` field and return
+    every backtick-quoted `_`-prefixed name it lists. Field boundaries are
+    located structurally (the next unindented `Header:` line, matching the
+    module docstring's own field layout - see the raw-line audit in this
+    ticket's rework), not by a hand-typed line range, so a later field
+    reorder or insertion does not silently widen or narrow the slice."""
+    assert __doc__ is not None
+    headers = list(_FIELD_HEADER_RE.finditer(__doc__))
+    start = next(m for m in headers if m.group(1) == "Public API")
+    later = [m for m in headers if m.start() > start.start()]
+    end = later[0].start() if later else len(__doc__)
+    field_text = __doc__[start.start():end]
+    return frozenset(re.findall(r"`(_[A-Za-z0-9_]+)`", field_text))
+
+
+def _ast_derived_helper_call_set() -> frozenset[str]:
+    """Walk THIS module's own source (read from disk, not `__doc__` or an
+    in-memory copy) and collect every `_`-prefixed module-level function
+    that is called DIRECTLY (by bare name, not via an attribute or an
+    indirect reference) from inside a `test_*` function body. This is the
+    exact method the module docstring's `Public API:` field claims to be
+    pinned against."""
+    source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    helper_defs = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("_")
+    }
+    called: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            for sub in ast.walk(node):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Name)
+                    and sub.func.id in helper_defs
+                ):
+                    called.add(sub.func.id)
+    return frozenset(called)
+
+
+def test_manifest_public_api_matches_ast_derived_call_set() -> None:
+    """DS-177 rework4 Major regression test. The module docstring's
+    `Public API:` list has now been hand-reconciled twice (DS-177 Fix 5;
+    then again to add `_is_docstring_hit`) and regressed once
+    (`_site_label_python` was added to
+    `test_site_label_python_form_feed_does_not_misalign` in rework3
+    without a matching manifest update, and nothing caught it - AC-5
+    passed at the prior commit and silently failed at this one). A third
+    hand-reconciliation is not a fix, so this test derives BOTH sides from
+    source - the manifest sentence itself (`_manifest_public_api_names`,
+    parsed from `__doc__`, not a duplicate hand-typed constant) and the
+    real AST call graph (`_ast_derived_helper_call_set`) - and asserts
+    BIDIRECTIONAL set equality, not containment: an omission (a helper
+    called by a test but missing from the manifest) and a phantom entry
+    (a manifest name no test actually calls, e.g. pointing at a renamed
+    or deleted helper) are both defects, and containment-only would catch
+    only the first."""
+    manifest = _manifest_public_api_names()
+    derived = _ast_derived_helper_call_set()
+    missing_from_manifest = derived - manifest
+    phantom_in_manifest = manifest - derived
+    assert not missing_from_manifest and not phantom_in_manifest, (
+        "module docstring 'Public API:' list is out of sync with the "
+        "AST-derived set of `_`-prefixed helpers called directly from "
+        f"test_* functions - missing from manifest: {sorted(missing_from_manifest)}; "
+        f"phantom in manifest (no test calls this name): {sorted(phantom_in_manifest)}"
     )


### PR DESCRIPTION
## Problem

Five defects in `bin/tests/test_discovery_zero_match_guard_spec.py`, found by the DS-176 implementation review and recorded as accepted debt at that merge. Deferring was the wrong call, and one of the five was not debt at all: it was a fail-closed regression DS-176's own final round introduced.

All five failed in the loud direction, so nothing was unprotected. But two of them **rejected correctly-written guards**, meaning the file enforced a narrower standard than `content/references/code-standards-detail.md` §Discovery-Based Check Discipline documents. A contributor writing a conforming guard would have hit an opaque red and had to reverse-engineer the real rule.

Ticket: DS-177.

## What shipped

The original five:

1. **`_check_form_c` broke on the first offset match** (regression from DS-176). With the phrase in both an assert's condition and its message on one line, only the leftmost hit was tested.
2. **Byte-vs-character offset mismatch.** `msg.col_offset` is a UTF-8 byte offset; `_line_start_offsets` counted characters.
3. **Overlap where the docstring said containment.** The stricter relation now ships.
4. **Hand-typed cardinals removed.** The `40+` worktree claim, then its `35-36` replacement, then two more found by an all-forms re-sweep (word form, not just numeral - the documented count-sync blind spot).
5. **Manifest `Public API:`** completed, then **pinned** - see below.

Plus four found during review:

6. **The `splitlines()` class**, which splits on `\x0c`, `\x0b`, U+2028/2029, U+0085 where the CPython tokenizer and `text.count("\n")` do not. Fixed at all three source-line-indexing sites (`_site_label_python`, `_site_label`'s yaml branch, `_conforms_to_mandated_form`); `:132` parses git stdout and is legitimately out of class.
7. **Three checker neuterings that survived green** - Form A's `>&2` check, Form B's stderr-direction check, and the `only_on_disk` set direction.
8. **A dangling cross-reference** and an **overstated docstring equivalence** (a lone `\r` is also a tokenizer boundary; unreachable in practice because `read_text` applies universal-newline translation).
9. **AC-5 pinned mechanically.** The `Public API:` list had been hand-reconciled twice and regressed once. It is now set-equality-pinned against an AST-derived walk of every `_`-helper any `test_*` function calls, bidirectionally, so over-declaration reddens as well as omission.

## Verification

Every fix ships a regression test proven to fail against the pre-fix implementation by function swap, not by assertion. The two label-site fixes are pinned **independently** - reverting either site reddens only its own test, so neither can revert silently behind the other.

**Gate neither narrowed nor widened.** All 7 live guard sites conform (4 Form A, 2 Form B, 1 Form C) with correct resolved labels; `disk_live == LIVE_GUARD_SITES` with both difference directions empty. The six-mutation real-file battery still reddens, with shasum-verified byte-identical restores.

**Vacuity sweep clean.** Every test carries a named, executed mutation that reddens it, with each mutation diff-confirmed as landed before trusting the result - a reviewer's own battery was silently vacuous once from heredoc quoting.

All three budget gates unmoved (test-only diff). Zero adapter drift against the verbatim `adapter-sync.yml` pathspec. Rebased onto current `main`; all commits DCO-valid with no merge commits.

## North Star alignment

**Pillar 7 (prevent defects at the producing step)** - served. Two defects silently rejected valid work; a contributor would have learned the real rule only by hitting a red gate.

**Pillar 2 (verifiable outcomes autonomously)** - served, and this is the substantive one. Each fix is pinned by a test proven to fail against the exact prior implementation, so the fix's shape is encoded rather than its symptom. AC-5 moved from hand-maintained to mechanically enforced.

**Pillar 1 (guard operator attention)** - served indirectly. These were surfaced as a debt list rather than fixed; that is the cost this closes.

**Pillar 5 (guard agent context)** - neutral. Test-only, no budgeted surface touched.

## Review rigor

Five implementation review rounds, on top of DS-176's seven passes on the same file. Every round found something, and the pattern is worth recording because it is the ticket's own subject:

- Round 1: the `splitlines()` class, fixed at two sites and declined at a third on "not part of the named fix" - the declined site demonstrably misclassified a conforming guard.
- Round 2: all three sites fixed, but only one pinned. Reverting either label site left the whole suite green.
- Round 3: both sites pinned - and the new test called a symbol the manifest did not list, reverting AC-5 which had passed one commit earlier.

Three consecutive rounds of the same shape: a named class repaired at the sites someone pointed at, while the sibling, the pin, or the manifest went unexamined. That is why AC-5 ended up mechanically pinned rather than hand-corrected a third time - a derived bidirectional assertion is the only form that has held anywhere in this repo.

AC-4's original wording ("no hand-typed cardinal remains anywhere") proved unachievable and was formally amended on the ticket to the rule actually enforced: no such cardinal unless it is pinned by a test that reddens on drift, or explicitly snapshot-framed with a re-derive-at-use-time disclaimer.

Two Minors carried deliberately: two `currently 2` echoes that quote the pinned prose rather than asserting an independent count, and nothing else.


## Final rounds

Two hardening rounds after sign-off, both closing findings in the newly-added manifest pin rather than in the original defects.

The pin initially sliced the whole `Public API:` docstring field, so a `_name` appearing in the field's rationale prose counted as declared - demonstrated blind by deleting a name from the list while mentioning it in prose. It now parses only the enumerated, comma/and-joined run of backtick names, and asserts loudly rather than degrading silently if that shape is absent. Separately, `ast.walk` was including nested function defs where the docstring claimed module-level, so a purely local `_helper` inside a test would have falsely reddened the pin and pressured the author into declaring a non-API name; that is now `tree.body`.

Both fixes are pinned by permanent regression tests proven RED against the pre-fix implementation, not just verified once by hand. That mattered: the unpinned-fix pattern - change lands, pin does not, next round finds it - produced a Major earlier in this same PR.

**Declined, deliberately:** `_PUBLIC_API_LIST_RE` does not accept a no-Oxford-comma two-name list, and a line-wrap split in a first or middle name reddens as "missing from manifest" rather than the locate assertion. Both fail safe in every probed position - they redden, never pass silently - so the only cost is a less precise error message on an edit nobody has made. The reviewer and the implementer independently reached the same conclusion.

Final: 1709 tests pass, 28 in this file. All six pin behaviours verified live with byte-identical restores: name deleted, phantom name, undeclared new helper, helper renamed in def and call sites, list-scope-vs-field-scope, and nested-local-does-not-trip. Seven live guard sites still conform, 4 Form A / 2 Form B / 1 Form C, with set equality empty in both directions.
