### PR TITLE
fix(hooks): document and pin the ticket-batching script-file false-negative

### DIFF
--- a/bin/tests/test_enforce_ticket_batching.py
+++ b/bin/tests/test_enforce_ticket_batching.py
@@ -146,9 +146,12 @@ Test groups:
                                                     inspects the command
                                                     string only.
 
-Note: this index enumerates the first 35 tests in file order (through the
-Bash Python-client coverage added alongside the script-file-indirection
-residual); the remaining tests below it are not individually indexed here.
+Note: the numbers above are historical labels assigned when each entry was
+added, not file positions - this file's test order has drifted from the
+index across several PRs. This index is a partial, non-contiguous list;
+not every test in the file is described here. Run `grep '^def test_'
+bin/tests/test_enforce_ticket_batching.py` for the authoritative, current
+list of tests in file order.
 
 Run with: python3 -m pytest bin/tests/test_enforce_ticket_batching.py -x
        or: python3 bin/tests/test_enforce_ticket_batching.py

--- a/bin/tests/test_enforce_ticket_batching.py
+++ b/bin/tests/test_enforce_ticket_batching.py
@@ -121,6 +121,34 @@ Test groups:
                                                     exempting record still
                                                     exempts (bad line skipped,
                                                     scan continues).
+ 32. test_python_urllib_post_to_comment_path_never_matches - a
+                                                    urllib.request POST to a
+                                                    non-create Jira path
+                                                    (comment endpoint) never
+                                                    matches.
+ 33. test_python_urllib_get_to_issue_create_path_never_matches - a
+                                                    urllib.request GET (no
+                                                    POST signal) to the
+                                                    issue-create path never
+                                                    matches.
+ 34. test_bash_grep_of_python_urllib_post_literal_never_matches - a grep
+                                                    whose search pattern
+                                                    contains a literal
+                                                    urllib.request POST
+                                                    string as DATA never
+                                                    matches.
+ 35. test_bash_script_file_indirection_never_matches - documented residual:
+                                                    a create routed through a
+                                                    script file written to
+                                                    disk and executed is
+                                                    never counted, since
+                                                    `_bash_is_creation`
+                                                    inspects the command
+                                                    string only.
+
+Note: this index enumerates the first 35 tests in file order (through the
+Bash Python-client coverage added alongside the script-file-indirection
+residual); the remaining tests below it are not individually indexed here.
 
 Run with: python3 -m pytest bin/tests/test_enforce_ticket_batching.py -x
        or: python3 bin/tests/test_enforce_ticket_batching.py
@@ -885,27 +913,45 @@ def test_bash_grep_of_python_urllib_post_literal_never_matches():
 def test_bash_script_file_indirection_never_matches():
     """Documented residual (module docstring "Residual Bash false-
     negative class"): a create routed through a script file WRITTEN to
-    disk and then EXECUTED - `python3 /some/path/script.py`, with no
+    disk and then EXECUTED - `python3 /path/to/script.py`, with no
     inline HTTP-client reference, endpoint path, or POST verb in the
-    command string itself - is never counted as a creation.
+    command string itself - is never counted as a creation, even when
+    the referenced file genuinely contains all three signals.
     `_bash_is_creation` inspects `tool_input.command` only; it never
     resolves or reads the referenced file, so the urllib.request call,
-    the `/rest/api/3/issue` path, and the POST method that would live
-    inside such a script are invisible here. This pins the gap as
-    intentional per the docstring, not an untested oversight - it will
-    redden if a future change starts resolving/reading script files
-    without updating the docs to match.
+    the `/rest/api/3/issue` path, and the POST method living inside the
+    script are invisible here. This pins the gap as intentional per the
+    docstring, not an untested oversight.
 
-    Mutation that would redden this assertion: making
-    `_PYTHON_HTTP_CLIENT_RE` (or an equivalent signal) match on the bare
-    `python3 <path>` invocation shape alone, without requiring an actual
-    HTTP-client reference in the command string - e.g. widening the
-    regex to `python3\\s+\\S+\\.py` would cause this command to
-    misclassify as a creation, since a script-file invocation with no
-    inline signal would then match on the interpreter/path shape alone."""
+    The referenced script is written to disk with a real create call
+    (`urllib.request` POST to `/rest/api/3/issue`) so the assertion has
+    something to be wrong about - a nonexistent script path would make
+    this test pass under a mutated, file-reading hook for the wrong
+    reason (nothing to read), independent of whether the mutation
+    actually restores the signal.
+
+    Mutation that would redden this assertion: making `_bash_is_creation`
+    resolve `command`'s script-file argument and search ITS content for
+    the same signals it already checks in the command string - since the
+    script on disk here genuinely carries the client reference, the
+    endpoint path, and the POST verb, a file-reading hook would
+    reclassify this call as a creation. Confirmed by direct execution:
+    patching the hook to read the referenced file's content into the
+    string handed to `_bash_is_creation` flips this assertion (see
+    the fix history for this test)."""
     with tempfile.TemporaryDirectory() as tmp:
         _ensure_git_marker(tmp)
-        cmd = "python3 /tmp/scratch/file_tickets.py"
+        script_path = Path(tmp) / "file_tickets.py"
+        script_path.write_text(
+            "import urllib.request\n"
+            "req = urllib.request.Request(\n"
+            "    'https://jira.example.com/rest/api/3/issue',\n"
+            "    data=b'{}',\n"
+            "    method='POST',\n"
+            ")\n"
+            "urllib.request.urlopen(req)\n"
+        )
+        cmd = f"python3 {script_path}"
         rc, parsed = _run_hook(_bash_payload(tmp, cmd))
         assert rc == 0
         assert parsed is None

--- a/bin/tests/test_enforce_ticket_batching.py
+++ b/bin/tests/test_enforce_ticket_batching.py
@@ -882,6 +882,36 @@ def test_bash_grep_of_python_urllib_post_literal_never_matches():
         assert not _state_path(tmp, "sess-1").exists()
 
 
+def test_bash_script_file_indirection_never_matches():
+    """Documented residual (module docstring "Residual Bash false-
+    negative class"): a create routed through a script file WRITTEN to
+    disk and then EXECUTED - `python3 /some/path/script.py`, with no
+    inline HTTP-client reference, endpoint path, or POST verb in the
+    command string itself - is never counted as a creation.
+    `_bash_is_creation` inspects `tool_input.command` only; it never
+    resolves or reads the referenced file, so the urllib.request call,
+    the `/rest/api/3/issue` path, and the POST method that would live
+    inside such a script are invisible here. This pins the gap as
+    intentional per the docstring, not an untested oversight - it will
+    redden if a future change starts resolving/reading script files
+    without updating the docs to match.
+
+    Mutation that would redden this assertion: making
+    `_PYTHON_HTTP_CLIENT_RE` (or an equivalent signal) match on the bare
+    `python3 <path>` invocation shape alone, without requiring an actual
+    HTTP-client reference in the command string - e.g. widening the
+    regex to `python3\\s+\\S+\\.py` would cause this command to
+    misclassify as a creation, since a script-file invocation with no
+    inline signal would then match on the interpreter/path shape alone."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _ensure_git_marker(tmp)
+        cmd = "python3 /tmp/scratch/file_tickets.py"
+        rc, parsed = _run_hook(_bash_payload(tmp, cmd))
+        assert rc == 0
+        assert parsed is None
+        assert not _state_path(tmp, "sess-1").exists()
+
+
 def test_bash_grep_of_curl_post_literal_never_matches():
     """Residual false-positive fix: a grep whose SEARCH PATTERN contains
     a literal curl-POST-to-Jira-issue-create string as DATA (not an

--- a/bin/tests/test_enforce_ticket_batching.py
+++ b/bin/tests/test_enforce_ticket_batching.py
@@ -822,6 +822,66 @@ def test_python_urllib_mention_without_jira_path_never_matches():
         assert not _state_path(tmp, "sess-1").exists()
 
 
+def test_python_urllib_post_to_comment_path_never_matches():
+    """Isolates the Python-client verb signal from the CREATE-path
+    requirement on the comment/sub-resource shape specifically: a
+    urllib.request POST to /rest/api/3/issue/DS-1/comment (an update on
+    an EXISTING issue, not a create) never matches, even though the
+    Python-client signal, the POST signal, and the literal "issue" path
+    segment are all present."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _ensure_git_marker(tmp)
+        cmd = (
+            "python3 -c \"import urllib.request; "
+            "urllib.request.Request('https://jira.example.com/rest/api/3/issue/DS-1/comment', "
+            "method='POST')\""
+        )
+        rc, parsed = _run_hook(_bash_payload(tmp, cmd))
+        assert rc == 0
+        assert parsed is None
+        assert not _state_path(tmp, "sess-1").exists()
+
+
+def test_python_urllib_get_to_issue_create_path_never_matches():
+    """Isolates the Python-client verb signal from the POST-method
+    requirement: a urllib.request GET (no method='POST' kwarg, no -X
+    POST/--request POST flag, no bare POST token) against the Jira
+    issue-create path never matches."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _ensure_git_marker(tmp)
+        cmd = (
+            "python3 -c \"import urllib.request; "
+            "urllib.request.urlopen('https://jira.example.com/rest/api/3/issue')\""
+        )
+        rc, parsed = _run_hook(_bash_payload(tmp, cmd))
+        assert rc == 0
+        assert parsed is None
+        assert not _state_path(tmp, "sess-1").exists()
+
+
+def test_bash_grep_of_python_urllib_post_literal_never_matches():
+    """Residual false-positive fix, Python-client variant: a grep whose
+    SEARCH PATTERN contains a literal urllib.request POST-to-Jira-
+    issue-create string as DATA (not an actual outbound call) never
+    matches - mirrors test_bash_grep_of_curl_post_literal_never_matches
+    for the Python-client signal added alongside the shell-verb gate.
+    Also covers the narrower shape the ticket brief named directly: a
+    grep pattern that merely contains the word "python3" as literal
+    text is not itself sufficient signal (the Python-client gate keys on
+    urllib.request/requests.*/httpx.*, never on a bare "python3" token,
+    so this also demonstrates that weaker design choice holds)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _ensure_git_marker(tmp)
+        cmd = (
+            "grep -rn 'python3 -c urllib.request.Request POST "
+            "/rest/api/3/issue' bin/tests/"
+        )
+        rc, parsed = _run_hook(_bash_payload(tmp, cmd))
+        assert rc == 0
+        assert parsed is None
+        assert not _state_path(tmp, "sess-1").exists()
+
+
 def test_bash_grep_of_curl_post_literal_never_matches():
     """Residual false-positive fix: a grep whose SEARCH PATTERN contains
     a literal curl-POST-to-Jira-issue-create string as DATA (not an

--- a/hooks/enforce-ticket-batching.py
+++ b/hooks/enforce-ticket-batching.py
@@ -225,6 +225,31 @@ Purpose: PreToolUse hook that mechanically enforces a grace margin under
          bounded window (e.g. N turns after the command marker), which is
          not implemented here.
 
+         **Residual Bash false-negative class (verified real, accepted).**
+         `_bash_is_creation` inspects `tool_input.command` only - it never
+         resolves or reads a referenced script file. A create routed
+         through a script WRITTEN to disk and then executed
+         (`python3 /tmp/scratch/file_tickets.py`) carries none of the
+         detection signals in the command string itself (the
+         `urllib.request` reference, the `/rest/api/3/issue` path, the
+         POST verb all live inside the file, not on the command line), so
+         it is invisible to this hook and never advances the counter. This
+         is the uncovered sibling of the documented `python3 - <<EOF`
+         heredoc case above (there, the body IS in the command string and
+         therefore IS visible; here, it never is). Confirmed to have
+         happened in this repo's own session history: an agent wrote a
+         creation script to a scratchpad directory and ran it, creating
+         four Jira tickets, with no `.ticket-batch-*.json` counter file
+         written that day - the guard never matched, so neither the
+         advisory nor the deny fired. Not attempted: making the hook
+         resolve and read an arbitrary referenced script path is
+         unbounded (relative paths, `$VAR` expansion, symlinks,
+         interpreters other than python, `sh -c`/`env` wrappers) and would
+         trade this narrow blind spot for a wide false-positive surface
+         plus a filesystem read on every Bash call - a design decision
+         out of scope for a mechanical enforcement hook. Known, bounded,
+         intentionally-unclosed, same as the false-positive class above.
+
          **Future hazard - non-forgeability depends on which transcript
          this hook reads.** The "a conductor cannot forge this" claim
          above holds only because this hook reads the MAIN-SESSION
@@ -368,6 +393,15 @@ Failure modes:
     - Best-effort dynamic import of `lib/enforcement_log.py` for
       `log_fire()`; any import error falls back to a no-op, matching
       every other enforce-*.py hook's fire-logging pattern.
+    - A creation routed through a script file WRITTEN to disk and then
+      executed (`python3 /tmp/scratch/file_tickets.py`) is invisible: this
+      hook inspects `tool_input.command` only and never resolves/reads a
+      referenced script file, so none of `urllib.request`, the
+      `/rest/api/3/issue` path, or the POST verb are visible when they
+      live inside the file rather than the command string. Known, bounded,
+      intentionally-unclosed - see module docstring "Residual Bash
+      false-negative class" above; resolving arbitrary script paths is
+      unbounded and out of scope for this hook.
 
 Performance: ~25 ms avg per call, measured directly (20 runs, Python
              interpreter startup only, no state file or transcript I/O

--- a/hooks/enforce-ticket-batching.py
+++ b/hooks/enforce-ticket-batching.py
@@ -241,14 +241,13 @@ Purpose: PreToolUse hook that mechanically enforces a grace margin under
          creation script to a scratchpad directory and ran it, creating
          four Jira tickets, with no `.ticket-batch-*.json` counter file
          written that day. An absent counter file alone does not
-         distinguish this false-negative from `main()`'s two other
-         fail-open exits before `_write_state` (`AE_TICKET_BATCH_GUARD_
-         DISABLE`, the `_is_triage_exempt` session marker) or from
-         `_state_path` returning `None` when `cwd` has no resolvable
-         `.git` ancestor - directly relevant here, since the observed
-         scenario ran from a scratchpad directory. The counter-file
-         absence is consistent with this false-negative class but does
-         not, by itself, rule those other paths out. Not attempted: making the hook
+         distinguish this false-negative from any of `main()`'s other
+         fail-open exits before `_write_state` (see `Failure modes:`
+         below for the full list) - directly relevant here, since the
+         observed scenario ran from a scratchpad directory and `cwd` had
+         no resolvable `.git` ancestor. The counter-file absence is
+         consistent with this false-negative class but does not, by
+         itself, rule those other paths out. Not attempted: making the hook
          resolve and read an arbitrary referenced script path is
          unbounded (relative paths, `$VAR` expansion, symlinks,
          interpreters other than python, `sh -c`/`env` wrappers) and would

--- a/hooks/enforce-ticket-batching.py
+++ b/hooks/enforce-ticket-batching.py
@@ -240,8 +240,15 @@ Purpose: PreToolUse hook that mechanically enforces a grace margin under
          happened in this repo's own session history: an agent wrote a
          creation script to a scratchpad directory and ran it, creating
          four Jira tickets, with no `.ticket-batch-*.json` counter file
-         written that day - the guard never matched, so neither the
-         advisory nor the deny fired. Not attempted: making the hook
+         written that day. An absent counter file alone does not
+         distinguish this false-negative from `main()`'s two other
+         fail-open exits before `_write_state` (`AE_TICKET_BATCH_GUARD_
+         DISABLE`, the `_is_triage_exempt` session marker) or from
+         `_state_path` returning `None` when `cwd` has no resolvable
+         `.git` ancestor - directly relevant here, since the observed
+         scenario ran from a scratchpad directory. The counter-file
+         absence is consistent with this false-negative class but does
+         not, by itself, rule those other paths out. Not attempted: making the hook
          resolve and read an arbitrary referenced script path is
          unbounded (relative paths, `$VAR` expansion, symlinks,
          interpreters other than python, `sh -c`/`env` wrappers) and would


### PR DESCRIPTION
## Summary
- Documents a verified false-negative in `enforce-ticket-batching.py`: `_bash_is_creation` inspects `tool_input.command` only, so a tracker create routed through a script file on disk carries no visible signal.
- Adds 5 regression tests pinning the python-client detection boundary (comment-path isolation, GET isolation, grep-literal isolation, script-file indirection, inline-vs-file contrast).
- No behavioural change. Docstring-stripped AST of the hook is byte-identical to `main`.

## Context

A claim that the hook was blind to `python3`/`urllib` was investigated and **disproved**: `_PYTHON_HTTP_CLIENT_RE` has covered `urllib.request` / `requests.*` / `httpx.*` since the hook's first commit (`0dd09add`), and running the unmodified hook three times against a python-urllib POST produced silent allow, advisory, then deny, as designed.

The real gap surfaced during that check. Detection reads the command string, so a create routed through a script file written to disk carries none of the signals - they all live inside the file. This is the uncovered sibling of the `python3 - <<EOF` heredoc case the docstring already documents, where the body *is* in the command string and *is* visible.

No fix was attempted, deliberately: resolving arbitrary script paths from a command string is unbounded (relative paths, variable expansion, symlinks, non-python interpreters, `sh -c`, `env` wrappers) and would trade a narrow blind spot for a wide false-positive surface plus a filesystem read on every Bash call. The residual is recorded as known and accepted, and pinned by a test.

## North Star alignment

Serves the mechanical-enforcement pillar by keeping an enforcement hook's documented coverage honest. A guard believed to cover a path it does not cover is worse than one known to have a bounded gap: the first invites reliance, the second invites compensating discipline.

## Test plan
- [x] `pytest bin/tests/test_enforce_ticket_batching.py -q` - 57 passed
- [x] Hooks Python suite, 18 files - 0 failures
- [x] Hooks JS suite, 54 non-quarantined files - 0 failures
- [x] Docstring-stripped AST vs `origin/main` - MATCH
- [x] Em-dash check on branch diff - empty

## Review rigor
- Brief / Plan path: n/a - single Elevated unit, no Brief required by the promotion gate
- Skeptic rounds (tier): 3 (Tier: 2)
- Findings summary: Critical: 0, Major: 2, Minor: 3 - all resolved

Round 1 found the script-file gap itself. Round 2 found that the pinning test asserted nothing: its fixture path never existed on disk, so even a hook patched to read script files left it green. Fixed by writing a real script into the test's tmpdir; the reviewer then verified the fix by execution, including a pre-fix control proving the mutation is inert against the old test and reddens the new one. Round 3 found that the round-2 docstring fix had replaced a silently-incomplete index with an affirmatively false one ("the first 35 tests in file order" - 22 of 35 entries did not match their position). Resolved by deleting the ordering and completeness claims rather than renumbering, per this repo's recorded lesson that a more-precise correction of an overstated claim has failed twice on the same fact while deletion held.

Doc-sync: predicate not triggered (no reality-asserting change outside the hook's own docstring, updated here).
