### PR TITLE
fix(ci): bound the install-zsh steps so a queue-starved job fails as itself

### DIFF
--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -40,18 +40,25 @@ jobs:
       # bin/tests/ into ONE failing test with a stack trace at the exact call,
       # instead of a killed job with no usable log.
       - name: pip install pytest pytest-timeout pyyaml
-        # Measured: n=78 successful runs, median 3s, p95 8s, max 11s
-        # (2026-08-15..08-19). 2 minutes is generous headroom for a PyPI
-        # network stall.
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing any value here.
         timeout-minutes: 2
         run: pip install pytest pytest-timeout pyyaml
       - name: install zsh (required for the bash/zsh parity matrix in test_phase8_telemetry_shell.py)
-        # Measured: n=76 successful runs, median 12s, p95 46s, max 89s
-        # (2026-08-15..08-19, apt mirror variance). 10 minutes is real
-        # headroom over that ceiling - the sibling bin-sh-tests job's zsh
-        # install (same command, separate runner) hit an actual timeout
-        # failure at ~312s under this step's own prior 5-minute bound on
-        # 2026-08-19, so 5 minutes was not real headroom.
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing any value here. This step's own prior, tighter bound
+        # (5 minutes) was empirically too tight and failed real runs; this
+        # step (and its sibling in bin-sh-tests, same command, separate
+        # runner) has also genuinely run past 20 minutes on an apt mirror
+        # stall and been killed by the job backstop above rather than its
+        # own step bound - a step-level bound turns that into a
+        # diagnosable failure at its own value instead of an
+        # undiagnosable one at the job backstop. That is the bound's
+        # intended job: catching a genuinely hung apt, not a slow one.
         timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y zsh
       - run: python3 -m pytest bin/tests/ -q --timeout=60 --timeout-method=thread
@@ -156,17 +163,25 @@ jobs:
         with:
           python-version: '3.11'
       - name: pip install pyyaml
-        # Measured: n=78 successful runs, median 2s, p95 4s, max 6s
-        # (2026-08-15..08-19). 2 minutes is generous headroom for a PyPI
-        # network stall.
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing any value here.
         timeout-minutes: 2
         run: pip install pyyaml
       - name: install zsh (required for bash/zsh parity assertion in test_check_resident_budget.sh)
-        # Measured: n=77 successful runs, median 13s, p95 86s, max 229s
-        # (2026-08-15..08-19, apt mirror variance). This exact step failed
-        # outright at ~312s on 2026-08-19, killed by its own prior
-        # 5-minute bound - that was not real headroom. 10 minutes gives
-        # margin over the measured 229s successful ceiling.
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing any value here. This step's own prior, tighter bound
+        # (5 minutes) was empirically too tight and failed real runs; this
+        # step (and its sibling in python-bin-tests, same command,
+        # separate runner) has also genuinely run past 20 minutes on an
+        # apt mirror stall and been killed by the job backstop above
+        # rather than its own step bound - a step-level bound turns that
+        # into a diagnosable failure at its own value instead of an
+        # undiagnosable one at the job backstop. That is the bound's
+        # intended job: catching a genuinely hung apt, not a slow one.
         timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: install gitleaks CLI (required by test_gitleaks_allowlist_scope.sh)
@@ -176,9 +191,10 @@ jobs:
         # succeed here. Version and checksum are read from
         # .github/workflows/gitleaks.yml at CI time rather than hardcoded, so
         # bumping that pin cannot silently drift from this install step.
-        # Measured: n=77 successful runs, median 1s, max 1s
-        # (2026-08-15..08-19) - a curl download of a small release asset. 2
-        # minutes is generous headroom for a GitHub Releases network stall.
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing any value here.
         timeout-minutes: 2
         run: |
           set -euo pipefail
@@ -196,11 +212,16 @@ jobs:
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
           gitleaks version
       - name: run shell bin tests
-        # This step measured 4m56s against the old 5-minute JOB timeout on a
-        # single PR, and was cancelled outright on main under queue pressure.
-        # 8 minutes is real headroom for the step's own runtime; queue wait no
-        # longer counts against it.
-        timeout-minutes: 8
+        # Bounded so a queue-starved or hung step fails as itself rather
+        # than consuming the job backstop. Re-derive the current
+        # distribution with `bash scripts/ci-step-durations.sh` before
+        # changing this value - a prior bound here (8 minutes) was derived
+        # from a single observation and gave only ~4% margin over the true
+        # measured max once a full run of completed executions (n=150,
+        # including failed/cancelled) was collected. 15 minutes keeps real
+        # margin over that measured max while staying well inside the job
+        # backstop above.
+        timeout-minutes: 15
         run: |
           set -e
           # bin/tests/test_codex_hooks_resolve.sh is also run by adapter-sync.yml -

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -37,6 +37,9 @@ jobs:
       # instead of a killed job with no usable log.
       - run: pip install pytest pytest-timeout pyyaml
       - name: install zsh (required for the bash/zsh parity matrix in test_phase8_telemetry_shell.py)
+        # Observed 10s-152s across recent successful runs (apt mirror
+        # variance); 5 minutes is real headroom over that ceiling.
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y zsh
       - run: python3 -m pytest bin/tests/ -q --timeout=60 --timeout-method=thread
         timeout-minutes: 5
@@ -141,6 +144,9 @@ jobs:
           python-version: '3.11'
       - run: pip install pyyaml
       - name: install zsh (required for bash/zsh parity assertion in test_check_resident_budget.sh)
+        # Observed 10s-152s across recent successful runs (apt mirror
+        # variance); 5 minutes is real headroom over that ceiling.
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: install gitleaks CLI (required by test_gitleaks_allowlist_scope.sh)
         # test_gitleaks_allowlist_scope.sh hard-fails under CI if gitleaks is

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -15,11 +15,15 @@ permissions:
 # cancelled the same way on main (run 31115638748, sha f81b63c0). The suites
 # themselves finish in well under a minute.
 #
-# So: job-level `timeout-minutes` is a BACKSTOP ONLY (20), and every real work
-# step carries its own `timeout-minutes`, which starts when the step starts and
-# is therefore immune to acquisition delay. Do not "fix" a queue-starvation
-# cancellation by raising the job timeout alone - that trades a fast silent
-# failure for a slow one and leaves the steps unbounded.
+# So: job-level `timeout-minutes` is a BACKSTOP ONLY (20), and every network
+# install/download step and every test-execution step carries its own
+# `timeout-minutes`, which starts when the step starts and is therefore immune
+# to acquisition delay. Do not "fix" a queue-starvation cancellation by raising
+# the job timeout alone - that trades a fast silent failure for a slow one and
+# leaves the steps unbounded. `actions/checkout` and `actions/setup-python` are
+# deliberately excluded from this policy: they are cache-backed GitHub-hosted
+# actions, not custom network commands, and no stall on either has been
+# observed here.
 jobs:
   python-bin-tests:
     runs-on: ubuntu-latest
@@ -35,11 +39,20 @@ jobs:
       # pytest-timeout converts an unbounded subprocess stall anywhere in
       # bin/tests/ into ONE failing test with a stack trace at the exact call,
       # instead of a killed job with no usable log.
-      - run: pip install pytest pytest-timeout pyyaml
+      - name: pip install pytest pytest-timeout pyyaml
+        # Measured: n=78 successful runs, median 3s, p95 8s, max 11s
+        # (2026-08-15..08-19). 2 minutes is generous headroom for a PyPI
+        # network stall.
+        timeout-minutes: 2
+        run: pip install pytest pytest-timeout pyyaml
       - name: install zsh (required for the bash/zsh parity matrix in test_phase8_telemetry_shell.py)
-        # Observed 10s-152s across recent successful runs (apt mirror
-        # variance); 5 minutes is real headroom over that ceiling.
-        timeout-minutes: 5
+        # Measured: n=76 successful runs, median 12s, p95 46s, max 89s
+        # (2026-08-15..08-19, apt mirror variance). 10 minutes is real
+        # headroom over that ceiling - the sibling bin-sh-tests job's zsh
+        # install (same command, separate runner) hit an actual timeout
+        # failure at ~312s under this step's own prior 5-minute bound on
+        # 2026-08-19, so 5 minutes was not real headroom.
+        timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y zsh
       - run: python3 -m pytest bin/tests/ -q --timeout=60 --timeout-method=thread
         timeout-minutes: 5
@@ -142,11 +155,19 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - run: pip install pyyaml
+      - name: pip install pyyaml
+        # Measured: n=78 successful runs, median 2s, p95 4s, max 6s
+        # (2026-08-15..08-19). 2 minutes is generous headroom for a PyPI
+        # network stall.
+        timeout-minutes: 2
+        run: pip install pyyaml
       - name: install zsh (required for bash/zsh parity assertion in test_check_resident_budget.sh)
-        # Observed 10s-152s across recent successful runs (apt mirror
-        # variance); 5 minutes is real headroom over that ceiling.
-        timeout-minutes: 5
+        # Measured: n=77 successful runs, median 13s, p95 86s, max 229s
+        # (2026-08-15..08-19, apt mirror variance). This exact step failed
+        # outright at ~312s on 2026-08-19, killed by its own prior
+        # 5-minute bound - that was not real headroom. 10 minutes gives
+        # margin over the measured 229s successful ceiling.
+        timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: install gitleaks CLI (required by test_gitleaks_allowlist_scope.sh)
         # test_gitleaks_allowlist_scope.sh hard-fails under CI if gitleaks is
@@ -155,6 +176,10 @@ jobs:
         # succeed here. Version and checksum are read from
         # .github/workflows/gitleaks.yml at CI time rather than hardcoded, so
         # bumping that pin cannot silently drift from this install step.
+        # Measured: n=77 successful runs, median 1s, max 1s
+        # (2026-08-15..08-19) - a curl download of a small release asset. 2
+        # minutes is generous headroom for a GitHub Releases network stall.
+        timeout-minutes: 2
         run: |
           set -euo pipefail
           version="$(grep -E '^[[:space:]]*GITLEAKS_VERSION:' .github/workflows/gitleaks.yml | head -1 | sed -E 's/^[^:]*:[[:space:]]*//')"

--- a/bin/tests/test_ci_step_timeouts.py
+++ b/bin/tests/test_ci_step_timeouts.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Purpose: Regression guard for .github/workflows/bin-tests.yml's TIMEOUT
+         POLICY comment (top of that file): every `run:` step in every job
+         must carry its own `timeout-minutes`, except `actions/checkout` and
+         `actions/setup-python` (cache-backed GitHub-hosted actions,
+         deliberately exempted by that same policy comment - no stall on
+         either has been observed there). Parses the YAML and enumerates
+         steps mechanically; never a hand-typed count of how many steps
+         exist (same discipline this repo uses for every other count-sync
+         site - see AGENTS.md's count-sync entries).
+
+Test groups:
+  1. test_every_run_step_has_timeout_minutes - the real assertion: every
+     `run:`-shaped step in every job of bin-tests.yml carries
+     `timeout-minutes`.
+  2. test_uses_steps_are_exempted_by_name - sanity check that the exemption
+     set actually matches `actions/checkout*` / `actions/setup-python*`
+     `uses:` steps and nothing else, so the exemption cannot silently widen
+     to cover a `run:` step that happens to share a job with an exempted
+     action.
+  3. test_mutation_missing_timeout_is_caught - deletes `timeout-minutes`
+     from one real `run:` step (bin-sh-tests' "install gitleaks CLI" step,
+     a copy of the parsed YAML, not the file on disk) and asserts the
+     checker function reports it as a violation, proving the checker
+     function does something more than the parse succeeding.
+
+Run with: python3 bin/tests/test_ci_step_timeouts.py
+       or: python3 -m pytest bin/tests/test_ci_step_timeouts.py
+"""
+from __future__ import annotations
+
+import copy
+import unittest
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".github"
+    / "workflows"
+    / "bin-tests.yml"
+)
+
+EXEMPT_ACTION_PREFIXES = ("actions/checkout", "actions/setup-python")
+
+
+def find_timeout_violations(workflow: dict) -> list[str]:
+    """Return a list of "<job>/<step name>" strings for every `run:` step
+    missing `timeout-minutes`. Steps whose `uses:` starts with one of
+    EXEMPT_ACTION_PREFIXES are skipped entirely (they have no `run:` key to
+    check in the first place, but the explicit skip keeps intent legible).
+    """
+    violations = []
+    jobs = workflow.get("jobs", {})
+    for job_name, job in jobs.items():
+        for step in job.get("steps", []):
+            uses = step.get("uses")
+            if uses is not None:
+                if any(uses.startswith(p) for p in EXEMPT_ACTION_PREFIXES):
+                    continue
+                # A `uses:` step that is NOT one of the exempted actions is
+                # outside this test's stated scope (the policy comment only
+                # discusses `run:` steps and the two named exemptions) -
+                # skip it without asserting either way.
+                continue
+            if "run" not in step:
+                continue
+            step_label = step.get("name", "<unnamed step>")
+            if "timeout-minutes" not in step:
+                violations.append(f"{job_name}/{step_label}")
+    return violations
+
+
+class TestCiStepTimeouts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(WORKFLOW_PATH, "r") as f:
+            cls.workflow = yaml.safe_load(f)
+
+    def test_every_run_step_has_timeout_minutes(self):
+        violations = find_timeout_violations(self.workflow)
+        self.assertEqual(
+            violations,
+            [],
+            "The following run: steps in bin-tests.yml are missing "
+            "timeout-minutes (policy comment at the top of that file "
+            "requires one on every run: step except actions/checkout and "
+            "actions/setup-python): " + ", ".join(violations),
+        )
+
+    def test_uses_steps_are_exempted_by_name(self):
+        jobs = self.workflow.get("jobs", {})
+        seen_uses = set()
+        for job in jobs.values():
+            for step in job.get("steps", []):
+                uses = step.get("uses")
+                if uses is not None:
+                    seen_uses.add(uses.split("@")[0])
+        # Every `uses:` step actually present in the file must be one of the
+        # two exempted actions - if a third action type is ever added to
+        # this workflow, this test forces a conscious decision about
+        # whether it needs a timeout-minutes-equivalent treatment rather
+        # than silently inheriting the exemption.
+        for uses in seen_uses:
+            self.assertIn(
+                uses,
+                EXEMPT_ACTION_PREFIXES,
+                f"uses: '{uses}' is not one of the two documented "
+                "timeout-exempt actions (actions/checkout, "
+                "actions/setup-python) - decide explicitly whether it "
+                "needs a duration bound.",
+            )
+
+    def test_mutation_missing_timeout_is_caught(self):
+        mutated = copy.deepcopy(self.workflow)
+        target_job = mutated["jobs"]["bin-sh-tests"]
+        found = False
+        for step in target_job["steps"]:
+            if step.get("name", "").startswith("install gitleaks CLI"):
+                self.assertIn(
+                    "timeout-minutes",
+                    step,
+                    "fixture step must start with timeout-minutes present, "
+                    "or this mutation test proves nothing",
+                )
+                del step["timeout-minutes"]
+                found = True
+                break
+        self.assertTrue(found, "could not locate the gitleaks install step to mutate")
+        violations = find_timeout_violations(mutated)
+        self.assertIn("bin-sh-tests/install gitleaks CLI (required by test_gitleaks_allowlist_scope.sh)", violations)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bin/tests/test_no_quadratic_body_join.sh
+++ b/bin/tests/test_no_quadratic_body_join.sh
@@ -6,10 +6,14 @@
 #          concatenation loop (quadratic in the number of body lines) with a
 #          single `"${body_lines[*]}"` IFS join (linear). This test is
 #          deliberately static rather than timing-based: the `bin-sh-tests`
-#          CI job runs under `timeout-minutes: 5` with only 3-63 seconds of
-#          measured headroom, and `.codex/build.sh` alone takes roughly 31s
-#          to run, so a wall-clock timing assertion here would risk killing
-#          the entire job with no diagnostic on a slow runner.
+#          CI job runs under a 20-minute job-level backstop with its own
+#          test-execution step ("run shell bin tests") separately bounded
+#          (see .github/workflows/bin-tests.yml), and `.codex/build.sh`
+#          alone takes roughly 31s to run - a wall-clock timing assertion
+#          here would still consume step budget with no diagnostic value on
+#          a slow runner. Re-derive the step's current duration
+#          distribution with `bash scripts/ci-step-durations.sh` rather than
+#          trusting a number in this comment.
 #
 # Public API: ./bin/tests/test_no_quadratic_body_join.sh
 #             Exits 0 (PASS) when neither build script contains the

--- a/scripts/ci-step-durations.sh
+++ b/scripts/ci-step-durations.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Purpose: Re-derive the real duration distribution of every step in a
+#          GitHub Actions workflow, straight from the Actions API, so a
+#          timeout-minutes bound in .github/workflows/*.yml can be justified
+#          by a reproducible measurement instead of a hand-written comment.
+#          This exists because three straight review rounds on the
+#          bin-tests.yml timeout PR each shipped a hand-typed distribution
+#          figure that was wrong or went stale before merge (a false "10s-
+#          152s" ceiling, a false "p95 86s", a "max 89s" that was already
+#          102s by the time it was reviewed). A script's output can be
+#          reproduced by anyone; a comment's claim can only be trusted.
+#
+# Public API: bash scripts/ci-step-durations.sh [WORKFLOW_FILE] [MAX_RUNS]
+#             WORKFLOW_FILE defaults to bin-tests.yml. MAX_RUNS (number of
+#             most-recent workflow runs to scan, across ALL conclusions -
+#             success, failure, cancelled, timed_out) defaults to 100.
+#             Prints one line per (job, step) with n / median / p95 / max,
+#             in seconds, to stdout. Exits 0 on success. Exits 1 if `gh` is
+#             unavailable, unauthenticated, or if zero step-duration rows
+#             were collected (a silent empty result must never be read as
+#             "the distribution is empty" - it means collection is broken).
+#
+# Upstream deps: `gh` CLI (authenticated against this repo), the GitHub
+#                Actions REST API (workflow runs + jobs endpoints), `python3`
+#                (median/p95/max arithmetic - no hand-rolled percentile math
+#                in shell).
+#
+# Downstream consumers: .github/workflows/bin-tests.yml's timeout-minutes
+#                        comments point back at this script instead of
+#                        embedding a distribution figure. Re-run before
+#                        changing any timeout-minutes value in that file.
+#
+# Failure modes: network/API failure from `gh api` propagates as a non-zero
+#                exit (set -e). A run whose job/step lacks both started_at
+#                and completed_at (never actually started - e.g. queue
+#                cancellation) is skipped for that step, not counted as a
+#                zero-second duration. Read-only; makes no repo or GitHub
+#                state changes.
+#
+# Collection hazard (already hit twice reviewing this file's callers): the
+# harness shell is zsh, which does not word-split an unquoted $ids in
+# `for id in $ids` - combined with `2>/dev/null` that silently yields an
+# empty result. This script avoids the hazard entirely: run ids are read
+# into a bash array via `mapfile`/process substitution, never split from an
+# unquoted variable, and it is invoked via `bash scripts/ci-step-durations.sh`
+# (see the shebang) so `for` never runs under a zsh interpreter here.
+
+set -euo pipefail
+
+WORKFLOW_FILE="${1:-bin-tests.yml}"
+MAX_RUNS="${2:-100}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ci-step-durations.sh: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ci-step-durations.sh: gh is not authenticated" >&2
+  exit 1
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+TMP_RUN_IDS="$(mktemp)"
+TMP_ROWS="$(mktemp)"
+trap 'rm -f "$TMP_RUN_IDS" "$TMP_ROWS"' EXIT
+
+# Every conclusion, not just success - a step that was killed by its own
+# timeout or the job backstop is exactly the data point a bound must be
+# derived from, and excluding it (success-only) is what produced the false
+# "10 minutes is real headroom" claim this script replaces.
+gh api --method GET "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs" \
+  --paginate \
+  -f per_page=100 \
+  -q '.workflow_runs[] | select(.status == "completed") | .id' \
+  > "$TMP_RUN_IDS" || true
+
+if [ ! -s "$TMP_RUN_IDS" ]; then
+  echo "ci-step-durations.sh: zero workflow runs found for ${WORKFLOW_FILE} - collection is broken, not clean" >&2
+  exit 1
+fi
+
+run_count=0
+: > "$TMP_ROWS"
+while IFS= read -r run_id; do
+  [ -z "$run_id" ] && continue
+  run_count=$((run_count + 1))
+  if [ "$run_count" -gt "$MAX_RUNS" ]; then
+    break
+  fi
+  gh api --method GET "repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 \
+    -q '.jobs[] | .name as $job | .steps[] | select(.started_at != null and .completed_at != null) | [$job, .name, .started_at, .completed_at] | @tsv' \
+    >> "$TMP_ROWS" || true
+done < "$TMP_RUN_IDS"
+
+if [ ! -s "$TMP_ROWS" ]; then
+  echo "ci-step-durations.sh: zero step-duration rows collected across ${run_count} runs - collection is broken, not clean" >&2
+  exit 1
+fi
+
+python3 - "$TMP_ROWS" <<'PYEOF'
+import sys
+import statistics
+from collections import defaultdict
+from datetime import datetime
+
+def parse_ts(s):
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ")
+
+rows = defaultdict(list)
+path = sys.argv[1]
+with open(path, "r") as f:
+    for line in f:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            continue
+        job, step, started, completed = parts
+        try:
+            dur = (parse_ts(completed) - parse_ts(started)).total_seconds()
+        except ValueError:
+            continue
+        if dur < 0:
+            continue
+        rows[(job, step)].append(dur)
+
+if not rows:
+    print("ci-step-durations.sh: parsed zero valid rows", file=sys.stderr)
+    sys.exit(1)
+
+print(f"{'job':<28} {'step':<70} {'n':>5} {'median_s':>9} {'p95_s':>7} {'max_s':>7}")
+for (job, step), durations in sorted(rows.items()):
+    durations.sort()
+    n = len(durations)
+    median = statistics.median(durations)
+    if n == 1:
+        p95 = durations[0]
+    else:
+        idx = min(n - 1, max(0, int(round(0.95 * (n - 1)))))
+        p95 = durations[idx]
+    mx = durations[-1]
+    print(f"{job:<28} {step:<70} {n:>5} {median:>9.1f} {p95:>7.1f} {mx:>7.1f}")
+PYEOF


### PR DESCRIPTION
## Summary
- Bounds every `run:` step in `bin-tests.yml`, so a queue-starved or hung step fails as itself instead of consuming the 20-minute job backstop.
- Replaces hand-written duration claims with `scripts/ci-step-durations.sh`, which derives them from the Actions API across all completed runs.
- Adds `bin/tests/test_ci_step_timeouts.py`, mechanically pinning the file's own timeout policy.

## Problem

`bin-tests.yml`'s header states its policy: the job-level `timeout-minutes` is a backstop only (20), and every real work step carries its own, which starts when the step starts. Several steps did not.

Measured consequence on PR #769, job `96130590212`: started 15:46:31Z, killed 16:06:51Z, exactly the 20-minute backstop, with `install zsh` cancelled and the `pytest bin/tests/` step **skipped**. No test assertion ran. It surfaces as bucket `cancel`, which reads as an infra blip, so the reflex is to re-run rather than diagnose. It was re-run twice before the cause was found.

## Why this took three rounds, and what changed on the third

Rounds 1 and 2 each shipped a false hand-written figure at a different site in the same file. Round 1 claimed a 10s-152s ceiling (true max 229s) and set a 5-minute bound - which then **caused a real failure at ~312s** (run `32276778235`, `##[error]The action 'install zsh (...)' has timed out after 5 minutes`). Round 2 corrected that and introduced "p95 86s" (measured 186s), while leaving a different step's bound un-re-derived. A third figure went stale during review.

Same defect class, three sites, constant severity. Round 3 changes the form rather than the numbers: no hand-written distribution claim remains in the workflow file.

## What the derivation found

`scripts/ci-step-durations.sh`, n=150 completed runs, all conclusions (not success-only - a distribution built from runs that survived is how you conclude a bound is safe):

| job | step | n | median | p95 | max |
|---|---|---|---|---|---|
| bin-sh-tests | install zsh | 150 | 11s | 70s | 1214s |
| bin-sh-tests | run shell bin tests | 150 | 288s | 413s | 462s |
| python-bin-tests | install zsh | 150 | 11s | 47s | 1210s |
| python-bin-tests | pytest bin/tests/ | 150 | 90s | 105s | 115s |

Two findings neither earlier round had. `run shell bin tests` sat at a **3.7% margin** against its 8-minute bound - one slow run from failing every PR - and nobody had re-derived it because it was not the step under discussion; it is now 15 minutes. And the 1210s/1214s maxima are genuine ~20-minute job-backstop kills, so the zsh comment now states that the bound is expected to fire on a hung apt rather than implying the step never exceeds it.

## Changes
- `.github/workflows/bin-tests.yml` - every `run:` step bounded; `install zsh` 10 min; `run shell bin tests` 8 -> 15 min; three previously-unbounded steps at 2 min; header policy restated so its claim is true, with `actions/checkout` and `actions/setup-python` as stated exclusions.
- `scripts/ci-step-durations.sh` - new, manifest header.
- `bin/tests/test_ci_step_timeouts.py` - new, manifest header. Mutation-verified: deleting a `timeout-minutes` from the live workflow turns it RED naming the offending step; restored, GREEN.
- `bin/tests/test_no_quadratic_body_join.sh` - fixed a stale claim that the `bin-sh-tests` job runs under `timeout-minutes: 5` (the job is 20; only the step is bounded).

## North Star alignment

Guards operator attention (Pillar 1) by making a gate's failure mode legible: a queue-starvation kill reporting as `cancel` costs re-runs and diagnosis on what looks like flaky infra. Advances mechanical left-shift (Pillar 7) by pinning the policy with a test rather than a comment, so the recurrence this PR needed three rounds to stop cannot return silently.

## Test plan
- [x] YAML validates (`yaml.safe_load`), before and after
- [x] `pytest bin/tests/ -q --timeout=60` - 1747 passed, 25 subtests
- [x] Regression-test mutation executed - RED then GREEN
- [x] `bash bin/tests/test_no_quadratic_body_join.sh` - pass
- [x] Em-dash check on branch diff - no matches
- [x] No hand-written distribution figure remains in the workflow file (grep-verified)

## Review rigor
- Brief / Plan path: n/a - single Elevated unit, no Brief required by the promotion gate
- Skeptic rounds (tier): 2 (Tier: 2), 3 engineer fix passes, round cap reached
- Findings summary: Critical: 0, Major: 6 across two rounds, all resolved; Minor: 3, two resolved and one promoted to Major in round 3

**Accepted debt, disclosed:** the 15-minute bound for `run shell bin tests` is a judgment call at ~1.95x the measured max, chosen to clearly exceed the 1.31x margin round 1 rejected while staying inside the 20-minute backstop. The reasoning and the reproducible measurement behind it are both in the file, so adjusting it is cheap.

Doc-sync: predicate not triggered (no count, list, path, or convention asserted in an intent-layer doc becomes false).
