### PR TITLE
DS-191: close a regression-test gap in the compaction guard (PR #797)

### DIFF
--- a/bin/tests/test_cleanup_worktrees.py
+++ b/bin/tests/test_cleanup_worktrees.py
@@ -2675,3 +2675,154 @@ def test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_e
         f"restore must succeed even after the explicit base branch is deleted and gc'd, "
         f"since compaction was correctly refused: {restore_proc.stderr}"
     )
+
+
+# --------------------------------------------------------------------------
+# DS-191 follow-up (closes a regression-test gap in PR #797, `64e4e330`).
+#
+# The test above proves the guard (`_archive_compaction_base`'s
+# explicit-base-mismatch refusal) produces a full-history bundle that
+# SURVIVES the mismatched base being destroyed and gc'd. It never proves
+# the INVERSE: that had compaction been applied against that same unsafe
+# base anyway, the resulting bundle would have become genuinely
+# unrestorable. Without that inverse, the guard's refusal is unfalsifiable
+# from this suite's point of view - a no-op guard and a load-bearing one
+# would both make the sibling test pass.
+#
+# This test supplies the inverse directly: it calls `_archive_branch_bundle`
+# with `exclude_ref` set to the SAME unsafe base (`origin/feat-x`) that
+# `_archive_compaction_base` would refuse to use - i.e. it constructs
+# exactly the bundle a defect in that guard would produce - then destroys
+# and gc's that base (same sequence as the sibling test, both repos) and
+# asserts the restore FAILS with git's own prerequisite error. This is an
+# observable-restorability assertion, not a return-value or header-line
+# proxy (both of those are asserted first, as preconditions, but the
+# defect this test guards against is a data-loss defect, so the payoff
+# assertion is the actual failed `git fetch` from the bundle).
+# --------------------------------------------------------------------------
+
+
+def test_archive_bundle_compaction_against_unsafe_base_becomes_unrestorable_after_base_destroyed_end_to_end(tmp_path):
+    """Fork point: the unproven branch is forked from `feat-x`'s own tip
+    (not from `main`), same as the sibling test above and for the same
+    reason - `feat-x`'s tip must genuinely be the bundle's prerequisite
+    under compaction, or destroying `feat-x` proves nothing."""
+    mod = _load_module_directly()
+    repo, origin = init_repo_with_origin(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat-x")
+    (repo / "feat-x-file.txt").write_text("feature work\n")
+    _git(repo, "add", "feat-x-file.txt")
+    _git(repo, "commit", "-q", "-m", "feat-x work")
+    _git(repo, "push", "-q", "origin", "feat-x")
+
+    branch = "worktree-agent-unsafe-compact"
+    wt = _make_unproven_branch_worktree(repo, ".claude/worktrees/agent-unsafe-compact", branch)
+    _git(repo, "checkout", "-q", "main")
+
+    # Bypass `_archive_compaction_base` entirely and pass the unsafe base
+    # straight through, exactly as a defect in that guard would - this
+    # function has no opinion of its own on whether `exclude_ref` is a
+    # durable ref.
+    ok, detail, bundle_path, compact = mod._archive_branch_bundle(str(repo), branch, "origin/feat-x")
+    assert ok, detail
+    assert compact is True, "expected genuine compaction against feat-x's tip"
+
+    header, _, _ = Path(bundle_path).read_bytes().partition(b"\n\n")
+    header_lines = header.split(b"\n")
+    assert any(line.startswith(b"-") for line in header_lines), (
+        f"expected a prerequisite (-prefixed) header line for a genuinely compact "
+        f"bundle, got: {header_lines!r}"
+    )
+
+    # Remove the worktree and branch ref (this function never does either
+    # itself), then destroy + gc `feat-x` on both the working repo and the
+    # bare origin - the exact permanent-loss trigger. Sequence matches the
+    # sibling test's own reflog-expiry discipline: `git gc --prune=now`
+    # does NOT expire reflogs on its own, and the `checkout` calls above
+    # populated HEAD's reflog with a path back to feat-x's tip, so an
+    # explicit `reflog expire` is required before gc on BOTH repos.
+    _git(repo, "worktree", "remove", "--force", str(wt))
+    _git(repo, "branch", "-D", branch)
+    _git(repo, "push", "-q", "origin", "--delete", "feat-x")
+    _git(repo, "branch", "-D", "feat-x")
+    subprocess.run(["git", "-C", str(origin), "branch", "-D", "feat-x"], capture_output=True, text=True)
+    _git(repo, "remote", "prune", "origin")
+    _git(repo, "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all")
+    subprocess.run(["git", "-C", str(repo), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(origin), "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"], capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(origin), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+
+    restore_proc = subprocess.run(
+        ["git", "-C", str(repo), "fetch", bundle_path, f"refs/heads/{branch}:refs/heads/{branch}"],
+        capture_output=True,
+        text=True,
+    )
+    assert restore_proc.returncode != 0, (
+        "expected restore to FAIL once the excluded base (feat-x) is destroyed and "
+        "gc'd - this is the exact data-loss failure mode _archive_compaction_base's "
+        "explicit-base-mismatch refusal exists to prevent; a restore that succeeds "
+        "here would mean the guard defends against nothing"
+    )
+    assert "prerequisite" in restore_proc.stderr.lower(), restore_proc.stderr
+
+
+# --------------------------------------------------------------------------
+# DS-191 follow-up. `_archive_branch_bundle`'s compaction gate is
+# `0 < unique_count < total_count` (bin/ds-cleanup-worktrees:1697). The
+# lower bound (`unique_count == 0`, branch fully contained in the exclude
+# ref) already has coverage via
+# `test_archive_bundle_defensive_guard_skips_empty_exclusion` (a mutation
+# widening the gate to admit 0 there is caught because the resulting
+# `--not` argv would create an empty bundle, triggering this function's own
+# TOCTOU retry path and changing the number of `git bundle create`
+# invocations that test asserts on).
+#
+# The UPPER bound (`unique_count == total_count` - the branch shares NO
+# commits with the exclude ref at all, e.g. a genuinely orphaned/disjoint
+# history) had no coverage at all: measured directly against this
+# checkout, widening the gate to `0 < unique_count <= total_count` left
+# all 118 pre-existing tests in this file green. This test closes that
+# gap. (It does not assert on restorability, unlike the test above -
+# measured separately, a bundle built with `--not <exclude_ref>` against a
+# disjoint history records NO prerequisite header line at all, since the
+# traversal never reaches a commit reachable from `exclude_ref`; such a
+# bundle is already self-contained regardless of whether `--not` was
+# applied, so the discriminating observable is the header/compact flag,
+# not restorability.)
+# --------------------------------------------------------------------------
+
+
+def test_archive_bundle_skips_exclusion_when_branch_shares_no_history_with_base(tmp_path):
+    mod = _load_module_directly()
+    repo, _origin = init_repo_with_origin(tmp_path)
+
+    # An orphan branch has no common ancestor with `main` at all, so
+    # `unique_count == total_count` relative to `main` - the exact upper
+    # boundary this gate must refuse to compact against.
+    _git(repo, "checkout", "-q", "--orphan", "disjoint-branch")
+    _git(repo, "rm", "-rf", "-q", ".")
+    (repo / "disjoint.txt").write_text("no shared history with main\n")
+    _git(repo, "add", "disjoint.txt")
+    _git(repo, "commit", "-q", "-m", "disjoint work")
+    branch = "disjoint-branch"
+
+    unique = _git(repo, "rev-list", "--count", branch, "--not", "main").stdout.strip()
+    total = _git(repo, "rev-list", "--count", branch).stdout.strip()
+    assert unique == total and int(total) > 0, (
+        f"precondition: branch must share zero history with the exclude ref "
+        f"(unique={unique}, total={total})"
+    )
+
+    ok, detail, bundle_path, compact = mod._archive_branch_bundle(str(repo), branch, "main")
+    assert ok, detail
+    assert compact is False, (
+        "expected compaction to be refused when the branch shares no history with "
+        "the exclude ref (unique_count == total_count)"
+    )
+
+    header, _, _ = Path(bundle_path).read_bytes().partition(b"\n\n")
+    header_lines = header.split(b"\n")
+    assert not any(line.startswith(b"-") for line in header_lines), (
+        f"expected NO prerequisite header line when the branch shares no history "
+        f"with the exclude ref, got: {header_lines!r}"
+    )

--- a/bin/tests/test_cleanup_worktrees.py
+++ b/bin/tests/test_cleanup_worktrees.py
@@ -1126,6 +1126,41 @@ def _make_unproven_branch_worktree(repo: Path, rel_path: str, branch: str) -> Pa
     return wt
 
 
+def _destroy_base_branch_and_gc_everywhere(repo: Path, origin: Path, base_branch: str) -> None:
+    """Deletes `base_branch` on both `repo`'s local checkout and the bare
+    `origin` remote, then fully expires reflogs and gc's both repos - the
+    exact permanent-loss trigger the DS-191 compaction tests rely on to
+    prove a bundle's prerequisite really becomes unreachable, not merely
+    absent from one ref.
+
+    `git gc --prune=now` does NOT expire reflog entries on its own
+    (measured: a plain `checkout -> branch -D -> gc --prune=now` sequence
+    leaves the deleted commit reachable, since HEAD's own reflog still
+    pins it) - an explicit `reflog expire` is required on BOTH repos
+    before gc, or the prune has nothing to orphan."""
+    _git(repo, "push", "-q", "origin", "--delete", base_branch)
+    _git(repo, "branch", "-D", base_branch)
+    subprocess.run(["git", "-C", str(origin), "branch", "-D", base_branch], capture_output=True, text=True)
+    _git(repo, "remote", "prune", "origin")
+    _git(repo, "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all")
+    subprocess.run(["git", "-C", str(repo), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-C", str(origin), "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"],
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "-C", str(origin), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+
+
+def _bundle_header_lines(bundle_path) -> list:
+    """Returns a bundle's header lines, split on the blank-line separator
+    from the payload - the read-partition-split idiom shared across the
+    compaction tests that assert on whether a bundle records a
+    `-`-prefixed prerequisite commit line."""
+    header, _, _ = Path(bundle_path).read_bytes().partition(b"\n\n")
+    return header.split(b"\n")
+
+
 # --------------------------------------------------------------------------
 # 19. (round-5) --archive-unproven is OPT-IN: without the flag, an unproven
 #     branch is reported and untouched, exactly as before round 5.
@@ -2635,36 +2670,23 @@ def test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_e
     archive_dir = repo / ".agentic" / "worktree-archive"
     bundles = sorted(archive_dir.glob(f"{branch}-*.bundle"))
     assert len(bundles) == 1
-    header, _, _ = bundles[0].read_bytes().partition(b"\n\n")
-    header_lines = header.split(b"\n")
+    header_lines = _bundle_header_lines(bundles[0])
     assert not any(line.startswith(b"-") for line in header_lines), (
         f"expected NO prerequisite header line (full-history bundle) when the explicit "
         f"base does not match auto-resolution, got: {header_lines!r}"
     )
 
+    # The archived branch ref ITSELF must also be deleted here (this tool
+    # never deletes it as part of --archive-unproven, by design) - before
+    # destroying feat-x below - otherwise it keeps feat-x's tip reachable
+    # as its own ancestor and gc can never orphan it, regardless of which
+    # base the bundle was built against.
+    _git(repo, "branch", "-D", branch)
     # Delete + gc the explicit base branch everywhere - the exact
     # permanent-loss trigger. A compact bundle against feat-x would now be
     # unrestorable ("Repository lacks these prerequisite commits"); a
-    # full-history bundle has no such dependency. The archived branch ref
-    # ITSELF must also be deleted here (this tool never deletes it as
-    # part of --archive-unproven, by design) - otherwise it keeps
-    # feat-x's tip reachable as its own ancestor and gc can never orphan
-    # it, regardless of which base the bundle was built against. HEAD's
-    # own reflog (populated by the `checkout` calls above) ALSO keeps the
-    # deleted commit reachable indefinitely - `git gc --prune=now` on its
-    # own does NOT expire reflog entries (measured: a plain `checkout ->
-    # branch -D -> gc --prune=now` sequence leaves the deleted commit
-    # present), so an explicit `reflog expire` is required first for the
-    # prune to actually happen.
-    _git(repo, "push", "-q", "origin", "--delete", "feat-x")
-    _git(repo, "branch", "-D", "feat-x")
-    _git(repo, "branch", "-D", branch)
-    subprocess.run(["git", "-C", str(origin), "branch", "-D", "feat-x"], capture_output=True, text=True)
-    _git(repo, "remote", "prune", "origin")
-    _git(repo, "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all")
-    subprocess.run(["git", "-C", str(repo), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(origin), "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"], capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(origin), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+    # full-history bundle has no such dependency.
+    _destroy_base_branch_and_gc_everywhere(repo, origin, "feat-x")
 
     restore_proc = subprocess.run(
         ["git", "-C", str(repo), "fetch", str(bundles[0]), f"refs/heads/{branch}:refs/heads/{branch}"],
@@ -2682,14 +2704,23 @@ def test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_e
 #
 # The test above proves the guard (`_archive_compaction_base`'s
 # explicit-base-mismatch refusal) produces a full-history bundle that
-# SURVIVES the mismatched base being destroyed and gc'd. It never proves
-# the INVERSE: that had compaction been applied against that same unsafe
-# base anyway, the resulting bundle would have become genuinely
-# unrestorable. Without that inverse, the guard's refusal is unfalsifiable
-# from this suite's point of view - a no-op guard and a load-bearing one
-# would both make the sibling test pass.
+# SURVIVES the mismatched base being destroyed and gc'd. That refusal
+# path is already covered by two existing tests (measured: mutating
+# `_archive_compaction_base` to a no-op that always returns
+# `resolved_base` unconditionally reddens both
+# `test_archive_compaction_base_skips_when_explicit_base_mismatches_auto_resolution`
+# and
+# `test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_end`).
 #
-# This test supplies the inverse directly: it calls `_archive_branch_bundle`
+# What was missing is the INVERSE premise: that a compact bundle built
+# against that same unsafe base really does become unrestorable once the
+# base is destroyed and gc'd. Nothing in this suite proved that a compact
+# bundle's `--not <exclude_ref>` prerequisite is genuinely load-bearing
+# for restorability - the two guard tests above never construct a compact
+# bundle at all, so they cannot speak to what compaction would have cost
+# had the guard not refused it.
+#
+# This test supplies that inverse directly: it calls `_archive_branch_bundle`
 # with `exclude_ref` set to the SAME unsafe base (`origin/feat-x`) that
 # `_archive_compaction_base` would refuse to use - i.e. it constructs
 # exactly the bundle a defect in that guard would produce - then destroys
@@ -2727,8 +2758,7 @@ def test_archive_bundle_compaction_against_unsafe_base_becomes_unrestorable_afte
     assert ok, detail
     assert compact is True, "expected genuine compaction against feat-x's tip"
 
-    header, _, _ = Path(bundle_path).read_bytes().partition(b"\n\n")
-    header_lines = header.split(b"\n")
+    header_lines = _bundle_header_lines(bundle_path)
     assert any(line.startswith(b"-") for line in header_lines), (
         f"expected a prerequisite (-prefixed) header line for a genuinely compact "
         f"bundle, got: {header_lines!r}"
@@ -2737,20 +2767,10 @@ def test_archive_bundle_compaction_against_unsafe_base_becomes_unrestorable_afte
     # Remove the worktree and branch ref (this function never does either
     # itself), then destroy + gc `feat-x` on both the working repo and the
     # bare origin - the exact permanent-loss trigger. Sequence matches the
-    # sibling test's own reflog-expiry discipline: `git gc --prune=now`
-    # does NOT expire reflogs on its own, and the `checkout` calls above
-    # populated HEAD's reflog with a path back to feat-x's tip, so an
-    # explicit `reflog expire` is required before gc on BOTH repos.
+    # sibling test's own reflog-expiry discipline via the shared helper.
     _git(repo, "worktree", "remove", "--force", str(wt))
     _git(repo, "branch", "-D", branch)
-    _git(repo, "push", "-q", "origin", "--delete", "feat-x")
-    _git(repo, "branch", "-D", "feat-x")
-    subprocess.run(["git", "-C", str(origin), "branch", "-D", "feat-x"], capture_output=True, text=True)
-    _git(repo, "remote", "prune", "origin")
-    _git(repo, "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all")
-    subprocess.run(["git", "-C", str(repo), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(origin), "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"], capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(origin), "gc", "--prune=now", "--aggressive"], capture_output=True, text=True)
+    _destroy_base_branch_and_gc_everywhere(repo, origin, "feat-x")
 
     restore_proc = subprocess.run(
         ["git", "-C", str(repo), "fetch", bundle_path, f"refs/heads/{branch}:refs/heads/{branch}"],
@@ -2784,11 +2804,12 @@ def test_archive_bundle_compaction_against_unsafe_base_becomes_unrestorable_afte
 # all 118 pre-existing tests in this file green. This test closes that
 # gap. (It does not assert on restorability, unlike the test above -
 # measured separately, a bundle built with `--not <exclude_ref>` against a
-# disjoint history records NO prerequisite header line at all, since the
-# traversal never reaches a commit reachable from `exclude_ref`; such a
-# bundle is already self-contained regardless of whether `--not` was
-# applied, so the discriminating observable is the header/compact flag,
-# not restorability.)
+# disjoint history records NO prerequisite header line at all regardless
+# of whether `--not` was applied, since the traversal never reaches a
+# commit reachable from `exclude_ref`; the header assertion below cannot
+# discriminate this case and is kept only as a same-shape precondition
+# check alongside the sibling tests - the sole discriminating observable
+# here is `compact is False`.)
 # --------------------------------------------------------------------------
 
 
@@ -2820,8 +2841,7 @@ def test_archive_bundle_skips_exclusion_when_branch_shares_no_history_with_base(
         "the exclude ref (unique_count == total_count)"
     )
 
-    header, _, _ = Path(bundle_path).read_bytes().partition(b"\n\n")
-    header_lines = header.split(b"\n")
+    header_lines = _bundle_header_lines(bundle_path)
     assert not any(line.startswith(b"-") for line in header_lines), (
         f"expected NO prerequisite header line when the branch shares no history "
         f"with the exclude ref, got: {header_lines!r}"

--- a/bin/tests/test_cleanup_worktrees.py
+++ b/bin/tests/test_cleanup_worktrees.py
@@ -1594,8 +1594,7 @@ def test_archive_bundle_excludes_already_on_base_objects(tmp_path):
     bundles = sorted(archive_dir.glob(f"{branch}-*.bundle"))
     assert len(bundles) == 1
     compact_bundle = bundles[0]
-    header, _, _ = compact_bundle.read_bytes().partition(b"\n\n")
-    header_lines = header.split(b"\n")
+    header_lines = _bundle_header_lines(compact_bundle)
     assert any(line.startswith(b"-") for line in header_lines), (
         f"expected a prerequisite (-prefixed) header line in a compact bundle, got: {header_lines!r}"
     )
@@ -1685,8 +1684,7 @@ def test_archive_unproven_prints_full_history_note_for_unverifiable_base(tmp_pat
     archive_dir = repo / ".agentic" / "worktree-archive"
     bundles = sorted(archive_dir.glob(f"{branch}-*.bundle"))
     assert len(bundles) == 1
-    header, _, _ = bundles[0].read_bytes().partition(b"\n\n")
-    header_lines = header.split(b"\n")
+    header_lines = _bundle_header_lines(bundles[0])
     assert not any(line.startswith(b"-") for line in header_lines), (
         f"expected no prerequisite header line for a full-history bundle, got: {header_lines!r}"
     )


### PR DESCRIPTION
## Summary

PR #797 (`64e4e330`) made `bin/ds-cleanup-worktrees`'s `--archive-unproven` bundles compact against a durable base ref instead of always bundling full history. The safety property that makes this correct is that compaction is only applied when the excluded base is genuinely a safe, durable prerequisite - otherwise a bundle whose prerequisite is later destroyed (base branch deleted, gc'd) becomes unrestorable.

The existing test (`test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_end`) only proved the guard's refusal path: when compaction is correctly skipped, the resulting full-history bundle survives its explicit base being destroyed. It supplies no coverage of the inverse premise - that a compact bundle built against that same unsafe base really does become unrestorable once the base is destroyed and gc'd - since no existing test ever constructs a compact bundle against an unsafe base at all. This PR adds that coverage.

## Changes

- `test_archive_bundle_compaction_against_unsafe_base_becomes_unrestorable_after_base_destroyed_end_to_end`: bypasses `_archive_compaction_base` directly (calling `_archive_branch_bundle` with the same unsafe base the guard would refuse), destroys and gc's that base on both the working repo and the bare origin (with explicit reflog expiry on both, per this repo's own known gc/reflog gotcha), and asserts the restore genuinely fails with git's own "lacks these prerequisite commits" error. This test is premise-pinning rather than unique mutation coverage: the guard's refusal path itself is covered by two existing tests - measured, mutating `_archive_compaction_base` to a no-op that always returns `resolved_base` unconditionally reddens both `test_archive_compaction_base_skips_when_explicit_base_mismatches_auto_resolution` and `test_archive_unproven_explicit_base_mismatch_survives_base_deletion_end_to_end`. This new test's payoff assertion (a compact bundle whose prerequisite is destroyed and gc'd becomes unrestorable) is a property of git's own bundle mechanics, not of this codebase. Its value is confirming that inverse premise actually holds, which the guard's correctness depends on but which no prior test exercised.
- `test_archive_bundle_skips_exclusion_when_branch_shares_no_history_with_base`: closes a second, independently measured gap in the same compaction gate (`0 < unique_count < total_count`) - the upper boundary (branch shares zero history with the exclude ref, e.g. a genuinely orphaned branch) had no test coverage; widening the gate to admit that boundary left all 118 pre-existing tests green.

Both new tests were verified to redden under their respective mutations and pass on unmodified code. Note: the mutation originally suspected as uncaught (widening the gate to `unique_count >= 0`) was measured and found to already be caught by an existing test (`test_archive_bundle_defensive_guard_skips_empty_exclusion`, via its TOCTOU retry path) - the genuinely uncaught gap was the upper boundary instead, addressed by the second new test above.

Also extracted the destroy-branch-and-gc-both-repos sequence (`_destroy_base_branch_and_gc_everywhere`) and the bundle-header read-partition-split idiom (`_bundle_header_lines`) into shared helpers, closing a Round 2 duplication finding. Round 2 applied `_bundle_header_lines` at three call sites (the two new DS-191 tests plus one pre-existing sibling test); Round 3 found two additional raw instances of the same idiom (in `test_archive_bundle_excludes_already_on_base_objects` and `test_archive_unproven_prints_full_history_note_for_unverifiable_base`) that Round 2's commit body overstated as already converted, and converted them. Verified load-bearing at every converted site: mutating the shared helper to return an empty list reddens the positive-assertion (`any(...)`) call sites, and a second mutation injecting a bogus prerequisite line reddens the negative-assertion (`not any(...)`) call sites - both mutations restored to the real implementation afterward. The `_destroy_base_branch_and_gc_everywhere` helper's own load-bearingness (Round 2 finding) is unaffected by this round's changes: breaking its reflog-expire step still reddens the unrestorable-bundle test, and the sibling survives-deletion test still does not redden from that mutation - a pre-existing property of that test's own restore-succeeds assertion (a full-history bundle is self-contained regardless of whether the excluded base is actually destroyed), not a regression from either extraction.

Test-only change. No behavior change to `bin/ds-cleanup-worktrees`.

## North Star alignment

This serves Pillar 2 (produce verifiable outcomes autonomously): it converts an assumption into a checked fact. The already-shipped compaction guard depends on git bundle-prerequisite mechanics that no test exercised, so the guard was trusted rather than verified. This adds premise-pinning coverage for that dependency plus genuinely new boundary coverage (the upper unique_count == total_count gate edge). Under Pillar 8 (machinery only as complicated as the benefit requires), the two tests added here name their justification concretely: (a) the specific failure they would have caught is a change to the compaction gate's bounds that silently produces bundles whose prerequisites are unrecoverable, which before this PR passed the full suite; (b) they retire when the compaction feature itself is removed. Both were mutation-verified reddenable rather than assumed load-bearing, and two assertions found non-discriminating during review were corrected rather than kept as decoration. It adds no capability and changes no runtime behavior.

## Test plan

- [x] `python3 -m pytest bin/tests/test_cleanup_worktrees.py -p no:cacheprovider -q` - 120 passed
- [x] `bash bin/tests/test_worktree_lifecycle_spec.sh` - PASS
- [x] `bash bin/tests/test_worktree_reap_report_only.sh` - PASS
- [x] Mutation-verified both new tests (redden under their respective gate mutations, pass on unmodified code)
- [x] Mutation-verified the extracted `_destroy_base_branch_and_gc_everywhere` helper is load-bearing for the unrestorable-bundle test; the sibling survives-deletion test is unaffected by this mutation for reasons unrelated to the extraction (see Changes above)
- [x] Round 3: mutation-verified `_bundle_header_lines` is load-bearing at the two newly converted call sites (see Changes above)

