### PR TITLE
DS-200: add resident conductor tenets to the delegation section

### DIFF
--- a/.claude/skills/dinostack/METHODOLOGY.md
+++ b/.claude/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.claude/skills/dinostack/SKILL.md
+++ b/.claude/skills/dinostack/SKILL.md
@@ -149,6 +149,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.codex/skills/dinostack/METHODOLOGY.md
+++ b/.codex/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **Codex spawn contract.** Delegate with `spawn_agent` only. Before any spawn that needs an

--- a/.cursor/rules/agent-methodology.mdc
+++ b/.cursor/rules/agent-methodology.mdc
@@ -58,6 +58,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.gemini/skills/dinostack/SKILL.md
+++ b/.gemini/skills/dinostack/SKILL.md
@@ -64,6 +64,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.github/skills/dinostack/SKILL.md
+++ b/.github/skills/dinostack/SKILL.md
@@ -68,6 +68,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -75,6 +75,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.kimi/skills/dinostack/METHODOLOGY.md
+++ b/.kimi/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.kimi/skills/dinostack/SKILL.md
+++ b/.kimi/skills/dinostack/SKILL.md
@@ -149,6 +149,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.omp/skills/dinostack/METHODOLOGY.md
+++ b/.omp/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.openclaw/skills/dinostack/METHODOLOGY.md
+++ b/.openclaw/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.opencode/skills/dinostack/METHODOLOGY.md
+++ b/.opencode/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/.pi/skills/dinostack/METHODOLOGY.md
+++ b/.pi/skills/dinostack/METHODOLOGY.md
@@ -45,6 +45,24 @@ Run this check once at the first skill invocation (and every `/`-command). Read 
 
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/bin/tests/test_ticket_offer_gate_trigger_wording_spec.py
+++ b/bin/tests/test_ticket_offer_gate_trigger_wording_spec.py
@@ -3,7 +3,7 @@
 Purpose: Regression guard for the stale ticket-offer-gate trigger wording
          defect (PR #755 round 1): a restatement of the OLD narrow trigger
          ("do not spawn any implementer" / "spawning the first implementer")
-         survived at content/sections/02-delegation.md:23 after the gate was
+         survived at content/sections/02-delegation.md:29 after the gate was
          widened to "first subagent spawn of any kind (exemptions apply)",
          and escaped four separate tree-wide searches before a manual rubric
          grade caught it. This test discovers gate-trigger CONTEXT lines by

--- a/content/sections/02-delegation.md
+++ b/content/sections/02-delegation.md
@@ -1,5 +1,23 @@
 ## Delegation
 
+### Conductor tenets
+
+Rules tell you what to do once you have recognized the situation. These tell you how to
+recognize it. Each one exists because a resident rule was loaded, understood, and still not
+applied - check a judgment call against these before acting on it.
+
+1. **The owner test.** Before producing anything yourself, ask whether a named agent's
+   contract already covers it. If one does, it is theirs.
+2. **A claim you cannot source is a claim you delete.** Provenance is the condition for a
+   sentence existing, not a label added afterwards. If you cannot name the return, the read,
+   or the measurement behind it, cut it - softening it into a hedge or a question keeps the
+   claim's influence and sheds its accountability.
+3. **Prefer an address over a retransmission, unless the receiver cannot reach it.** Every
+   retransmission through your context can drop or alter binding text, and you will not be
+   the one who notices. When the address does not resolve for the receiver (a worktree-
+   isolated agent, a gitignored path), restate the text in the brief and name which copy is
+   authoritative.
+
 **The main session agent is a conductor, not an implementer.** The conductor is the main session agent: it decomposes work, delegates to specialist subagents that do the implementation and investigation, and synthesizes results when those subagents report back. It stays available and focused on orchestration - responsive to the user at all times.
 
 **All delegated tasks run in the background by default.** Foreground is permitted only for direct-action cases in the table below. Never block inline - spawn in the background and wait for completion notification. On the current Claude Code harness, `Agent` spawns run in the background by default, and `hooks/enforce-background-spawn.py` enforces background-by-default on both `Task` and `Agent`. The conductor norm on Claude Code: omit `run_in_background` entirely on `Agent` spawns and rely on the harness default; never pass `false`. The one sanctioned synchronous agent is `wrap-ticket`, which runs to completion in line because the conductor holds `.agentic/wrap/lock` for its duration and Phase 12 cleanup must wait for it to return; treat that as a behavioral property of `wrap-ticket`, not a general exemption. For the payload-capture history and the asymmetric allow/deny hook mechanics: read `content/references/delegation-detail.md` §Background-Spawn Enforcement Detail.

--- a/hooks/enforce-worktree-isolation-spawn.py
+++ b/hooks/enforce-worktree-isolation-spawn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Purpose: PreToolUse hook that mechanically enforces the worktree-isolation
-         mandate in `content/sections/02-delegation.md:160-162` (restated in
+         mandate in `content/sections/02-delegation.md:178-180` (restated in
          `content/sections/11-worktree-lifecycle.md`): every `engineer`,
          `qa-engineer`, and `release-orchestrator` spawn MUST set
          `isolation: "worktree"` on the Agent tool call, with NO exception
@@ -48,7 +48,7 @@ Purpose: PreToolUse hook that mechanically enforces the worktree-isolation
          rather than a line number, which drifts on any surrounding edit.
 
          MANDATED_ROLES is a HARDCODED literal, matching the mandate's own
-         wording (`content/sections/02-delegation.md:160`, "Every concurrent
+         wording (`content/sections/02-delegation.md:178`, "Every concurrent
          `engineer`, `qa-engineer`, and `release-orchestrator` spawn") - it
          is not derived from any manifest or role-spec file because no
          single source of truth for "which roles require worktree

--- a/scripts/.methodology-baseline.sha256
+++ b/scripts/.methodology-baseline.sha256
@@ -1,6 +1,6 @@
 # methodology baseline: one <basename> <sha256> line per content/sections/[0-9][0-9]-*.md
 01-activation-preflight.md 0016f0860b8146b4381eda24553b9024e77afc1e7dfb9ce33d90f701f6a34076
-02-delegation.md 5aafea75c1ec4b13ed45c3ccae6283345bb1f1eae51f4612a547a2ab446a77ca
+02-delegation.md 773256c0846bd8b856fea0860e375ed3c3818c247cde8f25c7dd7f637d754b5d
 03-planning-artifacts.md c5334ecdfd84bad9a59be05a6cf0715696e003d52e86411bd7a2ec203ca547d0
 04-risk-classification.md fff995bca7837403505c889409d5c2c6fecd693caa0e226c1fd3cb8bb4bd8ea5
 05-qa-gate.md 3cfaa20df3f01f91a690f25ee726e2cec86f1129720dd920e8c522318e91a623


### PR DESCRIPTION
## Summary
- Adds a resident `### Conductor tenets` block opening `content/sections/02-delegation.md` - three tenets: the owner test, claim provenance, and address-over-retransmission.
- Repairs three line-number citations the +18 line shift invalidates, one of which was already stale by -12 before this change.
- Net +1,122 B per embed artifact. Claude embed 141,872 -> 142,994 B, leaving 2,006 B headroom against a ceiling this ticket may not raise.

## Jira
Closes [DS-200](https://solara6.atlassian.net/browse/DS-200)

## Why three tenets, not five

The ticket motivated a tenet per DS-187 failure class. An audit against the full resident set (12 `content/sections/*.md` plus `conventions.md` and `code-standards.md`) found two of the five classes already covered, and covered by the stronger form:

- Round-cap overrun is stated at `content/sections/05-qa-gate.md:21` and mechanically enforced by `hooks/enforce-skeptic-round-cap.py`.
- Decision reversal on unchanged facts is stated at `content/sections/02-delegation.md` under `**Decision stability.**`, backed by the `**Reversal tripwire:**` mechanism in the same line.

A tenet for either would be the restatement of existing mechanism that acceptance criterion 5 bars. Two earlier drafts proposed deleting resident prose to pay for the additions; both candidates turned out to be enforcement floors, so the tenets were dropped instead of the floors.

## North Star alignment

Advances Pillar 1 (guard operator attention) and Pillar 2 (produce verifiable outcomes autonomously): the DS-187 evidence is that every rule violated was already resident and loaded, so the gap was a principle to check a judgment call against, not more mechanism.

Cuts against it, stated plainly rather than omitted:

- **Pillar 8** (machinery only as complicated as the benefit requires) is in direct tension. This adds resident prose whose failure-catch is a judgment nudge, not a mechanical catch, and it names no retirement condition beyond the DS-187 failure classes ceasing to recur in evaluation telemetry.
- **Pillar 5** (guard agent context) is against it: +1,122 B against a ceiling DS-45 owns and this ticket may not raise. Post-merge headroom is ~2,006 B, so the next content addition of moderate size hits it. That is a foreseeable consequence of merging this.

The audit also weakens the ticket's own thesis for 2 of the 5 classes: for the round-cap class the resident rule was not merely loaded but hook-enforced, and the loop ran anyway. That is an enforcement-reach question this ticket cannot reach.

## Byte accounting (acceptance criterion 6)

| gate | before | after | headroom |
|---|---|---|---|
| claude `check-skill-embed-budget.sh` | 141,872 B | 142,994 B | 2,006 B |
| gemini `check-gemini-skill-budget.sh` | 136,045 B | 137,167 B | 7,833 B |
| kimi `check-kimi-skill-embed-budget.sh` | 141,865 B | 142,987 B | 10,218 B |
| codex, copilot | floor-bounded only | - | no ceiling on the growing artifact |
| resident `check-resident-budget.sh` | 391 B | 391 B | 209 B (0 delta) |

No CEILING constant is modified; no `scripts/*.sh` file appears in this diff. Net-negative was the target and is not achieved: a prior sweep of 89,211 B across the three largest resident files found 0 B of safe deletion, and every candidate surfaced across three plan-review rounds resolved to an enforcement floor. Acceptance criterion 6 permits this outcome explicitly.

## Citation repairs

The insertion shifts every line below line 2 by +18. The consumer set was re-derived with `git grep -nE "02-delegation\.md[:#][0-9]+"`, and each cited line was opened and content-verified rather than offset blindly:

- `hooks/enforce-worktree-isolation-spawn.py:4` - `:160-162` -> `:178-180`
- `hooks/enforce-worktree-isolation-spawn.py:51` - `:160` -> `:178`
- `bin/tests/test_ticket_offer_gate_trigger_wording_spec.py:6` - `:23` -> `:29`. This one was **already wrong by -12** before this change; its target sits at line 11 on `main`. Corrected to the true line, not shifted to a new wrong one.

## Test plan
- [x] `pytest bin/tests/ -q` - 1954 passed, 25 subtests passed
- [x] Python hook loop (20 files), shell hook loop, JS hook loop (55 files) - all fail=0
- [x] `scripts/build-all.sh` + `check-methodology-drift.sh --regenerate`, then `git diff --exit-code` over the verbatim `adapter-sync.yml` pathspec - clean
- [x] `check-symlinks-relative.sh` - all four skill symlinks relative
- [x] All six budget gates re-executed, not quoted
- [x] Em-dash and executable-fence checks scoped to the diff - both empty

Doc-sync: predicate not triggered (no reality-asserting change - new resident prose only; no new command/agent/rule file, count, or documented convention invalidated). `docs/index.html`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md`, and the risk-classification deck were each grepped; nothing goes stale.

QA: `qa_skip: docs-only`. `content/sections/**` is the runtime instruction surface for every agent session, but this change has no executable, UI, or service surface and adds no executable command fence - verified by a fence check on the diff.


[DS-200]: https://solara6.atlassian.net/browse/DS-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ