### PR TITLE
DS-200: stage condensed vision proposal, with gitignore carve-out and regression guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,11 @@ docs/technical/
 docs/operations/
 docs/overview/*
 !docs/overview/vision.md
+# The directory negation lets git descend; the `_proposed/*` re-exclusion is load-bearing because a
+# broader negation would be a later match than the .env/.DS_Store rules above and override them.
+!docs/overview/_proposed/
+docs/overview/_proposed/*
+!docs/overview/_proposed/*.md
 docs/_archive/session-learnings/
 
 # Stray .agentic/ runtime working dirs created when a command/subagent runs with a non-root cwd.

--- a/bin/tests/test_gitignore_proposed_carveout.py
+++ b/bin/tests/test_gitignore_proposed_carveout.py
@@ -1,0 +1,285 @@
+"""
+Purpose: Regression guard for the `docs/overview/_proposed/` carve-out in the
+         repo's root `.gitignore` (DS-200 U3). The carve-out must let
+         `_proposed/*.md` be tracked WITHOUT re-enabling tracking of secrets
+         and OS junk underneath it. An earlier round of DS-200 shipped the
+         two-line form
+
+             !docs/overview/_proposed/
+             !docs/overview/_proposed/**
+
+         which was measured, independently and twice, to make `.env` and
+         `.DS_Store` under `_proposed/` TRACKABLE: gitignore matching is
+         last-match-wins, and that broad `**` negation sits LATER in the file
+         than the repo-wide `.env` / `.env.local` / `.env*.local` / `.DS_Store`
+         rules, so it overrode them. The shipped three-line form re-excludes
+         the directory's contents (`docs/overview/_proposed/*`) before
+         negating only `*.md`, so no rule that matches a dotfile secret is
+         ever overridden.
+
+         Nothing else in the repo guards this, so a revert or a re-broadening
+         of the negation would land silently. That is what this file exists to
+         redden.
+
+Public API: pytest test functions only; no importable helpers are intended for
+            reuse outside this module.
+
+Upstream deps: stdlib (subprocess, os, pathlib) plus `pytest`, the module's
+            only non-stdlib dependency (parametrization and fixtures). Shells
+            out to the system `git` binary against a disposable pytest
+            `tmp_path` repo. Reads the LIVE root `.gitignore` of this
+            checkout (never a hand-typed copy - a fixture built from
+            remembered rules validates the fixture, not the repo). No network,
+            no writes anywhere outside `tmp_path`.
+
+Downstream consumers: none (leaf test module). Collected by
+            `python3 -m pytest bin/tests/ -q`, which is the `python-bin-tests`
+            job in `.github/workflows/bin-tests.yml`.
+
+Failure modes: every git subprocess that establishes or reads fixture state
+            (`init`, `add -A`, `ls-files -z`) runs with `check=True` and a
+            bounded timeout, so a broken fixture raises loudly rather than
+            yielding a misleading pass. The one exception is the diagnostic-
+            only `check-ignore -v` call in `_check_ignore_detail`, which runs
+            with `check=False` since a nonzero exit there is not itself a
+            fixture failure. `_trackable_set()` asserts the probe files it
+            wrote are actually on disk before consulting git, so an empty
+            result can never be mistaken for "everything is ignored".
+
+Performance: standard; one `git init` plus three git commands per
+             parametrized case (`add -A`, `ls-files -z`, `check-ignore -v`),
+             all local (~50ms each).
+
+Oracle note (deliberate, see DS-200 U3 brief item 4): this module does NOT use
+`git check-ignore` exit status as its oracle. Measured: `check-ignore -v`
+exits 0 when a NEGATION matches an untracked path, so exit status alone is
+ambiguous in both directions for exactly the rules under test here. Instead
+the oracle is real staging semantics - write every probe file, run `git add
+-A` (which silently skips ignored paths and stages everything else), then read
+`git ls-files`. That set IS the answer to "what can be committed", which is
+the property the carve-out exists to control, and it has no ambiguous case.
+`git check-ignore -v` output is still collected, but only as diagnostic detail
+in assertion messages.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# bin/tests/<this file> -> bin/tests -> bin -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIVE_GITIGNORE = REPO_ROOT / ".gitignore"
+
+_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+# The shipped three-line carve-out, as it appears in the live root .gitignore.
+# Used only as the search target for building the mutant below - the tests
+# themselves always run against the live file's real bytes.
+CORRECT_FORM = (
+    "!docs/overview/_proposed/\n"
+    "docs/overview/_proposed/*\n"
+    "!docs/overview/_proposed/*.md\n"
+)
+
+# The defective form an earlier DS-200 round shipped. Reinstating it is the
+# mutation this suite must redden.
+BROAD_NEGATION_FORM = (
+    "!docs/overview/_proposed/\n"
+    "!docs/overview/_proposed/**\n"
+)
+
+# Probe paths. Every one is created on disk in the fixture repo.
+PROPOSED = "docs/overview/_proposed"
+
+# Must stay IGNORED under _proposed/ - these are the paths the broad-negation
+# form leaked. `secret.env.local` matches NONE of the repo-wide .env rules
+# (they all anchor on a leading `.env`), so it is ignored solely by the middle
+# `docs/overview/_proposed/*` re-exclusion line - it is the probe that proves
+# that line is load-bearing on its own.
+SECRETS_UNDER_PROPOSED = (
+    f"{PROPOSED}/.env",
+    f"{PROPOSED}/.env.local",
+    f"{PROPOSED}/secret.env.local",
+    f"{PROPOSED}/.DS_Store",
+)
+
+# Must be TRACKABLE - the whole point of the carve-out.
+TRACKABLE_UNDER_PROPOSED = f"{PROPOSED}/vision.md"
+
+# Must stay IGNORED - the earlier rules the broad negation was overriding, plus
+# the `docs/overview/*` umbrella the carve-out is punched through.
+UNREGRESSED_IGNORED = (
+    ".env",
+    ".DS_Store",
+    "docs/overview/junk-probe.md",
+)
+
+# Pre-existing carve-out that must survive untouched.
+PREEXISTING_TRACKABLE = "docs/overview/vision.md"
+
+ALL_PROBES = (
+    *SECRETS_UNDER_PROPOSED,
+    TRACKABLE_UNDER_PROPOSED,
+    *UNREGRESSED_IGNORED,
+    PREEXISTING_TRACKABLE,
+)
+
+
+def _hermetic_env(tmp_path: Path) -> dict[str, str]:
+    """Env that isolates git from the operator's real config - in particular
+    from any global `core.excludesFile`, which would otherwise silently add
+    ignore rules this suite is not testing."""
+    global_config = tmp_path / "empty-gitconfig"
+    global_config.write_text("", encoding="utf-8")
+    home = tmp_path / "fixture-home"
+    home.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = str(global_config)
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
+
+
+def _git(args: list[str], cwd: Path, env: dict[str, str], check: bool = True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _check_ignore_detail(repo: Path, env: dict[str, str]) -> str:
+    """Diagnostic only, never the oracle: which rule git says matched each
+    probe. Included in assertion messages so a failure names the offending
+    .gitignore line instead of just the path."""
+    result = _git(
+        ["check-ignore", "-v", "--no-index", "--", *ALL_PROBES],
+        cwd=repo,
+        env=env,
+        check=False,
+    )
+    return result.stdout or "(no rule matched any probe)"
+
+
+def _trackable_set(tmp_path: Path, gitignore_text: str) -> tuple[set[str], str]:
+    """Build a scratch repo carrying `gitignore_text`, materialize every probe
+    path, then return (set of paths git will actually stage, diagnostic).
+
+    `git add -A` silently skips ignored paths and stages everything else, so
+    the resulting `git ls-files` IS the trackable set - real staging
+    semantics, not an exit-status inference."""
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    env = _hermetic_env(tmp_path)
+    _git(["init", "-q", "-b", "main"], cwd=repo, env=env)
+    (repo / ".gitignore").write_text(gitignore_text, encoding="utf-8")
+
+    for rel in ALL_PROBES:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"probe content for {rel}\n", encoding="utf-8")
+        assert path.is_file(), f"fixture invariant violated: failed to write probe {rel}"
+
+    _git(["add", "-A"], cwd=repo, env=env)
+    listed = _git(["ls-files", "-z"], cwd=repo, env=env).stdout
+    tracked = {entry for entry in listed.split("\0") if entry}
+    # `.gitignore` itself is always staged; drop it so callers compare probes.
+    tracked.discard(".gitignore")
+    return tracked, _check_ignore_detail(repo, env)
+
+
+def _live_gitignore_text() -> str:
+    return LIVE_GITIGNORE.read_text(encoding="utf-8")
+
+
+def test_live_gitignore_contains_the_three_line_carveout():
+    """Fails loudly if the carve-out is reverted or reshaped, so the behavior
+    tests below can never pass vacuously against a file that no longer has the
+    construct they describe."""
+    text = _live_gitignore_text()
+    assert CORRECT_FORM in text, (
+        "the three-line docs/overview/_proposed/ carve-out is missing from "
+        f"{LIVE_GITIGNORE}. Expected to find, contiguously:\n{CORRECT_FORM}"
+    )
+    assert "!docs/overview/_proposed/**" not in text, (
+        "the root .gitignore contains the broad `!docs/overview/_proposed/**` "
+        "negation. Under last-match-wins that overrides the repo-wide .env / "
+        ".DS_Store rules above it and makes secrets under _proposed/ "
+        "trackable - the exact defect this carve-out replaced."
+    )
+
+
+@pytest.mark.parametrize("rel", SECRETS_UNDER_PROPOSED)
+def test_secrets_under_proposed_are_ignored(tmp_path: Path, rel: str):
+    tracked, detail = _trackable_set(tmp_path, _live_gitignore_text())
+    assert rel not in tracked, (
+        f"{rel} is TRACKABLE under the live root .gitignore - a secret or OS "
+        f"junk file under docs/overview/_proposed/ must never be committable.\n"
+        f"check-ignore -v detail:\n{detail}"
+    )
+
+
+def test_proposed_markdown_is_trackable(tmp_path: Path):
+    tracked, detail = _trackable_set(tmp_path, _live_gitignore_text())
+    assert TRACKABLE_UNDER_PROPOSED in tracked, (
+        f"{TRACKABLE_UNDER_PROPOSED} is NOT trackable under the live root "
+        f".gitignore - the carve-out exists precisely to allow it.\n"
+        f"check-ignore -v detail:\n{detail}"
+    )
+
+
+@pytest.mark.parametrize("rel", UNREGRESSED_IGNORED)
+def test_earlier_rules_are_unregressed(tmp_path: Path, rel: str):
+    tracked, detail = _trackable_set(tmp_path, _live_gitignore_text())
+    assert rel not in tracked, (
+        f"{rel} became TRACKABLE - the _proposed/ carve-out has regressed a "
+        f"rule that sits earlier in the file.\ncheck-ignore -v detail:\n{detail}"
+    )
+
+
+def test_preexisting_overview_vision_carveout_survives(tmp_path: Path):
+    tracked, detail = _trackable_set(tmp_path, _live_gitignore_text())
+    assert PREEXISTING_TRACKABLE in tracked, (
+        f"{PREEXISTING_TRACKABLE} is no longer trackable - the pre-existing "
+        f"`!docs/overview/vision.md` carve-out has been broken.\n"
+        f"check-ignore -v detail:\n{detail}"
+    )
+
+
+def test_broad_negation_mutant_leaks_secrets(tmp_path: Path):
+    """The reddening mutation, codified.
+
+    Swapping the shipped three-line form for the two-line broad-negation form
+    that an earlier DS-200 round shipped must make `.env` and `.DS_Store`
+    under `_proposed/` trackable. If this test ever stops observing the leak,
+    the oracle above has gone blind and every assertion in this module is
+    decorative - so the leak is asserted POSITIVELY here rather than being
+    left as a one-off manual check."""
+    live = _live_gitignore_text()
+    assert CORRECT_FORM in live, "cannot build the mutant: shipped form not found"
+    mutant = live.replace(CORRECT_FORM, BROAD_NEGATION_FORM)
+    assert mutant != live, "mutation was a no-op"
+
+    tracked, detail = _trackable_set(tmp_path, mutant)
+    leaked = [rel for rel in SECRETS_UNDER_PROPOSED if rel in tracked]
+    assert set(leaked) == set(SECRETS_UNDER_PROPOSED), (
+        "the broad-negation mutant did NOT leak every secret probe, so the "
+        "oracle cannot distinguish the defect from the fix. Leaked: "
+        f"{sorted(leaked)}; expected all of {sorted(SECRETS_UNDER_PROPOSED)}.\n"
+        f"check-ignore -v detail:\n{detail}"
+    )
+    assert TRACKABLE_UNDER_PROPOSED in tracked, (
+        "sanity check failed: the mutant should still make vision.md "
+        "trackable, so the leak above is the ONLY behavioral difference."
+    )

--- a/docs/overview/_proposed/vision.md
+++ b/docs/overview/_proposed/vision.md
@@ -1,0 +1,118 @@
+# DinoStack Product Vision (North Star)
+
+> **Staged proposal - not canonical.** Discovery draft in `docs/overview/_proposed/`. The operator-owned `docs/overview/vision.md` has not been written or modified. Review, edit, and promote this when it matches your intent.
+
+**Status:** Condensed proposal derived from the ratified `docs/overview/vision.md` (2026-06-28).
+Same eight pillars, same boundaries, fewer bytes.
+
+## The problem
+
+Code generation is cheap; the scarce resource is the **operator's attention**: deciding what to
+build, trusting it was built correctly, and not babysitting the machine to find out. DinoStack is
+the protocol layer that makes delegated work *trustworthy enough to ignore*: structured
+delegation, risk classification, adversarial review (the Skeptic loop), code-quality gates, and
+named agents.
+
+## North Star (what every change should serve)
+
+1. **Guard operator attention.** Surface decisions and work-stoppages, not status. A change that
+   adds capability but increases what the operator must read, watch, or babysit is a regression,
+   not a feature. (The "attention test" is the tie-breaker when trade-offs are unclear.)
+2. **Produce verifiable outcomes autonomously.** Agents should drive work to a checkable result -
+   tests/lints/gates passing, an adversarial Skeptic sign-off, a clear `ok | needs_human |
+   blocked` exit - without a human in the loop for routine steps. Verifiability is what makes
+   autonomy safe to trust. The conductor does not do the work - it orchestrates agents that do. A
+   conductor that investigates, diagnoses, or asserts unverified conclusions has substituted its
+   own unchecked judgment for the adversarial verification this pillar guarantees. (The
+   "orchestration test": did this claim/artifact come from a subagent return or a conductor read
+   verified against `origin/main`, or did the conductor manufacture it directly? The latter is not
+   ready to spawn on.)
+3. **Low friction.** Sensible defaults, minimal setup, global-default/per-project-override
+   everywhere. The protocol should reduce ceremony, not add it.
+4. **Works for everyone (universality).** Every rule, command, and agent must work for any
+   operator, not just its author. No operator's identity, workspace, tracker, or local setup may
+   be baked into shared behavior: resolve per-operator context at runtime (e.g. "my assigned
+   tickets" via the tracker's own current-user, scoped to the configured project, never a
+   hardcoded account or workspace), honor the global-default / per-project-override seam, and
+   degrade gracefully when a capability isn't configured rather than breaking. (The "portability
+   test": would this behave correctly for a teammate with different credentials, a different
+   tracker, or a different harness?)
+5. **Guard agent context.** Agent context is scarce exactly the way operator attention is; this
+   pillar is the agent-facing counterpart to Pillar 1. Prefer changes that reduce what an agent
+   must load or emit to do the same job at equal or better quality: cut duplicated prose,
+   unconsumed return fields, always-loaded content that could be trigger-loaded instead, and
+   narration that surfaces no decision. Efficiency is won only by removing waste. (The "efficiency
+   test": does this change reduce what an agent must load or emit at the same correctness?)
+6. **Shorten wall-clock time to a finished, verified result.** Pillar 1 is what the operator reads,
+   Pillar 5 is what an agent loads; this is how long the operator waits. It can legitimately
+   conflict with Pillar 5: parallel fan-out spends more tokens to finish sooner, a chain of small
+   serial rounds spends fewer and takes far longer. When the two conflict, prefer the faster
+   wall-clock outcome unless the token cost is disproportionate - state that lean explicitly so an
+   agent can act on it without asking. Concretely: run independent units in parallel rather than
+   serializing them, batch findings into one rework round rather than one round per finding, do not
+   block behavior work behind infrastructure work, prefer same-PR rework over a fresh PR-and-CI
+   cycle per round, and count CI cycle time as part of the cost of an extra round. (The "latency
+   test": does this shorten the path from request to verified result without removing
+   verification?)
+7. **Prevent defects at the producing step, not just catch them at the reviewing step.** When a
+   review check is mechanical - a grep, a diff, a count comparison, a lookup - give the producing
+   agent that same check to run before it submits, so it never becomes a review round at all. This
+   applies only to mechanical checks: judgment-based checks (logic errors, edge cases, an
+   adversarial brief, a fabrication spot-check) require an independent reader and must NOT be
+   left-shifted, because moving them to the author destroys the independence that makes them work.
+   Left-shift is redundancy, not a handoff: the reviewer keeps running everything it ran before.
+   (The "prevention test": does this move a mechanical check earlier without weakening the later
+   one?)
+8. **Machinery only as complicated as the benefit requires.** The methodology's own machinery -
+   gates, hooks, count-pins, sweeps, counters, telemetry, and prose - is not exempt from Pillars 1,
+   5, and 6: self-referential machinery that protects the methodology spends the same scarce
+   attention, context, and wall-clock time as any other change, and is a cost charged against those
+   pillars, not one outside them. No new gate, hook, count-pin, or enforcement mechanism ships
+   without naming (a) a specific failure it would have caught and (b) the condition under which it
+   retires - a permanent enforcement floor whose retirement condition is "never" satisfies (b) by
+   naming it as such. An enumeration of banned shapes that grows by one entry per incident is a
+   smell: the principle a mechanism should have generalized from is missing, not that the
+   enumeration needs one more line. Binding prose lives at exactly one canonical site with pointers
+   to it; a verbatim copy is justified only when the text is embedded directly into a spawn prompt
+   (an agent cannot follow a pointer mid-task), is public-facing documentation serving a different
+   audience than the methodology's own source, or is a one-to-two-sentence normative restatement at
+   the point of use accompanied by a pointer to the canonical site. Simplification is won only by
+   deleting non-floor machinery whose failure-catching is measured at zero yield. A mechanism with
+   no named catch and no measured fires is not thereby a deletion candidate - it is first
+   instrumented, or its measurement gap otherwise closed, so the question is answered by
+   measurement, never by assumption. (The "simplicity test": can you name the specific failure this
+   mechanism would have caught and the condition under which it retires? If either cannot be named,
+   it does not ship.)
+
+**The boundary shared by Pillars 5, 6, 7, and 8.** An enforcement floor is never removed to satisfy
+a pillar, measured or not: it is not waste, it is never a pruning candidate however expensive it is
+to run, and cutting a gate, review round, or verification step to save tokens, to finish sooner, or
+to simplify is a regression against Pillar 2, never a win. This is the existing floor-vs-dial
+precedent: capability and efficiency changes move the risk-profile dial, they never remove a floor.
+Non-floor machinery is the separate case Pillar 8 governs: it becomes a deletion candidate only on
+a measured zero yield, never on assumption alone. Left-shifting a mechanical check under Pillar 7
+likewise never licenses weakening the reviewer's copy of it.
+
+## What it does
+
+Provides the portable, evolving rule set and agent definitions that let an operator delegate
+software work to sandboxed AE teams and get back results that are reviewed, gated, and ready to
+trust, escalating to the human only for genuine decisions.
+
+## Explicit non-goals
+
+- **Not** a tool that requires the operator to watch it work or read everything it produces.
+- **Not** single-operator software: behavior hardwired to one person's identity, tracker,
+  workspace, or machine has no place in the shared rule set.
+- **Not** self-defending machinery: a gate/hook/pin whose only demonstrated catch is defects in
+  other gates/hooks/pins is accretion, not protection - but removing an enforcement floor is never
+  the remedy; the remedy is instrumentation or replacing the mechanism's justification, per Pillar
+  8's boundary.
+
+## How to use this for PR alignment
+
+A pull request is **aligned** if it advances at least one pillar without regressing another
+(especially the attention test). Run each pillar's parenthesized test against the diff; failing any
+of them is misalignment, as is cutting a gate, review round, verification step, or enforcement
+floor to save tokens, to finish sooner, or to simplify. Misalignment is a *direction* signal for
+the operator, not necessarily a request-changes verdict on correctness.


### PR DESCRIPTION
## Summary
- Stages a condensed proposal of the North Star document at `docs/overview/_proposed/vision.md` (9,063 B, from a 14,356 B canonical). The canonical file is byte-identical to `main`.
- Adds the `.gitignore` carve-out that makes that path trackable at all, in a form measured not to override the repo-wide secret rules.
- Adds `bin/tests/test_gitignore_proposed_carveout.py`, a mutation-confirmed regression guard on that carve-out.

## Jira
Closes [DS-200](https://solara6.atlassian.net/browse/DS-200)

## Acceptance criterion 3 is NOT satisfied by this merge

This PR stages a **proposal only**. `docs/overview/vision.md` is operator-owned - agents read it and never write it - and `git diff --exit-code origin/main -- docs/overview/vision.md` is clean here. The new file carries the standard staged-proposal banner declaring itself non-canonical.

Criterion 3 closes only when the operator reads `docs/overview/_proposed/vision.md`, edits it to match their intent, and promotes it over the canonical file. Two downstream updates are deliberately deferred to that promotion and are tracked separately: `content/references/conductor-turn-format.md`, which cites `docs/overview/vision.md` by line number, and the verbatim Pillar 1 quote in `content/references/subagent-return-contract.md`. Both must stay pinned to the canonical document until it actually changes.

The full removed-clause list is below so the promotion can be reviewed rather than diff-read.

## What the condensation removed

- Document metadata (`Status: Ratified`, `Authored`).
- Four measured session anecdotes inside Pillars 5, 6, 7, 8 - evidence, not intent.
- Pillar 5's "That boundary is exact, not a matter of degree" clause, one of four near-identical boundary restatements, now stated once globally.
- Five of eight non-goals, each an inversion of that same global rule: capability-for-capability's-sake, not-a-finished-product, cut-verification-for-tokens, speed-over-verification, skip-the-reviewer's-copy. Three survive.
- The ~900 B single-sentence alignment rubric, replaced by three sentences.

## What review forced back in

An earlier round of this condensation dropped normative content without disclosing it. These are restored: Pillar 6's tie-break against Pillar 5; Pillar 8's single-canonical-site binding-prose rule and all three of its exceptions; Pillar 8's instrument-before-deleting constraint; Pillar 8's ban-list-growth smell; Pillar 5's trigger-loadable waste class; Pillar 2's "not ready to spawn on" verdict. The engineer's own audit additionally caught two floor-vs-dial clauses it had dropped unauthorized and restored those too.

A global statement that read "No pillar is ever satisfied by removing a gate, a review round, a verification step, or an enforcement floor" was also rewritten: as an absolute it was **stricter than canonical Pillar 8**, which permits deleting non-floor machinery on a measured zero yield and reserves the never-delete rule for enforcement floors. Promoting it as written would have banned a disposition the canonical document allows.

**Size deviation, disclosed:** 9,063 B against a 4,500-5,500 B target. The restoration work above made the target unreachable without re-weakening the document. Verified byte-identical to canonical: all 8 pillar titles, the `N. **Title.**` format that `bin/tests/test_ds_update_pillar_check_no_inline_list.py` parses, Pillar 1's body, and the staged-proposal banner.

## The `.gitignore` carve-out, and why it is three lines

`docs/overview/*` excludes the `_proposed` directory, and git never descends into an excluded directory, so the deliverable was unstageable without a carve-out - silently, with a clean-reading tree and every gate passing.

The first fix was `!docs/overview/_proposed/**`. That was measured, independently and twice, to make `.env`, `.env.local`, `secret.env.local`, and `.DS_Store` under `_proposed/` **trackable**: gitignore matching is last-match-wins, and that negation sits later in the file than the repo-wide secret rules at `.gitignore:14-19`. Note that `secret.env.local` matches none of those rules anyway - they all anchor on a leading `.env` - so it is ignored solely by the middle re-exclusion line.

The shipped form re-includes the directory, re-excludes its contents, then negates only `*.md`, and carries a two-line on-site comment explaining why the middle line is load-bearing. Every earlier rule is unregressed.

## The regression test

`bin/tests/test_gitignore_proposed_carveout.py` reads the **live root `.gitignore`** and copies those real bytes into a hermetic scratch repo - it does not hand-type the rules, which is exactly how an earlier verification in this ticket produced a false confirmation.

Its oracle is real staging semantics (`git add -A`, then `git ls-files`), not `git check-ignore` exit status: `check-ignore -v` exits 0 when a *negation* matches an untracked path, so exit status is ambiguous in both directions here.

Mutation-confirmed three ways by the reviewer, not only against the mutant it codifies: the two-line broad form reddens 6 of 11 cases; dropping just the middle re-exclusion reddens 3; appending a broad negation after the `*.md` rule reddens 5. It also codifies the original defect as a permanent positive assertion, so if the oracle ever goes blind that test fails rather than every other assertion silently becoming decorative. Collected by the `python-bin-tests` job in `.github/workflows/bin-tests.yml`.

## North Star alignment

Advances Pillar 7 (prevent defects at the producing step): the carve-out defect was invisible to every existing gate, and the new test closes it at the point of production rather than at review.

Cuts against it: the `.gitignore` change is a real, if narrow, loosening of a deliberate exclusion, and this adds machinery, which Pillar 8 charges against the same budget as any other change. The counter is that the machinery guards a measured secret-exposure path, and Pillar 8 explicitly never licenses deleting an enforcement floor to stay simple.

## Test plan
- [x] `pytest bin/tests/ -q` - 1965 passed, 25 subtests passed
- [x] New test in isolation - 11 passed
- [x] Mutation check against the original defect - reddens, with all four secrets appearing in the trackable set
- [x] `check-skill-embed-budget.sh` - SKILL.md delta exactly 0, confirming the vision content adds no embed bytes
- [x] Trackability proven by `git add` + `git ls-files --error-unmatch` + non-empty `git ls-tree HEAD`, not by `check-ignore`
- [x] Em-dash and executable-fence checks scoped to the diff - both empty

Doc-sync: predicate not triggered (no reality-asserting change to a documented count, list, path, or convention; the proposal is staged under `_proposed/` and explicitly non-authoritative).

QA: no runtime, UI, or service surface. The regression test is this unit's verification.


[DS-200]: https://solara6.atlassian.net/browse/DS-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ