### PR TITLE
fix(docs): correct stale AGENTS.md Deploy section to measured auto-deploy reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ A portable package of the agentic engineering protocol for AI-assisted software 
 - `git checkout <sha> -- <path>` inside a worktree resurrects files a later commit deleted (adds files present at `<sha>`, doesn't replay deletions). When basing a step on a non-`main` commit this way, `git rm` anything it deleted and gate on an exact `git ls-files` set.
 
 ## Deploy
-- Docs site deploy steps: `docs/technical/deploy.md` (local-only, not tracked upstream). Verify the linked project ID before `vercel --prod`.
+- The docs site (docs.dinostack.ai) auto-deploys on push to `main` via Vercel git integration (~3 min); verify with `curl -sI https://docs.dinostack.ai/<path> | grep last-modified`. There is no manual deploy step; do NOT run `vercel --prod` from a local CLI unless its authenticated scope demonstrably contains the `dinostack-docs` project (a mis-linked deploy once caused a live 404).
 - `dinostack-docs` Vercel project's Root Directory is `docs/`, so Vercel reads `docs/vercel.json` - repo-root `vercel.json` is ignored for redirects/rewrites/headers (once caused a live install-URL redirect to silently 404). Put Vercel redirect/rewrite/header changes in `docs/vercel.json`.
 
 ## Conventions


### PR DESCRIPTION
## Summary

Corrects the stale "## Deploy" section in AGENTS.md: `docs/technical/deploy.md` does not exist, and the docs site auto-deploys on push to `main` via Vercel git integration (measured: PR #819 merged 19:26:02Z, live site last-modified 19:28:56Z, no manual step). The stale instruction nearly caused a wrong-workspace deploy this session - the local `vercel` CLI is authenticated to an unrelated workspace containing no dinostack project, and following the old bullet's `vercel --prod` guidance would have interactively mis-linked (the exact 404-hazard class the bullet's own warning described).

New text: auto-deploy on push with a curl verification command, plus an explicit warning against local `vercel --prod` unless the CLI's authenticated scope demonstrably contains `dinostack-docs`. The second bullet (Root Directory / docs/vercel.json) remains accurate and untouched.

## North Star alignment

Pillar 1 (guard operator attention): a stale operational pointer burns session time and invites a destructive mis-deploy; correcting the record to measured reality is pure attention recovery. No mechanism, gate, or floor is touched - a one-bullet doc correction verified against live platform behavior.

Doc-sync: this IS the doc fix; no other surface references the removed path (grepped, zero hits).
