### PR TITLE
chore(agents): dedupe /dinostack prerequisite blockquotes to one per file (PL-20260825-9)

### DIFF
--- a/.codex/agents/adr-generator.toml
+++ b/.codex/agents/adr-generator.toml
@@ -61,7 +61,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
 ```
 
 ### Document Sections

--- a/.gemini/agents/adr-drift-detector.md
+++ b/.gemini/agents/adr-drift-detector.md
@@ -30,8 +30,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -116,8 +114,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -192,8 +188,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 

--- a/.gemini/agents/adr-generator.md
+++ b/.gemini/agents/adr-generator.md
@@ -48,8 +48,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -64,8 +62,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -183,8 +179,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -221,8 +215,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/.github/agents/adr-drift-detector.md
+++ b/.github/agents/adr-drift-detector.md
@@ -26,8 +26,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -112,8 +110,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -188,8 +184,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 

--- a/.github/agents/adr-generator.md
+++ b/.github/agents/adr-generator.md
@@ -44,8 +44,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -60,8 +58,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -179,8 +175,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -217,8 +211,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -9656,8 +9656,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -9742,8 +9740,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -9818,8 +9814,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 
@@ -9975,8 +9969,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -9991,8 +9983,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -10110,8 +10100,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -10148,8 +10136,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/.openclaw/skills/agent-adr-drift-detector/SKILL.md
+++ b/.openclaw/skills/agent-adr-drift-detector/SKILL.md
@@ -27,8 +27,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -113,8 +111,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -189,8 +185,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 

--- a/.openclaw/skills/agent-adr-generator/SKILL.md
+++ b/.openclaw/skills/agent-adr-generator/SKILL.md
@@ -45,8 +45,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -61,8 +59,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -180,8 +176,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -218,8 +212,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/.opencode/agents/adr-drift-detector.md
+++ b/.opencode/agents/adr-drift-detector.md
@@ -32,8 +32,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -118,8 +116,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -194,8 +190,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 

--- a/.opencode/agents/adr-generator.md
+++ b/.opencode/agents/adr-generator.md
@@ -46,8 +46,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -62,8 +60,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -181,8 +177,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -219,8 +213,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/content/agents/adr-drift-detector.md
+++ b/content/agents/adr-drift-detector.md
@@ -31,8 +31,6 @@ List all `.md` files in the found directory. If multiple directories exist, use 
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 2: Detect Project Identity
 
 To populate the report header, detect the project name:
@@ -117,8 +115,6 @@ Be conservative: if you cannot determine a reliable search strategy, classify as
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Phase 4: Build and Execute Search Strategies
 
 For each auditable ADR, design targeted searches. Execute them with Bash, Grep, or Glob.
@@ -193,8 +189,6 @@ Based on gathered evidence, assign one classification:
 **UNVERIFIABLE**: Decision is about process/human behavior, or search strategies cannot produce reliable signal either way without deeper semantic analysis. Provide a brief reason.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Phase 6: Produce the Drift Report
 

--- a/content/agents/adr-generator.md
+++ b/content/agents/adr-generator.md
@@ -48,8 +48,6 @@ Create an ADR as a markdown file following the standardized format below with th
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Required ADR Structure (template)
 
 ### Front Matter
@@ -64,8 +62,6 @@ tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 ```
 
 ### Document Sections
@@ -183,8 +179,6 @@ All ADRs must be saved in: `docs/adr/`
 
 ---
 
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
-
 ## Quality Checklist
 
 Before finalizing the ADR, verify:
@@ -221,8 +215,6 @@ Before finalizing the ADR, verify:
 10. **Capture Learnings In Flight**: the shard CLI is your capture path - `adr-generator` is one of the four roles the reference names, and your contract permits mutating commands - record each learning the moment it occurs via `ds-learning-shard append` rather than batching it to the end. What counts as a learning, the exact invocation, the cap and the `SESSION_KEY` rule are all defined in `~/DinoStack/.claude/skills/dinostack/references/learnings-capture-instruction.md`. Do not pre-filter for importance - the conductor classifies. Your return format defines no `learnings_candidate[]` field; the shard is your whole capture path.
 
 ---
-
-> **Prerequisite:** If the /dinostack skill has not been loaded in this session, invoke it first before proceeding.
 
 ## Agent Success Criteria
 

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -110,7 +110,7 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 ## PL-20260825-9
 - Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-25 (docs/planning/harness-pruning-2026-08-25.md)
-- File(s): content/agents/adr-drift-detector.md (4 copies) + content/agents/adr-generator.md (5 copies, one inside the fenced ADR template) + smaller repetition in sibling agent files
+- File(s): content/agents/adr-drift-detector.md (4 copies) + content/agents/adr-generator.md (5 copies, one inside the fenced ADR template)
 - Signal(s): Signal 3 (verbatim duplication within single files)
 - Confidence: MEDIUM
 - Rationale: The /dinostack prerequisite blockquote is repeated 4-5 times within single agent files; one top-of-file copy is the intentional pattern. The copy inside adr-generator.md's fenced ADR template is an outright defect - every generated ADR ships a skill-load instruction in its front matter. Approved: dedupe to one copy per file and remove the in-fence copy as a bug fix.

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -108,13 +108,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition:
 
 ## PL-20260825-9
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-25 (docs/planning/harness-pruning-2026-08-25.md)
 - File(s): content/agents/adr-drift-detector.md (4 copies) + content/agents/adr-generator.md (5 copies, one inside the fenced ADR template) + smaller repetition in sibling agent files
 - Signal(s): Signal 3 (verbatim duplication within single files)
 - Confidence: MEDIUM
 - Rationale: The /dinostack prerequisite blockquote is repeated 4-5 times within single agent files; one top-of-file copy is the intentional pattern. The copy inside adr-generator.md's fenced ADR template is an outright defect - every generated ADR ships a skill-load instruction in its front matter. Approved: dedupe to one copy per file and remove the in-fence copy as a bug fix.
-- Disposition:
+- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/823
 
 ## PL-20260825-10
 - Status: RAISED


### PR DESCRIPTION
## Summary
- `content/agents/adr-drift-detector.md` carried 4 copies of the `**Prerequisite:**` blockquote; `content/agents/adr-generator.md` carried 5, one of them embedded inside the fenced ADR front-matter template (a real bug - generated ADRs would ship a skill-load instruction verbatim in their own front matter).
- Every other `content/agents/*.md` file already carries exactly one copy at the top; those files are unmodified.
- Removed the extra copies, keeping the single top-of-file instance in each file. `bash scripts/build-all.sh` regenerated the 10 adapter artifacts that hardlink/derive from these two sources; no other adapter or content file changed.

## Per-file blockquote counts

| File | Before | After |
|---|---|---|
| `content/agents/adr-drift-detector.md` | 4 | 1 |
| `content/agents/adr-generator.md` | 5 (one inside the fenced ADR template) | 1 |
| all other `content/agents/*.md` | 1 | 1 (unchanged) |

## North Star alignment

Advances Pillar 5 (Guard agent context) directly - removing duplicated always-loaded prose is exactly the kind of waste that pillar names, and the in-template copy was actively harmful output (a generated artifact leaking an internal instruction). No pillar cuts against this change; it removes redundant text with no behavior change beyond the ADR-template bug fix, which itself advances Pillar 2 (verifiable outcomes: generated ADRs no longer carry stray instruction text).

## Doc-sync

Doc-sync: predicate not triggered (no reality-asserting change). Grepped `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` for any assertion about per-agent-file prerequisite-blockquote counts or the ADR template's fenced contents; the only prerequisite-related hits (`CONTRIBUTING.md:60`, `docs/index.html:941`, `docs/slides/contributing-slides.md:256`, `docs/slides/worktree-lifecycle-slides.md:376-379`) describe unrelated mechanisms (`.claude/build.sh`'s command-prepend step, install prerequisites, worktree-lifecycle bundle prerequisites) and are unaffected by this change.

## Test results

- `bash scripts/build-all.sh`: all 11 adapters built successfully; `git status --porcelain` showed only the 10 regenerated adapter files plus the 2 content sources - no unrelated hunks.
- Hooks JS suite (`for f in hooks/tests/test-*.js; do case "$f" in *test-wrap-acquire-lock.js|*test-wrap-release-lock.js) continue;; esac; node "$f" || echo "FAILED: $f"; done`): 0 `FAILED:` lines, 55 "N passed, 0 failed" summaries across the suite.
- `python3 -m pytest bin/tests/ -q`: `1994 passed, 25 subtests passed in 210.24s`.

## Ledger

Second commit on this branch flips `docs/pruning-ledger.md` PL-20260825-9 from `Status: RAISED` to `Status: ACTIONED` with this PR's URL as `Disposition:`.
