### PR TITLE
DS-206: converge stale hook path replacement in ds-doctor

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -951,6 +951,7 @@ upsert_hook(
 ENFORCE_BG_CMD = f"python3 {hooks_root}/hooks/enforce-background-spawn.py"
 ENFORCE_SINGULARITY_CMD = f"python3 {hooks_root}/hooks/enforce-orchestrator-singularity.py"
 ENFORCE_TIER_CMD = f"python3 {hooks_root}/hooks/enforce-tier.py"
+
 # Uses a GUARDED command string (like enforce-turn-shape.py, unlike its
 # bare-`python3 {path}` siblings above): `python3 <missing path>` exits 2
 # (BLOCKING on PreToolUse), so if this file were ever removed while the

--- a/bin/ds-doctor
+++ b/bin/ds-doctor
@@ -807,32 +807,52 @@ def _hook_replacement(cmd: str, repo_dir: Path) -> str | None:
     Returns the accumulated command when at least one occurrence was
     rewritten, else None.
 
-    Known limitations (pre-existing, unreachable from any current
-    producer):
+    Known limitations, unreachable from any current .claude/install.sh-
+    authored registration (both cited producer paths are space-delimited,
+    with no adjacent punctuation, and always normalized):
 
     1. A token whose string form does not exactly match
        repo_dir/hooks/<basename> due to a normalization difference (e.g. a
        non-normalized path with doubled separators) is not found by
-       str.replace and stays unrewritten for that occurrence, while another
-       occurrence in the same command may still cause `changed` to become
-       True - the caller then reports the command as repaired even though
-       one occurrence remains stale. For a command with only ONE
-       occurrence total (the lone-token case), the effect is different and
-       worse: `changed` stays False, the function returns None, and the
-       caller reports "OK hooks: ... all managed hook paths reference
-       repo_dir" - an already-correct verdict on a command that is not
-       actually correct.
-    2. An adjacent-punctuation stale token (e.g. `python3 <OLD>; echo
-       done` or `sh -c "python3 <OLD>"`) gets replaced by
-       `str(Path(token))`, which silently DROPS the punctuation -
-       corruption, not omission - producing `python3 <NEW> echo done` or a
-       string missing its closing quote.
+       str.replace and stays unrewritten for that occurrence. MEASURED
+       BEHAVIOR CHANGE introduced by this diff (not pre-existing): for a
+       command with MULTIPLE occurrences where at least one other
+       occurrence rewrites cleanly, `changed` still becomes True and the
+       caller reports the command as repaired even though the
+       normalization-mismatched occurrence remains stale - a silent
+       partial-repair report. For a command with only ONE occurrence
+       total (the lone-token case) the effect is worse and different in
+       kind: pre-fix, the old body returned `cmd.replace(...)`
+       unconditionally once the DinoStack-shape test passed, so a
+       normalization-mismatched lone token was returned UNCHANGED
+       (non-None) - this entered `drift`, so the operator saw a visible
+       but no-op `FIX hooks` line and read-only mode exited 1. Post-fix,
+       the `if new_result != result` guard correctly leaves `changed`
+       False for that same input, the function returns None, and
+       `check_hook_paths` takes its `if not drift` branch and reports "OK
+       hooks: ... all managed hook paths reference repo_dir" - exit 0.
+       This diff therefore converts a visible-but-useless drift signal
+       into a silent, positive false-healthy verdict for that specific
+       unreachable input. The input remains unreachable from any current
+       producer, which is the basis for accepting rather than closing
+       this gap, but the change in observable behavior for it is real and
+       is disclosed here rather than characterized as unchanged.
+    2. An adjacent-punctuation stale token in a FOREIGN (non-install.sh)
+       settings.json entry - e.g. `python3 <OLD>; echo done` or `sh -c
+       "python3 <OLD>"` - gets replaced by `str(Path(token))`, which
+       silently DROPS the punctuation - corruption, not omission -
+       producing `python3 <NEW> echo done` or a string missing its
+       closing quote. This requires a DinoStack-shaped stale path AND a
+       managed basename inside a foreign, punctuation-adjacent command
+       string; no such entry is known to exist in practice today, but
+       `_hook_replacement` walks every `command` string in
+       ~/.claude/settings.json, not only install.sh-authored ones, so the
+       reachability argument is scoped to install.sh's own registrations
+       only, not to the full input space this function actually walks.
 
-    No current producer (.claude/install.sh's f"{hooks_root}/hooks/{name}"
-    form) emits a token in either shape - both are space-delimited with no
-    adjacent punctuation and always normalized - so neither is reachable
-    today. Out of scope for this ticket; revisit if a future hook-
-    registration producer can emit such a token.
+    Both are out of scope for this ticket; revisit either if a future
+    hook-registration producer (install.sh-authored or foreign) can emit
+    such a token.
     """
     result = cmd
     changed = False

--- a/bin/ds-doctor
+++ b/bin/ds-doctor
@@ -814,29 +814,16 @@ def _hook_replacement(cmd: str, repo_dir: Path) -> str | None:
     1. A token whose string form does not exactly match
        repo_dir/hooks/<basename> due to a normalization difference (e.g. a
        non-normalized path with doubled separators) is not found by
-       str.replace and stays unrewritten for that occurrence. MEASURED
-       BEHAVIOR CHANGE introduced by this diff (not pre-existing): for a
-       command with MULTIPLE occurrences where at least one other
-       occurrence rewrites cleanly, `changed` still becomes True and the
-       caller reports the command as repaired even though the
-       normalization-mismatched occurrence remains stale - a silent
-       partial-repair report. For a command with only ONE occurrence
-       total (the lone-token case) the effect is worse and different in
-       kind: pre-fix, the old body returned `cmd.replace(...)`
-       unconditionally once the DinoStack-shape test passed, so a
-       normalization-mismatched lone token was returned UNCHANGED
-       (non-None) - this entered `drift`, so the operator saw a visible
-       but no-op `FIX hooks` line and read-only mode exited 1. Post-fix,
-       the `if new_result != result` guard correctly leaves `changed`
-       False for that same input, the function returns None, and
-       `check_hook_paths` takes its `if not drift` branch and reports "OK
-       hooks: ... all managed hook paths reference repo_dir" - exit 0.
-       This diff therefore converts a visible-but-useless drift signal
-       into a silent, positive false-healthy verdict for that specific
-       unreachable input. The input remains unreachable from any current
-       producer, which is the basis for accepting rather than closing
-       this gap, but the change in observable behavior for it is real and
-       is disclosed here rather than characterized as unchanged.
+       str.replace, so that occurrence stays stale. When it is the ONLY
+       stale occurrence in the command, `changed` never becomes True, the
+       function returns None, and `check_hook_paths` reports "OK hooks:
+       ... all managed hook paths reference repo_dir" - a healthy verdict
+       for a command that is not actually correct. When ANOTHER occurrence
+       in the same command rewrites cleanly, `changed` becomes True from
+       that occurrence and the function returns the partially-repaired
+       command string, with the normalization-mismatched occurrence still
+       present in it - `check_hook_paths` then reports the command as
+       repaired even though one occurrence remains stale.
     2. An adjacent-punctuation stale token in a FOREIGN (non-install.sh)
        settings.json entry - e.g. `python3 <OLD>; echo done` or `sh -c
        "python3 <OLD>"` - gets replaced by `str(Path(token))`, which

--- a/bin/ds-doctor
+++ b/bin/ds-doctor
@@ -64,6 +64,7 @@ Public API: ds-doctor [--fix] [--dry-run] [--cross-harness] [--json]
               FAIL <kind>: <detail>
               FIX symlink: <dst> : <old/broken target> -> <new target>
               FIX symlink: <dst> : <old/broken target> -> (removed, stale)
+              FIX hooks: <settings_path>: <old command> -> <new command>
               FIX hooks_snapshot [<state>]: <message>
               SKIP <kind>: <dst> (reason)
             Exits 0 (all pass / --fix resolved all), 1 (findings in read-only
@@ -783,30 +784,75 @@ def check_hook_paths(doc: Doctor) -> None:
         return
 
     for old_cmd, new_cmd in drift:
-        doc.repoint_symlink("hooks", settings_path, old_cmd, Path(new_cmd))
+        # NOT doc.repoint_symlink(): settings_path is a regular file, never
+        # a symlink, so repoint_symlink's os.symlink() call would raise
+        # FileExistsError (os.path.islink is False, nothing is removed) and
+        # force a FAIL + mark_unfixable (exit 2) on every successful repair
+        # here - the DS-206 Amendment 1 regression. Emit the FIX finding
+        # directly instead; it still counts toward has_unresolved_findings()
+        # in read-only/dry-run mode, and the real write happens below via
+        # _atomic_patch_settings, which emits its own OK/FAIL on completion.
+        doc._emit("FIX", f"hooks: {settings_path}: {old_cmd} -> {new_cmd}")
 
     if doc.fix:
         _atomic_patch_settings(doc, settings_path, data, {old: new for old, new in drift})
 
 
 def _hook_replacement(cmd: str, repo_dir: Path) -> str | None:
-    """If cmd references a managed hook at the wrong path, return the fixed cmd."""
+    """Converge every stale, DinoStack-shaped occurrence of every managed
+    hook basename present in cmd onto repo_dir/hooks/<basename>, across ALL
+    basenames referenced in cmd (result/changed hoisted above the basename
+    loop so frozenset iteration order is never load-bearing).
+
+    Returns the accumulated command when at least one occurrence was
+    rewritten, else None.
+
+    Known limitations (pre-existing, unreachable from any current
+    producer):
+
+    1. A token whose string form does not exactly match
+       repo_dir/hooks/<basename> due to a normalization difference (e.g. a
+       non-normalized path with doubled separators) is not found by
+       str.replace and stays unrewritten for that occurrence, while another
+       occurrence in the same command may still cause `changed` to become
+       True - the caller then reports the command as repaired even though
+       one occurrence remains stale. For a command with only ONE
+       occurrence total (the lone-token case), the effect is different and
+       worse: `changed` stays False, the function returns None, and the
+       caller reports "OK hooks: ... all managed hook paths reference
+       repo_dir" - an already-correct verdict on a command that is not
+       actually correct.
+    2. An adjacent-punctuation stale token (e.g. `python3 <OLD>; echo
+       done` or `sh -c "python3 <OLD>"`) gets replaced by
+       `str(Path(token))`, which silently DROPS the punctuation -
+       corruption, not omission - producing `python3 <NEW> echo done` or a
+       string missing its closing quote.
+
+    No current producer (.claude/install.sh's f"{hooks_root}/hooks/{name}"
+    form) emits a token in either shape - both are space-delimited with no
+    adjacent punctuation and always normalized - so neither is reachable
+    today. Out of scope for this ticket; revisit if a future hook-
+    registration producer can emit such a token.
+    """
+    result = cmd
+    changed = False
     for basename in MANAGED_HOOK_BASENAMES:
         if basename not in cmd:
             continue
-        tokens = cmd.split()
-        for token in tokens:
+        for token in cmd.split():
             if basename not in token:
                 continue
             token_path = Path(token)
-            expected = repo_dir / "hooks" / basename
             if _is_relative_to(token_path, repo_dir):
-                return None  # already correct
+                continue
             # Only fix paths that look like a DinoStack install
             if any(p == "DinoStack" or p.endswith("-DinoStack") for p in token_path.parts):
-                return cmd.replace(str(token_path), str(expected), 1)
-        break
-    return None
+                expected = repo_dir / "hooks" / basename
+                new_result = result.replace(str(token_path), str(expected))
+                if new_result != result:
+                    result = new_result
+                    changed = True
+    return result if changed else None
 
 
 def _atomic_patch_settings(

--- a/bin/tests/test_agentic_doctor_hook_replacement.py
+++ b/bin/tests/test_agentic_doctor_hook_replacement.py
@@ -304,6 +304,59 @@ def test_lone_token_normalization_mismatch_reports_false_healthy(tmp_path):
     )
 
 
+def test_multi_occurrence_partial_repair_leaves_mismatch_stale(tmp_path):
+    """CHARACTERIZATION TEST, not a supported-behavior guard: pins the
+    MEASURED pre-fix/post-fix EQUIVALENCE (not a difference) for the
+    multi-occurrence, same-basename, guarded-form shape - the only
+    realistic shape a normalization-mismatched token could co-occur with a
+    cleanly-repairable one in.
+
+    Measured identically against both origin/main's pre-fix
+    _hook_replacement and this file's live (post-fix) function: a guarded
+    command with one normalization-mismatched occurrence of a basename and
+    one cleanly-stale occurrence of the SAME basename returns a non-None,
+    partially-repaired string in which the mismatched occurrence is still
+    present verbatim. Pre-fix's `cmd.replace(..., count=1)` already
+    rewrote the clean occurrence and returned a non-None string with the
+    mismatched one untouched; post-fix's accumulator does the same. This
+    shape did NOT change between rounds - see Known limitation #1 in
+    _hook_replacement's own docstring, which now describes only this
+    present-tense behavior with no pre-fix/post-fix provenance claim.
+
+    Reddening mutation (VERIFIED by execution, not merely named): revert
+    _hook_replacement to its pre-fix body - confirmed to produce the SAME
+    non-None/mismatch-still-present result for this exact input, so this
+    test does NOT redden on that specific revert (that is the point: it
+    pins an equivalence, not a difference). It DOES redden on changing the
+    replace target from the Path-normalized `str(token_path)` to the raw
+    `token` substring - i.e. `result.replace(token, str(expected))`
+    instead of `result.replace(str(token_path), str(expected))` - because
+    the raw token string (still containing the doubled separator) exists
+    verbatim in `result`/`cmd`, so that mutation makes the mismatched
+    occurrence get silently rewritten too, failing this test's "still
+    present" assertion. Confirmed against a mutated copy of ds-doctor
+    before this test was finalized.
+    """
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    # Doubled separator - never matched by str.replace (Known limitation #1).
+    mismatched = f"{old_repo}//hooks/enforce-tier.py"
+    clean_stale = old_repo / "hooks" / "enforce-tier.py"
+    cmd = f"test -f {mismatched} && python3 {clean_stale} || exit 0"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None, (
+        "the clean occurrence alone should make changed True even though "
+        "the mismatched occurrence cannot be rewritten"
+    )
+    assert mismatched in result, (
+        "the normalization-mismatched occurrence must remain verbatim in "
+        "the returned command - if it is gone, str.replace started "
+        "matching it, which is a real behavior change requiring a "
+        "docstring update"
+    )
+    assert str(clean_stale) not in result
+
+
 def test_non_dinostack_shaped_path_untouched(tmp_path):
     """Negative case: a non-DinoStack-shaped stale path is left alone.
 

--- a/bin/tests/test_agentic_doctor_hook_replacement.py
+++ b/bin/tests/test_agentic_doctor_hook_replacement.py
@@ -1,0 +1,284 @@
+"""Unit + caller-level tests for bin/ds-doctor's _hook_replacement() (DS-206).
+
+Covers the accumulator rewrite that converges every stale, DinoStack-shaped
+occurrence of every managed hook basename present in a settings.json
+`command` string, in one call - fixing the bug where only the FIRST token
+matching the FIRST basename found was ever rewritten, leaving a guarded
+form's `test -f <NEW> && python3 <OLD> || exit 0` half-fixed.
+
+Run with: python3 -m pytest bin/tests/test_agentic_doctor_hook_replacement.py -x
+
+Test-first ordering (DS-206 spawn brief): this file was written and run
+against the UNMODIFIED (pre-fix) _hook_replacement before the fix landed.
+Expected red/green table per case, verified by that pre-fix run:
+
+  - test_fully_stale_guarded_form            RED pre-fix / GREEN post-fix
+  - test_half_fixed_guarded_form             RED pre-fix / GREEN post-fix
+  - test_mixed_stale_path_guarded_form       RED pre-fix / GREEN post-fix
+  - test_two_managed_basenames_one_command   RED pre-fix / GREEN post-fix
+  - test_three_distinct_stale_occurrences    RED pre-fix / GREEN post-fix
+  - test_bare_single_occurrence_stale_form   GREEN both pre-fix and post-fix
+                                              (already worked under count=1)
+  - test_already_correct_guarded_form        GREEN both pre-fix and post-fix
+                                              (returns None both ways)
+  - test_non_dinostack_shaped_path_untouched GREEN both pre-fix and post-fix
+                                              (negative case; returns None)
+  - test_caller_writes_fully_converged_command_to_disk
+                                              RED pre-fix / GREEN post-fix
+  - test_repair_exits_zero_with_no_fail_line (Amendment 1)
+                                              RED pre-fix (would FAIL/exit 2)
+                                              / GREEN post-fix
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+_BIN = Path(__file__).resolve().parent.parent
+_loader = importlib.machinery.SourceFileLoader("_ds_doctor_hr", str(_BIN / "ds-doctor"))
+_spec = importlib.util.spec_from_loader("_ds_doctor_hr", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+Doctor = _mod.Doctor
+_hook_replacement = _mod._hook_replacement
+check_hook_paths = _mod.check_hook_paths
+
+
+def _realpath(p: Path) -> Path:
+    return Path(os.path.realpath(str(p)))
+
+
+def _mkrepo(tmp_path: Path) -> Path:
+    """A realpath'd fixture repo_dir - never the real checkout.
+
+    Realpathed per the mandatory fixture-construction rule: _load_repo_dir()
+    always realpaths, so an un-realpathed fixture makes "already correct"
+    assertions pass for the wrong reason on macOS (/tmp -> /private/tmp).
+    """
+    repo = tmp_path / "DinoStack"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "hooks").mkdir(parents=True)
+    return _realpath(repo)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level cases against _hook_replacement directly
+# ---------------------------------------------------------------------------
+
+
+def test_fully_stale_guarded_form(tmp_path):
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old = old_repo / "hooks" / "enforce-turn-shape.py"
+    cmd = f"test -f {old} && python3 {old} || exit 0"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old) not in result
+    assert str(repo / "hooks" / "enforce-turn-shape.py") in result
+
+
+def test_half_fixed_guarded_form(tmp_path):
+    """The bug's own residue: test -f already points at NEW, python3 still OLD."""
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    new = repo / "hooks" / "enforce-turn-shape.py"
+    old = old_repo / "hooks" / "enforce-turn-shape.py"
+    cmd = f"test -f {new} && python3 {old} || exit 0"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old) not in result
+    assert str(new) in result
+
+
+def test_mixed_stale_path_guarded_form(tmp_path):
+    """Two distinct old locations for the same basename in one command."""
+    repo = _mkrepo(tmp_path)
+    old_repo_a = tmp_path / "old-a-DinoStack"
+    old_repo_b = tmp_path / "old-b-DinoStack"
+    old_a = old_repo_a / "hooks" / "enforce-turn-shape.py"
+    old_b = old_repo_b / "hooks" / "enforce-turn-shape.py"
+    cmd = f"test -f {old_a} && python3 {old_b} || exit 0"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old_a) not in result
+    assert str(old_b) not in result
+    assert str(repo / "hooks" / "enforce-turn-shape.py") in result
+
+
+def test_two_managed_basenames_one_command(tmp_path):
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old1 = old_repo / "hooks" / "enforce-background-spawn.py"
+    old2 = old_repo / "hooks" / "enforce-orchestrator-singularity.py"
+    cmd = f"python3 {old1}; python3 {old2}"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old1) not in result
+    assert str(old2) not in result
+    assert str(repo / "hooks" / "enforce-background-spawn.py") in result
+    assert str(repo / "hooks" / "enforce-orchestrator-singularity.py") in result
+
+
+def test_three_distinct_stale_occurrences(tmp_path):
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old1 = old_repo / "hooks" / "enforce-background-spawn.py"
+    old2 = old_repo / "hooks" / "enforce-orchestrator-singularity.py"
+    old3 = old_repo / "hooks" / "enforce-tier.py"
+    cmd = f"python3 {old1}; python3 {old2}; python3 {old3}"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old1) not in result
+    assert str(old2) not in result
+    assert str(old3) not in result
+
+
+def test_bare_single_occurrence_stale_form(tmp_path):
+    """Already worked under the pre-fix count=1 shape - GREEN both ways.
+
+    This assertion form is IDENTICAL pre-fix and post-fix; a passing run
+    here is not evidence the fix is applied, only that the bare single-token
+    case was never broken. Do not misread it as a red-run failure signal.
+    """
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old = old_repo / "hooks" / "enforce-tier.py"
+    cmd = f"python3 {old}"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old) not in result
+    assert str(repo / "hooks" / "enforce-tier.py") in result
+
+
+def test_already_correct_guarded_form(tmp_path):
+    """GREEN both ways by design - returns None, nothing to repair."""
+    repo = _mkrepo(tmp_path)
+    new = repo / "hooks" / "enforce-turn-shape.py"
+    cmd = f"test -f {new} && python3 {new} || exit 0"
+    result = _hook_replacement(cmd, repo)
+    assert result is None
+
+
+def test_non_dinostack_shaped_path_untouched(tmp_path):
+    """Negative case: a non-DinoStack-shaped stale path is left alone.
+
+    The accumulator replaced an early `return None` with full iteration over
+    all tokens and all managed basenames, widening the predicate's blast
+    radius. Nothing pre-existing pinned this negative case - pin it here.
+    """
+    repo = _mkrepo(tmp_path)
+    foreign = tmp_path / "some-other-project" / "hooks" / "enforce-tier.py"
+    cmd = f"python3 {foreign}"
+    result = _hook_replacement(cmd, repo)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Caller-level test: check_hook_paths / _atomic_patch_settings writes a
+# fully-converged command to disk. MANDATORY isolation: monkeypatch HOME and
+# delenv CLAUDE_CONFIG_DIR BEFORE constructing Doctor(...) or calling
+# check_hook_paths - without it this test rewrites the developer's real
+# ~/.claude/settings.json (reproduced by execution in prior review rounds).
+# ---------------------------------------------------------------------------
+
+
+def test_caller_writes_fully_converged_command_to_disk(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old1 = old_repo / "hooks" / "enforce-turn-shape.py"
+    old2 = old_repo / "hooks" / "enforce-tier.py"
+
+    claude_dir = fake_home / ".claude"
+    claude_dir.mkdir(parents=True)
+    settings_path = claude_dir / "settings.json"
+    settings = {
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": f"test -f {old1} && python3 {old1} || exit 0",
+                            "timeout": 10,
+                        }
+                    ],
+                }
+            ],
+            "PreToolUse": [
+                {
+                    "matcher": "Task",
+                    "hooks": [
+                        {"type": "command", "command": f"python3 {old2}", "timeout": 5}
+                    ],
+                }
+            ],
+        }
+    }
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+    doc = Doctor(repo_dir=repo, fix=True, json_mode=True)
+    check_hook_paths(doc)
+
+    written = json.loads(settings_path.read_text(encoding="utf-8"))
+    written_text = json.dumps(written)
+    assert str(old1) not in written_text
+    assert str(old2) not in written_text
+    assert str(repo / "hooks" / "enforce-turn-shape.py") in written_text
+    assert str(repo / "hooks" / "enforce-tier.py") in written_text
+
+
+def test_repair_exits_zero_with_no_fail_line(tmp_path, monkeypatch):
+    """Amendment 1 regression guard: a successful repair must not also
+    report itself as an unfixable FAIL via repoint_symlink's os.symlink
+    call against settings.json (a regular file, not a symlink) raising
+    FileExistsError.
+
+    Mutation that would redden this: reverting the check_hook_paths fix
+    back to `doc.repoint_symlink("hooks", settings_path, old_cmd,
+    Path(new_cmd))` (the plan's pre-Amendment-1 caller shape) reproduces
+    `FAIL hooks: could not re-point ...: [Errno 17] File exists` and
+    doc.fix mode's has_unresolved_findings() returns True.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old = old_repo / "hooks" / "enforce-tier.py"
+
+    claude_dir = fake_home / ".claude"
+    claude_dir.mkdir(parents=True)
+    settings_path = claude_dir / "settings.json"
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Task",
+                    "hooks": [
+                        {"type": "command", "command": f"python3 {old}", "timeout": 5}
+                    ],
+                }
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+    doc = Doctor(repo_dir=repo, fix=True, json_mode=True)
+    check_hook_paths(doc)
+
+    assert not any(status == "FAIL" for status, _ in doc.findings), doc.findings
+    assert not doc.has_unresolved_findings()
+    assert not doc.has_unfixable()

--- a/bin/tests/test_agentic_doctor_hook_replacement.py
+++ b/bin/tests/test_agentic_doctor_hook_replacement.py
@@ -10,17 +10,41 @@ Run with: python3 -m pytest bin/tests/test_agentic_doctor_hook_replacement.py -x
 
 Test-first ordering (DS-206 spawn brief): this file was written and run
 against the UNMODIFIED (pre-fix) _hook_replacement before the fix landed.
-Expected red/green table per case, verified by that pre-fix run:
+Expected red/green table per case, verified by that pre-fix run (round 1),
+and re-verified for the round-2 fixture rework (below):
 
   - test_fully_stale_guarded_form            RED pre-fix / GREEN post-fix
   - test_half_fixed_guarded_form             RED pre-fix / GREEN post-fix
   - test_mixed_stale_path_guarded_form       RED pre-fix / GREEN post-fix
   - test_two_managed_basenames_one_command   RED pre-fix / GREEN post-fix
+                                              (round 2: rewritten to a
+                                              space-delimited `&&`-joined
+                                              fixture with an exact-string
+                                              assertion - the original `;`-
+                                              joined form silently exercised
+                                              the punctuation-loss path
+                                              disclosed in Known limitation
+                                              #2 and did not pin it)
   - test_three_distinct_stale_occurrences    RED pre-fix / GREEN post-fix
+                                              (round 2: same rework as above)
+  - test_adjacent_punctuation_token_loses_punctuation (round 2, new)
+                                              GREEN both pre-fix and post-fix
+                                              (characterization test for the
+                                              pre-existing, disclosed, out-
+                                              of-scope corruption path -
+                                              unaffected by this diff)
   - test_bare_single_occurrence_stale_form   GREEN both pre-fix and post-fix
                                               (already worked under count=1)
   - test_already_correct_guarded_form        GREEN both pre-fix and post-fix
                                               (returns None both ways)
+  - test_lone_token_normalization_mismatch_reports_false_healthy (round 2, new)
+                                              RED pre-fix (returns non-None,
+                                              a visible no-op FIX) / GREEN
+                                              post-fix (returns None, the
+                                              disclosed silent false-healthy
+                                              verdict - see Known limitation
+                                              #1 in _hook_replacement's own
+                                              docstring)
   - test_non_dinostack_shaped_path_untouched GREEN both pre-fix and post-fix
                                               (negative case; returns None)
   - test_caller_writes_fully_converged_command_to_disk
@@ -28,6 +52,38 @@ Expected red/green table per case, verified by that pre-fix run:
   - test_repair_exits_zero_with_no_fail_line (Amendment 1)
                                               RED pre-fix (would FAIL/exit 2)
                                               / GREEN post-fix
+
+Round-2 fix pass (Skeptic review of commit 91b2d7d6, both Majors
+confirmed by independent measurement before this rework):
+
+  - MAJOR 1: _hook_replacement's docstring understated the lone-token
+    normalization-mismatch behavior as merely "pre-existing" - measured,
+    this diff changes it from a visible no-op FIX (pre-fix) to a silent
+    false-healthy OK (post-fix) for that unreachable input. Docstring
+    corrected; test_lone_token_normalization_mismatch_reports_false_healthy
+    added to pin the corrected, disclosed post-fix behavior.
+  - MAJOR 2: test_two_managed_basenames_one_command and
+    test_three_distinct_stale_occurrences used `;`-joined fixtures, which
+    measurably drop both semicolons in the repaired output (turning two
+    sequential hook invocations into one nonsense command) while still
+    passing on substring-only assertions. Reworked to the space-delimited
+    `&&`-joined shape real .claude/install.sh registrations actually use,
+    with an exact-string assertion. The punctuation-loss behavior itself
+    is now explicitly pinned, separately, by
+    test_adjacent_punctuation_token_loses_punctuation - named so a reader
+    cannot mistake it for a supported case.
+
+Reddening mutation for every round-2-touched case: revert
+_hook_replacement to its pre-fix body (single first-basename-then-break
+loop, unconditional `cmd.replace(str(token_path), str(expected), 1)`).
+Verified by running this file against a loader pointed at the pre-fix
+source (origin/main's ds-doctor, commit 91b2d7d6's parent): 8 of 12 cases
+fail, all on the stated stale-path / None / exact-string assertions (see
+round-2 fix-pass return for the full list); the 4 that stay green both
+ways are test_bare_single_occurrence_stale_form,
+test_already_correct_guarded_form,
+test_adjacent_punctuation_token_loses_punctuation, and
+test_non_dinostack_shaped_path_untouched.
 """
 
 from __future__ import annotations
@@ -111,31 +167,78 @@ def test_mixed_stale_path_guarded_form(tmp_path):
 
 
 def test_two_managed_basenames_one_command(tmp_path):
+    """Space-delimited, `&&`-joined shape - what .claude/install.sh's own
+    guarded multi-hook registrations actually look like. NOT semicolon-
+    joined: a `;`-adjacent stale token is a distinct, disclosed corruption
+    path (see test_adjacent_punctuation_token_loses_punctuation below) and
+    must not be conflated with ordinary multi-basename convergence.
+    """
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
     old1 = old_repo / "hooks" / "enforce-background-spawn.py"
     old2 = old_repo / "hooks" / "enforce-orchestrator-singularity.py"
-    cmd = f"python3 {old1}; python3 {old2}"
+    new1 = repo / "hooks" / "enforce-background-spawn.py"
+    new2 = repo / "hooks" / "enforce-orchestrator-singularity.py"
+    cmd = f"python3 {old1} && python3 {old2}"
     result = _hook_replacement(cmd, repo)
     assert result is not None
     assert str(old1) not in result
     assert str(old2) not in result
-    assert str(repo / "hooks" / "enforce-background-spawn.py") in result
-    assert str(repo / "hooks" / "enforce-orchestrator-singularity.py") in result
+    # Exact-string assertion, not mere substring containment: pins that the
+    # `&&` joiner and spacing are preserved, not merely that the stale paths
+    # are gone (a corrupting repair that also removed the joiner would still
+    # pass the weaker substring-only form used pre-fix-round-2).
+    assert result == f"python3 {new1} && python3 {new2}"
 
 
 def test_three_distinct_stale_occurrences(tmp_path):
+    """Space-delimited, `&&`-joined shape (see test_two_managed_basenames_
+    one_command's docstring for why `;` is deliberately not used here)."""
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
     old1 = old_repo / "hooks" / "enforce-background-spawn.py"
     old2 = old_repo / "hooks" / "enforce-orchestrator-singularity.py"
     old3 = old_repo / "hooks" / "enforce-tier.py"
-    cmd = f"python3 {old1}; python3 {old2}; python3 {old3}"
+    new1 = repo / "hooks" / "enforce-background-spawn.py"
+    new2 = repo / "hooks" / "enforce-orchestrator-singularity.py"
+    new3 = repo / "hooks" / "enforce-tier.py"
+    cmd = f"python3 {old1} && python3 {old2} && python3 {old3}"
     result = _hook_replacement(cmd, repo)
     assert result is not None
     assert str(old1) not in result
     assert str(old2) not in result
     assert str(old3) not in result
+    assert result == f"python3 {new1} && python3 {new2} && python3 {new3}"
+
+
+def test_adjacent_punctuation_token_loses_punctuation(tmp_path):
+    """CHARACTERIZATION TEST, not a supported-behavior guard: pins the
+    disclosed, accepted corruption in _hook_replacement's Known limitations
+    #2 - a stale token immediately followed by punctuation (here, a `;`
+    with no separating space) is replaced via `str(Path(token))`, which
+    silently drops the trailing punctuation from the token's own string
+    form. `.claude/install.sh` never emits this shape (its registrations
+    are always space-delimited, no adjacent punctuation), so this input is
+    unreachable from any current producer - this test exists ONLY to make
+    the accepted-but-real corruption path explicit and machine-checked, so
+    a reader cannot mistake test_two_managed_basenames_one_command or
+    test_three_distinct_stale_occurrences (both now `&&`-joined) as
+    covering this shape. If this assertion ever starts failing because the
+    punctuation is preserved, that is an IMPROVEMENT to document, not a
+    regression to chase.
+    """
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    old = old_repo / "hooks" / "enforce-tier.py"
+    new = repo / "hooks" / "enforce-tier.py"
+    cmd = f"python3 {old}; echo done"
+    result = _hook_replacement(cmd, repo)
+    assert result is not None
+    assert str(old) not in result
+    # The trailing semicolon (adjacent to the stale token, no separating
+    # space) is silently dropped - this is the disclosed corruption, not a
+    # well-formed repair.
+    assert result == f"python3 {new} echo done"
 
 
 def test_bare_single_occurrence_stale_form(tmp_path):
@@ -162,6 +265,43 @@ def test_already_correct_guarded_form(tmp_path):
     cmd = f"test -f {new} && python3 {new} || exit 0"
     result = _hook_replacement(cmd, repo)
     assert result is None
+
+
+def test_lone_token_normalization_mismatch_reports_false_healthy(tmp_path):
+    """CHARACTERIZATION TEST for the Major-1 fix-round-2 disclosure, not a
+    supported-behavior guard: pins the MEASURED pre-fix vs post-fix
+    difference for a lone (single-occurrence) token whose string form has
+    a normalization difference from repo_dir/hooks/<basename> (here, a
+    doubled path separator).
+
+    Pre-fix (verified against origin/main at commit 91b2d7d6's parent):
+    the old body returned `cmd.replace(...)` unconditionally once the
+    DinoStack-shape test passed, so this lone mismatched token was
+    returned UNCHANGED (non-None) - a visible but no-op `FIX hooks` line,
+    read-only exit 1.
+
+    Post-fix (this test, against the live function): `changed` stays
+    False because `new_result != result` never holds (str.replace found
+    nothing to replace), so the function returns None - `check_hook_paths`
+    then reports "OK hooks: ... all managed hook paths reference
+    repo_dir", exit 0. This is a silent, positive false-healthy verdict
+    for an unreachable-from-any-current-producer input; accepted per
+    Pillar 8, not fixed, but must not be characterized as unchanged
+    behavior - it is a real, disclosed regression in this one dimension
+    for this specific unreachable input.
+    """
+    repo = _mkrepo(tmp_path)
+    old_repo = tmp_path / "old-DinoStack"
+    # Doubled separator - Path()/str() round-tripping does not normalize
+    # this away, so str.replace(str(token_path), ...) never matches.
+    mismatched = f"{old_repo}//hooks/enforce-tier.py"
+    cmd = f"python3 {mismatched}"
+    result = _hook_replacement(cmd, repo)
+    assert result is None, (
+        "post-fix, a lone normalization-mismatched token must report None "
+        "(silent false-healthy) per the disclosed Known limitation #1 - "
+        "if this changes, update both this test and the docstring together"
+    )
 
 
 def test_non_dinostack_shaped_path_untouched(tmp_path):

--- a/bin/tests/test_agentic_doctor_hook_replacement.py
+++ b/bin/tests/test_agentic_doctor_hook_replacement.py
@@ -8,82 +8,17 @@ form's `test -f <NEW> && python3 <OLD> || exit 0` half-fixed.
 
 Run with: python3 -m pytest bin/tests/test_agentic_doctor_hook_replacement.py -x
 
-Test-first ordering (DS-206 spawn brief): this file was written and run
-against the UNMODIFIED (pre-fix) _hook_replacement before the fix landed.
-Expected red/green table per case, verified by that pre-fix run (round 1),
-and re-verified for the round-2 fixture rework (below):
-
-  - test_fully_stale_guarded_form            RED pre-fix / GREEN post-fix
-  - test_half_fixed_guarded_form             RED pre-fix / GREEN post-fix
-  - test_mixed_stale_path_guarded_form       RED pre-fix / GREEN post-fix
-  - test_two_managed_basenames_one_command   RED pre-fix / GREEN post-fix
-                                              (round 2: rewritten to a
-                                              space-delimited `&&`-joined
-                                              fixture with an exact-string
-                                              assertion - the original `;`-
-                                              joined form silently exercised
-                                              the punctuation-loss path
-                                              disclosed in Known limitation
-                                              #2 and did not pin it)
-  - test_three_distinct_stale_occurrences    RED pre-fix / GREEN post-fix
-                                              (round 2: same rework as above)
-  - test_adjacent_punctuation_token_loses_punctuation (round 2, new)
-                                              GREEN both pre-fix and post-fix
-                                              (characterization test for the
-                                              pre-existing, disclosed, out-
-                                              of-scope corruption path -
-                                              unaffected by this diff)
-  - test_bare_single_occurrence_stale_form   GREEN both pre-fix and post-fix
-                                              (already worked under count=1)
-  - test_already_correct_guarded_form        GREEN both pre-fix and post-fix
-                                              (returns None both ways)
-  - test_lone_token_normalization_mismatch_reports_false_healthy (round 2, new)
-                                              RED pre-fix (returns non-None,
-                                              a visible no-op FIX) / GREEN
-                                              post-fix (returns None, the
-                                              disclosed silent false-healthy
-                                              verdict - see Known limitation
-                                              #1 in _hook_replacement's own
-                                              docstring)
-  - test_non_dinostack_shaped_path_untouched GREEN both pre-fix and post-fix
-                                              (negative case; returns None)
-  - test_caller_writes_fully_converged_command_to_disk
-                                              RED pre-fix / GREEN post-fix
-  - test_repair_exits_zero_with_no_fail_line (Amendment 1)
-                                              RED pre-fix (would FAIL/exit 2)
-                                              / GREEN post-fix
-
-Round-2 fix pass (Skeptic review of commit 91b2d7d6, both Majors
-confirmed by independent measurement before this rework):
-
-  - MAJOR 1: _hook_replacement's docstring understated the lone-token
-    normalization-mismatch behavior as merely "pre-existing" - measured,
-    this diff changes it from a visible no-op FIX (pre-fix) to a silent
-    false-healthy OK (post-fix) for that unreachable input. Docstring
-    corrected; test_lone_token_normalization_mismatch_reports_false_healthy
-    added to pin the corrected, disclosed post-fix behavior.
-  - MAJOR 2: test_two_managed_basenames_one_command and
-    test_three_distinct_stale_occurrences used `;`-joined fixtures, which
-    measurably drop both semicolons in the repaired output (turning two
-    sequential hook invocations into one nonsense command) while still
-    passing on substring-only assertions. Reworked to the space-delimited
-    `&&`-joined shape real .claude/install.sh registrations actually use,
-    with an exact-string assertion. The punctuation-loss behavior itself
-    is now explicitly pinned, separately, by
-    test_adjacent_punctuation_token_loses_punctuation - named so a reader
-    cannot mistake it for a supported case.
-
-Reddening mutation for every round-2-touched case: revert
-_hook_replacement to its pre-fix body (single first-basename-then-break
-loop, unconditional `cmd.replace(str(token_path), str(expected), 1)`).
-Verified by running this file against a loader pointed at the pre-fix
-source (origin/main's ds-doctor, commit 91b2d7d6's parent): 8 of 12 cases
-fail, all on the stated stale-path / None / exact-string assertions (see
-round-2 fix-pass return for the full list); the 4 that stay green both
-ways are test_bare_single_occurrence_stale_form,
-test_already_correct_guarded_form,
-test_adjacent_punctuation_token_loses_punctuation, and
-test_non_dinostack_shaped_path_untouched.
+Test-first ordering (DS-206): this file was written and run against the
+UNMODIFIED (pre-fix) _hook_replacement before the fix landed, and against
+the live (post-fix) function after. Each test's own docstring states its
+expected pre-fix/post-fix status (RED pre-fix / GREEN post-fix, or GREEN
+both ways for a characterization test) and, where the case is a
+characterization test rather than a plain regression case, its verified
+reddening mutation - deliberately not duplicated here, since a second copy
+of that information drifts independently of the code and the tests
+themselves (this file has already gone through three review rounds where
+a hand-maintained summary of this kind went stale on the round it was
+supposed to describe).
 """
 
 from __future__ import annotations
@@ -128,6 +63,9 @@ def _mkrepo(tmp_path: Path) -> Path:
 
 
 def test_fully_stale_guarded_form(tmp_path):
+    """RED pre-fix / GREEN post-fix: both the `test -f` and `python3`
+    clauses of a guarded form point at the same stale basename occurrence
+    (the simplest fully-unconverted case)."""
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
     old = old_repo / "hooks" / "enforce-turn-shape.py"
@@ -139,7 +77,8 @@ def test_fully_stale_guarded_form(tmp_path):
 
 
 def test_half_fixed_guarded_form(tmp_path):
-    """The bug's own residue: test -f already points at NEW, python3 still OLD."""
+    """RED pre-fix / GREEN post-fix. The bug's own residue: test -f already
+    points at NEW, python3 still OLD."""
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
     new = repo / "hooks" / "enforce-turn-shape.py"
@@ -152,7 +91,8 @@ def test_half_fixed_guarded_form(tmp_path):
 
 
 def test_mixed_stale_path_guarded_form(tmp_path):
-    """Two distinct old locations for the same basename in one command."""
+    """RED pre-fix / GREEN post-fix. Two distinct old locations for the
+    same basename in one command."""
     repo = _mkrepo(tmp_path)
     old_repo_a = tmp_path / "old-a-DinoStack"
     old_repo_b = tmp_path / "old-b-DinoStack"
@@ -167,11 +107,12 @@ def test_mixed_stale_path_guarded_form(tmp_path):
 
 
 def test_two_managed_basenames_one_command(tmp_path):
-    """Space-delimited, `&&`-joined shape - what .claude/install.sh's own
-    guarded multi-hook registrations actually look like. NOT semicolon-
-    joined: a `;`-adjacent stale token is a distinct, disclosed corruption
-    path (see test_adjacent_punctuation_token_loses_punctuation below) and
-    must not be conflated with ordinary multi-basename convergence.
+    """RED pre-fix / GREEN post-fix. Space-delimited, `&&`-joined shape -
+    what .claude/install.sh's own guarded multi-hook registrations
+    actually look like. NOT semicolon-joined: a `;`-adjacent stale token
+    is a distinct, disclosed corruption path (see
+    test_adjacent_punctuation_token_loses_punctuation below) and must not
+    be conflated with ordinary multi-basename convergence.
     """
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
@@ -192,8 +133,9 @@ def test_two_managed_basenames_one_command(tmp_path):
 
 
 def test_three_distinct_stale_occurrences(tmp_path):
-    """Space-delimited, `&&`-joined shape (see test_two_managed_basenames_
-    one_command's docstring for why `;` is deliberately not used here)."""
+    """RED pre-fix / GREEN post-fix. Space-delimited, `&&`-joined shape
+    (see test_two_managed_basenames_one_command's docstring for why `;`
+    is deliberately not used here)."""
     repo = _mkrepo(tmp_path)
     old_repo = tmp_path / "old-DinoStack"
     old1 = old_repo / "hooks" / "enforce-background-spawn.py"
@@ -212,7 +154,8 @@ def test_three_distinct_stale_occurrences(tmp_path):
 
 
 def test_adjacent_punctuation_token_loses_punctuation(tmp_path):
-    """CHARACTERIZATION TEST, not a supported-behavior guard: pins the
+    """GREEN both pre-fix and post-fix. CHARACTERIZATION TEST, not a
+    supported-behavior guard: pins the
     disclosed, accepted corruption in _hook_replacement's Known limitations
     #2 - a stale token immediately followed by punctuation (here, a `;`
     with no separating space) is replaced via `str(Path(token))`, which
@@ -268,11 +211,11 @@ def test_already_correct_guarded_form(tmp_path):
 
 
 def test_lone_token_normalization_mismatch_reports_false_healthy(tmp_path):
-    """CHARACTERIZATION TEST for the Major-1 fix-round-2 disclosure, not a
-    supported-behavior guard: pins the MEASURED pre-fix vs post-fix
-    difference for a lone (single-occurrence) token whose string form has
-    a normalization difference from repo_dir/hooks/<basename> (here, a
-    doubled path separator).
+    """RED pre-fix / GREEN post-fix. CHARACTERIZATION TEST for the Major-1
+    fix-round-2 disclosure, not a supported-behavior guard: pins the
+    MEASURED pre-fix vs post-fix difference for a lone (single-occurrence)
+    token whose string form has a normalization difference from
+    repo_dir/hooks/<basename> (here, a doubled path separator).
 
     Pre-fix (verified against origin/main at commit 91b2d7d6's parent):
     the old body returned `cmd.replace(...)` unconditionally once the
@@ -305,11 +248,10 @@ def test_lone_token_normalization_mismatch_reports_false_healthy(tmp_path):
 
 
 def test_multi_occurrence_partial_repair_leaves_mismatch_stale(tmp_path):
-    """CHARACTERIZATION TEST, not a supported-behavior guard: pins the
-    MEASURED pre-fix/post-fix EQUIVALENCE (not a difference) for the
-    multi-occurrence, same-basename, guarded-form shape - the only
-    realistic shape a normalization-mismatched token could co-occur with a
-    cleanly-repairable one in.
+    """GREEN both pre-fix and post-fix. CHARACTERIZATION TEST, not a
+    supported-behavior guard: pins the MEASURED pre-fix/post-fix
+    EQUIVALENCE (not a difference) for the multi-occurrence,
+    same-basename, guarded-form shape.
 
     Measured identically against both origin/main's pre-fix
     _hook_replacement and this file's live (post-fix) function: a guarded
@@ -358,7 +300,8 @@ def test_multi_occurrence_partial_repair_leaves_mismatch_stale(tmp_path):
 
 
 def test_non_dinostack_shaped_path_untouched(tmp_path):
-    """Negative case: a non-DinoStack-shaped stale path is left alone.
+    """GREEN both pre-fix and post-fix. Negative case: a non-DinoStack-
+    shaped stale path is left alone.
 
     The accumulator replaced an early `return None` with full iteration over
     all tokens and all managed basenames, widening the predicate's blast
@@ -381,6 +324,11 @@ def test_non_dinostack_shaped_path_untouched(tmp_path):
 
 
 def test_caller_writes_fully_converged_command_to_disk(tmp_path, monkeypatch):
+    """RED pre-fix / GREEN post-fix. Verifies AC1's actual caller contract:
+    check_hook_paths/_atomic_patch_settings write a fully-converged command
+    to disk (a guarded Stop-hook entry plus a separate PreToolUse entry,
+    two different basenames), not merely that the unit function returns
+    one."""
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
@@ -432,7 +380,9 @@ def test_caller_writes_fully_converged_command_to_disk(tmp_path, monkeypatch):
 
 
 def test_repair_exits_zero_with_no_fail_line(tmp_path, monkeypatch):
-    """Amendment 1 regression guard: a successful repair must not also
+    """RED pre-fix (Amendment 1's own defect, introduced by the accumulator
+    widening drift's reach, fixed in the same commit) / GREEN post-fix.
+    Amendment 1 regression guard: a successful repair must not also
     report itself as an unfixable FAIL via repoint_symlink's os.symlink
     call against settings.json (a regular file, not a symlink) raising
     FileExistsError.


### PR DESCRIPTION
## Summary

- `_hook_replacement` now converges every stale, DinoStack-shaped occurrence across every managed basename in one call, instead of rewriting only the first (`count=1`) and breaking after the first matching basename.
- This repairs the half-fixed residue the bug itself leaves on affected machines (`test -f <NEW> && python3 <OLD> || exit 0`), which the old code reported as healthy and `--fix` could not touch.
- `check_hook_paths` emits its FIX finding directly rather than through `repoint_symlink`, which tried to `os.symlink()` over `~/.claude/settings.json` (a regular file), raised `FileExistsError`, and forced exit 2 on every successful repair.
- Adds `bin/tests/test_agentic_doctor_hook_replacement.py` (13 cases), the first test coverage `_hook_replacement` has had.
- Fixes a comment/statement ambiguity at `.claude/install.sh:953-954`.

## Jira

Closes [DS-206](https://solara6.atlassian.net/browse/DS-206)

## Test plan

- [x] `python3 -m pytest bin/tests/ -q` - 2088 passed
- [x] `bash bin/tests/test_agentic_doctor.sh` - 107 passed
- [x] `bash bin/tests/test_agentic_doctor_ds_prefix.sh` - 21 passed
- [x] `bash bin/tests/test_ds_doctor_precommit_fallback_safety.sh` - 7 passed
- [x] `bash bin/tests/test_ds_doctor_precommit_source_parity.sh` - 9 passed
- [x] Pre-fix red run: the new suite against pre-fix `bin/ds-doctor` gives 8 failed / 5 passed, every failure on its stated assertion, none a collection error. Re-verified independently by the reviewer.
- [x] End-to-end in an isolated `HOME`/`FAKE_REPO` fixture: pre-fix `EXIT=2` with `FAIL hooks: could not re-point ... [Errno 17] File exists`; post-fix `EXIT=0`, no FAIL line, zero stale occurrences.
- [x] Containment: real `~/.claude/settings.json`, `~/.claude-spacedinosaurs/settings.json`, `settings.local.json`, and `.git/hooks/pre-commit` byte-identical before and after full runs.
- [x] Frozenset iteration order not load-bearing: byte-identical output across 10 `PYTHONHASHSEED` values on a 4-occurrence, 3-basename command.

## North Star alignment

Advances **Pillar 2 (verifiable outcomes)**: a successful hook repair now reports success and exit 0, where it previously always exited 2 (a contract `bin/ds-update:51` and `scripts/update.js:846` both consume as "unfixable"). Advances **Pillar 1 (operator attention)** by removing a spurious operator-facing FAIL on every successful repair.

**Pillar 8 (machinery only as complicated as the benefit requires)** cut against an earlier draft and shaped this one. Two review rounds designed a partial-repair reporting contract (a tuple return, a caller-side FAIL/`mark_unfixable` branch, a post-condition scan). It was deleted before implementation: its only justifying input is a path token that survives `Path()` normalization differently than written, and no producer emits one (`.claude/install.sh` builds all 32 registrations as `f"{hooks_root}/hooks/{name}"`; the snapshot key `<basename>-<12hex>` is not DinoStack-shaped and never reaches the rewrite branch). Pillar 8 requires naming a specific failure a mechanism would have caught; that could not be named, so it did not ship.

**Pillar 2 regression, disclosed not denied:** for a lone normalization-mismatched token, this diff converts a visible-but-useless `FIX`/exit-1 into a silent `OK`/exit-0. Unreachable from any current producer, documented in `_hook_replacement`'s docstring in present tense, and the reporting contract that would catch it is deferred to a follow-up ticket rather than abandoned.

## Doc-sync

`Doc-sync: checked docs/updating.md:45-52, README.md:23, bin/AGENTS.md:26, hooks/AGENTS.md:260-274, docs/index.html:968-1000, bin/ds-update:51, scripts/update.js:838-849 - all describe --fix/ds-doctor generically without asserting occurrence-count, basename-order, or full-vs-partial-repair semantics; none go stale under this change. docs/updating.md:51 ("exit 0 = all fixed, 2 = some unfixable") remains true and is now accurate for the hook-repair path for the first time. No doc updates required.`

## Accepted debt (unresolved Minor findings)

Both are narrative prose in the test module's docstring, non-blocking, and carry no runtime, behavioral, or test-status consequence. Recorded here rather than fixed, per the reviewer's judgment that a further round costs more than the fix; clean up on the next touch of the file.

1. The replacement module header contains a hand-typed cardinal ("three review rounds") that the fourth review round falsifies, and its staleness attribution is over-broad. The fix is deleting the parenthetical justification, not renumbering it.
2. That header states each characterization test carries "its verified reddening mutation". True outright for one of three, adequate for a second, absent for `test_adjacent_punctuation_token_loses_punctuation`.

## Known limitations (pre-existing, unreachable from current producers)

- A token whose string form does not match after `Path` normalization is not found by `str.replace` and stays stale. Alone, the function returns `None` and the caller reports healthy; alongside a cleanly-repairable occurrence, the caller reports the command repaired with one occurrence still stale.
- An adjacent-punctuation token is replaced by `str(Path(token))`, dropping the punctuation (corruption, not omission). Pinned as an explicit characterization test.
- `doc.repoint_symlink` used for a non-symlink kind elsewhere is untouched; only the `hooks` call site is in scope here.

## Review rigor

- Brief / Plan path: `.agentic/ds-206-architect-plan.md` (gitignored; 5 architect passes)
- Plan review: 4 rounds, Criticals 2 -> 2 -> 1 -> 0, then an operator-authorized Pillar 8 descope plus a final review
- Implementation review: 3 rounds, ending 0 Critical / 0 Major / 2 Minor, sign-off granted
- `_hook_replacement` and `check_hook_paths` executable bodies are AST-identical across all four commits; every commit after the first changed documentation and tests only


[DS-206]: https://solara6.atlassian.net/browse/DS-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ