### PR TITLE
docs(protocol): neutralize pinned model id in ds-configure-team example (PL-20260826-3)

### DIFF
--- a/.claude/commands/ds-configure-team.md
+++ b/.claude/commands/ds-configure-team.md
@@ -50,7 +50,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.claude/commands/ds-configure-team.md
+++ b/.claude/commands/ds-configure-team.md
@@ -51,12 +51,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.cursor/commands/ds-configure-team.md
+++ b/.cursor/commands/ds-configure-team.md
@@ -45,12 +45,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.cursor/commands/ds-configure-team.md
+++ b/.cursor/commands/ds-configure-team.md
@@ -44,7 +44,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.gemini/commands/ds-configure-team.toml
+++ b/.gemini/commands/ds-configure-team.toml
@@ -51,12 +51,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \\
   --non-interactive \\
   --assign architect=claude \\
-  --assign engineer=omp:kimi/kimi-k2.7 \\
-  --assign debugger=kimi:kimi-k2.7 \\
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \\
+  --assign debugger=kimi \\
   --assign skeptic=pi \\
   [--default-harness claude] \\
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.gemini/commands/ds-configure-team.toml
+++ b/.gemini/commands/ds-configure-team.toml
@@ -50,7 +50,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \\
   --non-interactive \\
-  --assign architect=claude:claude-opus-4-5 \\
+  --assign architect=claude \\
   --assign engineer=omp:kimi/kimi-k2.7 \\
   --assign debugger=kimi:kimi-k2.7 \\
   --assign skeptic=pi \\

--- a/.github/prompts/ds-configure-team.prompt.md
+++ b/.github/prompts/ds-configure-team.prompt.md
@@ -48,12 +48,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.github/prompts/ds-configure-team.prompt.md
+++ b/.github/prompts/ds-configure-team.prompt.md
@@ -47,7 +47,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14894,12 +14894,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14893,7 +14893,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.openclaw/skills/ds-configure-team/SKILL.md
+++ b/.openclaw/skills/ds-configure-team/SKILL.md
@@ -50,12 +50,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/.openclaw/skills/ds-configure-team/SKILL.md
+++ b/.openclaw/skills/ds-configure-team/SKILL.md
@@ -49,7 +49,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.opencode/commands/ds-configure-team.md
+++ b/.opencode/commands/ds-configure-team.md
@@ -48,7 +48,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/.opencode/commands/ds-configure-team.md
+++ b/.opencode/commands/ds-configure-team.md
@@ -49,12 +49,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/content/commands/ds-configure-team.md
+++ b/content/commands/ds-configure-team.md
@@ -45,12 +45,14 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 bin/ds-team configure \
   --non-interactive \
   --assign architect=claude \
-  --assign engineer=omp:kimi/kimi-k2.7 \
-  --assign debugger=kimi:kimi-k2.7 \
+  --assign engineer=omp:REPLACE_WITH_MODEL_ID \
+  --assign debugger=kimi \
   --assign skeptic=pi \
   [--default-harness claude] \
   [--path .agentic/team.yml]
 ```
+
+`omp:REPLACE_WITH_MODEL_ID` is a placeholder demonstrating the optional `harness:model` form - substitute a real model id for your installed harness (see `bin/ds-team discover` in Step 2 below to list what is actually available). No specific model id is recommended or endorsed by this doc.
 
 `--assign` accepts `role=harness:model` (model is optional). Repeat for each role. `--default-harness` sets the fallback harness for any unassigned role. `--path` overrides the output location (default `.agentic/team.yml`). All 7 harnesses (`codex`, `gemini`, `cursor-agent`, `kimi`, `pi`, `omp`, `claude`) are valid `--assign` targets and all accept a `model`.
 

--- a/content/commands/ds-configure-team.md
+++ b/content/commands/ds-configure-team.md
@@ -44,7 +44,7 @@ For non-interactive use - useful in scripts or automated onboarding - pass assig
 ```bash
 bin/ds-team configure \
   --non-interactive \
-  --assign architect=claude:claude-opus-4-5 \
+  --assign architect=claude \
   --assign engineer=omp:kimi/kimi-k2.7 \
   --assign debugger=kimi:kimi-k2.7 \
   --assign skeptic=pi \

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -168,7 +168,7 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Signal(s): Signal 1
 - Confidence: HIGH
 - Rationale: Non-interactive wizard example pins claude-opus-4-5 with no disclaimer. Approved; neutralize to a placeholder per the "don't pin models" directive.
-- Disposition: Dropped the pinned model id, keeping `--assign architect=claude` (harness default, per the file's own documented `--assign` optional-model semantics). Non-Claude cross-provider ids in this file were swept and left as out-of-scope. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/837
+- Disposition: Neutralized all three pinned model ids in the non-interactive `--assign` example block (`architect=claude`, `debugger=kimi`, `engineer=omp:REPLACE_WITH_MODEL_ID`) per the "don't pin models" directive. The disclaimed interactive-wizard transcript ids ("shown for reference only") were deliberately retained. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/837
 
 ## PL-20260826-4
 - Status: ACTIONED

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -162,13 +162,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition: Replaced pinned model ids with `<model-id-1>`/`<model-id-2>` placeholders and added the tier-map-example.yml-style illustrative-example disclaimer. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/840
 
 ## PL-20260826-3
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-26 (docs/planning/harness-pruning-2026-08-26.md)
 - File(s): content/commands/ds-configure-team.md (line ~47)
 - Signal(s): Signal 1
 - Confidence: HIGH
 - Rationale: Non-interactive wizard example pins claude-opus-4-5 with no disclaimer. Approved; neutralize to a placeholder per the "don't pin models" directive.
-- Disposition:
+- Disposition: Dropped the pinned model id, keeping `--assign architect=claude` (harness default, per the file's own documented `--assign` optional-model semantics). Non-Claude cross-provider ids in this file were swept and left as out-of-scope. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/837
 
 ## PL-20260826-4
 - Status: ACTIONED


### PR DESCRIPTION
## Summary
- Removes the pinned `claude-opus-4-5` model id from `ds-configure-team.md`'s non-interactive `--assign` example, replacing it with `--assign architect=claude` (harness default, per the file's own documented `--assign role=harness:model` optional-model semantics).
- **Round 2 correction:** round 1 also left `--assign engineer=omp:kimi/kimi-k2.7` and `--assign debugger=kimi:kimi-k2.7` pinned in the same non-interactive example block, and justified leaving them under a false "example harness-discovered model ids" rationale. They were not discovered output - they were hardcoded literals, the same class of defect as the `claude-opus-4-5` this PR already removed. Fixed by: converting `debugger` to the bare `--assign debugger=kimi` harness-only form, and converting `engineer` to `--assign engineer=omp:REPLACE_WITH_MODEL_ID`, an explicit unambiguous placeholder (verified executable via `bin/ds-team configure --non-interactive ...` - see Test plan) that keeps the optional `harness:model` syntax demonstrated without endorsing or pinning any specific model. An adjacent sentence clarifies the placeholder and points to `bin/ds-team discover` (Step 2) to find real available models.
- The interactive-transcript model ids shown elsewhere in the file (`minimax/MiniMax-M3`, `kimi/kimi-k2.7`, `glm/glm-5.2`, in the sample wizard output) are unaffected by this correction - they are genuinely discovered-output examples (i.e. representative output of `bin/ds-team discover` against a real machine), not pinned defaults, and the file already carries a "Discovered models are shown for reference only" disclaimer immediately after that transcript.
- Doc-sync: predicate not triggered (no reality-asserting change) - swept docs/index.html, docs/slides/*.md, README.md, CONTRIBUTING.md, content/SKILL.md for pinned ids; zero hits found outside this file.
- Flips `docs/pruning-ledger.md` `## PL-20260826-3` from RAISED to ACTIONED (second commit on this branch, round 1).

## North Star alignment
Pillar 4 (universality): pinned model ids baked one vendor's specific model version into a shared cross-harness example, contradicting "no operator's identity, workspace, tracker, or local setup may be baked into shared behavior." The `--assign role=harness:model` form already documents model as optional and defaulting to the harness's own session default; the round-2 fix additionally removes the two remaining hardcoded literals so no example line in the block pins a real model id, while keeping the `harness:model` syntax demonstrated via an explicit placeholder.

## Test plan
- [x] `bash scripts/build-all.sh` - 11 adapters built, only expected command/skill files changed, symlinks unchanged.
- [x] Hooks JS suite (excluding the two wrap-lock files quarantined into the separate `wrap-lock-tests` job) - 55 passed, 0 failed.
- [x] `python3 -m pytest bin/tests/ -q` - 2074 passed, 1 flaky unrelated concurrency test failed on first run (`test_grant_consumption_atomic_under_concurrency`, a timing-sensitive lock-race test in `test_enforce_ticket_batching.py`, unrelated to this doc-only change), re-ran in isolation and passed; 25 subtests passed.
- [x] Em-dash check on added lines - none found.
- [x] Ran the exact post-fix example block verbatim (`bin/ds-team configure --non-interactive --assign architect=claude --assign engineer=omp:REPLACE_WITH_MODEL_ID --assign debugger=kimi --assign skeptic=pi --default-harness claude --path <scratch>`) - exit code 0, emitted valid `team.yml` with `engineer: {harness: omp, model: REPLACE_WITH_MODEL_ID}` and `debugger: kimi`.
