### PR TITLE
docs(protocol): drop Claude attribution trailer from Phase 8 commit template (PL-20260826-1)

### DIFF
--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2356,6 +2356,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.claude/commands/ds-implement-ticket.md
+++ b/.claude/commands/ds-implement-ticket.md
@@ -2356,7 +2356,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -8403,16 +8403,6 @@
     },
     {
       "expected_target": "hashed-source-occurrence",
-      "generated_token": "short",
-      "kind": "display-only",
-      "occurrence_hash": "52827728992904db5a2b7426dd274e9198d9b363a6a6f8e0dae5dc1197cc0719",
-      "resolution_mode": "display-only",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-implement-ticket.md",
-      "source_token": "short"
-    },
-    {
-      "expected_target": "hashed-source-occurrence",
       "generated_token": "-",
       "kind": "display-only",
       "occurrence_hash": "52cce85b2127327d0132338fc58e53fd6113c30be19e61620e442fff704bc866",
@@ -13740,6 +13730,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-implement-ticket.md",
       "source_token": "fi"
+    },
+    {
+      "expected_target": "hashed-source-occurrence",
+      "generated_token": "short",
+      "kind": "display-only",
+      "occurrence_hash": "a347bcd5bec2a1f3b2b920bffc2605e14c63ae1aad9dc87412f744f66f2d7835",
+      "resolution_mode": "display-only",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-implement-ticket.md",
+      "source_token": "short"
     },
     {
       "expected_target": "hashed-source-occurrence",

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2412,6 +2412,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.codex/skills/implement-ticket/SKILL.md
+++ b/.codex/skills/implement-ticket/SKILL.md
@@ -2412,7 +2412,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.copilot/references/conventions-detail.md
+++ b/.copilot/references/conventions-detail.md
@@ -199,7 +199,7 @@ Per-line self-check: would a future reader need this line to know what to build,
 
 Subject line: `type(scope): <imperative description>`, written in the imperative mood. The cap is on the whole subject INCLUDING the `type(scope):` prefix - ≤ 50 characters total, leaving roughly 25-35 characters for the description on typical scopes. A description that cannot fit pushes the detail into the body. Conventional git subject-line guidance: git truncates long subjects in tooling output, and 50 is the traditional subject cap. This is guidance, not a repo-precedent claim - subjects in this repo routinely run 60-120+ characters.
 
-The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Co-Authored-By, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
+The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
 
 ### Assembled PR bodies
 

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2350,7 +2350,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.cursor/commands/ds-implement-ticket.md
+++ b/.cursor/commands/ds-implement-ticket.md
@@ -2350,6 +2350,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.cursor/references/conventions-detail.md
+++ b/.cursor/references/conventions-detail.md
@@ -199,7 +199,7 @@ Per-line self-check: would a future reader need this line to know what to build,
 
 Subject line: `type(scope): <imperative description>`, written in the imperative mood. The cap is on the whole subject INCLUDING the `type(scope):` prefix - ≤ 50 characters total, leaving roughly 25-35 characters for the description on typical scopes. A description that cannot fit pushes the detail into the body. Conventional git subject-line guidance: git truncates long subjects in tooling output, and 50 is the traditional subject cap. This is guidance, not a repo-precedent claim - subjects in this repo routinely run 60-120+ characters.
 
-The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Co-Authored-By, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
+The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
 
 ### Assembled PR bodies
 

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2356,6 +2356,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.gemini/commands/ds-implement-ticket.toml
+++ b/.gemini/commands/ds-implement-ticket.toml
@@ -2356,7 +2356,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.gemini/references/conventions-detail.md
+++ b/.gemini/references/conventions-detail.md
@@ -199,7 +199,7 @@ Per-line self-check: would a future reader need this line to know what to build,
 
 Subject line: `type(scope): <imperative description>`, written in the imperative mood. The cap is on the whole subject INCLUDING the `type(scope):` prefix - ≤ 50 characters total, leaving roughly 25-35 characters for the description on typical scopes. A description that cannot fit pushes the detail into the body. Conventional git subject-line guidance: git truncates long subjects in tooling output, and 50 is the traditional subject cap. This is guidance, not a repo-precedent claim - subjects in this repo routinely run 60-120+ characters.
 
-The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Co-Authored-By, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
+The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
 
 ### Assembled PR bodies
 

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2353,6 +2353,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.github/prompts/ds-implement-ticket.prompt.md
+++ b/.github/prompts/ds-implement-ticket.prompt.md
@@ -2353,7 +2353,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -18497,6 +18497,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -2880,7 +2880,7 @@ Per-line self-check: would a future reader need this line to know what to build,
 
 Subject line: `type(scope): <imperative description>`, written in the imperative mood. The cap is on the whole subject INCLUDING the `type(scope):` prefix - ≤ 50 characters total, leaving roughly 25-35 characters for the description on typical scopes. A description that cannot fit pushes the detail into the body. Conventional git subject-line guidance: git truncates long subjects in tooling output, and 50 is the traditional subject cap. This is guidance, not a repo-precedent claim - subjects in this repo routinely run 60-120+ characters.
 
-The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Co-Authored-By, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
+The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
 
 ### Assembled PR bodies
 
@@ -18497,7 +18497,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2355,6 +2355,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.openclaw/skills/ds-implement-ticket/SKILL.md
+++ b/.openclaw/skills/ds-implement-ticket/SKILL.md
@@ -2355,7 +2355,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2354,6 +2354,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/.opencode/commands/ds-implement-ticket.md
+++ b/.opencode/commands/ds-implement-ticket.md
@@ -2354,7 +2354,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2350,7 +2350,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
-  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
+  COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi
 

--- a/content/commands/ds-implement-ticket.md
+++ b/content/commands/ds-implement-ticket.md
@@ -2350,6 +2350,7 @@ else
   NL=$'
 '
   # §Commit messages: imperative; whole subject incl. prefix ≤ 50 chars.
+  # Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here.
   COMMIT_MSG="type(scope): short imperative description${NL}${NL}More detail on what changed and why if needed.${NL}Closes [TICKET_PREFIX]-NNN${NL}${NL}${DEVTRAILER:+${DEVTRAILER}${NL}}Signed-off-by: ${SO_NAME} <${SO_EMAIL}>"
   git -C "$COMMIT_CHECKOUT" commit -m "$COMMIT_MSG"
 fi

--- a/content/references/conventions-detail.md
+++ b/content/references/conventions-detail.md
@@ -199,7 +199,7 @@ Per-line self-check: would a future reader need this line to know what to build,
 
 Subject line: `type(scope): <imperative description>`, written in the imperative mood. The cap is on the whole subject INCLUDING the `type(scope):` prefix - ≤ 50 characters total, leaving roughly 25-35 characters for the description on typical scopes. A description that cannot fit pushes the detail into the body. Conventional git subject-line guidance: git truncates long subjects in tooling output, and 50 is the traditional subject cap. This is guidance, not a repo-precedent claim - subjects in this repo routinely run 60-120+ characters.
 
-The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Co-Authored-By, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
+The body below the blank line is uncapped; put detail there. Trailer lines (Closes, Developer, Signed-off-by) are excluded from the subject cap and pass through unchanged.
 
 ### Assembled PR bodies
 

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -144,13 +144,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition:
 
 ## PL-20260826-1
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-26 (docs/planning/harness-pruning-2026-08-26.md)
 - File(s): content/commands/ds-implement-ticket.md (line ~2353, Phase 8 COMMIT_MSG template)
 - Signal(s): Signal 1 (explicit model-version reference)
 - Confidence: HIGH
 - Rationale: The Phase 8 commit template hardcodes the trailer "Co-Authored-By: Claude Sonnet 4.6" - a live template, not an example, so every current-model session misattributes its commits. Operator decision 2026-08-26: approved; per the operator's standing directive there is to be NO Claude attribution in PRs or commits, so the trailer is deleted outright rather than parameterized.
-- Disposition:
+- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/838
 
 ## PL-20260826-2
 - Status: RAISED


### PR DESCRIPTION
## Summary
- Deletes the hardcoded `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer from the Phase 8 COMMIT_MSG template in `content/commands/ds-implement-ticket.md` - per operator directive, no Claude attribution in PRs or commits, deleted outright rather than parameterized.
- Removes the same trailer from its example list in `content/references/conventions-detail.md` §Commit messages (Closes, Developer, Signed-off-by remain).
- Regenerates all 11 adapters (`bash scripts/build-all.sh`) and the Codex skill-compatibility inventory (content hash changed).

## North Star alignment
Pillar 4 (universality): the hardcoded trailer misattributed every commit to a specific model regardless of which model actually ran the session - a baked-in assumption that broke for any operator on a different model. Pillar 8 (machinery only as complicated as the benefit requires): deletion over parameterizing a model-name variable, since the operator directive is "no attribution" rather than "attribute correctly."

## Doc-sync
Doc-sync: triggered (content/commands, content/references edit) -> ran `bash scripts/build-all.sh` (11/11 adapters OK), regenerated `.codex/skill-compatibility.yml`. Swept `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` for Co-Authored-By/Claude Sonnet/noreply@anthropic - zero hits, nothing stale.

## Test plan
- [x] `bash scripts/check-command-file-budget.sh` - OK, -62 B delta
- [x] `python3 scripts/check-command-arg-substitution.py` - OK, zero violations
- [x] hooks JS suite (55 files, excludes wrap-lock-tests pair) - all pass
- [x] `python3 -m pytest bin/tests/ -q` - 2075 passed, 25 subtests passed
- [x] em-dash check on added lines - none
- [x] symlinks relative, adapter diff scoped to expected files only

## Fix round (Skeptic Minor, operator-directive-aligned)
- Added one prohibitive sentence immediately adjacent to the Phase 8 COMMIT_MSG template in `content/commands/ds-implement-ticket.md`: "Do not append any Co-Authored-By, Generated-with, or other AI-attribution trailer to the commit message - harness defaults that add one are overridden here." Closes the gap where a harness's documented default trailer-append behavior could silently reintroduce the deleted attribution at runtime, since the template was previously silent on the topic.
- Commit: `ae5497cf8175e1a3e474e5907586436bf6efacd6`
- Verification: `check-command-file-budget.sh` OK (delta +99 B, 5621 B headroom); `build-all.sh` 11/11 adapters, 9 files/9 insertions, no unrelated hunks; `check-symlinks-relative.sh` OK; `check-command-arg-substitution.py` zero violations; hooks JS suite (excl. wrap-lock pair) all pass; `pytest bin/tests/ -q` 2075 passed, 25 subtests passed; em-dash check on added lines - none.
