### PR TITLE
docs(protocol): delete falsified self-claims from ds-prune-harness (PL-20260826-4)

### DIFF
--- a/.claude/commands/ds-prune-harness.md
+++ b/.claude/commands/ds-prune-harness.md
@@ -74,13 +74,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.cursor/commands/ds-prune-harness.md
+++ b/.cursor/commands/ds-prune-harness.md
@@ -68,13 +68,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.gemini/commands/ds-prune-harness.toml
+++ b/.gemini/commands/ds-prune-harness.toml
@@ -74,13 +74,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.github/prompts/ds-prune-harness.prompt.md
+++ b/.github/prompts/ds-prune-harness.prompt.md
@@ -71,13 +71,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -21655,13 +21655,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.openclaw/skills/ds-prune-harness/SKILL.md
+++ b/.openclaw/skills/ds-prune-harness/SKILL.md
@@ -73,13 +73,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/.opencode/commands/ds-prune-harness.md
+++ b/.opencode/commands/ds-prune-harness.md
@@ -72,13 +72,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/content/commands/ds-prune-harness.md
+++ b/content/commands/ds-prune-harness.md
@@ -68,13 +68,13 @@ Before including any candidate, apply the floor-vs-dial test from `content/refer
 
 The analyst applies each signal to every file in scope and flags candidates as they are found. No signal is skipped except Signal 4 when findings.md is absent at both resolver paths (see Signal 4).
 
-**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. NOTE: on the current corpus, no model-version references exist in rules/references/agents - this signal is primarily a forward-looking guard. If it fires, flag with HIGH confidence.
+**Signal 1 - explicit model-version reference.** Candidate if the named version is older than the current deployed model. If it fires, flag with HIGH confidence.
 
 **Signal 2 - "because the model forgets" framing.** Candidate if that failure class has not appeared in findings.md (resolved via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback) in the last 6 months, or the rule has no known firing instance. MEDIUM confidence.
 
 **Signal 3 - verbatim duplication across files.** Flag the duplicate, not the canonical (usually the longer or more detailed version). EXCEPTION: cross-reference duplication is NOT a candidate. Intentional repetition - a preamble appearing in both a rule file AND the command that instructs agents to follow the rule, the execution contract appearing in both `METHODOLOGY.md` AND `implement-ticket.md`, the Skeptic sign-off format appearing in both `skeptic-protocol.md` AND `METHODOLOGY.md` - is load-bearing structural redundancy, not accidental bloat. The analyst must explicitly test: "would deleting this copy break a cross-reference another doc depends on?" If yes, not a candidate. MEDIUM confidence when the duplication is genuinely accidental.
 
-**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists (as is currently the case for this repo), SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
+**Signal 4 - contradiction with findings.md entries.** Resolve findings.md via `.agentic/findings.md` preferred, legacy `.claude/findings.md` fallback. If neither path exists, SKIP this signal entirely and note "Signal 4 skipped: findings.md does not exist at either resolver path in this repo" in the proposal's signal summary. Do not produce false candidates.
 
 **Signal 5 - orphaned fallback text.** Sections labeled "fallback", "legacy", or "if the agent cannot" where the older behavior no longer occurs. MEDIUM confidence.
 

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -171,13 +171,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition:
 
 ## PL-20260826-4
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-26 (docs/planning/harness-pruning-2026-08-26.md)
 - File(s): content/commands/ds-prune-harness.md (lines ~71 and ~77)
 - Signal(s): Signal 4 (contradiction with live state) + falsified Signal-1 NOTE
 - Confidence: MEDIUM
 - Rationale: Two parenthetical self-claims are now false: "no model-version references exist in rules/references/agents" (falsified by tier-map-example.yml among others) and "findings.md does not exist at either resolver path" (.agentic/findings.md exists, 7 entries). The 2026-08-25 run had to override its own contract because of the second. Approved: delete both stale asides per the prefer-deletion rule.
-- Disposition:
+- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/839
 
 ## PL-20260826-5
 - Status: RAISED


### PR DESCRIPTION
## Summary

- Deletes two falsified self-claims from `content/commands/ds-prune-harness.md` (PL-20260826-4, operator-approved): Signal 1's "no model-version references exist" NOTE (falsified - `content/references/tier-map-example.yml`, `role-models.md`, `role-models-example.yml` all carry model ids, e.g. `gpt-4o-mini` at `tier-map-example.yml:27`) and Signal 4's "(as is currently the case for this repo)" aside claiming `.agentic/findings.md` does not exist (falsified - it currently exists in this checkout, 1246 bytes). Surrounding instructions stand alone unedited.
- Ran `bash scripts/build-all.sh`; 7 adapter files regenerated (plus the content/ source) with only this file's diff propagated (symlinks unchanged, no unrelated hunks).
- Swept the file for other checkably-false corpus-state assertions of the same class; found none beyond the two named.
- Second commit flips ledger entry `PL-20260826-4` in `docs/pruning-ledger.md` from `RAISED` to `ACTIONED` with this PR's URL, per Step 4's "close the ledger entry in the same PR diff as the deletion" rule.

## North Star alignment

Serves Pillar 7 (prevent defects at the producing step - a false self-claim in the methodology's own instruction text misleads any agent or analyst that trusts it, exactly the defect this deletion removes) and Pillar 8 (machinery/prose only as complicated as accurate - deleting a stale parenthetical rather than rewriting it, per the repo's prefer-deletion convention, and nothing else in the file depends on either aside). No pillar cuts against this change: it is a pure deletion of two asides that were not load-bearing for any surrounding instruction (verified - the conditional logic in both signals is unchanged and correct on its own).

## Doc-sync

Doc-sync: predicate not triggered for `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` - grepped all five for restatements of either falsified claim ("no model-version references exist", "as is currently the case for this repo", "findings.md does not exist at either resolver path") and found none.

## Test plan

- [x] `bash scripts/build-all.sh` - all 11 adapters built, only `ds-prune-harness` targets changed
- [x] hooks JS suite (excluding `test-wrap-acquire-lock.js`/`test-wrap-release-lock.js`) - ALL PASS
- [x] `python3 -m pytest bin/tests/ -q` - 2074 passed, 1 failed in full-suite run (`test_agentic_migrate.py::TestApplyFailedShardTimestampDedupAndResolution::test_hand_fix_with_no_further_writes_appends_resolved_line`), confirmed flaky/pre-existing and unrelated to this diff - passes in isolation (`1 passed in 0.21s`)
- [x] em-dash check on added lines in this branch's diff - none found

