### PR TITLE
docs(protocol): neutralize pinned model ids in ds-cost pricing example (PL-20260826-2)

### DIFF
--- a/.claude/commands/ds-cost.md
+++ b/.claude/commands/ds-cost.md
@@ -67,15 +67,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.cursor/commands/ds-cost.md
+++ b/.cursor/commands/ds-cost.md
@@ -61,15 +61,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.gemini/commands/ds-cost.toml
+++ b/.gemini/commands/ds-cost.toml
@@ -67,15 +67,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.github/prompts/ds-cost.prompt.md
+++ b/.github/prompts/ds-cost.prompt.md
@@ -64,15 +64,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14996,15 +14996,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.openclaw/skills/ds-cost/SKILL.md
+++ b/.openclaw/skills/ds-cost/SKILL.md
@@ -66,15 +66,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/.opencode/commands/ds-cost.md
+++ b/.opencode/commands/ds-cost.md
@@ -65,15 +65,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/content/commands/ds-cost.md
+++ b/content/commands/ds-cost.md
@@ -61,15 +61,21 @@ Place at `~/.agentic/pricing.yml`. Rates are USD per 1M tokens. The file is
 user-maintained; `/ds-cost` refuses to print dollar figures when it
 is absent.
 
+THIS SHAPE IS AN ILLUSTRATIVE EXAMPLE ONLY - the model ids and rates below
+are not kept current with provider releases. Substitute your own current
+model ids and rates; `/ds-cost` looks up each event's recorded model string
+as a literal key into `models:`, so any id you use here works as long as it
+matches.
+
 ```
 updated: 2026-04-15
 models:
-  claude-sonnet-4-6:
+  <model-id-1>:      # e.g. a fast/cheap tier model id
     input: 3.00
     output: 15.00
     cache_creation: 3.75
     cache_read: 0.30
-  claude-opus-4-7:
+  <model-id-2>:      # e.g. a max-capability tier model id
     input: 15.00
     output: 75.00
     cache_creation: 18.75

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -153,13 +153,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition:
 
 ## PL-20260826-2
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-26 (docs/planning/harness-pruning-2026-08-26.md)
 - File(s): content/commands/ds-cost.md (lines ~64-77, pricing.yml example)
 - Signal(s): Signal 1
 - Confidence: HIGH
 - Rationale: Example pricing config pins claude-sonnet-4-6 and claude-opus-4-7 with concrete per-token rates and no disclaimer. Operator decision 2026-08-26: approved; per the "don't pin models" directive, neutralize ids to placeholders.
-- Disposition:
+- Disposition: Replaced pinned model ids with `<model-id-1>`/`<model-id-2>` placeholders and added the tier-map-example.yml-style illustrative-example disclaimer. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/840
 
 ## PL-20260826-3
 - Status: RAISED


### PR DESCRIPTION
## Summary
- The `~/.agentic/pricing.yml` example in `content/commands/ds-cost.md` pinned `claude-sonnet-4-6`/`claude-opus-4-7` with concrete per-token rates and no staleness disclaimer.
- Per operator directive (don't pin models), replace the model ids with `<model-id-1>`/`<model-id-2>` placeholders and add the same "illustrative example, not kept current with provider releases" disclaimer that `content/references/tier-map-example.yml` already uses. The yaml shape (keys, nesting, rate units) is unchanged so the example remains genuinely illustrative.
- Verified `bin/ds-cost`'s pricing consumption behavior still reads true against the surrounding prose: `_load_pricing()` (bin/ds-cost:157-178) treats `models:` as a plain dict and does no id validation; `_price_row()` (bin/ds-cost:379-404) looks up each event's recorded model string as a literal dict key, rendering `?`/"Missing rates for: ..." on a miss (bin/ds-cost:434-482); the >90-day staleness warning (bin/ds-cost:465-476) is unaffected by this change. No behavior-claim edits were needed.
- Docs-currency: grepped repo for `claude-sonnet-4-6`/`claude-opus-4-7` outside adapter-generated copies of this same command file - only `docs/pruning-ledger.md` (the tracking entry itself, flipped to ACTIONED in this PR) referenced them. No hits in `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, or `content/SKILL.md`.
- `Doc-sync: predicate triggered (content/commands/** edit) -> ran scripts/build-all.sh, regenerated 7 adapter copies of ds-cost (.claude, .cursor, .gemini, .github/prompts, .hermes, .openclaw, .opencode); no other doc surface referenced the pinned ids.`

## North Star alignment
Serves Pillar 4 (works for everyone / universality): a pinned, dated model-id-and-rate example baked one provider catalog snapshot into shared docs, which silently goes stale for every operator once providers rev their catalogs. Replacing it with a labeled placeholder shape (matching the existing `tier-map-example.yml` precedent) keeps the example genuinely illustrative without pinning a value that isn't kept current.

## Test plan
- [x] `bash scripts/build-all.sh` - regenerated 7 adapter copies, no unrelated hunks, symlinks unchanged
- [x] hooks JS suite (excl. the 2 wrap-lock-tests files): 55 passed, 0 failed
- [x] `python3 -m pytest bin/tests/ -q`: 2075 passed, 25 subtests passed
- [x] em-dash check on added lines: none
- [x] `docs/overview/vision.md` read; North Star note above

## Accepted debt (round-1 Skeptic Minor, non-blocking)
- The inherited disclaimer sentence "not kept current with provider releases" described real ids in tier-map-example.yml; here the values are placeholders, which cannot go stale - wording nit for a future touch.
