### PR TITLE
docs(protocol): neutralize stale model ids in tier-map example (PL-20260825-4)

### DIFF
--- a/content/references/tier-map-example.yml
+++ b/content/references/tier-map-example.yml
@@ -7,9 +7,10 @@
 # To enable tier routing:
 #   1. Copy this file to ~/.agentic/tier-map.yml (or .agentic/tier-map.yml
 #      in a project root for project-specific overrides).
-#   2. Edit the model names below to match your provider's current catalog.
-#      The names here are examples only and are not kept current with
-#      provider releases - edit to suit your needs.
+#   2. Replace each placeholder below with a real model id from your
+#      provider's current catalog. This file intentionally uses
+#      placeholders instead of concrete model ids so it never goes stale
+#      as providers release and retire models - edit to suit your needs.
 #   3. Restart the session. No rebuild needed.
 #
 # If no tier map exists when a Codex/Gemini agent is spawned, the conductor
@@ -24,12 +25,12 @@
 
 codex:
   tiers:
-    1: gpt-4o-mini      # example, edit to suit your needs
-    2: gpt-4o           # example, edit to suit your needs
-    3: o3               # example, edit to suit your needs
+    1: <cheap-fast-model-id>      # tier 1, replace with a real model id
+    2: <balanced-model-id>        # tier 2, replace with a real model id
+    3: <max-capability-model-id>  # tier 3, replace with a real model id
 
 gemini:
   tiers:
-    1: gemini-2.0-flash # example, edit to suit your needs
-    2: gemini-2.0-pro   # example, edit to suit your needs
-    3: gemini-ultra-2   # example, edit to suit your needs
+    1: <cheap-fast-model-id>      # tier 1, replace with a real model id
+    2: <balanced-model-id>        # tier 2, replace with a real model id
+    3: <max-capability-model-id>  # tier 3, replace with a real model id

--- a/content/references/tier-map-example.yml
+++ b/content/references/tier-map-example.yml
@@ -7,10 +7,12 @@
 # To enable tier routing:
 #   1. Copy this file to ~/.agentic/tier-map.yml (or .agentic/tier-map.yml
 #      in a project root for project-specific overrides).
-#   2. Replace each placeholder below with a real model id from your
-#      provider's current catalog. This file intentionally uses
-#      placeholders instead of concrete model ids so it never goes stale
-#      as providers release and retire models - edit to suit your needs.
+#   2. Replace each placeholder below with a real model id from that
+#      section's own provider catalog - Codex placeholders take a Codex
+#      model id, Gemini placeholders take a Gemini model id. This file
+#      intentionally uses placeholders instead of concrete model ids so
+#      it never goes stale as providers release and retire models - edit
+#      to suit your needs.
 #   3. Restart the session. No rebuild needed.
 #
 # If no tier map exists when a Codex/Gemini agent is spawned, the conductor
@@ -25,12 +27,12 @@
 
 codex:
   tiers:
-    1: <cheap-fast-model-id>      # tier 1, replace with a real model id
-    2: <balanced-model-id>        # tier 2, replace with a real model id
-    3: <max-capability-model-id>  # tier 3, replace with a real model id
+    1: REPLACE_WITH_CODEX_CHEAP_FAST_MODEL_ID      # tier 1, replace with a real Codex model id
+    2: REPLACE_WITH_CODEX_BALANCED_MODEL_ID        # tier 2, replace with a real Codex model id
+    3: REPLACE_WITH_CODEX_MAX_CAPABILITY_MODEL_ID  # tier 3, replace with a real Codex model id
 
 gemini:
   tiers:
-    1: <cheap-fast-model-id>      # tier 1, replace with a real model id
-    2: <balanced-model-id>        # tier 2, replace with a real model id
-    3: <max-capability-model-id>  # tier 3, replace with a real model id
+    1: REPLACE_WITH_GEMINI_CHEAP_FAST_MODEL_ID      # tier 1, replace with a real Gemini model id
+    2: REPLACE_WITH_GEMINI_BALANCED_MODEL_ID        # tier 2, replace with a real Gemini model id
+    3: REPLACE_WITH_GEMINI_MAX_CAPABILITY_MODEL_ID  # tier 3, replace with a real Gemini model id

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -68,8 +68,8 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - File(s): content/references/tier-map-example.yml (model id entries)
 - Signal(s): Signal 1 (explicit model-version reference)
 - Confidence: HIGH
-- Rationale: Example tier map names gpt-4o-mini, gpt-4o, o3, gemini-2.0-* era models, stale relative to current provider lineups. The file self-disclaims ("examples only, not kept current"), so this is a refresh, not a behavioral premise on a dead model. Operator decision 2026-08-26: approved under the don't-pin-models directive - neutralized to placeholders (`<cheap-fast-model-id>`, `<balanced-model-id>`, `<max-capability-model-id>`) rather than refreshed to a new set of concrete ids, so the file cannot go stale again.
-- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/841
+- Rationale: Example tier map names gpt-4o-mini, gpt-4o, o3, gemini-2.0-* era models, stale relative to current provider lineups. The file self-disclaims ("examples only, not kept current"), so this is a refresh, not a behavioral premise on a dead model. Operator decision 2026-08-25: explicitly deferred - the disclaimer is accepted as sufficient for now; refresh in a later pass. Operator decision 2026-08-26: approved under the don't-pin-models directive.
+- Disposition: Neutralized to placeholders rather than refreshed to a new set of concrete ids, so the file cannot go stale again. PR: https://github.com/Space-Dinosaurs/DinoStack/pull/841
 
 ## PL-20260825-5
 - Status: RAISED

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -63,13 +63,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition: Rewritten in https://github.com/Space-Dinosaurs/DinoStack/pull/827 - all five defects fixed (including a fifth, sibling-reported staleness at line ~212's Skeptic Protocol Section 0 citation). The general-purpose guidance was scoped, not deleted: verification found every spawn-capable adapter ships the full named-agent roster and Cursor has no spawning at all, so no live portability role exists today, but `general-purpose` remains an explicit fallback row for a harness that might need it in future. Note on axis substitution: the Rationale above calls for scoping this guidance "to harnesses lacking named agents" (a portability axis), but the implementation scoped it on task-fit instead ("use a named agent unless none of the named agents fit the task"). The harness-lineup check found every spawn-capable adapter ships the named roster, so the portability axis had no live referent to scope against; the kernel's own task-fit fallback wording was used instead.
 
 ## PL-20260825-4
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-25 (docs/planning/harness-pruning-2026-08-25.md)
 - File(s): content/references/tier-map-example.yml (model id entries)
 - Signal(s): Signal 1 (explicit model-version reference)
 - Confidence: HIGH
-- Rationale: Example tier map names gpt-4o-mini, gpt-4o, o3, gemini-2.0-* era models, stale relative to current provider lineups. The file self-disclaims ("examples only, not kept current"), so this is a refresh, not a behavioral premise on a dead model. Operator decision 2026-08-25: explicitly deferred - the disclaimer is accepted as sufficient for now; refresh in a later pass.
-- Disposition:
+- Rationale: Example tier map names gpt-4o-mini, gpt-4o, o3, gemini-2.0-* era models, stale relative to current provider lineups. The file self-disclaims ("examples only, not kept current"), so this is a refresh, not a behavioral premise on a dead model. Operator decision 2026-08-26: approved under the don't-pin-models directive - neutralized to placeholders (`<cheap-fast-model-id>`, `<balanced-model-id>`, `<max-capability-model-id>`) rather than refreshed to a new set of concrete ids, so the file cannot go stale again.
+- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/841
 
 ## PL-20260825-5
 - Status: RAISED


### PR DESCRIPTION
## Summary
- `content/references/tier-map-example.yml` named stale model ids (`gpt-4o-mini`, `gpt-4o`, `o3`, `gemini-2.0-*` era). Per the operator's "don't pin models" directive, this replaces the concrete ids with placeholder forms that illustrate the yaml shape (tier keys, harness sections, the id slot) without pinning to a point-in-time provider catalog, so the example cannot go stale again.
- Consumer check: file self-disclaims "Nothing in this repo reads this file" and is confirmed not parsed as live config anywhere in `content/`, `bin/`, or `hooks/` (grep swept). Two doc references to the file (`content/references/risk-config-and-tiers.md`, `docs/configuration-reference.md`) point at it by path only, not by concrete id, so no other doc needed updating.
- Flips `docs/pruning-ledger.md` `## PL-20260825-4` from RAISED to ACTIONED with this PR URL.

## Round 2 (this update)
- **Ledger history restored** (Major): the flip had deleted the 2026-08-25 operator deferral sentence ("explicitly deferred - the disclaimer is accepted as sufficient for now; refresh in a later pass."). Restored it in Rationale, appended the 2026-08-26 approval decision after it, and moved the neutralize-vs-refresh implementation narrative into `Disposition:` alongside the PR link, matching the schema PR #840 established for its own ledger flip.
- **Shell-metacharacter placeholders removed** (Minor): `<cheap-fast-model-id>` style placeholders would produce a shell redirect if pasted unedited into the `--model <name>` CLI form documented at `risk-config-and-tiers.md:168`. Converted to `REPLACE_WITH_..._MODEL_ID` form, matching the convention sibling PR #837 round-2 adopted (`REPLACE_WITH_MODEL_ID`).
- **Provider-distinct placeholders** (Minor): codex and gemini sections previously carried byte-identical placeholders. Each placeholder now embeds its provider name (`REPLACE_WITH_CODEX_*`, `REPLACE_WITH_GEMINI_*`), and the adjacent instruction now reads per-provider ("Codex placeholders take a Codex model id, Gemini placeholders take a Gemini model id").

## North Star alignment
Primarily Pillar 4 (works for everyone / universality): hardcoding provider model ids in a shared reference example ties it to one moment's vendor catalog and silently goes stale for every operator regardless of which provider they use. Neutralizing to shape-illustrative, provider-distinct, shell-safe placeholders keeps the example correct and portable indefinitely rather than requiring a future refresh cycle - no pillar regressed (file remains valid, structurally-illustrative yaml; not read at runtime by anything).

## Doc-sync
Doc-sync: triggered (reality-asserting change to a public reference example) -> grepped `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` for the stale ids (gpt-4o-mini, gpt-4o, o3, gemini-2.0-*, gemini-ultra-2) and the old placeholder forms (`cheap-fast-model-id`, `balanced-model-id`, `max-capability-model-id`) - zero hits, no updates needed there. Updated `docs/pruning-ledger.md` PL-20260825-4 entry (Status + Rationale + Disposition) in this PR per the ledger's own ACTIONED-transition rule.

## Test plan
- [x] `bash scripts/build-all.sh` - all 11 adapters built, zero drift (`git status --short` shows only the two intended source files)
- [x] Confirmed the yml is not glob-parsed or hardlinked by any adapter build script (only markdown references it by path)
- [x] Hooks JS suite (excluding the two wrap-lock files): 55 passed, 0 failed
- [x] `python3 -m pytest bin/tests/ -q`: 2075 passed, 25 subtests passed
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` - valid YAML post-edit (round 2 placeholders parse cleanly)
- [x] Em-dash check on added lines (round 2 diff) - none