### PR TITLE
docs(protocol): consolidate ds-wrap duplicated normative blocks to wrap-context-format pointers (PL-20260826-5)

### DIFF
--- a/.claude/commands/ds-wrap.md
+++ b/.claude/commands/ds-wrap.md
@@ -131,15 +131,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -21042,16 +21042,6 @@
       "source_token": "/ds-wrap"
     },
     {
-      "expected_target": "hooks/stop-context.js",
-      "generated_token": "$AE_REPO_DIR/hooks/stop-context.js",
-      "kind": "operational",
-      "occurrence_hash": "1a633bfffa0a298262368a43fc22c479fa33a1ce39abd3c7afc17c2709fa3e61",
-      "resolution_mode": "validated-repository",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": "hooks/stop-context.js"
-    },
-    {
       "expected_target": ".agentic/tracking.md",
       "generated_token": "$AE_PROJECT_DIR/.agentic/tracking.md",
       "kind": "operational",
@@ -21066,16 +21056,6 @@
       "generated_token": "$wrap",
       "kind": "operational",
       "occurrence_hash": "1a96813329a400e8ac08dbbc7356ee2d71c4f3e563758ac0a84297b9dfe8a750",
-      "resolution_mode": "native-skill",
-      "scope": "dinostack-repository",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": "/ds-wrap"
-    },
-    {
-      "expected_target": "wrap",
-      "generated_token": "$wrap",
-      "kind": "operational",
-      "occurrence_hash": "1b0564233fc719f8d98decfdbe8be27910aae6615fc318a5c4fabe810f3a51a2",
       "resolution_mode": "native-skill",
       "scope": "dinostack-repository",
       "source": "content/commands/ds-wrap.md",
@@ -21260,6 +21240,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-wrap.md",
       "source_token": ".claude/<name>.md"
+    },
+    {
+      "expected_target": "content/references/wrap-context-format.md",
+      "generated_token": "$AE_REPO_DIR/content/references/wrap-context-format.md",
+      "kind": "operational",
+      "occurrence_hash": "255f78448ad9d4d529569ca4f1da7c54d54230536be2ef5b03026929f85e6d9a",
+      "resolution_mode": "validated-repository",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-wrap.md",
+      "source_token": "content/references/wrap-context-format.md"
     },
     {
       "expected_target": "content/commands/ds-init-project.md",
@@ -23112,16 +23102,6 @@
       "source_token": "/ds-wrap"
     },
     {
-      "expected_target": "wrap",
-      "generated_token": "$wrap",
-      "kind": "operational",
-      "occurrence_hash": "8ee0c672ef69ccdd29293da6ab5131c063f5639545cbd306e6c2f985fd2e8e05",
-      "resolution_mode": "native-skill",
-      "scope": "dinostack-repository",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": "/ds-wrap"
-    },
-    {
       "expected_target": ".agentic/compression-state.json",
       "generated_token": "$AE_PROJECT_DIR/.agentic/compression-state.json",
       "kind": "operational",
@@ -23220,6 +23200,16 @@
       "scope": "canonical-source",
       "source": "content/commands/ds-wrap.md",
       "source_token": "command"
+    },
+    {
+      "expected_target": ".agentic/wrap/deferred-activity.jsonl",
+      "generated_token": "$AE_PROJECT_DIR/.agentic/wrap/deferred-activity.jsonl",
+      "kind": "operational",
+      "occurrence_hash": "9658bc8b33c73227da54e9bbc298a30ff31d2160ad6df49b90d48e3f331a90c0",
+      "resolution_mode": "invoked-project-path",
+      "scope": "invoked-project",
+      "source": "content/commands/ds-wrap.md",
+      "source_token": ".agentic/wrap/deferred-activity.jsonl"
     },
     {
       "expected_target": "filesystem read",
@@ -23460,16 +23450,6 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-wrap.md",
       "source_token": ".agentic/wrap/lock"
-    },
-    {
-      "expected_target": ".agentic/wrap/deferred-activity.jsonl",
-      "generated_token": "$AE_PROJECT_DIR/.agentic/wrap/deferred-activity.jsonl",
-      "kind": "operational",
-      "occurrence_hash": "a7b120f828538e8b46c085ed4d735bbabea7316f16a17abcd6025291cf86ef5d",
-      "resolution_mode": "invoked-project-path",
-      "scope": "invoked-project",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": ".agentic/wrap/deferred-activity.jsonl"
     },
     {
       "expected_target": "hashed-source-occurrence",
@@ -24512,16 +24492,6 @@
       "source_token": ".claude/findings.md"
     },
     {
-      "expected_target": "wrap",
-      "generated_token": "$wrap",
-      "kind": "operational",
-      "occurrence_hash": "e4d26e44621d13c1ee670a9b229396f47a222aa4889013055044a0ace51d7374",
-      "resolution_mode": "native-skill",
-      "scope": "dinostack-repository",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": "/ds-wrap"
-    },
-    {
       "expected_target": "content/commands/ds-init-project.md",
       "generated_token": "manual workflow 'ds-init-project' via `$AE_REPO_DIR/bin/ds-codex-dispatch command ds-init-project`",
       "kind": "operational",
@@ -24780,6 +24750,16 @@
       "scope": "invoked-project",
       "source": "content/commands/ds-wrap.md",
       "source_token": ".agentic/compression-state.json"
+    },
+    {
+      "expected_target": "content/references/wrap-context-format.md",
+      "generated_token": "$AE_REPO_DIR/content/references/wrap-context-format.md",
+      "kind": "operational",
+      "occurrence_hash": "f1a1c490ad5782c4500e41e4c948795d0d6937d61b8b51f72c5451606f1fc52b",
+      "resolution_mode": "validated-repository",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-wrap.md",
+      "source_token": "content/references/wrap-context-format.md"
     },
     {
       "expected_target": "hooks/lib/enforcement_log.py",

--- a/.codex/skills/wrap/SKILL.md
+++ b/.codex/skills/wrap/SKILL.md
@@ -186,15 +186,9 @@ This section is the source of truth for the Claude-only deferred-wrap marker sch
 
 **2. `$AE_PROJECT_DIR/.agentic/wrap/last-wrap` (the wrap-recency sentinel).** This project-local sentinel is written only after a successful `$wrap` Part A write. Claude and OpenCode marker consumers use it for staging suppression. The current Codex Stop hook writes only `~/.codex/projects/[hash]/context.md` and does not consume this sentinel; migration is deferred to `context-writer-migration`.
 
-**3. `$AE_PROJECT_DIR/.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `$AE_PROJECT_DIR/.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `$AE_REPO_DIR/content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by $wrap
-
-This is what `$AE_REPO_DIR/hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `$wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by $wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `$AE_REPO_DIR/content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.cursor/commands/ds-wrap.md
+++ b/.cursor/commands/ds-wrap.md
@@ -124,15 +124,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.gemini/commands/ds-wrap.toml
+++ b/.gemini/commands/ds-wrap.toml
@@ -130,15 +130,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.github/prompts/ds-wrap.prompt.md
+++ b/.github/prompts/ds-wrap.prompt.md
@@ -127,15 +127,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -24222,15 +24222,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.openclaw/skills/ds-wrap/SKILL.md
+++ b/.openclaw/skills/ds-wrap/SKILL.md
@@ -129,15 +129,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/.opencode/commands/ds-wrap.md
+++ b/.opencode/commands/ds-wrap.md
@@ -128,15 +128,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/content/commands/ds-wrap.md
+++ b/content/commands/ds-wrap.md
@@ -124,15 +124,9 @@ This section is the single source of truth for the on-disk artifacts that drive 
 
 **2. `.agentic/wrap/last-wrap` (the wrap-recency sentinel).** A single line containing the `session_id` of the session whose `/ds-wrap` (sync or background enrichment) last successfully wrote `_wrap.md`. Atomic write. This sentinel fully replaces any header-date parsing - no site parses the `_wrap.md` header date to decide "was this session wrapped." Consumers: (a) the Stop hook's marker-staging suppression (do not stage a marker if the current `session_id` equals `last-wrap`), and (b) the OpenCode plugin's equivalent suppression. It is written ONLY after a successful Part A `_wrap.md` write - never staged early (writing it during Step 0a would suppress this very session's own recovery marker).
 
-**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** Spillover existed only because a held `wrap/lock` made a per-turn writer SKIP its `context.md` write; per-turn writers now write session-private shards and are never skipped, so nothing is deferred. The drain below is RETAINED so records written before that change are not orphaned, and it folds them into `_wrap.md`'s curated `## Recent Focus` region. Historical record schema, for readers of an existing file:
+**3. `.agentic/wrap/deferred-activity.jsonl` (the spillover log).** **No longer produced.** The historical record schema and the drain procedure are NORMATIVE in `content/references/wrap-context-format.md` §"Spillover-drain procedure" - not restated here.
 
-    {"schema_version": 1, "ts": "<ISO8601 UTC>", "session_id": "<uuid>", "recent_focus": ["<msg>"], "paths_referenced": ["<path>"], "uncommitted": ["<status code + path>"], "tools_used": ["<tool>"]}
-
-**Pinned header prefix (NORMATIVE).** Exactly one byte-exact prefix is the contract between writer and matcher:
-
-    # Session Context\n*Written by /ds-wrap
-
-This is what `hooks/stop-context.js` and `.opencode/plugins/session-context.ts` test via `startsWith`, and what every `/ds-wrap` Output-1 / merge write must emit as its first two lines. The on-disk header date is a UTC calendar date (`date -u +%Y-%m-%d`); the header STRING does NOT contain the "UTC" literal - it stays `*Written by /ds-wrap on YYYY-MM-DD. ...` exactly as the Output-1 template (Step 1) reads. The matcher only tests the pinned prefix (which stops before the date), so the date format and the absence of the "UTC" literal are both compatible. The Part A merge rule (the "(merged context)" header rewrite) appends after the date and is outside the pinned prefix - it stays. The rolling-session-label merge (Part A) is preserved unchanged.
+**Pinned header prefix (NORMATIVE).** NORMATIVE in `content/references/wrap-context-format.md` §"Pinned header prefix (NORMATIVE)" - the byte-exact prefix, the date-format caveat, and the matcher contract are not restated here.
 
 **Step 0a - Stage the deferred-wrap safety-net** (runs BEFORE Step 0).
 

--- a/docs/pruning-ledger.md
+++ b/docs/pruning-ledger.md
@@ -180,13 +180,13 @@ This file's path is resolved per-repo, not hardcoded: prefer a tracked `.agentic
 - Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/839
 
 ## PL-20260826-5
-- Status: RAISED
+- Status: ACTIONED
 - Source: ds-prune-harness run 2026-08-26 (docs/planning/harness-pruning-2026-08-26.md)
 - File(s): content/commands/ds-wrap.md (lines ~127-135, Deferred-enrichment data model section)
 - Signal(s): Signal 3 (verbatim duplication)
 - Confidence: MEDIUM
 - Rationale: ds-wrap.md carries verbatim copies of the pinned header prefix block and the spillover record schema whose declared single normative home is content/references/wrap-context-format.md ("Edit the algorithm here, not in either consumer"). Nothing depends on ds-wrap.md's copies. Approved: consolidate to pointers, keeping the pending-<session_id>.json marker schema that ds-wrap.md genuinely owns.
-- Disposition:
+- Disposition: https://github.com/Space-Dinosaurs/DinoStack/pull/842
 
 ## PL-20260826-6
 - Status: RAISED


### PR DESCRIPTION
## Summary

`content/commands/ds-wrap.md`'s "Deferred-enrichment data model" section carried verbatim copies of two blocks whose declared single normative home is `content/references/wrap-context-format.md` ("Edit the algorithm here, not in either consumer"):

- The historical `deferred-activity.jsonl` record schema (byte-identical `schema_version: 1` JSON line, present in both files).
- The "Pinned header prefix (NORMATIVE)" block, including the date-format caveat prose (near-verbatim between the two files, differing only in framing).

Both copies in `content/commands/ds-wrap.md` are replaced with one-line pointers to the reference's `§"Spillover-drain procedure"` and `§"Pinned header prefix (NORMATIVE)"` sections respectively. The `.agentic/wrap/pending-<session_id>.json` per-session marker schema is genuinely owned by ds-wrap.md - verified it does not appear anywhere in `wrap-context-format.md` (`grep` for `pending-<session_id>`, `claimed_kind`, `claimed_by` returns no matches) - so it is left untouched.

`content/references/wrap-context-format.md` itself was not touched at all (it is sha256-pinned end-to-end by `test-wrap-context-format-golden.js` from its rolling-session-label-merge NORMATIVE marker to EOF).

## North Star alignment

Advances **Pillar 8** (machinery only as complicated as the benefit requires): "Binding prose lives at exactly one canonical site with pointers to it; a verbatim copy is justified only when..." - this diff removes two verbatim copies that met none of Pillar 8's stated exceptions (not embedded in a spawn prompt, not public-facing docs for a different audience, and longer than a 1-2 sentence normative restatement). Also advances **Pillar 5** (guard agent context) by cutting ~74 net lines/bytes of duplicated prose an agent reading ds-wrap.md would otherwise load. No pillar cuts against this change - it is a pure text consolidation with no behavior change (both pinning tests, `test-wrap-context-format-golden.js` and `test-wrap-md-partA-parity.js`, pass unmodified).

## Verification

- Confirmed duplication before editing: the `deferred-activity.jsonl` schema line was byte-identical between the two files; the "Pinned header prefix" block was near-verbatim (same byte-exact prefix, same date-format caveat sentences).
- Confirmed `pending-<session_id>.json` marker schema is NOT present in `wrap-context-format.md` (kept in ds-wrap.md).
- `content/references/wrap-context-format.md` diff is empty (untouched).
- Full hooks JS suite (55 files, excludes the 2 quarantined into `wrap-lock-tests`): 0 failed.
- `test-wrap-context-format-golden.js`: 20 passed, 0 failed.
- `test-wrap-md-partA-parity.js`: 19 passed, 0 failed (confirms the whole-flow lock retention and no algorithm re-inlining).
- `python3 -m pytest bin/tests/ -q`: 2075 passed, 25 subtests passed.
- `bash scripts/build-all.sh`: all 11 adapters built; only ds-wrap.md-derived adapter artifacts changed plus the `.codex/skill-compatibility.yml` hunk is this PR&#x27;s own token movements (5 removed / 3 added occurrence records, all sourced to content/commands/ds-wrap.md) - round-1 Skeptic measured a fresh inventory regen at origin/main as byte-identical to the committed file, so there was no pre-existing drift; the earlier attribution here was wrong.
- Em-dash check on added lines: none.

Doc-sync: predicate not triggered (no reality-asserting change - pure internal prose consolidation with no behavior, count, path, or convention change; grepped docs/index.html, docs/slides/*.md, README.md, CONTRIBUTING.md, content/SKILL.md for restatements of the moved blocks - none found).

## Test plan

- [x] `bash scripts/build-all.sh` clean
- [x] Full hooks JS suite green (55/55)
- [x] `bin/tests/` pytest suite green (2075 passed)
- [x] Both prose-pinning tests for this surface pass unmodified

## Round-1 Skeptic resolution note
The Major was a false verification attestation in this body (the .codex/skill-compatibility.yml hunk was attributed to pre-existing origin/main drift; the Skeptic measured origin/main's committed inventory as byte-identical to a fresh regen, so the hunk is this PR's own - and was line-by-line verified correct). Corrected above; the shipped diff needed no change.

## Accepted debt (Skeptic Minors, non-blocking)
- The deleted ds-wrap.md sentence asserted a retired startsWith contract in hooks/stop-context.js - its deletion is a correctness gain; noting the "differing only in framing" claim was imprecise.
- wrap-context-format.md's §Pinned header prefix cites hooks/lib/context-rollup.js isWrapAuthored, a symbol that exists nowhere in the repo - pre-existing, sha256-pinned (golden regen needed), recorded as a next-run ledger candidate.
