### PR TITLE
fix(ci): remove zero-yield macOS runner leg, add concurrency and timeouts repo-wide

### DIFF
--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:
   check-adapter-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/agent-fragment-sync.yml
+++ b/.github/workflows/agent-fragment-sync.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:
   check-agent-fragment-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/bin-tests.yml
+++ b/.github/workflows/bin-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 # TIMEOUT POLICY (all three jobs below).

--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -3,6 +3,14 @@ on:
   schedule:
     - cron: '0 0 * * *'   # daily 00:00 UTC
   workflow_dispatch: {}
+# No cancel-in-progress: this job commits and pushes to main. Cancelling a
+# run mid-push (or mid-commit) could leave the working tree or the remote
+# branch in a half-updated state. The group still serializes overlapping
+# runs (a stray manual dispatch overlapping the daily schedule queues
+# instead of racing) without tearing one down while it writes.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,10 +14,23 @@ on:
 permissions:
   contents: read
 
+# Cancelling an in-progress PR run on a new push is the standard, safe case
+# (a superseded push makes the old analysis moot). Cancelling a push:main or
+# schedule run is riskier here: the analyze job's final step uploads SARIF
+# results to the code-scanning tab, and a cancelled mid-upload run could
+# leave that publish half-applied for the affected commit. The expression
+# below cancels only pull_request runs; push/schedule runs still share the
+# group (so an overlapping run queues instead of racing) but are never torn
+# down mid-publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codex-skill-budget.yml
+++ b/.github/workflows/codex-skill-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-codex-skill-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -29,11 +29,11 @@ jobs:
   # defect the ubuntu leg missed - its only two solo failures were
   # infrastructure flakes. The BSD-utils/older-bash concern it existed to
   # backstop was already engineered around in .codex/build.sh (routes the
-  # escape passes through python3; see that file around lines 428-436).
+  # escape passes through python3; see that file around lines 428-447).
   # Removed rather than demoted to a weekly cron.
   check-codex-skill-sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -5,17 +5,66 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Weekly on Sundays at 03:00 UTC - off-peak slot for the macOS-only
+    # backstop leg (see check-codex-skill-sync-macos below).
+    - cron: '0 3 * * 0'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  # Required PR/push status check (context: "check-codex-skill-sync", pinned
+  # in the `main` branch ruleset). Ubuntu-only - this job MUST NOT carry a
+  # strategy.matrix key. GitHub Actions appends " (<matrix value>)" to the
+  # reported check name for ANY job with a matrix block, even a single-value
+  # one - verified against a real public job (materialyzeai/maml's
+  # .github/workflows/lint.yml `build` job, `matrix: { python-version:
+  # [3.11] }`) whose actual run reported as "build (3.11)", not "build". A
+  # matrix here would make the required context unsatisfiable again.
   check-codex-skill-sync:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+      - name: Bootstrap ignored prompt runtime
+        run: python3 .codex/lib/prompt-wrappers.py build --repo .
+      - name: Check codex skill sync
+        run: bash scripts/check-codex-skill-sync.sh
+      - name: Run full Codex skill test suite
+        run: python3 scripts/test/test_codex_skills.py
+      - name: Run clean-clone mutation gate
+        run: python3 scripts/test/test_codex_skills.py --clean-clone
+      - name: Run public Codex build
+        run: bash .codex/build.sh
+      - name: Verify public build is clean
+        run: git diff --exit-code
+
+  # macOS-only backstop for the same bash/BSD-utils-sensitive steps. This
+  # repo has documented macOS-only bash 3.2 / BSD-utils defects that only a
+  # macOS runner catches (see root AGENTS.md), so coverage is kept, just off
+  # the billed-per-PR path: macos-latest runners bill at a 10x multiplier
+  # and this suite is the repo's slowest (~14 min wall clock on ubuntu), so
+  # running it on every PR and every push to main was costing ~140 billable
+  # minutes twice per merged PR. Never runs on pull_request or push (see the
+  # `if:` guard) - only a weekly cron or manual dispatch. Steps are
+  # byte-equivalent to the job above: same checkout, same setup-python 3.11,
+  # same pip install, same five run steps in the same order, including the
+  # --clean-clone mutation gate and the git diff --exit-code verification.
+  check-codex-skill-sync-macos:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # Weekly on Sundays at 03:00 UTC - off-peak slot for the macOS-only
-    # backstop leg (see check-codex-skill-sync-macos below).
-    - cron: '0 3 * * 0'
   workflow_dispatch: {}
 
 concurrency:
@@ -27,43 +23,16 @@ jobs:
   # .github/workflows/lint.yml `build` job, `matrix: { python-version:
   # [3.11] }`) whose actual run reported as "build (3.11)", not "build". A
   # matrix here would make the required context unsatisfiable again.
+  #
+  # No secondary-platform leg: across all 1,534 historical runs of this
+  # workflow, the (now-removed) non-Linux job never caught a cross-platform
+  # defect the ubuntu leg missed - its only two solo failures were
+  # infrastructure flakes. The BSD-utils/older-bash concern it existed to
+  # backstop was already engineered around in .codex/build.sh (routes the
+  # escape passes through python3; see that file around lines 428-436).
+  # Removed rather than demoted to a weekly cron.
   check-codex-skill-sync:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-      - run: pip install pyyaml
-      - name: Bootstrap ignored prompt runtime
-        run: python3 .codex/lib/prompt-wrappers.py build --repo .
-      - name: Check codex skill sync
-        run: bash scripts/check-codex-skill-sync.sh
-      - name: Run full Codex skill test suite
-        run: python3 scripts/test/test_codex_skills.py
-      - name: Run clean-clone mutation gate
-        run: python3 scripts/test/test_codex_skills.py --clean-clone
-      - name: Run public Codex build
-        run: bash .codex/build.sh
-      - name: Verify public build is clean
-        run: git diff --exit-code
-
-  # macOS-only backstop for the same bash/BSD-utils-sensitive steps. This
-  # repo has documented macOS-only bash 3.2 / BSD-utils defects that only a
-  # macOS runner catches (see root AGENTS.md), so coverage is kept, just off
-  # the billed-per-PR path: macos-latest runners bill at a 10x multiplier
-  # and this suite is the repo's slowest (~14 min wall clock on ubuntu), so
-  # running it on every PR and every push to main was costing ~140 billable
-  # minutes twice per merged PR. Never runs on pull_request or push (see the
-  # `if:` guard) - only a weekly cron or manual dispatch. Steps are
-  # byte-equivalent to the job above: same checkout, same setup-python 3.11,
-  # same pip install, same five run steps in the same order, including the
-  # --clean-clone mutation gate and the git diff --exit-code verification.
-  check-codex-skill-sync-macos:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -35,20 +35,42 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # Step-level timeouts below are per the bin-tests.yml TIMEOUT POLICY:
+      # job-level timeout-minutes is a BACKSTOP ONLY, not a substitute for
+      # bounding each step. actions/checkout and actions/setup-python are
+      # exempted (cache-backed GitHub-hosted actions; no stall observed on
+      # either), matching that same policy. Sizing for the rest is measured
+      # from 3 real CI runs (2026-08-27, runs
+      # 33116849013/33120085840/33122847127) via `gh api .../jobs` per-step
+      # timings, taken before the macOS leg was removed (irrelevant to the
+      # ubuntu leg's own timings). "Run full Codex skill test suite" measured
+      # 13m16s-20m3s across the 3 runs; 25 min gives ~25% headroom over the
+      # observed max. Small setup steps measured well under 15s each; 2 min
+      # is a generous multiple, not a tight fit. "Run clean-clone mutation
+      # gate" measured 31s-47s; 5 min is ~6x headroom. Timed step timeouts
+      # sum to 39 min, kept under the 45-min job timeout so each step's own
+      # bound - not the job-level backstop - is what actually fires on a hang.
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - run: pip install pyyaml
+        timeout-minutes: 2
       - name: Bootstrap ignored prompt runtime
         run: python3 .codex/lib/prompt-wrappers.py build --repo .
+        timeout-minutes: 2
       - name: Check codex skill sync
         run: bash scripts/check-codex-skill-sync.sh
+        timeout-minutes: 2
       - name: Run full Codex skill test suite
         run: python3 scripts/test/test_codex_skills.py
+        timeout-minutes: 25
       - name: Run clean-clone mutation gate
         run: python3 scripts/test/test_codex_skills.py --clean-clone
+        timeout-minutes: 5
       - name: Run public Codex build
         run: bash .codex/build.sh
+        timeout-minutes: 2
       - name: Verify public build is clean
         run: git diff --exit-code
+        timeout-minutes: 1

--- a/.github/workflows/command-arg-substitution.yml
+++ b/.github/workflows/command-arg-substitution.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-command-arg-substitution:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Run command arg-substitution gate

--- a/.github/workflows/command-file-budget.yml
+++ b/.github/workflows/command-file-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-command-file-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/copilot-skill-budget.yml
+++ b/.github/workflows/copilot-skill-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-copilot-skill-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -13,6 +17,7 @@ jobs:
   dco-check:
     name: DCO Signed-off-by check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Skip DCO for bot commits
         if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/gemini-skill-budget.yml
+++ b/.github/workflows/gemini-skill-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-gemini-skill-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -21,6 +25,10 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Full-history scan (fetch-depth: 0), no observed-duration figure to
+    # derive a tighter bound from - 15 min is a conservative ceiling well
+    # above a normal full-repo gitleaks run.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/hooks-tests.yml
+++ b/.github/workflows/hooks-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/kimi-skill-budget.yml
+++ b/.github/workflows/kimi-skill-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-kimi-skill-embed-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/methodology-drift.yml
+++ b/.github/workflows/methodology-drift.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-drift:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Run methodology drift check

--- a/.github/workflows/no-false-umbrella-claims.yml
+++ b/.github/workflows/no-false-umbrella-claims.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:
   check-no-false-umbrella-claims:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: Guard - no stale /ds-init-project Step 9 targeted-gitignore-block claims

--- a/.github/workflows/no-planning-docs.yml
+++ b/.github/workflows/no-planning-docs.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:
   check-no-planning-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: Guard - docs/planning must not be tracked

--- a/.github/workflows/pr-review-rigor.yml
+++ b/.github/workflows/pr-review-rigor.yml
@@ -11,12 +11,16 @@ name: pr-review-rigor
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read
 jobs:
   check-review-rigor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/pr-review-rigor.yml
+++ b/.github/workflows/pr-review-rigor.yml
@@ -1,9 +1,12 @@
 # Advisory check: large PRs should carry review-rigor evidence, and a PR should never
 # bundle commits that are the head of another still-open PR (a superseded/duplicate PR).
 #
-# This is advisory-only - it is NOT a merge blocker. It is never registered as a required
-# status check; it exists to surface a red-X signal for human reviewers to weigh, same as
-# vision-alignment-check.yml.
+# This is advisory-only - it is NOT a merge blocker. Verified against the live main
+# ruleset (repos/Space-Dinosaurs/DinoStack/rulesets/14778332, 16 required contexts,
+# 2026-08-28): "check-review-rigor" is NOT in that list, so this check is never
+# registered as a required status check, unlike vision-alignment-check.yml, whose
+# "check-vision-alignment" job IS required. It exists to surface a red-X signal for
+# human reviewers to weigh, not to gate the merge.
 #
 # Keep the label regex in sync with the "## Review rigor" section in
 # .github/PULL_REQUEST_TEMPLATE.md.

--- a/.github/workflows/resident-budget.yml
+++ b/.github/workflows/resident-budget.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check-resident-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Run resident budget check
@@ -19,6 +24,7 @@ jobs:
 
   check-skill-embed-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,15 @@ on:
     # Weekly on Saturdays at 01:30 UTC.
     - cron: '30 1 * * 6'
 
+# No cancel-in-progress: this job calls publish_results: true, which
+# publishes the analysis to the OpenSSF Scorecard API. Cancelling a run
+# mid-publish could leave a partial or inconsistent published result. The
+# group still serializes overlapping runs (a push landing during the weekly
+# schedule run queues instead of racing) without tearing one down mid-write.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -15,6 +24,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/slides-sync.yml
+++ b/.github/workflows/slides-sync.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/vision-alignment-check.yml
+++ b/.github/workflows/vision-alignment-check.yml
@@ -1,12 +1,16 @@
 name: vision-alignment-check
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read
 jobs:
   check-vision-alignment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/bin/tests/test_gate_provenance.sh
+++ b/bin/tests/test_gate_provenance.sh
@@ -267,7 +267,12 @@ _test_d4_extraction() {
   local wf="$REPO_DIR/.github/workflows/codex-skill-sync.yml"
   local diff_lineno job_start_line generator_cmds expected
 
-  diff_lineno="$(grep -n "git diff --exit-code" "$wf" | head -1 | cut -d: -f1)"
+  # Anchored to end-of-line so this only matches a genuinely BARE
+  # `git diff --exit-code` (no pathspec) - a plain substring grep would
+  # still match `git diff --exit-code -- .codex/` and silently certify a
+  # rewritten, no-longer-bare line as still satisfying D4's entry-point
+  # precondition (DS-182 round-3 Minor: bareness was unchecked here).
+  diff_lineno="$(grep -nE 'git diff --exit-code[[:space:]]*$' "$wf" | head -1 | cut -d: -f1)"
   if [[ -z "$diff_lineno" ]]; then
     _fail "codex-skill-sync.yml no longer contains a bare 'git diff --exit-code' assertion - re-verify D4's only real-repo entry point before trusting this test"
     return

--- a/bin/tests/test_gate_provenance.sh
+++ b/bin/tests/test_gate_provenance.sh
@@ -250,8 +250,10 @@ _test_d3_no_false_positive "scripts" "self-referential false positive (was: this
 # D4 is only actually ENTERED (its scratch-clone-and-execute step reached)
 # when D1 finds a whole-tree (no-pathspec) `git diff --exit-code` assertion
 # and no D1/D2/D3 rule matched the target first. The only such assertion in
-# this repo today is .github/workflows/codex-skill-sync.yml:36, and every
-# real target its preceding generator commands touch (all under .codex/) is
+# this repo today is in .github/workflows/codex-skill-sync.yml (its line
+# number is looked up at check time below, not hard-pinned - the workflow
+# gets edited often enough that a literal line number goes stale), and
+# every real target its preceding generator commands touch (all under .codex/) is
 # already caught by D1's earlier adapter-sync.yml pathspec, so D4 can never
 # be observed producing a real DERIVED verdict in this repo as it stands -
 # see scripts/gate-provenance.sh's own D4 comment block for why. What CAN
@@ -266,8 +268,8 @@ _test_d4_extraction() {
   local diff_lineno job_start_line generator_cmds expected
 
   diff_lineno="$(grep -n "git diff --exit-code" "$wf" | head -1 | cut -d: -f1)"
-  if [[ "$diff_lineno" != "36" ]]; then
-    _fail "codex-skill-sync.yml's bare git diff --exit-code moved off line 36 (now $diff_lineno) - re-verify D4's only real-repo entry point before trusting this test"
+  if [[ -z "$diff_lineno" ]]; then
+    _fail "codex-skill-sync.yml no longer contains a bare 'git diff --exit-code' assertion - re-verify D4's only real-repo entry point before trusting this test"
     return
   fi
 
@@ -292,7 +294,7 @@ _test_d4_extraction() {
     'bash .codex/build.sh')"
 
   if [[ "$generator_cmds" == "$expected" ]]; then
-    _pass "D4 extraction (fixed [[:space:]] regex) finds all 5 real generator commands preceding codex-skill-sync.yml:36's whole-tree diff assertion"
+    _pass "D4 extraction (fixed [[:space:]] regex) finds all 5 real generator commands preceding codex-skill-sync.yml:${diff_lineno}'s whole-tree diff assertion"
   else
     _fail "D4 extraction did not match the 5 expected commands. Got:
 $generator_cmds

--- a/scripts/gate-provenance.sh
+++ b/scripts/gate-provenance.sh
@@ -96,8 +96,10 @@
 # mutation check; see bin/tests/test_gate_provenance.sh's D4 extraction
 # test for the removed instance and why. Fixed to `[[:space:]]` and
 # confirmed against the real, live
-# .github/workflows/codex-skill-sync.yml:36 (the only bare, no-pathspec
-# `git diff --exit-code` in this repo, i.e. the only real trigger for D4)
+# .github/workflows/codex-skill-sync.yml (the only bare, no-pathspec
+# `git diff --exit-code` in this repo, i.e. the only real trigger for D4 -
+# its line number moves as the workflow is edited, so it is looked up at
+# check time rather than hard-pinned)
 # in bin/tests/test_gate_provenance.sh, which extracts and pins the exact
 # 5 real generator commands. Every path D1/D2/D3 do not resolve now
 # genuinely reaches D4's scratch-clone-and-execute step (measured: 6m42s

--- a/scripts/test/test_codex_skills.py
+++ b/scripts/test/test_codex_skills.py
@@ -2012,7 +2012,20 @@ class CodexSkillGenerationTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("python3 scripts/test/test_codex_skills.py --clean-clone", workflow)
-        self.assertIn("os: [ubuntu-latest, macos-latest]", workflow)
+        self.assertIn("runs-on: ubuntu-latest", workflow)
+        # No secondary-platform matrix leg: GitHub Actions appends
+        # " (<matrix value>)" to the reported check name for ANY job with a
+        # strategy.matrix key, even a single-value one - a matrix here would
+        # make the required context "check-codex-skill-sync" unsatisfiable.
+        # Strip comment lines first so illustrative prose mentioning
+        # "matrix:"/"strategy:" (e.g. a citation of another repo's job)
+        # cannot be mistaken for an actual YAML key.
+        code_lines = [
+            line for line in workflow.splitlines() if not line.strip().startswith("#")
+        ]
+        code_text = "\n".join(code_lines)
+        self.assertNotIn("strategy:", code_text)
+        self.assertNotIn("matrix:", code_text)
         self.assertIn("bash .codex/build.sh", workflow)
         self.assertIn("git diff --exit-code", workflow)
         precommit = (self.repo / "hooks/pre-commit").read_text(encoding="utf-8")

--- a/scripts/test/test_codex_skills.py
+++ b/scripts/test/test_codex_skills.py
@@ -2007,27 +2007,30 @@ class CodexSkillGenerationTests(unittest.TestCase):
 
     def test_ci_precommit_and_public_docs_cover_native_skill_surface(self) -> None:
         workflow = (self.repo / ".github/workflows/codex-skill-sync.yml").read_text(encoding="utf-8")
-        self.assertIn(
-            "run: python3 scripts/test/test_codex_skills.py\n",
-            workflow,
-        )
-        self.assertIn("python3 scripts/test/test_codex_skills.py --clean-clone", workflow)
-        self.assertIn("runs-on: ubuntu-latest", workflow)
-        # No secondary-platform matrix leg: GitHub Actions appends
-        # " (<matrix value>)" to the reported check name for ANY job with a
-        # strategy.matrix key, even a single-value one - a matrix here would
-        # make the required context "check-codex-skill-sync" unsatisfiable.
-        # Strip comment lines first so illustrative prose mentioning
-        # "matrix:"/"strategy:" (e.g. a citation of another repo's job)
-        # cannot be mistaken for an actual YAML key.
+        # Strip comment lines FIRST, before any assertion runs, so every
+        # assertion below that is meant to describe LIVE configuration reads
+        # `code_text` rather than the raw `workflow` text - a commented-out
+        # or illustrative line (e.g. "# runs-on: ubuntu-latest (was)") must
+        # never satisfy a check that a live key is actually set.
         code_lines = [
             line for line in workflow.splitlines() if not line.strip().startswith("#")
         ]
         code_text = "\n".join(code_lines)
+        self.assertIn(
+            "run: python3 scripts/test/test_codex_skills.py\n",
+            code_text,
+        )
+        self.assertIn("python3 scripts/test/test_codex_skills.py --clean-clone", code_text)
+        self.assertIn("\n  check-codex-skill-sync:\n", code_text)
+        self.assertIn("runs-on: ubuntu-latest", code_text)
+        # No secondary-platform matrix leg: GitHub Actions appends
+        # " (<matrix value>)" to the reported check name for ANY job with a
+        # strategy.matrix key, even a single-value one - a matrix here would
+        # make the required context "check-codex-skill-sync" unsatisfiable.
         self.assertNotIn("strategy:", code_text)
         self.assertNotIn("matrix:", code_text)
-        self.assertIn("bash .codex/build.sh", workflow)
-        self.assertIn("git diff --exit-code", workflow)
+        self.assertIn("bash .codex/build.sh", code_text)
+        self.assertIn("git diff --exit-code", code_text)
         precommit = (self.repo / "hooks/pre-commit").read_text(encoding="utf-8")
         self.assertIn('scripts/check-codex-skill-sync.sh"', precommit)
         self.assertIn('"$REPO_DIR/.codex/skills"', precommit)


### PR DESCRIPTION
## Result

Removes the GitHub Actions macOS runner leg that accounted for roughly $1,000 of spend, and closes the two structural gaps that let it run unbounded.

`.github/workflows/codex-skill-sync.yml` was the repo's sole macOS consumer. It ran a `[ubuntu-latest, macos-latest]` matrix on every `pull_request` event and every `push` to `main`, with no `paths:` filter, no `concurrency:` group, and no `timeout-minutes`. Across 1,534 historical runs the macOS leg never caught a cross-platform defect the ubuntu leg missed; its only two solo failures were infrastructure flakes (an Actions `Internal Server Error` and a transient `OSError: [Errno 5]` in `os.fsync`). The bash-3.2 slow path that would have justified it was already engineered around in `.codex/build.sh` before the matrix was added.

Changes:

- macOS job deleted. The surviving `check-codex-skill-sync` job is ubuntu-only and carries no `strategy:` key.
- `concurrency:` added to all 23 workflow files. `cancel-in-progress: true` for read-only checks; `false` for `changelog-publish` and `scorecard` (external publish side effects); `${{ github.event_name == 'pull_request' }}` for `codeql` so SARIF uploads are never torn down mid-write.
- `timeout-minutes` added to every job that lacked one, plus step-level timeouts on the surviving codex job per `bin-tests.yml`'s TIMEOUT POLICY (2/2/2/25/5/2/1, summing to 39 under the 45-minute job backstop), sized from three measured runs.
- Test assertions repinned to the new single-job reality and hardened: job id pinned, `runs-on` and matrix-absence now asserted against comment-stripped text rather than raw file text, and the `gate-provenance` bareness check anchored so `git diff --exit-code -- <path>` no longer satisfies it.

Incidental fix: `check-codex-skill-sync` is required in ruleset 14778332 as a bare context string, but a matrixed job reports `check-codex-skill-sync (ubuntu-latest)`. Removing the matrix makes that required check satisfiable, which measured run history indicates it has not been since the matrix landed.

## Verification

Local runs at the final commit:

- `bash bin/tests/test_gate_provenance.sh` -> 35 passed, 0 failed
- `python3 scripts/test/test_codex_skills.py` -> 110 tests, OK; `--clean-clone` -> OK
- `bin-sh-tests` glob over `bin/tests/test_*.sh` -> 66 files, 0 failures
- `pytest bin/tests/` -> 2103 passed, 25 subtests passed
- `hooks-js-tests` loop, quarantine set re-derived from the `case` arms in `hooks-tests.yml` -> 55 files, 0 failures
- `wrap-lock-tests` (the 2 quarantined files) -> 80 and 33 passed, 0 failed
- `bin/tests/test_ci_step_timeouts.py` -> 3 passed
- YAML parse on all 23 workflow files -> OK

Every new or changed assertion was mutation-tested: a commented-out `runs-on` with a live `macos-latest`, a job rename, a non-bare `git diff --exit-code`, and an inserted matrix each redden the relevant check.

Two Skeptic rounds. Round 1 found 2 Criticals, both proven by execution: the required check failed on its own change (a test asserted the deleted matrix string), and `bin-sh-tests` failed on a hard-pinned line number. Round 2 found 1 Major, also demonstrated: an assertion reading raw file text instead of stripped text gave a false pass. All resolved.

## Ticket

none

## North Star alignment

**Serves:**

- Shorten wall-clock time, and keep machinery only as complicated as the benefit requires: the macOS leg had a measured zero catch rate across 1,534 runs, so this is a deletion justified by measurement rather than by assumption.
- Prevent defects at the producing step: a job rename, a non-bare diff assertion, and a stale `runs-on` comment would each previously have passed every existing assertion. Each is now mechanically caught, and each fix was mutation-tested to confirm it reddens pre-fix.
- Guard operator attention: step-level timeouts turn an opaque 45-minute job-backstop kill into a diagnosable failure at the hung step.

**Cuts against:**

- Verifiable outcomes: removing the macOS leg is a real reduction in coverage. A Codex-adapter macOS-only regression would no longer be caught by this workflow at all. This is a deliberate trade against a measured-zero-yield leg, not the removal of an enforcement floor, but it is a trade.
- The `gate-provenance` D4 path still cannot be exercised end-to-end without a multi-minute scratch clone (opt-in via `RUN_SLOW_D4_TEST=1`). That pre-existing limitation is unchanged here, not introduced.

Net: trades a measured-zero-yield test leg for CI cost and time, while strengthening every assertion the review showed could pass on defeated config.

## AI assistance

Investigated, implemented, and reviewed with Claude Code across investigator, engineer, and skeptic subagents. Two adversarial review rounds; 3 Criticals and 1 Major found and resolved before merge. Human operator directed the macOS deletion decision.
