### PR TITLE
fix(bin): retry _pr_state across configured gh accounts (DS-217)

### DIFF
--- a/bin/ds-cleanup-worktrees
+++ b/bin/ds-cleanup-worktrees
@@ -324,10 +324,17 @@ Public API (CLI):
                           operator-settable AGGREGATE per-repo ceiling, and
                           that aggregate cap has no replacement here - a repo
                           with N worktree entries is bounded only at
-                          `_NETWORK_TIMEOUT_SECONDS` times (up to 2 network
-                          calls per entry, plus 1 per repo for `gh auth
-                          status`), with no overall per-repo ceiling -
-                          verified against the code, not merely asserted.
+                          `_NETWORK_TIMEOUT_SECONDS` times a per-entry call
+                          count that is now WORST-CASE 2 + 2*M on the first
+                          entry that reaches a failed `gh pr list` (M = the
+                          count of OTHER, non-active, configured `gh`
+                          accounts - DS-217's multi-account retry; see
+                          `_pr_state`'s own docstring for the full per-path
+                          derivation), 1 on a succeeding entry, and 0 on any
+                          later entry in the same repo once that repo's
+                          retry outcome is cached - with no overall
+                          per-repo ceiling. Re-verified against the code as
+                          of the DS-217 retry-loop fix, not merely asserted.
   root ...                Positional root directories (requires
                           `--multi-repo`; see that flag's description
                           above for the full scan/dedup/config-fallback
@@ -728,7 +735,16 @@ independent, additive protections.
 Upstream deps: Python 3 stdlib only (argparse, fnmatch, json, os, re, shutil,
                subprocess, sys, time, pathlib, collections, typing). `git`
                (CLI) and, unless --no-gh, `gh` (CLI, for the PR-state leg -
-               degrades gracefully when absent or unauthenticated). `du`
+               degrades gracefully when absent or unauthenticated). DS-217's
+               multi-account retry additionally depends on `gh auth status
+               --json hosts` (account/host enumeration) and `gh auth token
+               --user <login>` (per-account credential fetch) - both
+               degrade to "no retry attempted" on any failure (see
+               `_gh_configured_accounts` / `_gh_token_for_login`), and both
+               imply a dependency on `gh`'s own local credential store
+               (`gh auth login` state) being populated for more than the
+               active account when the retry path is to do anything useful.
+               `du`
                (CLI, `--measure-size` ONLY - round-2 Skeptic Major 3 fix:
                `_measure_size_kb` shells out to `du -sk <path>`; OPT-IN, so
                its absence/failure never affects any other code path - see
@@ -788,7 +804,12 @@ Downstream consumers: content/commands/ds-cleanup-worktrees.md (Step 2
                       config-file fallback, dedup, per-repo base
                       isolation, report read-only guarantee, fast/deep
                       tier cost and ranking, usage errors, mixed-repo
-                      exit codes - same auto-collection).
+                      exit codes - same auto-collection) and
+                      bin/tests/test_ds217_gh_multi_account.py (DS-217's
+                      `_pr_state` multi-account retry: second-login
+                      resolution, active-account skip, positive/negative
+                      per-repo caching, revoked-account filtering,
+                      single-account cost parity - same auto-collection).
 
 Failure modes: SINGLE-REPO MODE (`--multi-repo` absent) - exits 0 on
                success INCLUDING partial degradation (gh
@@ -889,8 +910,14 @@ Performance: (DS-196 correction: full mode IS now the mode an automatic call
              filesystem-bound, not a subprocess, but scales with the
              worktree's own file count), `_compute_origin_reachable`'s `git
              branch -r --contains` (DS-196, local-only, no network), and
-             (unless --no-gh) `git ls-remote` + one `gh pr list`, plus a
-             final `git worktree prune`. Not designed for repositories
+             (unless --no-gh) `git ls-remote` plus `_pr_state`'s `gh pr
+             list` query - 1 call on that entry's success path or when a
+             prior entry in the same repo already cached this repo's
+             winning env/all-failed result, up to 2 + 2*M calls (M = the
+             count of OTHER configured `gh` accounts, DS-217's multi-
+             account retry) on the FIRST entry in a repo whose default
+             query fails - plus a final `git worktree prune`. Not
+             designed for repositories
              with very large worktree counts; v1's full-mode `--no-gh`
              run measured 14.94s across ~31 entries on the live 38-
              worktree checkout (the network round-trip `--no-gh` failed to
@@ -1674,19 +1701,60 @@ def _gh_available(repo: str, no_gh: bool) -> bool:
 #: is not a URL-parsing defect - passing explicit `-R owner/repo` does
 #: not fix it either.
 #:
-#: `_gh_configured_logins` / `_gh_token_for_login` below implement a
-#: bounded retry: `_pr_state` tries the default (no override) call first
-#: - so the common single-account case is byte-for-byte unchanged in
-#: behavior and cost - and only on failure walks the OTHER configured
-#: logins' tokens via `GH_TOKEN`, short-circuiting on first success. The
-#: winning env (or the discovered fact that every login failed) is cached
-#: per real repo path so later branches in the same repo, and repeat runs
-#: against a repo none of the configured accounts can see, cost zero
-#: additional `gh` calls - see the two module-level caches below
-#: `_pr_state`'s docstring. A revoked/expired account (`state` other than
-#: `"success"`) is filtered out of the candidate list entirely, since
-#: probing it would cost a full `_NETWORK_TIMEOUT_SECONDS` timeout for a
-#: token that can never succeed.
+#: `_gh_configured_accounts` / `_gh_configured_logins` / `_gh_token_for_
+#: login` below implement a bounded retry: `_pr_state` tries the default
+#: (no override) call first - the SUCCESS path is byte-for-byte unchanged
+#: in behavior and cost from pre-DS-217 (exactly one `gh` call) - and only
+#: on failure walks the OTHER (non-active) configured logins' tokens via
+#: `GH_TOKEN`, short-circuiting on first success. "OTHER" is load-bearing:
+#: the default call already queried under the ACTIVE account's token, so
+#: the retry loop explicitly skips the active login rather than re-
+#: probing it - `_gh_configured_accounts` returns `(login, host, active)`
+#: tuples from the SAME `gh auth status --json hosts` payload the retry
+#: loop already needs, so identifying "which login is active" costs no
+#: additional `gh` call. The FAILURE path therefore costs, for a repo with
+#: exactly one configured (active) account, exactly 2 `gh` calls (the
+#: failed default `gh pr list` plus the one `gh auth status --json hosts`
+#: call needed to confirm there are no other accounts to try) - one more
+#: than pre-DS-217's single failed attempt, since determining "no other
+#: accounts configured" itself requires a call. For a repo with N OTHER
+#: (non-active) configured accounts, the failure path costs up to 2 + 2N
+#: calls in the worst case (every candidate fails): 1 default attempt + 1
+#: auth-status call + 2 calls (token fetch, retry `pr list`) per
+#: candidate, short-circuiting on first success. The winning env (or the
+#: discovered fact that every login failed) is cached per real repo path
+#: so later branches in the same repo, and repeat runs against a repo
+#: none of the configured accounts can see, cost zero additional `gh`
+#: calls - see the two module-level caches below `_pr_state`'s docstring.
+#: A revoked/expired account (`state` other than `"success"`) is filtered
+#: out of the candidate list entirely, since probing it would cost a full
+#: `_NETWORK_TIMEOUT_SECONDS` timeout for a token that can never succeed.
+#:
+#: KNOWN LIMITATION (out of this unit's scope - do not fix here): the
+#: retry loop is only ever reached when `_pr_state_query`'s default call
+#: fails, which itself is only reached when `_gh_available` already
+#: returned True. `_gh_available` gates on plain `gh auth status`, which
+#: exits nonzero when ANY configured account (active or not) has an auth
+#: problem - so on a machine with one healthy active account and one
+#: revoked inactive account, `gh_ok` is False and `_pr_state` is never
+#: called at all, making this retry machinery unreachable on that
+#: machine. Widening `_gh_available`'s gate is a real fix but changes the
+#: blast radius of a PR that is otherwise cleared on safety; left alone
+#: pending a separate ticket.
+#:
+#: HOST LIMITATION: `_gh_token_for_login` calls `gh auth token --user
+#: <login>` with NO `--hostname` - on a multi-host `gh` config (e.g. a
+#: github.com login plus a GitHub Enterprise login sharing the same
+#: username) this always fetches the DEFAULT host's token, never an
+#: enterprise host's, for a login that exists on both. `_gh_configured_
+#: accounts` dedups by `(host, login)` rather than `login` alone so a
+#: same-named login on two hosts is not silently collapsed into one
+#: candidate, but the token lookup itself remains host-blind - accepted
+#: as a documented limitation rather than fixed, since making the lookup
+#: genuinely host-aware would also require making the `GH_TOKEN`-override
+#: env itself host-aware (`gh` reads `GH_ENTERPRISE_TOKEN`/`GITHUB_
+#: ENTERPRISE_TOKEN` for non-default hosts, not `GH_TOKEN`), which is
+#: materially more surface than this fix warrants.
 #:
 #: SECURITY: `_gh_token_for_login` returns a live, usable GitHub
 #: credential. It is passed ONLY as a subprocess `env` value (via `_run`'s
@@ -1694,12 +1762,23 @@ def _gh_available(repo: str, no_gh: bool) -> bool:
 #: destined for output, a NOTE, `--explain` output, or an exception
 #: message - grep this module's own diff before trusting that discipline
 #: on any future edit here.
-def _gh_configured_logins() -> List[str]:
-    """Returns every `login` configured in `gh auth status --json hosts`,
-    across all hosts, ACTIVE ACCOUNT FIRST, deduplicated, in otherwise
-    stable (host-then-list) order. Filters to entries whose `state` field
-    is exactly `"success"` - a revoked/expired/pending account is dropped
+def _gh_configured_accounts() -> List[Tuple[str, str, bool]]:
+    """Returns every `(login, host, is_active)` configured in `gh auth
+    status --json hosts`, across all hosts, ACTIVE ACCOUNTS FIRST,
+    deduplicated by `(host, login)` (NOT by `login` alone - a same-named
+    login configured on two different hosts, e.g. github.com plus a
+    GitHub Enterprise host, is two distinct candidates, not one - see the
+    HOST LIMITATION note in the DS-217 block above), in otherwise stable
+    (host-then-list) order. Filters to entries whose `state` field is
+    exactly `"success"` - a revoked/expired/pending account is dropped
     from the list entirely (see the DS-217 block above for why).
+
+    This is the SHARED parse of the one `gh auth status --json hosts`
+    call: both `_gh_configured_logins` (login-only view) and `_pr_state`'s
+    retry loop (which also needs to know WHICH login is active, so it can
+    skip re-probing the account the default call already used) are built
+    on top of this single function - neither makes its own `gh auth
+    status` call.
 
     Returns `[]` on ANY parse or exec failure (missing `gh` binary,
     nonzero exit, unparseable JSON, unexpected shape) - NEVER raises.
@@ -1721,10 +1800,10 @@ def _gh_configured_logins() -> List[str]:
     hosts = payload.get("hosts")
     if not isinstance(hosts, dict):
         return []
-    active: List[str] = []
-    inactive: List[str] = []
+    active: List[Tuple[str, str, bool]] = []
+    inactive: List[Tuple[str, str, bool]] = []
     seen = set()
-    for _host, accounts in hosts.items():
+    for host, accounts in hosts.items():
         if not isinstance(accounts, list):
             continue
         for account in accounts:
@@ -1733,18 +1812,35 @@ def _gh_configured_logins() -> List[str]:
             if account.get("state") != "success":
                 continue
             login = account.get("login")
-            if not login or not isinstance(login, str) or login in seen:
+            if not login or not isinstance(login, str):
                 continue
-            seen.add(login)
-            (active if account.get("active") else inactive).append(login)
+            dedup_key = (host, login)
+            if dedup_key in seen:
+                continue
+            seen.add(dedup_key)
+            is_active = bool(account.get("active"))
+            (active if is_active else inactive).append((login, host, is_active))
     return active + inactive
+
+
+def _gh_configured_logins() -> List[str]:
+    """Login-only view of `_gh_configured_accounts` (active-first,
+    deduplicated) - kept for any caller that only needs the ordered login
+    list, not the host/active detail. See `_gh_configured_accounts` for
+    the full contract (including the `[]`-on-any-failure guarantee).
+    """
+    return [login for login, _host, _active in _gh_configured_accounts()]
 
 
 def _gh_token_for_login(login: str) -> Optional[str]:
     """`gh auth token --user <login>` for the given login, or `None` on
     ANY failure (missing binary, nonzero exit, empty output) - NEVER
     raises. The returned value is a live credential - see the SECURITY
-    note above `_gh_configured_logins`.
+    note above `_gh_configured_accounts`.
+
+    HOST-BLIND (no `--hostname` passed): see the HOST LIMITATION note in
+    the DS-217 block above `_gh_configured_accounts` for why this is a
+    documented, deliberate limitation rather than a fix candidate here.
     """
     try:
         proc = _run(["gh", "auth", "token", "--user", login], timeout=_NETWORK_TIMEOUT_SECONDS)
@@ -1761,7 +1857,10 @@ def _gh_token_for_login(login: str) -> Optional[str]:
 #: override, inherited environment) call already succeeded for this repo
 #: and no retry is needed; a dict means that `GH_TOKEN` override is the
 #: one that worked. Absence of a key means "not yet resolved for this
-#: repo" - distinct from a resolved-to-`None` entry.
+#: repo" - distinct from a resolved-to-`None` entry. Probe with `in` /
+#: `[]`, never `.get(key, <sentinel>)` - the annotation below is honest
+#: (every VALUE stored is `Optional[Dict[str, str]]`) only as long as no
+#: string sentinel is ever compared against it.
 _PR_STATE_ENV_CACHE: Dict[str, Optional[Dict[str, str]]] = {}
 
 #: Set of repos (same `os.path.realpath` keying) where the default call
@@ -1771,6 +1870,20 @@ _PR_STATE_ENV_CACHE: Dict[str, Optional[Dict[str, str]]] = {}
 #: `_NETWORK_TIMEOUT_SECONDS` times the configured-account count, times
 #: every remaining worktree entry in that repo, on a machine with several
 #: inaccessible repos and ~110 entries, absent this cache).
+#:
+#: DISCLOSURE: this cache cannot distinguish "every configured account's
+#: token is genuinely unable to see this repo" from "a transient network
+#: blip or rate limit hit on the FIRST entry this repo was ever resolved
+#: for". Both land a repo in this set for the rest of the process, and a
+#: repo added for the transient reason then makes zero further `gh` calls
+#: (including for branches that a retry moments later would have
+#: resolved fine) until the process restarts. This is intentionally
+#: fail-SAFE, never fail-DANGEROUS: a repo stuck here reports
+#: `("not_checked", True)` (an honest "could not confirm" signal that
+#: keeps every caller's SKIP_PR_QUERY_ERROR / SKIP-not-REMOVE handling
+#: engaged), never a fabricated `"NONE"`/absence result - so the failure
+#: mode this cache cannot rule out costs an over-cautious SKIP for the
+#: rest of the run, not an unsafe REMOVE.
 _PR_STATE_ALL_FAILED_REPOS: set = set()
 
 
@@ -1816,30 +1929,54 @@ def _pr_state(repo: str, branch: str) -> Tuple[str, bool]:
     single-attempt query (one `gh pr list` call under a given env
     override) lives in `_pr_state_query` below; this function tries the
     default (inherited-environment) call first, then - only on failure -
-    each OTHER configured `gh` login's token via `GH_TOKEN`, short-
-    circuiting on first success, and caches both the winning env and an
-    all-failed result per repo (see `_PR_STATE_ENV_CACHE` /
-    `_PR_STATE_ALL_FAILED_REPOS` above `_gh_configured_logins`). A repo
-    with exactly one configured account (the common case) costs exactly
-    one `gh` call per branch, identical to pre-DS-217 behavior.
+    each OTHER (non-active) configured `gh` login's token via `GH_TOKEN`,
+    short-circuiting on first success, and caches both the winning env
+    and an all-failed result per repo (see `_PR_STATE_ENV_CACHE` /
+    `_PR_STATE_ALL_FAILED_REPOS` above `_gh_configured_accounts`). The
+    active login is identified from the SAME `_gh_configured_accounts`
+    call the retry loop already needs (no second `gh auth status` call)
+    and is explicitly skipped, since the default call above already
+    queried under it.
+
+    Measured `gh`-call cost per branch (see the DS-217 rationale block
+    above `_gh_configured_accounts` for the full derivation):
+      - SUCCESS path (default call succeeds): exactly 1 `gh` call,
+        byte-for-byte identical to pre-DS-217 behavior, for ANY number of
+        configured accounts.
+      - FAILURE path, exactly one configured (active) account: exactly 2
+        `gh` calls (the failed default `gh pr list`, plus the one `gh
+        auth status --json hosts` call needed to confirm there is no
+        other account to retry) - one more than pre-DS-217's single
+        failed attempt.
+      - FAILURE path, N OTHER (non-active) configured accounts: up to
+        2 + 2N calls in the worst case (every candidate also fails),
+        short-circuiting on first success.
+    Both cache above cap this cost at the FIRST resolution per repo -
+    every later branch in the same repo costs at most 1 additional call.
     """
     repo_key = os.path.realpath(repo)
 
     if repo_key in _PR_STATE_ALL_FAILED_REPOS:
         return "not_checked", True
 
-    cached_env = _PR_STATE_ENV_CACHE.get(repo_key, "unresolved")
-    if cached_env != "unresolved":
-        return _pr_state_query(repo, branch, cached_env)
+    if repo_key in _PR_STATE_ENV_CACHE:
+        return _pr_state_query(repo, branch, _PR_STATE_ENV_CACHE[repo_key])
 
     # First resolution for this repo: try the default call (no override)
-    # first, so the single-account case matches pre-DS-217 cost exactly.
+    # first, so the single-account SUCCESS case matches pre-DS-217 cost
+    # exactly (see the cost breakdown in this function's own docstring).
     state, errored = _pr_state_query(repo, branch, None)
     if not errored:
         _PR_STATE_ENV_CACHE[repo_key] = None
         return state, errored
 
-    for login in _gh_configured_logins():
+    for login, _host, is_active in _gh_configured_accounts():
+        if is_active:
+            # The default (no-override) call above already queried under
+            # the active account's own token - re-probing it here would
+            # cost an extra `gh auth token` + `gh pr list` round trip for
+            # an attempt whose outcome is already known.
+            continue
         token = _gh_token_for_login(login)
         if not token:
             continue

--- a/bin/ds-cleanup-worktrees
+++ b/bin/ds-cleanup-worktrees
@@ -1068,10 +1068,22 @@ _ARCHIVABLE_UNPROVEN_DISPOSITIONS = frozenset(
 
 
 def _run(
-    args: List[str], cwd: Optional[str] = None, timeout: Optional[float] = None
+    args: List[str],
+    cwd: Optional[str] = None,
+    timeout: Optional[float] = None,
+    env: Optional[Dict[str, str]] = None,
 ) -> subprocess.CompletedProcess:
+    """`env=None` (the default) inherits the current process environment,
+    identical to every pre-existing call site - this parameter is
+    additive-only. `env={...}` REPLACES the subprocess environment
+    entirely (Python's own `subprocess.run` semantics), so a caller that
+    wants to add/override on top of the inherited environment (e.g.
+    `_pr_state`'s `GH_TOKEN` retry) must build the dict as
+    `{**os.environ, "GH_TOKEN": token}` itself - `_run` performs no
+    merging.
+    """
     try:
-        return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+        return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout, env=env)
     except subprocess.TimeoutExpired:
         # Synthetic failure result - callers treat any nonzero returncode as
         # "could not determine", never as proof of anything. rc=124 mirrors
@@ -1643,6 +1655,125 @@ def _gh_available(repo: str, no_gh: bool) -> bool:
     return proc.returncode == 0
 
 
+#: DS-217 OPERATOR DECISION (2026-08-27): `gh` on this machine (and, per
+#: `AGENTS.md`'s universality pillar, potentially any operator's machine)
+#: can be logged into MULTIPLE GitHub accounts simultaneously
+#: (`gh auth status --json hosts` lists one entry per account). The
+#: ACTIVE account's token is scoped to only the repos it can see, and
+#: GitHub's GraphQL layer returns the IDENTICAL generic "Could not
+#: resolve to a Repository" error for "the repo does not exist" and "the
+#: repo exists but this token cannot see it" - so `_pr_state`'s
+#: pre-existing single-account query was silently misreporting every
+#: repo owned by a DIFFERENT logged-in account as a query failure
+#: (`SKIP_PR_QUERY_ERROR`), even though a second locally-configured
+#: account's token could answer the query fine. Measured on this machine
+#: across three remote shapes - an SSH remote alias, and two plain-HTTPS
+#: remotes with no alias - all of which failed identically under the
+#: active account; `GH_TOKEN=$(gh auth token --user <other-login>) gh pr
+#: list ...` against the SSH-alias repo succeeded, returning `[]`. This
+#: is not a URL-parsing defect - passing explicit `-R owner/repo` does
+#: not fix it either.
+#:
+#: `_gh_configured_logins` / `_gh_token_for_login` below implement a
+#: bounded retry: `_pr_state` tries the default (no override) call first
+#: - so the common single-account case is byte-for-byte unchanged in
+#: behavior and cost - and only on failure walks the OTHER configured
+#: logins' tokens via `GH_TOKEN`, short-circuiting on first success. The
+#: winning env (or the discovered fact that every login failed) is cached
+#: per real repo path so later branches in the same repo, and repeat runs
+#: against a repo none of the configured accounts can see, cost zero
+#: additional `gh` calls - see the two module-level caches below
+#: `_pr_state`'s docstring. A revoked/expired account (`state` other than
+#: `"success"`) is filtered out of the candidate list entirely, since
+#: probing it would cost a full `_NETWORK_TIMEOUT_SECONDS` timeout for a
+#: token that can never succeed.
+#:
+#: SECURITY: `_gh_token_for_login` returns a live, usable GitHub
+#: credential. It is passed ONLY as a subprocess `env` value (via `_run`'s
+#: `env=` parameter) and MUST NEVER be written to a `print`, an f-string
+#: destined for output, a NOTE, `--explain` output, or an exception
+#: message - grep this module's own diff before trusting that discipline
+#: on any future edit here.
+def _gh_configured_logins() -> List[str]:
+    """Returns every `login` configured in `gh auth status --json hosts`,
+    across all hosts, ACTIVE ACCOUNT FIRST, deduplicated, in otherwise
+    stable (host-then-list) order. Filters to entries whose `state` field
+    is exactly `"success"` - a revoked/expired/pending account is dropped
+    from the list entirely (see the DS-217 block above for why).
+
+    Returns `[]` on ANY parse or exec failure (missing `gh` binary,
+    nonzero exit, unparseable JSON, unexpected shape) - NEVER raises.
+    `_pr_state`'s retry loop treats an empty list as "no additional
+    accounts to try", not as an error in its own right.
+    """
+    try:
+        proc = _run(["gh", "auth", "status", "--json", "hosts"], timeout=_NETWORK_TIMEOUT_SECONDS)
+    except OSError:
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    hosts = payload.get("hosts")
+    if not isinstance(hosts, dict):
+        return []
+    active: List[str] = []
+    inactive: List[str] = []
+    seen = set()
+    for _host, accounts in hosts.items():
+        if not isinstance(accounts, list):
+            continue
+        for account in accounts:
+            if not isinstance(account, dict):
+                continue
+            if account.get("state") != "success":
+                continue
+            login = account.get("login")
+            if not login or not isinstance(login, str) or login in seen:
+                continue
+            seen.add(login)
+            (active if account.get("active") else inactive).append(login)
+    return active + inactive
+
+
+def _gh_token_for_login(login: str) -> Optional[str]:
+    """`gh auth token --user <login>` for the given login, or `None` on
+    ANY failure (missing binary, nonzero exit, empty output) - NEVER
+    raises. The returned value is a live credential - see the SECURITY
+    note above `_gh_configured_logins`.
+    """
+    try:
+        proc = _run(["gh", "auth", "token", "--user", login], timeout=_NETWORK_TIMEOUT_SECONDS)
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    token = proc.stdout.strip()
+    return token or None
+
+
+#: Per-repo (keyed by `os.path.realpath(repo)`) cache of the WINNING env
+#: override for `_pr_state` queries: `None` means the default (no
+#: override, inherited environment) call already succeeded for this repo
+#: and no retry is needed; a dict means that `GH_TOKEN` override is the
+#: one that worked. Absence of a key means "not yet resolved for this
+#: repo" - distinct from a resolved-to-`None` entry.
+_PR_STATE_ENV_CACHE: Dict[str, Optional[Dict[str, str]]] = {}
+
+#: Set of repos (same `os.path.realpath` keying) where the default call
+#: AND every configured account's token all failed to answer the query.
+#: A repo in this set makes ZERO further `gh` calls from `_pr_state` -
+#: see that function's docstring for the cost rationale (up to
+#: `_NETWORK_TIMEOUT_SECONDS` times the configured-account count, times
+#: every remaining worktree entry in that repo, on a machine with several
+#: inaccessible repos and ~110 entries, absent this cache).
+_PR_STATE_ALL_FAILED_REPOS: set = set()
+
+
 def _pr_state(repo: str, branch: str) -> Tuple[str, bool]:
     """Returns `(state, query_errored)`.
 
@@ -1680,11 +1811,62 @@ def _pr_state(repo: str, branch: str) -> Tuple[str, bool]:
     order spanning OPEN/MERGED/CLOSED). The fix below fetches every row
     (no `--limit`) and explicitly prefers OPEN over recency - see the
     selection logic itself.
+
+    DS-217: this is the multi-account-retry ORCHESTRATOR. The actual
+    single-attempt query (one `gh pr list` call under a given env
+    override) lives in `_pr_state_query` below; this function tries the
+    default (inherited-environment) call first, then - only on failure -
+    each OTHER configured `gh` login's token via `GH_TOKEN`, short-
+    circuiting on first success, and caches both the winning env and an
+    all-failed result per repo (see `_PR_STATE_ENV_CACHE` /
+    `_PR_STATE_ALL_FAILED_REPOS` above `_gh_configured_logins`). A repo
+    with exactly one configured account (the common case) costs exactly
+    one `gh` call per branch, identical to pre-DS-217 behavior.
+    """
+    repo_key = os.path.realpath(repo)
+
+    if repo_key in _PR_STATE_ALL_FAILED_REPOS:
+        return "not_checked", True
+
+    cached_env = _PR_STATE_ENV_CACHE.get(repo_key, "unresolved")
+    if cached_env != "unresolved":
+        return _pr_state_query(repo, branch, cached_env)
+
+    # First resolution for this repo: try the default call (no override)
+    # first, so the single-account case matches pre-DS-217 cost exactly.
+    state, errored = _pr_state_query(repo, branch, None)
+    if not errored:
+        _PR_STATE_ENV_CACHE[repo_key] = None
+        return state, errored
+
+    for login in _gh_configured_logins():
+        token = _gh_token_for_login(login)
+        if not token:
+            continue
+        override_env = {**os.environ, "GH_TOKEN": token}
+        state, errored = _pr_state_query(repo, branch, override_env)
+        if not errored:
+            _PR_STATE_ENV_CACHE[repo_key] = override_env
+            return state, errored
+
+    _PR_STATE_ALL_FAILED_REPOS.add(repo_key)
+    return "not_checked", True
+
+
+def _pr_state_query(repo: str, branch: str, env: Optional[Dict[str, str]]) -> Tuple[str, bool]:
+    """Single-attempt `gh pr list` query under the given environment
+    override (`None` inherits the current process environment unchanged -
+    see `_run`'s own env-passthrough docstring). Returns `(state,
+    query_errored)` using the exact vocabulary and OPEN-safety-override
+    selection logic documented on `_pr_state` above; extracted verbatim
+    from that function's pre-DS-217 body so the retry orchestration in
+    `_pr_state` can call it once per candidate env.
     """
     proc = _run(
         ["gh", "pr", "list", "--head", branch, "--state", "all", "--json", "number,state"],
         cwd=repo,
         timeout=_NETWORK_TIMEOUT_SECONDS,
+        env=env,
     )
     if proc.returncode != 0:
         return "not_checked", True

--- a/bin/ds-cleanup-worktrees
+++ b/bin/ds-cleanup-worktrees
@@ -330,11 +330,14 @@ Public API (CLI):
                           count of OTHER, non-active, configured `gh`
                           accounts - DS-217's multi-account retry; see
                           `_pr_state`'s own docstring for the full per-path
-                          derivation), 1 on a succeeding entry, and 0 on any
+                          derivation), 1 on a succeeding entry, and on any
                           later entry in the same repo once that repo's
-                          retry outcome is cached - with no overall
-                          per-repo ceiling. Re-verified against the code as
-                          of the DS-217 retry-loop fix, not merely asserted.
+                          retry outcome is cached: 1 call when the cached
+                          outcome is a winning env (a prior entry's retry
+                          found a working account), or 0 calls when the
+                          cached outcome is all-failed (every account
+                          already failed for a prior entry) - with no
+                          overall per-repo ceiling.
   root ...                Positional root directories (requires
                           `--multi-repo`; see that flag's description
                           above for the full scan/dedup/config-fallback
@@ -911,12 +914,14 @@ Performance: (DS-196 correction: full mode IS now the mode an automatic call
              worktree's own file count), `_compute_origin_reachable`'s `git
              branch -r --contains` (DS-196, local-only, no network), and
              (unless --no-gh) `git ls-remote` plus `_pr_state`'s `gh pr
-             list` query - 1 call on that entry's success path or when a
-             prior entry in the same repo already cached this repo's
-             winning env/all-failed result, up to 2 + 2*M calls (M = the
-             count of OTHER configured `gh` accounts, DS-217's multi-
-             account retry) on the FIRST entry in a repo whose default
-             query fails - plus a final `git worktree prune`. Not
+             list` query - 1 call on that entry's success path, or on a
+             later entry in the same repo once a prior entry already
+             cached a WINNING env for this repo; 0 calls on a later entry
+             once a prior entry already cached an ALL-FAILED result for
+             this repo; up to 2 + 2*M calls (M = the count of OTHER
+             configured `gh` accounts, DS-217's multi-account retry) on
+             the FIRST entry in a repo whose default query fails - plus a
+             final `git worktree prune`. Not
              designed for repositories
              with very large worktree counts; v1's full-mode `--no-gh`
              run measured 14.94s across ~31 entries on the live 38-
@@ -1754,7 +1759,16 @@ def _gh_available(repo: str, no_gh: bool) -> bool:
 #: genuinely host-aware would also require making the `GH_TOKEN`-override
 #: env itself host-aware (`gh` reads `GH_ENTERPRISE_TOKEN`/`GITHUB_
 #: ENTERPRISE_TOKEN` for non-default hosts, not `GH_TOKEN`), which is
-#: materially more surface than this fix warrants.
+#: materially more surface than this fix warrants. This is a cost, not a
+#: pure win: on a two-host config sharing the same login, `_gh_configured_
+#: accounts`'s `(host, login)` dedup still yields both entries as
+#: distinct candidates, so the retry loop fetches and probes the
+#: identical default-host token twice (one redundant `gh auth token` plus
+#: one redundant `gh pr list`, each bounded by
+#: `_NETWORK_TIMEOUT_SECONDS`). The wasted probe cannot produce a WRONG
+#: answer - `GH_TOKEN` is ignored for non-default hosts and `gh` resolves
+#: the base repo from the remote token-independently - so the dedup
+#: choice is still correct, just not free.
 #:
 #: SECURITY: `_gh_token_for_login` returns a live, usable GitHub
 #: credential. It is passed ONLY as a subprocess `env` value (via `_run`'s
@@ -1825,9 +1839,13 @@ def _gh_configured_accounts() -> List[Tuple[str, str, bool]]:
 
 def _gh_configured_logins() -> List[str]:
     """Login-only view of `_gh_configured_accounts` (active-first,
-    deduplicated) - kept for any caller that only needs the ordered login
-    list, not the host/active detail. See `_gh_configured_accounts` for
-    the full contract (including the `[]`-on-any-failure guarantee).
+    deduplicated). Test-facing only - no production call site uses this
+    view at HEAD; `_pr_state`'s retry loop consumes
+    `_gh_configured_accounts` directly for the host/active detail it
+    needs. Kept as the ordered-login-list assertion surface for tests 4
+    and 9 in `bin/tests/test_ds217_gh_multi_account.py`. See
+    `_gh_configured_accounts` for the full contract (including the
+    `[]`-on-any-failure guarantee).
     """
     return [login for login, _host, _active in _gh_configured_accounts()]
 

--- a/bin/tests/test_ds217_gh_multi_account.py
+++ b/bin/tests/test_ds217_gh_multi_account.py
@@ -87,7 +87,7 @@ def _fake_gh_multi_account(tmp_path: Path, *, accounts, success_tokens, call_log
     `accounts`: list of `(login, state, active)` tuples - rendered
     verbatim into a `gh auth status --json hosts` JSON payload (single
     host `github.com`), in the given order (active-first ordering is
-    `_gh_configured_logins`'s own job to produce, not this fixture's).
+    `_gh_configured_accounts`'s own job to produce, not this fixture's).
 
     `success_tokens`: set of `GH_TOKEN` values (as seen by the `pr list`
     invocation) that make `gh pr list` succeed with `[]`. Use `""` to
@@ -98,10 +98,10 @@ def _fake_gh_multi_account(tmp_path: Path, *, accounts, success_tokens, call_log
 
     `gh auth token --user <login>` returns `token-<login>` for any login
     present in `accounts` (regardless of its `state` - filtering revoked
-    accounts out of the candidate list is `_gh_configured_logins`'s job,
-    not this fixture's; a mutation that deletes that filter must still be
-    able to obtain a token for the revoked login and observe a real
-    query attempt).
+    accounts out of the candidate list is `_gh_configured_accounts`'s
+    job, not this fixture's; a mutation that deletes that filter must
+    still be able to obtain a token for the revoked login and observe a
+    real query attempt).
 
     Every invocation appends one line (subcommand words only, never a
     token value) to `call_log`, so tests can assert an exact `gh` call

--- a/bin/tests/test_ds217_gh_multi_account.py
+++ b/bin/tests/test_ds217_gh_multi_account.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Purpose: pytest suite for DS-217's `_pr_state` multi-account `gh` retry in
+         bin/ds-cleanup-worktrees. Covers: resolving a query via a SECOND
+         configured `gh` login when the default (no-override) call fails;
+         positive per-repo env caching (a later branch in the same repo
+         reuses the winning env with exactly one more `gh` call, not
+         once per account again); negative per-repo caching (a repo where
+         every configured account fails makes ZERO further `gh` calls on
+         a later entry); the revoked/expired-account filter in
+         `_gh_configured_logins`; and the single-account case staying
+         call-count-identical to pre-DS-217 behavior.
+
+         Every fake `gh` stub below is a tiny bash script - no real `gh`
+         binary, network, or auth state is ever touched by this file.
+         `monkeypatch.setenv("PATH", ...)` prepends the stub's directory
+         directly onto the REAL process environment (rather than
+         patching `subprocess.run`), because `_pr_state`'s retry loop
+         builds its `GH_TOKEN`-override env as `{**os.environ,
+         "GH_TOKEN": token}` - a patched-argument approach that doesn't
+         also mutate real `os.environ` would silently miss that literal
+         `os.environ` reference and give the override calls the
+         unmodified system PATH. A shared `CALL_LOG` file records one
+         line per invocation (subcommand only, never a token) so each
+         scenario can assert an exact `gh` call count.
+
+Public API: none (test module; invoked via `python3 -m pytest`).
+
+Upstream deps: bin/ds-cleanup-worktrees (module under test, imported
+               directly via SourceFileLoader, mirroring
+               bin/tests/test_cleanup_worktrees.py's own
+               `_load_module_directly` pattern - `_pr_state`,
+               `_gh_configured_logins`, `_PR_STATE_ENV_CACHE`, and
+               `_PR_STATE_ALL_FAILED_REPOS` are called/reset directly).
+
+Downstream consumers: CI (`python3 -m pytest bin/tests/ -q`, auto-collected
+                      per `.github/workflows/bin-tests.yml`).
+
+Failure modes: no real DinoStack checkout, worktree, branch, or `gh` auth
+               state is ever touched by this file. Each scenario gets a
+               fresh module object (own `_PR_STATE_ENV_CACHE` /
+               `_PR_STATE_ALL_FAILED_REPOS` globals), and `monkeypatch`
+               restores `PATH`/`GH_TOKEN` after every test.
+
+Performance: each scenario shells out to the fake `gh` stub a handful of
+             times. Sub-second per test.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery as _ilm
+import importlib.util as _ilu
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "ds-cleanup-worktrees"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _load_module_directly():
+    """Fresh module object per call - mirrors
+    bin/tests/test_cleanup_worktrees.py's own helper of the same name, so
+    each test gets its own `_PR_STATE_ENV_CACHE` / `_PR_STATE_ALL_FAILED_
+    REPOS` module globals rather than sharing state with any other test
+    file's import of the same script."""
+    loader = _ilm.SourceFileLoader("ds_cleanup_worktrees_ds217", str(SCRIPT))
+    spec = _ilu.spec_from_loader("ds_cleanup_worktrees_ds217", loader)
+    mod = _ilu.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def _fake_gh_multi_account(tmp_path: Path, *, accounts, success_tokens, call_log: Path) -> Path:
+    """Builds a fake `gh` on its own PATH-prepend dir.
+
+    `accounts`: list of `(login, state, active)` tuples - rendered
+    verbatim into a `gh auth status --json hosts` JSON payload (single
+    host `github.com`), in the given order (active-first ordering is
+    `_gh_configured_logins`'s own job to produce, not this fixture's).
+
+    `success_tokens`: set of `GH_TOKEN` values (as seen by the `pr list`
+    invocation) that make `gh pr list` succeed with `[]`. Use `""` to
+    mean "GH_TOKEN unset/empty" (the default, no-override attempt).
+    ANY other `GH_TOKEN` value fails `pr list` with a nonzero exit and a
+    stderr message mirroring GitHub's real generic
+    "Could not resolve to a Repository" ambiguity.
+
+    `gh auth token --user <login>` returns `token-<login>` for any login
+    present in `accounts` (regardless of its `state` - filtering revoked
+    accounts out of the candidate list is `_gh_configured_logins`'s job,
+    not this fixture's; a mutation that deletes that filter must still be
+    able to obtain a token for the revoked login and observe a real
+    query attempt).
+
+    Every invocation appends one line (subcommand words only, never a
+    token value) to `call_log`, so tests can assert an exact `gh` call
+    count."""
+    bin_dir = tmp_path / f"fakebin-{len(list(tmp_path.glob('fakebin-*')))}"
+    bin_dir.mkdir(exist_ok=True)
+    gh = bin_dir / "gh"
+
+    host_accounts = ",".join(
+        f'{{"state":"{state}","active":{"true" if active else "false"},'
+        f'"host":"github.com","login":"{login}"}}'
+        for login, state, active in accounts
+    )
+    hosts_json = f'{{"hosts":{{"github.com":[{host_accounts}]}}}}'
+
+    token_cases = "\n".join(f'    {login}) echo "token-{login}" ;;' for login, _state, _active in accounts)
+
+    success_case = "|".join(f'"{tok}"' for tok in success_tokens) or '"__never__"'
+
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$1 $2 $3" >> "{call_log}"\n'
+        'if [ "$1" = "auth" ] && [ "$2" = "status" ] && [ "$3" = "--json" ]; then\n'
+        f"  echo '{hosts_json}'\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi\n'
+        'if [ "$1" = "auth" ] && [ "$2" = "token" ]; then\n'
+        '  case "$4" in\n'
+        f"{token_cases}\n"
+        '    *) exit 1 ;;\n'
+        "  esac\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then\n'
+        f'  case "${{GH_TOKEN:-}}" in\n'
+        f"    {success_case}) echo '[]'; exit 0 ;;\n"
+        '    *) echo "gh: could not resolve to a Repository" >&2; exit 1 ;;\n'
+        "  esac\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+    return bin_dir
+
+
+def _call_lines(call_log: Path) -> list:
+    if not call_log.exists():
+        return []
+    return [line for line in call_log.read_text().splitlines() if line.strip()]
+
+
+def _pr_list_call_count(call_log: Path) -> int:
+    return sum(1 for line in _call_lines(call_log) if line.startswith("pr list"))
+
+
+@pytest.fixture(autouse=True)
+def _clean_gh_env(monkeypatch):
+    """Every scenario in this file assumes the AMBIENT environment carries
+    no `GH_TOKEN` - a real one set on the developer/CI machine would make
+    the default (no-override) `_pr_state_query` call succeed even under
+    the fake `gh` stub, since `env=None` inherits the process environment
+    unchanged and the stub reads `${GH_TOKEN:-}` from whatever it
+    inherits."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+
+def _prepend_fake_gh(monkeypatch, gh_dir: Path) -> None:
+    """Prepends `gh_dir` onto the REAL `os.environ["PATH"]` via
+    `monkeypatch.setenv` (restored automatically after the test) - not a
+    `subprocess.run` argument patch. `_pr_state`'s retry loop builds its
+    `GH_TOKEN`-override env as `{**os.environ, "GH_TOKEN": token}`, a
+    literal reference to the real environment mapping, so only mutating
+    `os.environ` itself reaches that code path."""
+    monkeypatch.setenv("PATH", f"{gh_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+# --------------------------------------------------------------------------
+# 1. Multi-account resolution: default call fails, second configured
+#    login's token succeeds. Named mutation: revert `_pr_state` to a
+#    single unconditional call (no retry loop at all) -> the default
+#    attempt's failure becomes the final answer -> reddens to
+#    ("not_checked", True) instead of ("NONE", False).
+# --------------------------------------------------------------------------
+
+
+def test_multi_account_resolves_via_second_login(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[("acct-a", "success", True), ("acct-b", "success", False)],
+        success_tokens={"token-acct-b"},
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    state, errored = mod._pr_state(str(tmp_path), "some-branch")
+    assert (state, errored) == ("NONE", False), (state, errored, _call_lines(call_log))
+    assert _pr_list_call_count(call_log) == 3, _call_lines(call_log)  # default + acct-a + acct-b
+
+
+# --------------------------------------------------------------------------
+# 2. Positive cache: a second `_pr_state` call for a DIFFERENT branch in
+#    the same repo reuses the winning env with exactly one more `pr list`
+#    call (not once per account again). Named mutation: drop the positive
+#    cache (`_PR_STATE_ENV_CACHE` write/read) -> the second call re-runs
+#    the whole retry loop -> call count rises to 6, not 4.
+# --------------------------------------------------------------------------
+
+
+def test_positive_cache_reuses_winning_env(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[("acct-a", "success", True), ("acct-b", "success", False)],
+        success_tokens={"token-acct-b"},
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    state1, errored1 = mod._pr_state(str(tmp_path), "branch-one")
+    assert (state1, errored1) == ("NONE", False)
+    assert _pr_list_call_count(call_log) == 3, _call_lines(call_log)
+
+    state2, errored2 = mod._pr_state(str(tmp_path), "branch-two")
+    assert (state2, errored2) == ("NONE", False)
+    assert _pr_list_call_count(call_log) == 4, _call_lines(call_log)  # exactly one more
+
+
+# --------------------------------------------------------------------------
+# 3. Negative cache: a repo where every configured account fails makes
+#    ZERO further `gh` calls on a second entry. Named mutation: drop the
+#    negative cache (`_PR_STATE_ALL_FAILED_REPOS` write/read) -> the
+#    second call re-runs the whole retry loop -> call count doubles.
+# --------------------------------------------------------------------------
+
+
+def test_negative_cache_short_circuits_second_entry(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[("acct-a", "success", True), ("acct-b", "success", False)],
+        success_tokens=set(),  # nothing ever succeeds
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    state1, errored1 = mod._pr_state(str(tmp_path), "branch-one")
+    assert (state1, errored1) == ("not_checked", True)
+    calls_after_first = _pr_list_call_count(call_log)
+    assert calls_after_first == 3, _call_lines(call_log)  # default + acct-a + acct-b
+
+    state2, errored2 = mod._pr_state(str(tmp_path), "branch-two")
+    assert (state2, errored2) == ("not_checked", True)
+    assert _pr_list_call_count(call_log) == calls_after_first, _call_lines(call_log)  # zero more
+
+
+# --------------------------------------------------------------------------
+# 4. Revoked-account filter: an account whose `state` is not `"success"`
+#    is never returned by `_gh_configured_logins` (and therefore never
+#    probed). Named mutation: drop the `state != "success"` filter ->
+#    the revoked login appears in the returned list -> reddens.
+# --------------------------------------------------------------------------
+
+
+def test_revoked_account_excluded_from_configured_logins(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[
+            ("acct-active", "success", True),
+            ("acct-revoked", "expired", False),
+        ],
+        success_tokens=set(),
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    logins = mod._gh_configured_logins()
+    assert logins == ["acct-active"], logins
+
+
+# --------------------------------------------------------------------------
+# 5. Single-account case: behavior and `gh` call count match pre-DS-217
+#    behavior exactly - the default call succeeds, so the retry loop
+#    never runs and `_gh_configured_logins` is never even called. Named
+#    mutation: make the retry loop run unconditionally (drop the
+#    `if not errored: return` early-out after the default attempt) ->
+#    extra `gh auth status --json hosts` / `gh auth token` calls appear
+#    even though the first attempt already succeeded -> call count rises
+#    above 1.
+# --------------------------------------------------------------------------
+
+
+def test_single_account_call_count_unchanged(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[("acct-solo", "success", True)],
+        success_tokens={""},  # default (no GH_TOKEN override) call succeeds
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    state, errored = mod._pr_state(str(tmp_path), "only-branch")
+    assert (state, errored) == ("NONE", False)
+    assert len(_call_lines(call_log)) == 1, _call_lines(call_log)  # exactly the one pr-list call

--- a/bin/tests/test_ds217_gh_multi_account.py
+++ b/bin/tests/test_ds217_gh_multi_account.py
@@ -3,13 +3,18 @@
 Purpose: pytest suite for DS-217's `_pr_state` multi-account `gh` retry in
          bin/ds-cleanup-worktrees. Covers: resolving a query via a SECOND
          configured `gh` login when the default (no-override) call fails;
-         positive per-repo env caching (a later branch in the same repo
-         reuses the winning env with exactly one more `gh` call, not
-         once per account again); negative per-repo caching (a repo where
-         every configured account fails makes ZERO further `gh` calls on
-         a later entry); the revoked/expired-account filter in
-         `_gh_configured_logins`; and the single-account case staying
-         call-count-identical to pre-DS-217 behavior.
+         the retry loop SKIPPING the active account (round-2 Major 1 fix -
+         the default call already queried under it); positive per-repo env
+         caching (a later branch in the same repo reuses the winning env
+         with exactly one more `gh` call, not once per account again);
+         negative per-repo caching (a repo where every OTHER configured
+         account fails makes ZERO further `gh` calls on a later entry); the
+         revoked/expired-account filter in `_gh_configured_accounts`; the
+         single-account case staying call-count-identical to pre-DS-217
+         behavior on the SUCCESS path; the single-account FAILURE path's
+         exact 2-call cost (round-2 Minor fix); the `(host, login)` dedup
+         in `_gh_configured_accounts`; `_gh_token_for_login`'s empty-output
+         guard; and `_gh_configured_accounts`'s nonzero-exit guard.
 
          Every fake `gh` stub below is a tiny bash script - no real `gh`
          binary, network, or auth state is ever touched by this file.
@@ -30,7 +35,8 @@ Upstream deps: bin/ds-cleanup-worktrees (module under test, imported
                directly via SourceFileLoader, mirroring
                bin/tests/test_cleanup_worktrees.py's own
                `_load_module_directly` pattern - `_pr_state`,
-               `_gh_configured_logins`, `_PR_STATE_ENV_CACHE`, and
+               `_gh_configured_accounts`, `_gh_configured_logins`,
+               `_gh_token_for_login`, `_PR_STATE_ENV_CACHE`, and
                `_PR_STATE_ALL_FAILED_REPOS` are called/reset directly).
 
 Downstream consumers: CI (`python3 -m pytest bin/tests/ -q`, auto-collected
@@ -174,11 +180,13 @@ def _prepend_fake_gh(monkeypatch, gh_dir: Path) -> None:
 
 
 # --------------------------------------------------------------------------
-# 1. Multi-account resolution: default call fails, second configured
-#    login's token succeeds. Named mutation: revert `_pr_state` to a
-#    single unconditional call (no retry loop at all) -> the default
-#    attempt's failure becomes the final answer -> reddens to
-#    ("not_checked", True) instead of ("NONE", False).
+# 1. Multi-account resolution: default call fails, second (non-active)
+#    configured login's token succeeds, and the ACTIVE login (acct-a) is
+#    never re-probed - the default call already queried under it (round-2
+#    Major 1 fix). Named mutation: revert `_pr_state` to a single
+#    unconditional call (no retry loop at all) -> the default attempt's
+#    failure becomes the final answer -> reddens to ("not_checked", True)
+#    instead of ("NONE", False).
 # --------------------------------------------------------------------------
 
 
@@ -195,7 +203,11 @@ def test_multi_account_resolves_via_second_login(tmp_path, monkeypatch):
 
     state, errored = mod._pr_state(str(tmp_path), "some-branch")
     assert (state, errored) == ("NONE", False), (state, errored, _call_lines(call_log))
-    assert _pr_list_call_count(call_log) == 3, _call_lines(call_log)  # default + acct-a + acct-b
+    # default (acct-a, inherited env) + acct-b retry ONLY - acct-a (active)
+    # is never re-probed via GH_TOKEN.
+    assert _pr_list_call_count(call_log) == 2, _call_lines(call_log)
+    token_fetch_calls = [line for line in _call_lines(call_log) if line.startswith("auth token")]
+    assert len(token_fetch_calls) == 1, _call_lines(call_log)  # only acct-b's token fetched
 
 
 # --------------------------------------------------------------------------
@@ -220,11 +232,11 @@ def test_positive_cache_reuses_winning_env(tmp_path, monkeypatch):
 
     state1, errored1 = mod._pr_state(str(tmp_path), "branch-one")
     assert (state1, errored1) == ("NONE", False)
-    assert _pr_list_call_count(call_log) == 3, _call_lines(call_log)
+    assert _pr_list_call_count(call_log) == 2, _call_lines(call_log)  # default (acct-a) + acct-b
 
     state2, errored2 = mod._pr_state(str(tmp_path), "branch-two")
     assert (state2, errored2) == ("NONE", False)
-    assert _pr_list_call_count(call_log) == 4, _call_lines(call_log)  # exactly one more
+    assert _pr_list_call_count(call_log) == 3, _call_lines(call_log)  # exactly one more
 
 
 # --------------------------------------------------------------------------
@@ -249,7 +261,7 @@ def test_negative_cache_short_circuits_second_entry(tmp_path, monkeypatch):
     state1, errored1 = mod._pr_state(str(tmp_path), "branch-one")
     assert (state1, errored1) == ("not_checked", True)
     calls_after_first = _pr_list_call_count(call_log)
-    assert calls_after_first == 3, _call_lines(call_log)  # default + acct-a + acct-b
+    assert calls_after_first == 2, _call_lines(call_log)  # default (acct-a) + acct-b, acct-a not retried
 
     state2, errored2 = mod._pr_state(str(tmp_path), "branch-two")
     assert (state2, errored2) == ("not_checked", True)
@@ -308,3 +320,123 @@ def test_single_account_call_count_unchanged(tmp_path, monkeypatch):
     state, errored = mod._pr_state(str(tmp_path), "only-branch")
     assert (state, errored) == ("NONE", False)
     assert len(_call_lines(call_log)) == 1, _call_lines(call_log)  # exactly the one pr-list call
+
+
+# --------------------------------------------------------------------------
+# 6. Single-account FAILURE path (round-2 Major 1 regression test): the
+#    lone configured account is ACTIVE, the default call fails, and
+#    there are no OTHER accounts to retry - the retry loop must make
+#    exactly 2 `gh` calls total (the failed default `gh pr list` plus the
+#    one `gh auth status --json hosts` call needed to discover there is
+#    nothing else to try), NEVER a third call re-probing the active
+#    account's own token. Named mutation: remove the `if is_active:
+#    continue` guard in `_pr_state`'s retry loop -> the retry loop
+#    re-probes acct-solo via `GH_TOKEN` -> total call count rises to 4
+#    (auth status + auth token + 2x pr list) instead of 2.
+# --------------------------------------------------------------------------
+
+
+def test_single_account_failure_path_does_not_reprobe_active(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[("acct-solo", "success", True)],
+        success_tokens=set(),  # nothing ever succeeds
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    state, errored = mod._pr_state(str(tmp_path), "only-branch")
+    assert (state, errored) == ("not_checked", True)
+    lines = _call_lines(call_log)
+    assert len(lines) == 2, lines  # default pr-list (fails) + auth status --json hosts
+    assert _pr_list_call_count(call_log) == 1, lines  # never a retry pr-list call
+    assert not any(line.startswith("auth token") for line in lines)  # active account never re-probed
+
+
+# --------------------------------------------------------------------------
+# 7. Minor fix regression: `_gh_configured_accounts` dedups by `(host,
+#    login)`, but a login repeated on the SAME host must still collapse
+#    to one candidate (the `seen` dedup). Named mutation: remove the
+#    `if dedup_key in seen: continue` guard -> the duplicate entry
+#    appears twice in the returned list -> reddens.
+# --------------------------------------------------------------------------
+
+
+def test_configured_accounts_dedups_repeated_login_same_host(tmp_path, monkeypatch):
+    call_log = tmp_path / "calls.log"
+    gh_dir = _fake_gh_multi_account(
+        tmp_path,
+        accounts=[
+            ("acct-active", "success", True),
+            ("acct-dup", "success", False),
+            ("acct-dup", "success", False),
+        ],
+        success_tokens=set(),
+        call_log=call_log,
+    )
+    _prepend_fake_gh(monkeypatch, gh_dir)
+    mod = _load_module_directly()
+
+    accounts = mod._gh_configured_accounts()
+    logins = [login for login, _host, _active in accounts]
+    assert logins == ["acct-active", "acct-dup"], accounts
+
+
+# --------------------------------------------------------------------------
+# 8. `_gh_token_for_login`'s empty-output guard: a `gh auth token` call
+#    that exits 0 but prints nothing must return `None`, not an empty
+#    string. Named mutation: change `return token or None` to
+#    `return token` -> an empty-string token is returned instead of
+#    `None` -> reddens.
+# --------------------------------------------------------------------------
+
+
+def test_gh_token_for_login_empty_output_returns_none(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "fakebin-empty-token"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text("#!/usr/bin/env bash\necho -n \"\"\nexit 0\n")
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    mod = _load_module_directly()
+
+    assert mod._gh_token_for_login("someone") is None
+
+
+# --------------------------------------------------------------------------
+# 9. `_gh_configured_accounts`'s nonzero-exit guard: a `gh auth status
+#    --json hosts` call that exits nonzero must return `[]`, never
+#    attempt to parse stdout as JSON. Named mutation: remove the
+#    `if proc.returncode != 0: return []` check -> the function tries to
+#    `json.loads` stderr-shaped/garbage stdout and either raises or
+#    returns a wrong-shaped result -> reddens.
+# --------------------------------------------------------------------------
+
+
+def test_configured_accounts_nonzero_exit_returns_empty(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "fakebin-nonzero"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    # Deliberately emits WELL-FORMED, parseable JSON on stdout alongside a
+    # nonzero exit - if the returncode check were removed, `json.loads`
+    # would succeed and the (bogus) account would be returned instead of
+    # `[]`. A malformed-JSON body would pass even without the returncode
+    # check (the `except (ValueError, TypeError)` catches it too), which
+    # would make this mutation vacuous.
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then\n'
+        '  echo \'{"hosts":{"github.com":[{"state":"success","active":true,'
+        '"host":"github.com","login":"acct-from-failed-call"}]}}\'\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    mod = _load_module_directly()
+
+    assert mod._gh_configured_accounts() == []
+    assert mod._gh_configured_logins() == []


### PR DESCRIPTION
## Summary

- `bin/ds-cleanup-worktrees` reports `ELIGIBLE = 0` on this machine across 18 repos because `_pr_state`'s single-account `gh pr list` call fails on any repo owned by a *different* locally-configured `gh` account - GitHub's GraphQL layer returns the identical generic "Could not resolve to a Repository" error for "does not exist" and "exists but this token cannot see it".
- `_pr_state` now tries the default (no-override) call first (byte-for-byte unchanged cost for the single-account case), then retries via `GH_TOKEN` for each other configured, non-revoked `gh` login, short-circuiting on first success.
- Adds a positive per-repo env cache (later branches in the same repo reuse the winning env) and a negative per-repo cache (a repo none of the configured accounts can see makes zero further `gh` calls).
- `_run` gains an optional `env=` passthrough (default `None`, inherits current environment - additive, backward compatible).

## North Star alignment

This aligns with the "Works for everyone" (universality) pillar: shared DinoStack behavior must not silently assume a single logged-in `gh` account. Multiple GitHub accounts logged in simultaneously via `gh auth login` is a common, supported `gh` configuration (not an edge case unique to this machine), and the pre-existing single-account query silently misreported every such operator's inaccessible-to-the-active-account repos as a query failure rather than genuinely resolving them. The fix degrades gracefully (falls back to the pre-existing single-call behavior/cost when only one account is configured, and to `SKIP_PR_QUERY_ERROR` when no configured account can answer) rather than requiring any new configuration - no new CLI flag, no new config file, no operator setup step. It does not touch the model-capability/enforcement-floor axis and introduces no new gate.

## Test plan

- [x] `python3 -m pytest bin/tests/ -q -p no:cacheprovider` - 2108 passed
- [x] hooks JS suite (55 files, excluding the 2 wrap-lock-tests-quarantined files) - all pass
- [x] `bin/tests/test_worktree_reap_report_only.sh` - all checks passed
- [x] `bash scripts/build-all.sh` + `git diff --exit-code` against the adapter-sync pathspec - no drift
- [x] 5 new regression tests in `bin/tests/test_ds217_gh_multi_account.py`, each with a named mutation verified to redden it (multi-account resolution, positive cache, negative cache, revoked-account filter, single-account cost parity)
- [x] Live verification against a real multi-account-affected repo: before the fix, `gh pr list --head main --state all --json number,state` fails with `Could not resolve to a Repository`; after the fix, `_pr_state` resolves via the second configured account (`NONE`/`False` instead of `not_checked`/`True`), and a real dry-run entry that previously reported `SKIP_PR_QUERY_ERROR` now reports `REMOVE (pr-merged)`