### PR TITLE
fix(bin): unquote git porcelain paths before protected-content gate (DS-219)

### DIFF
--- a/bin/ds-cleanup-worktrees
+++ b/bin/ds-cleanup-worktrees
@@ -1603,6 +1603,83 @@ def _is_protected_ignored_path(rel_path: str) -> bool:
     return any(fnmatch.fnmatch(basename, pattern) for pattern in _PROTECTED_CONTENT_BASENAME_PATTERNS)
 
 
+def _unquote_porcelain_path(raw: str) -> str:
+    """Undo `git status --porcelain`'s C-style path quoting (DS-219).
+
+    Git wraps a path in a leading/trailing `"` and C-escapes its interior
+    whenever the path contains a space, a double quote, a backslash, or a
+    non-ASCII byte - independent of `core.quotepath` (that setting only
+    controls whether non-ASCII bytes are octal-escaped INSIDE the quotes,
+    not whether quoting happens at all). Before this fix, `_git_status_
+    and_ignored` never unquoted the `!! `-prefixed path it extracted, so
+    a quoted path retained its wrapping `"` and every basename/pattern
+    match downstream (`_is_protected_ignored_path`, `_is_allowlisted_
+    ignored_path`) silently failed - a protected `*.local` file with a
+    space in its name was reported as not-protected and became eligible
+    for `git worktree remove` to delete. Fails open on real content.
+
+    Fast path: a `raw` that does not both start AND end with `"` (len>=2)
+    is returned unchanged - zero overhead for the overwhelmingly common
+    unquoted case, and a strict no-op on paths that were never quoted.
+
+    Escape sequences decoded: `\\"` -> `"`, `\\\\` -> `\\`, and `\\NNN`
+    (exactly three octal digits) -> that raw byte. Git's `quote_c_style`
+    also defines `\\a \\b \\f \\n \\r \\t \\v` as single-character C
+    escapes; those are deliberately decoded too, on the same fast/slow
+    split - a filename containing a literal newline or tab byte is rare
+    but not impossible, and leaving those sequences un-decoded would
+    silently reintroduce the exact class of bug this function exists to
+    fix (a literal backslash-n in the reported path failing basename
+    matches against patterns like `*.local`). Decoding is unconditional
+    once the quoted slow path is entered, so there's no correctness
+    trade-off to omitting them.
+
+    Never raises: a malformed/truncated escape (stray trailing `\\`, an
+    incomplete `\\NN` octal run) degrades by keeping the raw remainder as
+    literal bytes rather than raising, matching this file's existing
+    fail-safe posture. Raw bytes are accumulated and decoded as UTF-8
+    with `errors="surrogateescape"` so an invalid byte sequence still
+    round-trips to *some* deterministic string instead of raising.
+    """
+    if len(raw) < 2 or raw[0] != '"' or raw[-1] != '"':
+        return raw
+    inner = raw[1:-1]
+    simple_escapes = {
+        '"': b'"',
+        "\\": b"\\",
+        "a": b"\a",
+        "b": b"\b",
+        "f": b"\f",
+        "n": b"\n",
+        "r": b"\r",
+        "t": b"\t",
+        "v": b"\v",
+    }
+    out = bytearray()
+    i = 0
+    n = len(inner)
+    while i < n:
+        ch = inner[i]
+        if ch == "\\" and i + 1 < n:
+            nxt = inner[i + 1]
+            if nxt in simple_escapes:
+                out.extend(simple_escapes[nxt])
+                i += 2
+                continue
+            octal = inner[i + 1 : i + 4]
+            if len(octal) == 3 and all(c in "01234567" for c in octal):
+                out.append(int(octal, 8) & 0xFF)
+                i += 4
+                continue
+            # Malformed/unknown escape: keep the backslash literally.
+            out.extend(ch.encode("utf-8", errors="surrogateescape"))
+            i += 1
+            continue
+        out.extend(ch.encode("utf-8", errors="surrogateescape"))
+        i += 1
+    return out.decode("utf-8", errors="surrogateescape")
+
+
 def _git_status_and_ignored(worktree_path: str, strict_ignored: bool) -> Tuple[str, List[str]]:
     """Single combined `git status --porcelain --ignored=matching` call.
     Returns (dirty_status, offending_ignored_paths). dirty_status is
@@ -1614,6 +1691,13 @@ def _git_status_and_ignored(worktree_path: str, strict_ignored: bool) -> Tuple[s
     denylist when `strict_ignored` is False (round-3 default - see
     `_is_protected_ignored_path`'s docstring and the operator-decision
     comment on `_PROTECTED_CONTENT_DIR_PREFIXES` above).
+
+    DS-219: the raw `!! `-prefixed path is passed through
+    `_unquote_porcelain_path` before any predicate sees it - git C-quotes
+    a path containing a space, `"`, `\\`, or a non-ASCII byte, and an
+    un-unquoted path silently defeated every basename/pattern match
+    below, fail-OPEN (reporting protected content as removable). See
+    that function's docstring for the full defect and escape-set detail.
     """
     proc = _run(["git", "-C", worktree_path, "status", "--porcelain", "--ignored=matching"])
     if proc.returncode != 0:
@@ -1624,7 +1708,7 @@ def _git_status_and_ignored(worktree_path: str, strict_ignored: bool) -> Tuple[s
         if not line.strip():
             continue
         if line.startswith("!! "):
-            rel = line[3:]
+            rel = _unquote_porcelain_path(line[3:])
             blocked = (not _is_allowlisted_ignored_path(rel)) if strict_ignored else _is_protected_ignored_path(rel)
             if blocked:
                 offenders.append(rel)

--- a/bin/tests/test_cleanup_worktrees.py
+++ b/bin/tests/test_cleanup_worktrees.py
@@ -3716,3 +3716,109 @@ def test_measure_size_never_passed_by_automatic_callers():
     assert "--measure-size" not in reap_run_invocation
     assert "--measure-size" not in base_sync_invocation
     assert "--measure-size" not in worktree_lifecycle_invocation
+
+
+# --------------------------------------------------------------------------
+# DS-219: `git status --porcelain` C-quotes a path containing a space, a
+# double quote, a backslash, or a non-ASCII byte - independent of
+# `core.quotepath` (which controls only octal-escaping of non-ASCII bytes
+# INSIDE the quotes, not whether quoting happens at all). Before the fix,
+# `_git_status_and_ignored` extracted the raw `!! `-prefixed text without
+# unquoting it, so a quoted protected path (e.g. a `*.local` file with a
+# space in its name) silently failed every downstream basename/pattern
+# match and the guard failed OPEN - the worktree became eligible for
+# removal despite holding irreplaceable protected content.
+#
+# Every scenario below drives REAL `git status --porcelain` output against
+# a REAL file with an awkward name - never a hand-constructed porcelain
+# string, since the quoting behavior under test is git's own and a
+# hand-built fixture would validate the fixture, not the fix.
+# --------------------------------------------------------------------------
+
+
+def test_protected_content_with_space_in_name_blocks_removal(tmp_path):
+    repo, _origin = init_repo_with_origin(tmp_path)
+    commit_gitignore_on_main(repo, "*.local\n")
+    wt = add_worktree(repo, ".claude/worktrees/agent-space", "worktree-agent-space", push=False)
+    target = wt / "config with space.local"
+    target.write_text("SECRET=1\n")
+
+    # Precondition proving the hazard is real: plain git porcelain output
+    # for this exact file is quoted.
+    ignored_status = subprocess.run(
+        ["git", "-C", str(wt), "status", "--porcelain", "--ignored=matching"],
+        capture_output=True,
+        text=True,
+    )
+    assert '"config with space.local"' in ignored_status.stdout, ignored_status.stdout
+
+    proc = run_reap(repo, dry_run=False)
+    assert proc.returncode == 0, proc.stderr
+    result = outcomes(proc.stdout)
+    assert result[str(wt)].startswith("SKIP_PROTECTED_CONTENT"), result[str(wt)]
+    assert str(wt) in worktree_paths(repo)
+    assert target.exists(), "the space-named protected file must survive"
+
+
+def test_protected_content_with_embedded_quote_blocks_removal(tmp_path):
+    repo, _origin = init_repo_with_origin(tmp_path)
+    commit_gitignore_on_main(repo, ".env*\n")
+    wt = add_worktree(repo, ".claude/worktrees/agent-quote", "worktree-agent-quote", push=False)
+    target_name = '.env"weird'
+    target = wt / target_name
+    os.close(os.open(str(target).encode("utf-8"), os.O_CREAT | os.O_WRONLY, 0o644))
+    target.write_text("SECRET=1\n")
+
+    ignored_status = subprocess.run(
+        ["git", "-C", str(wt), "status", "--porcelain", "--ignored=matching"],
+        capture_output=True,
+        text=True,
+    )
+    assert "weird" in ignored_status.stdout and "\\\"" in ignored_status.stdout, ignored_status.stdout
+
+    proc = run_reap(repo, dry_run=False)
+    assert proc.returncode == 0, proc.stderr
+    result = outcomes(proc.stdout)
+    assert result[str(wt)].startswith("SKIP_PROTECTED_CONTENT"), result[str(wt)]
+    assert str(wt) in worktree_paths(repo)
+    assert target.exists(), "the embedded-quote protected file must survive"
+
+
+def test_protected_content_with_non_ascii_blocks_removal(tmp_path):
+    repo, _origin = init_repo_with_origin(tmp_path)
+    commit_gitignore_on_main(repo, "*.local\n")
+    wt = add_worktree(repo, ".claude/worktrees/agent-nonascii", "worktree-agent-nonascii", push=False)
+    # U+2713 (CHECK MARK) has no NFC/NFD decomposition ambiguity, avoiding
+    # any macOS filesystem Unicode-normalization confound.
+    raw_name = "config✓.local"
+    target_path = wt / raw_name
+    os.close(os.open(str(target_path).encode("utf-8"), os.O_CREAT | os.O_WRONLY, 0o644))
+    with open(target_path, "wb") as f:
+        f.write(b"SECRET=1\n")
+
+    # Derive the actual on-disk filename from a real directory listing -
+    # never hand-assert the string, since the filesystem may normalize it.
+    on_disk_names = [p.name for p in wt.iterdir() if p.name.startswith("config")]
+    assert len(on_disk_names) == 1, on_disk_names
+    actual_target = wt / on_disk_names[0]
+
+    proc = run_reap(repo, dry_run=False)
+    assert proc.returncode == 0, proc.stderr
+    result = outcomes(proc.stdout)
+    assert result[str(wt)].startswith("SKIP_PROTECTED_CONTENT"), result[str(wt)]
+    assert str(wt) in worktree_paths(repo)
+    assert actual_target.exists(), "the non-ASCII-named protected file must survive"
+
+
+def test_git_status_and_ignored_unquotes_offenders(tmp_path):
+    """Unit-level: `_git_status_and_ignored` must return the UNQUOTED,
+    human-readable path in its `offenders` list, not the raw quoted form
+    git emits - covering the same consumer `SKIP_PROTECTED_CONTENT`
+    reporting reads from (`:2569`)."""
+    repo, _origin = init_repo_with_origin(tmp_path)
+    commit_gitignore_on_main(repo, "*.local\n")
+    (repo / "config with space.local").write_text("SECRET=1\n")
+
+    _dirty_status, offenders = ds_cleanup_worktrees._git_status_and_ignored(str(repo), False)
+    assert "config with space.local" in offenders, offenders
+    assert not any(o.startswith('"') for o in offenders), offenders


### PR DESCRIPTION
## Summary

`bin/ds-cleanup-worktrees`'s protected-content gate (`_is_protected_ignored_path` / `_is_allowlisted_ignored_path`) is fed raw `!! `-prefixed paths from `git status --porcelain --ignored=matching` in `_git_status_and_ignored`. Git C-quotes any path containing a space, a double quote, a backslash, or a non-ASCII byte - independent of `core.quotepath`, which only affects octal-escaping of non-ASCII bytes inside the quotes, not whether quoting happens at all. The extraction loop never unquoted this text, so a quoted protected path (e.g. a `*.local` file with a space in its name) retained its wrapping `"` and every basename/pattern match downstream silently failed. The guard fails OPEN in exactly this case: a genuinely protected worktree becomes eligible for `git worktree remove`, which destroys the protected content.

Reproduced against real git output on three trigger classes: a space (`!! "config with space.local"`), an embedded quote (`!! ".env\"weird"`), and a non-ASCII byte (`!! ".env\342\234\223"`).

## Changes

- New `_unquote_porcelain_path` helper (placed immediately above `_git_status_and_ignored`): fast-paths unquoted input (the overwhelmingly common case), otherwise strips the outer quotes and C-unescapes the interior (`\"`, `\\`, `\NNN` octal, plus the single-character C escapes `\a \b \f \n \r \t \v` per git's own `quote_c_style`). Accumulates raw bytes and decodes as UTF-8 with `errors="surrogateescape"`; never raises.
- Single call-site change: `rel = line[3:]` -> `rel = _unquote_porcelain_path(line[3:])`, the sole `!! ` extraction site in the file, feeding both predicates and the `offenders` list surfaced in `SKIP_PROTECTED_CONTENT` output.
- Four new regression tests in `bin/tests/test_cleanup_worktrees.py`, each driving REAL `git status` output against a REAL file with an awkward name (space, embedded quote, non-ASCII U+2713) - never a hand-constructed porcelain string. A fourth unit-level test asserts `_git_status_and_ignored`'s `offenders` list contains the unquoted path.
- Docstring update on `_git_status_and_ignored` documenting the fix (DS-219 annotation, following this file's existing round-N convention).

## Mutation testing

Reverting the call site to `rel = line[3:]` reddens all three new end-to-end tests (`test_protected_content_with_space_in_name_blocks_removal`, `test_protected_content_with_embedded_quote_blocks_removal`, `test_protected_content_with_non_ascii_blocks_removal`) - each fails with `REMOVE (ancestor-of-base)` instead of `SKIP_PROTECTED_CONTENT`. Confirmed, then restored the fix.

All pre-existing protected-content tests (`14`, `14b`, `14c`, `test_agentic_protected_set_still_blocks_removal`, `test_reaped_telemetry_dir_is_covered_by_existing_gitignore`, `test_strict_ignored_restores_round2_allowlist_behavior`, `test_strict_ignored_leaves_agentic_events_jsonl_blocking_unchanged`) pass unmodified.

## Out of scope (named, not fixed)

`bin/ds-update:623-641` has the identical extraction bug but is display-only (prints a dirty-file list, never gates a deletion) - cosmetic, not fixed here. `hooks/stop-context.js` and `scripts/update.js` parse `git status --porcelain` for display-only dirty detection and appear unaffected.

## North Star alignment

This closes a live fail-open in a destructive-operation safety guard - the gate exists specifically to prevent `ds-cleanup-worktrees` from silently deleting irreplaceable gitignored content, and it was defeated by ordinary filenames (a space is not an edge case). Fixing it strengthens "works for everyone" (the trigger is filename-shape, not any operator-specific configuration) without adding new surface area - one helper function, one call-site line, no new flags or config.

## Test plan

- [x] `python3 -m pytest bin/tests/ -q -p no:cacheprovider` - 2116 passed
- [x] `bin/tests/test_worktree_reap_report_only.sh` - all checks passed
- [x] Mutation test on all three end-to-end regression tests (see above)
- [x] `git diff --exit-code` against adapter dirs - clean (no adapter-touching changes in this PR)