### PR TITLE
DS-220: surface gh query failures in the worktree-reap summary

### DIFF
--- a/.claude/commands/ds-cleanup-worktrees.md
+++ b/.claude/commands/ds-cleanup-worktrees.md
@@ -33,7 +33,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.cursor/commands/ds-cleanup-worktrees.md
+++ b/.cursor/commands/ds-cleanup-worktrees.md
@@ -27,7 +27,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.gemini/commands/ds-cleanup-worktrees.toml
+++ b/.gemini/commands/ds-cleanup-worktrees.toml
@@ -33,7 +33,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.github/prompts/ds-cleanup-worktrees.prompt.md
+++ b/.github/prompts/ds-cleanup-worktrees.prompt.md
@@ -30,7 +30,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -14765,7 +14765,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.openclaw/skills/ds-cleanup-worktrees/SKILL.md
+++ b/.openclaw/skills/ds-cleanup-worktrees/SKILL.md
@@ -32,7 +32,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/.opencode/commands/ds-cleanup-worktrees.md
+++ b/.opencode/commands/ds-cleanup-worktrees.md
@@ -31,7 +31,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).

--- a/automation/dinostack-worktree-reap/README.md
+++ b/automation/dinostack-worktree-reap/README.md
@@ -67,9 +67,9 @@ Each run invokes the DEEP tier: `ds-cleanup-worktrees --multi-repo --report --js
 `--count-only` - a scheduled, unattended run is off the interactive fast-first-look path, so it
 always pays for the accurate per-entry evaluation). The JSON `rows` are re-sorted worst-first by
 `nonroot_worktrees` and the top ~5 repos are summarized as `<count> worktree(s) (<eligible>
-eligible to remove)  <repo path>`; if any repo's entries hit a `gh pr list` query failure
+eligible to remove)  <repo path>`. If any repo's entries hit a `gh pr list` query failure
 (`SKIP_PR_QUERY_ERROR`), a NOTE naming the affected repos (capped at 5) is appended, since
-`eligible` is a FLOOR (not an exact count) for those repos, then pushed via:
+`eligible` is a FLOOR (not an exact count) for those repos. The summary is then pushed via:
 
 - **macOS banner** (`osascript`, best-effort - macOS frequently suppresses notifications posted
   by `launchd` background jobs, so don't rely on it as the primary channel).

--- a/automation/dinostack-worktree-reap/README.md
+++ b/automation/dinostack-worktree-reap/README.md
@@ -2,22 +2,23 @@
 
 Runs `ds-cleanup-worktrees --multi-repo --report --json` on a daily schedule against every
 repo your `~/.agentic/cleanup-worktrees.json` already names, and pushes a "worst repos by
-worktree count" summary. **Report/notify only - this job never removes anything.** It exists
+worktree count" summary (plus a NOTE naming any repo with a `gh` query failure, when present).
+**Report/notify only - this job never removes anything.** It exists
 to catch machine-wide worktree accumulation between whatever per-session nudges already fire
 (see "Retirement condition" below).
 
 **Runs outside `~/Documents` - no Full Disk Access needed.** Same rationale as the
 `dinostack-pr-review` package: macOS privacy protection (TCC) blocks `launchd` jobs from
-touching `~/Documents`, where this repo lives. `install.sh` copies the two files the job needs
-- `bin/ds-cleanup-worktrees` and its `bin/tests/worktree_model.py` import, in their original
-relative layout - into `~/.dinostack-worktree-reap/bin/`, and the scheduled job runs only from
-there. Unlike the pr-review package, this job never copies any *target* repo's own files (no
+touching `~/Documents`, where this repo lives. `install.sh` copies the files the job needs - `run.sh`
+itself plus `bin/ds-cleanup-worktrees` and its `bin/tests/worktree_model.py` import, in their
+original relative layout - into `~/.dinostack-worktree-reap/`, and the scheduled job runs only
+from there. Unlike the pr-review package, this job never copies any *target* repo's own files (no
 `PROJECT_DIR`); it only ever reads target repos through `ds-cleanup-worktrees --report`, which
 is structurally read-only.
 
-> **Trade-off:** the copied `ds-cleanup-worktrees` + `worktree_model.py` are a snapshot taken
-> at install time. After you change either file in the repo, **re-run `install.sh`** so the
-> scheduled report picks up the change.
+> **Trade-off:** the copied `run.sh` + `ds-cleanup-worktrees` + `worktree_model.py` are a
+> snapshot taken at install time. After you change any of these files in the repo, **re-run
+> `install.sh`** so the scheduled report picks up the change.
 
 ## Install (one time)
 
@@ -66,7 +67,9 @@ Each run invokes the DEEP tier: `ds-cleanup-worktrees --multi-repo --report --js
 `--count-only` - a scheduled, unattended run is off the interactive fast-first-look path, so it
 always pays for the accurate per-entry evaluation). The JSON `rows` are re-sorted worst-first by
 `nonroot_worktrees` and the top ~5 repos are summarized as `<count> worktree(s) (<eligible>
-eligible to remove)  <repo path>`, then pushed via:
+eligible to remove)  <repo path>`; if any repo's entries hit a `gh pr list` query failure
+(`SKIP_PR_QUERY_ERROR`), a NOTE naming the affected repos (capped at 5) is appended, since
+`eligible` is a FLOOR (not an exact count) for those repos, then pushed via:
 
 - **macOS banner** (`osascript`, best-effort - macOS frequently suppresses notifications posted
   by `launchd` background jobs, so don't rely on it as the primary channel).
@@ -88,6 +91,14 @@ and is deliberately NOT held back to pre-DS-196 semantics. `run.sh` itself is un
 stays report-only (`--multi-repo --report --json`, no removal-capable flag - see
 `bin/tests/test_worktree_reap_report_only.sh`). The deployed copy under `~/.dinostack-worktree-reap/`
 is a point-in-time snapshot taken by `install.sh` (see Upstream deps below) - it does NOT pick
+up this change automatically; **re-run `automation/dinostack-worktree-reap/install.sh` after
+this merge** to refresh it.
+
+**DS-220 query-failure NOTE.** `run.sh`'s summary now also scans every discovered repo (not
+just the worst ~5) for a nonzero `pr_query_error_count` and appends a `NOTE:` naming the
+affected repos (capped at 5), plus a FLOOR disclosure scoped to the `eligible` figure only -
+worktree counts are exact local git enumeration and unaffected by a `gh` failure. Same
+snapshot caveat as above: the deployed copy under `~/.dinostack-worktree-reap/` does NOT pick
 up this change automatically; **re-run `automation/dinostack-worktree-reap/install.sh` after
 this merge** to refresh it.
 

--- a/automation/dinostack-worktree-reap/run.sh
+++ b/automation/dinostack-worktree-reap/run.sh
@@ -9,6 +9,10 @@
 #          READ-ONLY: never invokes a sweep, `--archive-unproven`, or any
 #          removal-capable flag - `--report` cannot remove anything under any
 #          combination of flags (see content/commands/ds-cleanup-worktrees.md).
+#          DS-220: the summary also scans EVERY discovered repo (not just the
+#          worst ~5) for a nonzero `pr_query_error_count` and appends a NOTE
+#          naming the affected repos, since a `gh pr list` query failure is
+#          never proof a repo has no unproven-branch worktrees.
 #
 # Public API: none (not sourced or imported; invoked as a standalone script
 #             by launchd or manually via `bash run.sh`).
@@ -197,6 +201,21 @@ for r in top:
 
 if truncated:
     lines.append("(list truncated by --max-repos)")
+
+pr_query_error_total = data.get("pr_query_error_total")
+if pr_query_error_total:
+    affected = [r.get("repo", "?") for r in rows if r.get("pr_query_error_count")]
+    shown = affected[:5]
+    more = len(affected) - len(shown)
+    repo_list = ", ".join(shown) + (f", +{more} more" if more > 0 else "")
+    lines.append(
+        f"NOTE: {pr_query_error_total} worktree(s) across {len(affected)} repo(s) had a "
+        f"`gh pr list` query failure (SKIP_PR_QUERY_ERROR) - never treated as proof of no PR; "
+        f"preserved, never archived or removed. Worktree counts above are exact (local git "
+        f"enumeration, unaffected by gh); only the 'eligible to remove' figures for these "
+        f"repos are a FLOOR, not an exact figure, while these failures are nonzero. "
+        f"Affected: {repo_list}"
+    )
 
 print("\n".join(lines))
 PYEOF

--- a/bin/tests/test_worktree_reap_summary_query_failures.sh
+++ b/bin/tests/test_worktree_reap_summary_query_failures.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# Purpose: Runtime regression test for DS-220 (DS-217 unit 2 follow-up):
+#          asserts automation/dinostack-worktree-reap/run.sh's summary NOTE
+#          for a nonzero `pr_query_error_total` is derived by scanning the
+#          FULL `rows` list, not just the worst-5 `top` slice, and that the
+#          NOTE only ever appears when the failure count is actually
+#          nonzero. Builds two INDEPENDENT `mktemp -d` roots (never a shared
+#          LOG_DIR - run.sh derives its log filename at one-second
+#          granularity and opens it append-mode, so sharing a directory
+#          makes any assertion timing-dependent), each with its own
+#          `logs/` subdir, its own copy of the real run.sh, its own
+#          config.env, and its own stub `DS_CLEANUP_BIN` python script that
+#          ignores its arguments and prints a fixed JSON payload. The
+#          fail-root payload has 6 rows: 5 clean rows plus one row named
+#          `unique-tail-repo-zzz` (shares no substring with the other five
+#          in either direction) ranked LOWEST by `nonroot_worktrees` - so it
+#          is never in the worst-5 `top` slice - carrying
+#          `pr_query_error_count: 2` and a top-level
+#          `pr_query_error_total: 2`. The clean-root payload has the same
+#          6-row shape with every `pr_query_error_count` (and the top-level
+#          total) at 0.
+#
+#          Two named mutations this test is verified to redden (see the
+#          Failure modes note below for how each was confirmed):
+#            (1) revert the implementation's scan source from `rows` to
+#                `top` inside run.sh's summary-builder heredoc - the
+#                fail-root NOTE assertions (repo name, backtick phrase,
+#                FLOOR phrase) all fail, since `unique-tail-repo-zzz` never
+#                appears in `top`.
+#            (2) make the NOTE block unconditional (drop the
+#                `if pr_query_error_total:` guard) - the clean-root
+#                negative assertion (NOTE phrase absent) fails, since the
+#                NOTE then prints even when the failure count is 0.
+#
+# Public API: ./bin/tests/test_worktree_reap_summary_query_failures.sh
+#             Exits 0 on all pass, 1 on any failure.
+#
+# Upstream deps: bash, python3 (invokes the real run.sh, which itself shells
+#                out to "$PYTHON_BIN" against the stub DS_CLEANUP_BIN this
+#                test writes), mktemp, grep. Never touches
+#                ~/.dinostack-worktree-reap or any real repo.
+#
+# Downstream consumers: bin-sh-tests CI job (auto-collected via the
+#                        bin/tests/test_*.sh glob in
+#                        .github/workflows/bin-tests.yml).
+#
+# Failure modes: fails loud on a missing/empty log file (never a vacuous
+#                pass on an absent artifact); the clean-root sub-case
+#                asserts exit 0, a non-empty log, AND the positive control
+#                "worst-repos summary:" BEFORE asserting the NOTE phrase is
+#                absent, so an accidentally-empty or never-written log
+#                cannot be misread as "the NOTE is correctly absent". Both
+#                named mutations above were manually applied to run.sh and
+#                confirmed to redden the specific assertions cited, then
+#                reverted before this file was committed.
+#
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REAL_RUN_SH="$REPO_ROOT/automation/dinostack-worktree-reap/run.sh"
+
+FAILURES=0
+fail() {
+  echo "FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+pass() {
+  echo "PASS: $1"
+}
+
+if [[ ! -f "$REAL_RUN_SH" ]]; then
+  fail "run.sh not found at $REAL_RUN_SH"
+  echo "=== 1 failure(s) ===" >&2
+  exit 1
+fi
+
+# --- Shared no-op PATH shim: never narrow PATH (breaks mkdir/date/head/
+#     find/tail/tr/cut) - only prepend a directory holding a no-op
+#     `osascript` so run.sh's best-effort banner never pops a real macOS
+#     notification during this test. -------------------------------------
+FAKEBIN="$(mktemp -d)"
+cat >"$FAKEBIN/osascript" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$FAKEBIN/osascript"
+export PATH="$FAKEBIN:$PATH"
+
+CLEANUP_ROOTS=()
+cleanup() {
+  for d in ${CLEANUP_ROOTS[@]+"${CLEANUP_ROOTS[@]}"}; do
+    rm -f "$d"/* "$d"/logs/* 2>/dev/null || true
+    rmdir "$d/logs" 2>/dev/null || true
+    rmdir "$d" 2>/dev/null || true
+  done
+  rm -f "$FAKEBIN/osascript" 2>/dev/null || true
+  rmdir "$FAKEBIN" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- setup_root <root> <payload_file> ------------------------------------
+# Materializes one independent run root: a copy of the real run.sh, its own
+# config.env (own LOG_DIR, own stub DS_CLEANUP_BIN), and a stub python
+# script that ignores every argument and prints the given fixed payload.
+setup_root() {
+  local root="$1"
+  local payload_file="$2"
+
+  cp "$REAL_RUN_SH" "$root/run.sh"
+  chmod +x "$root/run.sh"
+  mkdir -p "$root/logs"
+
+  cp "$payload_file" "$root/payload.json"
+
+  cat >"$root/fake-ds-cleanup-worktrees.py" <<'PYEOF'
+#!/usr/bin/env python3
+import os
+here = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(here, "payload.json"), encoding="utf-8") as f:
+    print(f.read().strip())
+PYEOF
+
+  cat >"$root/config.env" <<EOF
+DS_CLEANUP_BIN="$root/fake-ds-cleanup-worktrees.py"
+PYTHON_BIN="python3"
+LOG_DIR="$root/logs"
+EXTRA_PATH=""
+EOF
+}
+
+# --- Fail-root: 6 rows, lowest-ranked row carries the query failure. -----
+FAIL_ROOT="$(mktemp -d)"
+CLEANUP_ROOTS+=("$FAIL_ROOT")
+FAIL_PAYLOAD="$(mktemp)"
+cat >"$FAIL_PAYLOAD" <<'JSON'
+{
+  "tier": "deep",
+  "rows": [
+    {"repo": "aaa-repo-one", "nonroot_worktrees": 50, "eligible": 5, "pr_query_error_count": 0},
+    {"repo": "bbb-repo-two", "nonroot_worktrees": 40, "eligible": 4, "pr_query_error_count": 0},
+    {"repo": "ccc-repo-three", "nonroot_worktrees": 30, "eligible": 3, "pr_query_error_count": 0},
+    {"repo": "ddd-repo-four", "nonroot_worktrees": 20, "eligible": 2, "pr_query_error_count": 0},
+    {"repo": "eee-repo-five", "nonroot_worktrees": 10, "eligible": 1, "pr_query_error_count": 0},
+    {"repo": "unique-tail-repo-zzz", "nonroot_worktrees": 1, "eligible": 1, "pr_query_error_count": 2}
+  ],
+  "truncated": false,
+  "pr_query_error_total": 2
+}
+JSON
+setup_root "$FAIL_ROOT" "$FAIL_PAYLOAD"
+rm -f "$FAIL_PAYLOAD"
+
+# --- Clean-root: same 6-row shape, every failure count at 0. -------------
+CLEAN_ROOT="$(mktemp -d)"
+CLEANUP_ROOTS+=("$CLEAN_ROOT")
+CLEAN_PAYLOAD="$(mktemp)"
+cat >"$CLEAN_PAYLOAD" <<'JSON'
+{
+  "tier": "deep",
+  "rows": [
+    {"repo": "clean-repo-one", "nonroot_worktrees": 50, "eligible": 5, "pr_query_error_count": 0},
+    {"repo": "clean-repo-two", "nonroot_worktrees": 40, "eligible": 4, "pr_query_error_count": 0},
+    {"repo": "clean-repo-three", "nonroot_worktrees": 30, "eligible": 3, "pr_query_error_count": 0},
+    {"repo": "clean-repo-four", "nonroot_worktrees": 20, "eligible": 2, "pr_query_error_count": 0},
+    {"repo": "clean-repo-five", "nonroot_worktrees": 10, "eligible": 1, "pr_query_error_count": 0},
+    {"repo": "clean-repo-six", "nonroot_worktrees": 1, "eligible": 1, "pr_query_error_count": 0}
+  ],
+  "truncated": false,
+  "pr_query_error_total": 0
+}
+JSON
+setup_root "$CLEAN_ROOT" "$CLEAN_PAYLOAD"
+rm -f "$CLEAN_PAYLOAD"
+
+# --- latest_log <root> ---------------------------------------------------
+# Finds the single run-*.log run.sh just wrote in <root>/logs.
+latest_log() {
+  local root="$1"
+  find "$root/logs" -maxdepth 1 -name 'run-*.log' -type f | sort | tail -1
+}
+
+# === Fail-root sub-case ====================================================
+bash "$FAIL_ROOT/run.sh" >/dev/null 2>&1
+fail_rc=$?
+if [[ "$fail_rc" -eq 0 ]]; then
+  pass "fail-root run.sh exited 0"
+else
+  fail "fail-root run.sh exited $fail_rc (expected 0)"
+fi
+
+FAIL_LOG="$(latest_log "$FAIL_ROOT")"
+if [[ -z "$FAIL_LOG" || ! -f "$FAIL_LOG" ]]; then
+  fail "fail-root: no run-*.log found under $FAIL_ROOT/logs"
+elif [[ ! -s "$FAIL_LOG" ]]; then
+  fail "fail-root: log file $FAIL_LOG is empty"
+else
+  pass "fail-root: log file exists and is non-empty"
+
+  if grep -qF "worst-repos summary:" "$FAIL_LOG"; then
+    pass "fail-root: log contains positive-control 'worst-repos summary:' line"
+  else
+    fail "fail-root: log missing positive-control 'worst-repos summary:' line"
+  fi
+
+  if grep -qF "unique-tail-repo-zzz" "$FAIL_LOG"; then
+    pass "fail-root: log names the lowest-ranked affected repo (unique-tail-repo-zzz)"
+  else
+    fail "fail-root: log does not name unique-tail-repo-zzz - the scan is not covering the full rows list"
+  fi
+
+  if grep -qF 'had a `gh pr list` query failure' "$FAIL_LOG"; then
+    pass "fail-root: log contains the backtick-quoted \`gh pr list\` precedent phrase"
+  else
+    fail "fail-root: log missing the backtick-quoted \`gh pr list\` precedent phrase"
+  fi
+
+  if grep -qF "Worktree counts above are exact" "$FAIL_LOG" \
+      && grep -qF "FLOOR, not an exact figure" "$FAIL_LOG"; then
+    pass "fail-root: log contains the FLOOR disclosure scoped to eligible only"
+  else
+    fail "fail-root: log missing the FLOOR disclosure (worktree-counts-exact + FLOOR phrase co-occurring)"
+  fi
+fi
+
+# === Clean-root sub-case ===================================================
+bash "$CLEAN_ROOT/run.sh" >/dev/null 2>&1
+clean_rc=$?
+if [[ "$clean_rc" -eq 0 ]]; then
+  pass "clean-root run.sh exited 0"
+else
+  fail "clean-root run.sh exited $clean_rc (expected 0)"
+fi
+
+CLEAN_LOG="$(latest_log "$CLEAN_ROOT")"
+if [[ -z "$CLEAN_LOG" || ! -f "$CLEAN_LOG" ]]; then
+  fail "clean-root: no run-*.log found under $CLEAN_ROOT/logs"
+elif [[ ! -s "$CLEAN_LOG" ]]; then
+  fail "clean-root: log file $CLEAN_LOG is empty"
+else
+  pass "clean-root: log file exists and is non-empty"
+
+  # Positive control FIRST - an absence assertion on a missing/empty file
+  # would otherwise pass vacuously.
+  if grep -qF "worst-repos summary:" "$CLEAN_LOG"; then
+    pass "clean-root: log contains positive-control 'worst-repos summary:' line"
+
+    if grep -qF 'had a `gh pr list` query failure' "$CLEAN_LOG"; then
+      fail "clean-root: log unexpectedly contains the query-failure NOTE phrase"
+    else
+      pass "clean-root: log correctly omits the query-failure NOTE phrase"
+    fi
+  else
+    fail "clean-root: log missing positive-control 'worst-repos summary:' line - cannot trust the absence check below"
+  fi
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "=== $FAILURES failure(s) ===" >&2
+  exit 1
+fi
+
+echo "=== all checks passed ==="
+exit 0

--- a/bin/tests/test_worktree_reap_summary_query_failures.sh
+++ b/bin/tests/test_worktree_reap_summary_query_failures.sh
@@ -21,17 +21,29 @@
 #          6-row shape with every `pr_query_error_count` (and the top-level
 #          total) at 0.
 #
-#          Two named mutations this test is verified to redden (see the
+#          Three named mutations this test is verified to redden (see the
 #          Failure modes note below for how each was confirmed):
-#            (1) revert the implementation's scan source from `rows` to
-#                `top` inside run.sh's summary-builder heredoc - the
-#                fail-root NOTE assertions (repo name, backtick phrase,
-#                FLOOR phrase) all fail, since `unique-tail-repo-zzz` never
-#                appears in `top`.
+#            (1) revert the implementation's `affected` scan source from
+#                `rows` to `top` inside run.sh's summary-builder heredoc -
+#                ONLY the fail-root repo-name assertion fails
+#                (unique-tail-repo-zzz never appears in `top`, so `affected`
+#                is empty). The backtick-phrase and FLOOR-phrase assertions
+#                still PASS under this mutation: `pr_query_error_total` is
+#                read from the top-level JSON field (never re-derived from
+#                `top`), so the NOTE block's `if pr_query_error_total:`
+#                guard still fires and the NOTE still prints - degenerately,
+#                as "across 0 repo(s) ... Affected: " - carrying both the
+#                backtick phrase and the FLOOR phrase intact. Measured: 1
+#                failure, not 3.
 #            (2) make the NOTE block unconditional (drop the
 #                `if pr_query_error_total:` guard) - the clean-root
 #                negative assertion (NOTE phrase absent) fails, since the
 #                NOTE then prints even when the failure count is 0.
+#            (3) change the shared `gh pr list` NOTE-prefix wording in
+#                either run.sh or bin/ds-cleanup-worktrees (e.g. append a
+#                character to "never treated") - the cross-file wording-
+#                parity assertion fails, since the two sources no longer
+#                share the pinned literal substring verbatim.
 #
 # Public API: ./bin/tests/test_worktree_reap_summary_query_failures.sh
 #             Exits 0 on all pass, 1 on any failure.
@@ -50,8 +62,13 @@
 #                asserts exit 0, a non-empty log, AND the positive control
 #                "worst-repos summary:" BEFORE asserting the NOTE phrase is
 #                absent, so an accidentally-empty or never-written log
-#                cannot be misread as "the NOTE is correctly absent". Both
-#                named mutations above were manually applied to run.sh and
+#                cannot be misread as "the NOTE is correctly absent". The
+#                cross-file wording-parity assertion (mutation 3) checks
+#                for presence of the pinned literal in each source file
+#                independently, so it cannot pass vacuously on a grep that
+#                matches neither file - it fails loud whenever either file
+#                lacks the shared phrase, including when both are missing.
+#                All three named mutations above were manually applied and
 #                confirmed to redden the specific assertions cited, then
 #                reverted before this file was committed.
 #
@@ -253,6 +270,29 @@ else
   else
     fail "clean-root: log missing positive-control 'worst-repos summary:' line - cannot trust the absence check below"
   fi
+fi
+
+# === Cross-file wording-parity check =======================================
+# run.sh's NOTE construction (automation/dinostack-worktree-reap/run.sh)
+# duplicates the "`gh pr list` query failure ... never treated" wording
+# from bin/ds-cleanup-worktrees's own SKIP_PR_QUERY_ERROR NOTE, with
+# nothing else pinning the two equal (extraction is impractical: separate
+# process, separate deployed snapshot, embedded heredoc). Both sources
+# carry the pinned literal on a single line each - grep -qF is checked
+# against EACH FILE INDEPENDENTLY, so an empty-to-empty comparison (the
+# recorded failure mode for this class of check) is not possible: either
+# file's grep can fail on its own, and both must independently succeed.
+CLEANUP_BIN_SRC="$REPO_ROOT/bin/ds-cleanup-worktrees"
+CROSS_FILE_PHRASE='`gh pr list` query failure (SKIP_PR_QUERY_ERROR) - never treated'
+
+if [[ ! -f "$CLEANUP_BIN_SRC" ]]; then
+  fail "cross-file: bin/ds-cleanup-worktrees not found at $CLEANUP_BIN_SRC"
+elif ! grep -qF "$CROSS_FILE_PHRASE" "$REAL_RUN_SH"; then
+  fail "cross-file: run.sh no longer contains the shared NOTE-prefix phrase verbatim"
+elif ! grep -qF "$CROSS_FILE_PHRASE" "$CLEANUP_BIN_SRC"; then
+  fail "cross-file: bin/ds-cleanup-worktrees no longer contains the shared NOTE-prefix phrase verbatim"
+else
+  pass "cross-file: NOTE-prefix wording matches verbatim between run.sh and bin/ds-cleanup-worktrees"
 fi
 
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/content/commands/ds-cleanup-worktrees.md
+++ b/content/commands/ds-cleanup-worktrees.md
@@ -27,7 +27,8 @@ automatically instead of run by hand, `automation/dinostack-worktree-reap/` is a
 macOS `launchd` package (report/notify only - it never calls a removal-capable flag). It runs
 `ds-cleanup-worktrees --multi-repo --report --json` daily against the same
 `~/.agentic/cleanup-worktrees.json` config `--multi-repo` already reads, and pushes a
-worst-repos-by-worktree-count summary via a macOS banner and Telegram. See
+worst-repos-by-worktree-count summary (plus a NOTE naming any repo with a `gh` query failure,
+when present) via a macOS banner and Telegram. See
 `automation/dinostack-worktree-reap/README.md` for setup, cadence, and its retirement
 condition (this belt-and-suspenders schedule should be retired if a future measurement shows
 the SessionStart nudge already catches everything it would).


### PR DESCRIPTION
## Summary
- The scheduled worktree-reap job's summary never read `pr_query_error_count` / `pr_query_error_total`, so a run where every `gh` PR-state query failed printed output indistinguishable from a genuinely clean sweep. DS-217 unit 2 put the data on the JSON payload; this closes the operator-facing half.
- `run.sh`'s summary now scans the **full** `rows` list (not the worst-5 slice) and appends a NOTE naming the affected repos, capped at 5 + `+N more`, reusing `bin/ds-cleanup-worktrees`' existing NOTE wording verbatim.
- The FLOOR disclosure is scoped to the `eligible` figure only. `nonroot_worktrees` is a local git enumeration a `gh` failure cannot affect, so calling it a floor would have been false.
- Adds `bin/tests/test_worktree_reap_summary_query_failures.sh`, which executes the real `run.sh` end-to-end against crafted payloads in two independent temp roots - not a hand-written expected string, which the ticket explicitly rejects.
- Documents that the deployed `~/.dinostack-worktree-reap/run.sh` is a point-in-time snapshot needing a post-merge `install.sh` re-run, and corrects a pre-existing README claim that `install.sh` copies only "the two files the job needs" (it has always also copied `run.sh`).

## Jira
Closes [DS-220](https://solara6.atlassian.net/browse/DS-220)

## Test plan
- [x] New test: 11 assertions pass, exit 0; idempotent across consecutive runs; leaves nothing behind
- [x] **Pre-fix check** - reverting `run.sh` to `origin/main` and re-running the new test fails 3 assertions, so the test would have caught the original defect
- [x] Mutation `rows`->`top`: reddens exactly the repo-name assertion (the NOTE still prints degenerately as "across 0 repo(s)"), verified by direct log capture
- [x] Mutation unconditional-NOTE: reddens the clean-root absence assertion while the positive control still passes
- [x] Cross-file pin reddens in **both** directions and in all three vacuity shapes (both files mutated; sibling file deleted)
- [x] `bin/tests/test_worktree_reap_report_only.sh` passes and is byte-identical to `origin/main` (acceptance criterion 5)
- [x] `scripts/build-all.sh` + `git diff --exit-code` against the verbatim 17-entry pathspec - clean; 7 adapter copies confirmed the correct count by independent grep
- [x] Runs clean under `/bin/bash` 3.2.57 with `set -u`
- [ ] **Post-merge operator action:** re-run `automation/dinostack-worktree-reap/install.sh` on any machine hosting the scheduled job - CI exercises the repo copy only

## North Star alignment
Advances **Pillar 1 (guard operator attention)**: the scheduled reap runs unattended and its summary is the only signal an operator sees. A run where `gh` resolved nothing previously looked identical to a clean sweep - a silently under-reporting floor presented as a result. Also advances **Pillar 2 (verifiable outcomes)**: the ticket demanded execution of the real consumer, and the pre-fix check above is what makes the green result evidence rather than decoration.

Cuts against **Pillar 8 (machinery only as complicated as the benefit requires)**: this adds a test file, a conditional block, and a doc-sync touch to `content/commands/**` that pulls in the adapter rebuild chain. Justified per Pillar 8's naming requirement - the specific failure is DS-217 unit 2's Skeptic-measured defect, where a real payload carrying `pr_query_error_total: 1` produced a summary mentioning it nowhere. Retirement condition is "never", in the permanent-floor sense Pillar 8 allows: `gh` multi-account resolution failures remain structurally possible on any machine, which DS-217 unit 1's own scope note states its fix cannot cover.

Mildly cuts against **Pillars 3 and 6 (low friction, wall-clock)** via the doc-sync chain and the manual redeploy step. Both are the mandatory consequence of the change actually reaching the operator it exists to help.

## Review rigor
- Brief / Plan path: `.agentic/ds-220-architect-plan.md` (gitignored by repo convention)
- Plan review: 4 rounds (Tier 2) - 5 Major, 2 Major, 3 Major, 2 Major; zero Criticals throughout
- Implementation review: 2 rounds (Tier 2) - round 1: 0 Critical / 1 Major / 2 Minor; round 2: 0 Critical / 0 Major / 2 Minor, sign-off granted
- Findings summary: all Majors closed. 2 Minors carried as accepted debt - (a) the test manifest's stated verification basis was narrower than its attestation implied, though the attestation itself is factually correct as independently confirmed; (b) the cross-file pin is line-based, so a cosmetic re-wrap preserving the emitted message would still redden it. The code comment discloses this.
- QA: `qa_skip: null`; all runtime-required scenarios executed by both the engineer and the reviewer independently

Doc-sync: predicate clause 5 (user-facing behavior) triggered -> updated `automation/dinostack-worktree-reap/README.md` and `content/commands/ds-cleanup-worktrees.md`. `docs/index.html` and `docs/slides/*.md` checked - no matching assertion found.

Developer: admin-fullmetalblanket

Model: claude-opus-5[1m]


[DS-220]: https://solara6.atlassian.net/browse/DS-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ