### PR TITLE
fix(ds-doctor): stop reporting 'no enabledPlugins entries' for configs that have them

### DIFF
--- a/bin/ds-doctor
+++ b/bin/ds-doctor
@@ -1670,17 +1670,23 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
         match-all by design (see the "matcher": null discussion below) -
         it is confirmed, not unconfirmable, so it can OK or FAIL like any
         other match-all matcher, never WARN for being missing.
-    All four "nothing to scan" states above stay severity OK, but are NOT
-    worded identically (follow-up to DS-198): a missing settings.json, a
-    settings.json with no "enabledPlugins" key, an empty "enabledPlugins"
-    object, and an "enabledPlugins" object whose entries are all `false`
-    are four genuinely different configs an operator would want to tell
-    apart when debugging why a plugin isn't being scanned - the last one
-    in particular means the operator's config DOES have entries, they are
-    just all disabled. Collapsing these into one "no enabledPlugins
-    entries" message previously reported the fourth state as if it were
-    the first (or second/third) - a "the key is empty/absent" claim on a
-    file that in fact lists N disabled plugins by name.
+    The "known-clean nothing configured here" bullet just above covers
+    several DIFFERENT OK branches in this function, worded independently
+    (a missing plugins directory OK's as "nothing to check", a separate
+    branch entirely) - it is not the same set as the "nothing to scan"
+    wording this paragraph documents. Within the enabledPlugins path
+    specifically, five states all stay severity OK but are worded
+    distinctly, not collapsed into one message (follow-up to DS-198): a
+    missing settings.json; a settings.json present but with no
+    "enabledPlugins" key at all; an "enabledPlugins" key present but an
+    explicit JSON null; an "enabledPlugins" key present as an empty
+    object; and an "enabledPlugins" object whose entries are all `false`.
+    These are five genuinely different configs an operator would want to
+    tell apart when debugging why a plugin isn't being scanned - the last
+    one is the most consequential: the operator's file genuinely lists N
+    plugins by name, just disabled, and the pre-fix message ("no plugins
+    enabled (no enabledPlugins entries in <path>)") told them there were
+    no entries at all.
     By contrast, every value this function reads that is PRESENT but the
     wrong JSON type or otherwise unconfirmable (a non-dict settings_data
     or enabledPlugins, an enabledPlugins entry whose value is not a
@@ -1734,13 +1740,23 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
     settings_path = plugins_dir.parent / "settings.json"
     enabled_plugins: list[str] = []
     enabled_incomplete = False
+    # Cached once, not re-called at the final OK-message branch below - a
+    # second .is_file() call there would leave a TOCTOU window (the file
+    # could appear or disappear between the two calls, causing a run that
+    # never read any content to report "no 'enabledPlugins' key" for a
+    # file it never actually inspected).
+    settings_exists = settings_path.is_file()
+    # key_present distinguishes "no 'enabledPlugins' key at all" from
+    # "key present with an explicit JSON null value" - dict.get() alone
+    # conflates the two (both return None), which previously mislabeled a
+    # present `"enabledPlugins": null` as "no key" in the final message.
+    key_present = False
     # None until settings.json is read and its "enabledPlugins" key is
-    # inspected - stays None when the file is missing entirely, which is
-    # exactly the state the final OK-message branch below needs to tell
-    # apart from "file present, key absent" (both used to collapse into
-    # the identical "no enabledPlugins entries" wording).
+    # inspected - stays None when the file is missing entirely or the key
+    # is absent or explicitly null; key_present/settings_exists disambiguate
+    # which of those it is at the final OK-message branch below.
     enabled: object | None = None
-    if settings_path.is_file():
+    if settings_exists:
         try:
             settings_data = json.loads(settings_path.read_text(encoding="utf-8"))
         except Exception as exc:
@@ -1765,6 +1781,7 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
                 "- could not determine enabledPlugins",
             )
             return
+        key_present = "enabledPlugins" in settings_data
         enabled = settings_data.get("enabledPlugins")
         if enabled is not None and not isinstance(enabled, dict):
             doc.warn(
@@ -1824,19 +1841,28 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
                 "could not confirm any plugin's enabled state (see WARN "
                 "lines above) - not a confirmed-clean scan",
             )
-        elif not settings_path.is_file():
+        elif not settings_exists:
             # No settings.json at all - distinct from "file present but no
             # enabledPlugins key" and from "key present with entries, none
-            # enabled" (DS-198 follow-up: these three used to collapse
-            # into one "no enabledPlugins entries" message).
+            # enabled" (DS-198 follow-up: these used to collapse into one
+            # "no enabledPlugins entries" message).
             doc.ok(
                 "foreign_agent_hook",
                 f"no {settings_path} found - nothing to scan",
             )
-        elif enabled is None:
+        elif not key_present:
             doc.ok(
                 "foreign_agent_hook",
                 f"{settings_path}: no 'enabledPlugins' key - nothing to "
+                "scan",
+            )
+        elif enabled is None:
+            # Key IS present but its value is an explicit JSON null - a
+            # different state from "no key at all" (Skeptic-verified live:
+            # settings_data.get() alone cannot tell these apart).
+            doc.ok(
+                "foreign_agent_hook",
+                f"{settings_path}: 'enabledPlugins' is null - nothing to "
                 "scan",
             )
         elif not enabled:

--- a/bin/ds-doctor
+++ b/bin/ds-doctor
@@ -1670,6 +1670,17 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
         match-all by design (see the "matcher": null discussion below) -
         it is confirmed, not unconfirmable, so it can OK or FAIL like any
         other match-all matcher, never WARN for being missing.
+    All four "nothing to scan" states above stay severity OK, but are NOT
+    worded identically (follow-up to DS-198): a missing settings.json, a
+    settings.json with no "enabledPlugins" key, an empty "enabledPlugins"
+    object, and an "enabledPlugins" object whose entries are all `false`
+    are four genuinely different configs an operator would want to tell
+    apart when debugging why a plugin isn't being scanned - the last one
+    in particular means the operator's config DOES have entries, they are
+    just all disabled. Collapsing these into one "no enabledPlugins
+    entries" message previously reported the fourth state as if it were
+    the first (or second/third) - a "the key is empty/absent" claim on a
+    file that in fact lists N disabled plugins by name.
     By contrast, every value this function reads that is PRESENT but the
     wrong JSON type or otherwise unconfirmable (a non-dict settings_data
     or enabledPlugins, an enabledPlugins entry whose value is not a
@@ -1723,6 +1734,12 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
     settings_path = plugins_dir.parent / "settings.json"
     enabled_plugins: list[str] = []
     enabled_incomplete = False
+    # None until settings.json is read and its "enabledPlugins" key is
+    # inspected - stays None when the file is missing entirely, which is
+    # exactly the state the final OK-message branch below needs to tell
+    # apart from "file present, key absent" (both used to collapse into
+    # the identical "no enabledPlugins entries" wording).
+    enabled: object | None = None
     if settings_path.is_file():
         try:
             settings_data = json.loads(settings_path.read_text(encoding="utf-8"))
@@ -1807,11 +1824,38 @@ def check_foreign_agent_hooks(doc: Doctor) -> None:
                 "could not confirm any plugin's enabled state (see WARN "
                 "lines above) - not a confirmed-clean scan",
             )
-        else:
+        elif not settings_path.is_file():
+            # No settings.json at all - distinct from "file present but no
+            # enabledPlugins key" and from "key present with entries, none
+            # enabled" (DS-198 follow-up: these three used to collapse
+            # into one "no enabledPlugins entries" message).
             doc.ok(
                 "foreign_agent_hook",
-                "no plugins enabled (no enabledPlugins entries in "
-                f"{settings_path}) - nothing to scan",
+                f"no {settings_path} found - nothing to scan",
+            )
+        elif enabled is None:
+            doc.ok(
+                "foreign_agent_hook",
+                f"{settings_path}: no 'enabledPlugins' key - nothing to "
+                "scan",
+            )
+        elif not enabled:
+            doc.ok(
+                "foreign_agent_hook",
+                f"{settings_path}: 'enabledPlugins' is empty - nothing to "
+                "scan",
+            )
+        else:
+            # Key present with entries but none are `true` - genuinely
+            # different from "no entries at all" (the false state this
+            # branch used to report as). See module docstring's MISSING
+            # discussion for why these are kept distinct.
+            doc.ok(
+                "foreign_agent_hook",
+                f"{settings_path}: 'enabledPlugins' has "
+                f"{len(enabled)} " + (
+                    "entry" if len(enabled) == 1 else "entries"
+                ) + ", none enabled - nothing to scan",
             )
         return
 

--- a/bin/tests/test_agentic_doctor.sh
+++ b/bin/tests/test_agentic_doctor.sh
@@ -2354,6 +2354,32 @@ else
   _fail "T21v foreign_agent_hook: the two OK messages should differ\nno-enabled: $NOENABLED_LINE\nscanned: $SCANNED_LINE"
 fi
 
+# T21v2: an enabledPlugins object with entries that are ALL `false` is a
+# genuinely different config from "no enabledPlugins key at all" (T21v's
+# NOENABLED_LINE fixture, {} settings.json) - the operator's config here
+# DOES name 3 plugins, they're just disabled. The pre-fix message
+# ("no plugins enabled (no enabledPlugins entries in <path>) - nothing to
+# scan") falsely reported this as an empty/absent key. Reddened by
+# reverting to that literal string: the grep below fails and the count
+# assertion has nothing to match.
+cat > "$T21_HOME/.claude/settings.json" <<EOF
+{
+  "enabledPlugins": {"one@mkt": false, "two@mkt": false, "three@mkt": false}
+}
+EOF
+t21_invoke
+RC=$(cat "$T21_HOME/.exit")
+OUT=$(cat "$T21_HOME/.out")
+ALLFALSE_LINE=$(echo "$OUT" | grep "^OK foreign_agent_hook:")
+if [[ "$RC" == "0" ]] \
+   && echo "$ALLFALSE_LINE" | grep -qE "enabledPlugins.*\b3\b.*entries.*none enabled" \
+   && ! echo "$ALLFALSE_LINE" | grep -q "no enabledPlugins entries in" \
+   && [[ "$ALLFALSE_LINE" != "$NOENABLED_LINE" ]]; then
+  _pass "T21v2 foreign_agent_hook: 3 disabled entries reports the actual count, distinct from the no-key OK message"
+else
+  _fail "T21v2 foreign_agent_hook: 3 all-false enabledPlugins entries should report 'has 3 entries, none enabled', not the no-key wording, exit 0\nrc=$RC\n$OUT"
+fi
+
 # T21w: the enabled-plugin count in the "scanned N enabled plugin(s), none
 # register..." OK message must be pinned to the ACTUAL number of enabled
 # plugins - not merely present, and not merely differ from the

--- a/bin/tests/test_agentic_doctor.sh
+++ b/bin/tests/test_agentic_doctor.sh
@@ -2380,6 +2380,30 @@ else
   _fail "T21v2 foreign_agent_hook: 3 all-false enabledPlugins entries should report 'has 3 entries, none enabled', not the no-key wording, exit 0\nrc=$RC\n$OUT"
 fi
 
+# T21v3: an explicit "enabledPlugins": null is a DIFFERENT state from the
+# key being absent entirely - dict.get() returns None for both, which
+# previously mislabeled a present-but-null key as "no 'enabledPlugins'
+# key" (Skeptic Minor 1 on the initial fix, verified live). Reddened by
+# reverting key_present to a bare `enabled is not None` check: the "no
+# 'enabledPlugins' key" wording would then match this fixture too.
+cat > "$T21_HOME/.claude/settings.json" <<EOF
+{
+  "enabledPlugins": null
+}
+EOF
+t21_invoke
+RC=$(cat "$T21_HOME/.exit")
+OUT=$(cat "$T21_HOME/.out")
+NULL_LINE=$(echo "$OUT" | grep "^OK foreign_agent_hook:")
+if [[ "$RC" == "0" ]] \
+   && echo "$NULL_LINE" | grep -qE "enabledPlugins.*null" \
+   && ! echo "$NULL_LINE" | grep -q "no 'enabledPlugins' key" \
+   && [[ "$NULL_LINE" != "$NOENABLED_LINE" ]]; then
+  _pass "T21v3 foreign_agent_hook: explicit enabledPlugins:null reports null, distinct from the no-key OK message"
+else
+  _fail "T21v3 foreign_agent_hook: explicit enabledPlugins:null should report 'enabledPlugins is null', not the no-key wording, exit 0\nrc=$RC\n$OUT"
+fi
+
 # T21w: the enabled-plugin count in the "scanned N enabled plugin(s), none
 # register..." OK message must be pinned to the ACTUAL number of enabled
 # plugins - not merely present, and not merely differ from the
@@ -2494,11 +2518,11 @@ t21_invoke
 RC=$(cat "$T21_HOME/.exit")
 OUT=$(cat "$T21_HOME/.out")
 if echo "$OUT" | grep -q "^WARN foreign_agent_hook:.*enabledPlugins.*not an object" \
-   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:.*no plugins enabled" \
+   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:" \
    && [[ "$RC" == "0" ]]; then
-  _pass "T21y foreign_agent_hook: list-typed enabledPlugins WARNs, never a masked 'no plugins enabled' OK"
+  _pass "T21y foreign_agent_hook: list-typed enabledPlugins WARNs, never a masked OK"
 else
-  _fail "T21y foreign_agent_hook: list-typed enabledPlugins should WARN, never OK 'no plugins enabled', exit 0\nrc=$RC\n$OUT"
+  _fail "T21y foreign_agent_hook: list-typed enabledPlugins should WARN, never any OK, exit 0\nrc=$RC\n$OUT"
 fi
 
 # T21y2: same defect, non-dict top-level settings.json (a JSON array
@@ -2510,11 +2534,11 @@ t21_invoke
 RC=$(cat "$T21_HOME/.exit")
 OUT=$(cat "$T21_HOME/.out")
 if echo "$OUT" | grep -q "^WARN foreign_agent_hook:.*unexpected schema" \
-   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:.*no plugins enabled" \
+   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:" \
    && [[ "$RC" == "0" ]]; then
   _pass "T21y2 foreign_agent_hook: non-dict top-level settings.json WARNs, never a masked OK"
 else
-  _fail "T21y2 foreign_agent_hook: non-dict settings.json should WARN, never OK 'no plugins enabled', exit 0\nrc=$RC\n$OUT"
+  _fail "T21y2 foreign_agent_hook: non-dict settings.json should WARN, never any OK, exit 0\nrc=$RC\n$OUT"
 fi
 
 # T21y3: an enabledPlugins ENTRY whose value is a truthy non-boolean (the
@@ -2551,11 +2575,11 @@ t21_invoke
 RC=$(cat "$T21_HOME/.exit")
 OUT=$(cat "$T21_HOME/.out")
 if echo "$OUT" | grep -q "^WARN foreign_agent_hook:.*enabledPlugins.*non-boolean.*wrongtypevalue@mkt" \
-   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:.*no plugins enabled" \
+   && ! echo "$OUT" | grep -q "^OK foreign_agent_hook:" \
    && [[ "$RC" == "0" ]]; then
-  _pass "T21y3 foreign_agent_hook: truthy non-boolean enabledPlugins VALUE WARNs, never a masked 'no plugins enabled' OK"
+  _pass "T21y3 foreign_agent_hook: truthy non-boolean enabledPlugins VALUE WARNs, never a masked OK"
 else
-  _fail "T21y3 foreign_agent_hook: non-boolean enabledPlugins value (1) should WARN naming wrongtypevalue@mkt, never OK 'no plugins enabled', exit 0\nrc=$RC\n$OUT"
+  _fail "T21y3 foreign_agent_hook: non-boolean enabledPlugins value (1) should WARN naming wrongtypevalue@mkt, never any OK, exit 0\nrc=$RC\n$OUT"
 fi
 
 # T21y4: a boolean-true, genuinely hazardous plugin sibling alongside a


### PR DESCRIPTION
## Problem

`ds-doctor`'s `check_foreign_agent_hooks` reported this on a clean run:

```
OK foreign_agent_hook: no plugins enabled (no enabledPlugins entries in <path>) - nothing to scan
```

The parenthetical was false. On the machine where it was observed, that file had eight `enabledPlugins` entries, all `false`. The message collapsed four distinct on-disk states into one string, and reported "no entries" for a config that had eight. An operator debugging why their plugin was not being scanned would be told something untrue about their own config.

## Change

The single OK branch is split into five, each true of its state:

| State | Message |
|---|---|
| settings.json missing | `no <path> found - nothing to scan` |
| key absent | `<path>: no 'enabledPlugins' key - nothing to scan` |
| key present, value `null` | `<path>: 'enabledPlugins' is null - nothing to scan` |
| key present, empty object | `<path>: 'enabledPlugins' is empty - nothing to scan` |
| N entries, none enabled | `<path>: 'enabledPlugins' has N entries, none enabled - nothing to scan` |

Severity stays `OK` on all five. No exit code, scan scope, WARN path or FAIL path changes.

The `null` case is separated from the absent case because `dict.get()` returns `None` for both - reporting an explicit `null` as "no key" would have been a new false claim of exactly the kind this change exists to remove.

## The part worth reviewing

Rewording the message silently defanged three existing regression guards. `T21y`, `T21y2` and `T21y3` each asserted the *absence* of the old literal:

```sh
! echo "$OUT" | grep -q "^OK foreign_agent_hook:.*no plugins enabled"
```

Once that string stopped being emitted anywhere, those assertions became unsatisfiable - permanently green, guarding nothing. This was found by mutation rather than inspection: reintroducing the masked-OK defect they were written for gave `108 passed, 0 failed` against the reworded source and `106 passed, 2 failed` against the original.

All three now pin the stable structural prefix `^OK foreign_agent_hook:` instead of a message body, so a future rewording cannot repeat this.

The general shape is worth stating because the natural search misses it: a positive pin fails loud when its string changes, so grepping for "tests that would break" finds those. A negative pin fails silent, so the same grep structurally cannot find it - it does not break, which is the whole problem.

## Verification

- `test_agentic_doctor.sh`: 109 passed, 0 failed (2 new tests)
- Both new tests mutation-verified. `T21v3` reddens when `key_present` is derived from `enabled is not None` (the exact defect shape it guards). The restored `T21y3` reddens under `if enabled_incomplete:` -> `if False:`, reproducing the reviewer's numbers exactly
- `pytest bin/tests/`: 2157 passed, 25 subtests
- Full `bin/tests/test_*.sh` glob (65 files): all pass
- Hooks JS suite (57 files): all pass
- Five-state matrix verified live against the built binary, messages distinct and accurate, singular/plural correct at N=1 and N=2

## Also fixed

- A docstring paragraph claimed "all four states above" while the list above it enumerated a different, unrelated set of branches.
- `settings_path.is_file()` was evaluated twice, leaving a window where a file appearing between the calls would be reported as having no `enabledPlugins` key without ever being read. Now cached once.

## North Star alignment

**Prevent defects at the producing step**: the diagnostic no longer asserts something false about the operator's own configuration.

**Guard operator attention**: the previous message sent anyone debugging plugin enablement in the wrong direction. Five branches is more code than one, but each corresponds to a distinct fact an operator needs, and the alternative was a single string that is wrong in four of the five cases.

**Produce verifiable outcomes**: the three restored guards now actually guard. The change's most valuable effect is arguably the pins it repaired rather than the message it fixed.

Doc-sync: predicate not triggered (no reality-asserting change). Verified by grep that no doc, command, or script references these message strings.
