### PR TITLE
Remove the context-mode ctx_* recommendation from the methodology

### DIFF
--- a/.claude/commands/ds-ticket-triage.md
+++ b/.claude/commands/ds-ticket-triage.md
@@ -230,13 +230,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.claude/skills/dinostack/SKILL.md
+++ b/.claude/skills/dinostack/SKILL.md
@@ -784,13 +784,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.copilot/references/code-standards-detail.md
+++ b/.copilot/references/code-standards-detail.md
@@ -6,7 +6,6 @@ Purpose: Detailed code-standards reference blocks extracted from
          CLI usage for all browser verification tasks), the
          Discovery-Based Check Discipline block (mandated hard-fail forms
          for any check whose result depends on a discovered set of items),
-         the Context Window Management block (ctx_* MCP tool usage detail),
          and the Package Management block (dependency-versioning rules).
 
 Public API: Read-only reference document. Cross-referenced from:
@@ -19,8 +18,7 @@ Upstream deps: content/rules/code-standards.md (parent rules file; read
                rules).
 
 Downstream consumers: engineer agents (run per-language quality gates
-                      after every implementation; consult Context Window
-                      Management when ctx_* tools are present, and Package
+                      after every implementation; consult Package
                       Management when adding/upgrading a dependency);
                       content/sections/12-protocol-details.md (code
                       standards reference).
@@ -72,26 +70,6 @@ Every discovery-based check MUST hard-fail on zero discovered items, and MUST do
 A docstring reference to a guard's failure phrase (documenting what the guard does, or citing it as precedent for a sibling check) is the only sanctioned way to mention the phrase outside an actual guard - it is classified DOCUMENTATION, not a violation and not a guard, and does not count toward a check's live-guard total. A phrase mention anywhere else that is not a docstring (a `#` comment, a non-first-statement string, ordinary prose) reports as NON-CONFORMING; this is deliberate, not an oversight, so route future mentions of a guard phrase into a docstring or an actual guard.
 
 Reference implementations that conform: the `hooks-python-tests`, `bin-sh-tests`, `hooks-js-tests`, and `hooks-sh-tests` CI jobs, and `hooks/tests/test-hooks-pep604-guard.py`'s Form-B guards.
-
-## Context Window Management
-
-**See `content/rules/code-standards.md` §Context Window Management for the inline output-size threshold that triggers preferring `ctx_execute`/`ctx_batch_execute` over raw `Bash`.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.
-
-Key tools and their uses:
-- `ctx_execute(language, code)` - run a single script; only stdout enters context
-- `ctx_execute_file(path, language, code)` - analyze a file for inspection only; use `Read` instead when you intend to subsequently `Edit` the file
-
-> Never use `ctx_execute` or `ctx_execute_file` to create or modify files - these tools are for analysis, processing, and computation only. Use the native `Write`/`Edit` tools for all file writes.
-
-- `ctx_batch_execute(commands, queries)` - run multiple commands and search results in one call; replaces 10-30 Bash + search steps
-- `ctx_index(content, source)` / `ctx_search(queries)` - build and query a knowledge base from arbitrary content
-- `ctx_fetch_and_index(url, source)` - fetch a URL, index it, cache for 24 hours
-
-> When ctx tools are available, prefer `ctx_fetch_and_index` over `WebFetch` for URL fetches - `WebFetch` pulls full page content into context.
-
-**Raw Bash remains appropriate per the Tool Discipline rule in `content/rules/code-standards.md`** - `git`, builds, installs, process management, and any operation that needs direct filesystem side effects.
-
-**Platform support:** fully supported on Claude Code, Cursor, Codex CLI, OpenCode, Kimi, and oh-my-pi. The tools are available when `ctx_execute` is present as a callable tool in the session. When unavailable, fall back to the `Read`/`Glob`/`Grep` tool-discipline in `content/rules/code-standards.md`.
 
 ## Package Management
 

--- a/.cursor/commands/ds-ticket-triage.md
+++ b/.cursor/commands/ds-ticket-triage.md
@@ -224,13 +224,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.cursor/references/code-standards-detail.md
+++ b/.cursor/references/code-standards-detail.md
@@ -6,7 +6,6 @@ Purpose: Detailed code-standards reference blocks extracted from
          CLI usage for all browser verification tasks), the
          Discovery-Based Check Discipline block (mandated hard-fail forms
          for any check whose result depends on a discovered set of items),
-         the Context Window Management block (ctx_* MCP tool usage detail),
          and the Package Management block (dependency-versioning rules).
 
 Public API: Read-only reference document. Cross-referenced from:
@@ -19,8 +18,7 @@ Upstream deps: content/rules/code-standards.md (parent rules file; read
                rules).
 
 Downstream consumers: engineer agents (run per-language quality gates
-                      after every implementation; consult Context Window
-                      Management when ctx_* tools are present, and Package
+                      after every implementation; consult Package
                       Management when adding/upgrading a dependency);
                       content/sections/12-protocol-details.md (code
                       standards reference).
@@ -72,26 +70,6 @@ Every discovery-based check MUST hard-fail on zero discovered items, and MUST do
 A docstring reference to a guard's failure phrase (documenting what the guard does, or citing it as precedent for a sibling check) is the only sanctioned way to mention the phrase outside an actual guard - it is classified DOCUMENTATION, not a violation and not a guard, and does not count toward a check's live-guard total. A phrase mention anywhere else that is not a docstring (a `#` comment, a non-first-statement string, ordinary prose) reports as NON-CONFORMING; this is deliberate, not an oversight, so route future mentions of a guard phrase into a docstring or an actual guard.
 
 Reference implementations that conform: the `hooks-python-tests`, `bin-sh-tests`, `hooks-js-tests`, and `hooks-sh-tests` CI jobs, and `hooks/tests/test-hooks-pep604-guard.py`'s Form-B guards.
-
-## Context Window Management
-
-**See `content/rules/code-standards.md` §Context Window Management for the inline output-size threshold that triggers preferring `ctx_execute`/`ctx_batch_execute` over raw `Bash`.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.
-
-Key tools and their uses:
-- `ctx_execute(language, code)` - run a single script; only stdout enters context
-- `ctx_execute_file(path, language, code)` - analyze a file for inspection only; use `Read` instead when you intend to subsequently `Edit` the file
-
-> Never use `ctx_execute` or `ctx_execute_file` to create or modify files - these tools are for analysis, processing, and computation only. Use the native `Write`/`Edit` tools for all file writes.
-
-- `ctx_batch_execute(commands, queries)` - run multiple commands and search results in one call; replaces 10-30 Bash + search steps
-- `ctx_index(content, source)` / `ctx_search(queries)` - build and query a knowledge base from arbitrary content
-- `ctx_fetch_and_index(url, source)` - fetch a URL, index it, cache for 24 hours
-
-> When ctx tools are available, prefer `ctx_fetch_and_index` over `WebFetch` for URL fetches - `WebFetch` pulls full page content into context.
-
-**Raw Bash remains appropriate per the Tool Discipline rule in `content/rules/code-standards.md`** - `git`, builds, installs, process management, and any operation that needs direct filesystem side effects.
-
-**Platform support:** fully supported on Claude Code, Cursor, Codex CLI, OpenCode, Kimi, and oh-my-pi. The tools are available when `ctx_execute` is present as a callable tool in the session. When unavailable, fall back to the `Read`/`Glob`/`Grep` tool-discipline in `content/rules/code-standards.md`.
 
 ## Package Management
 

--- a/.cursor/rules/code-standards.mdc
+++ b/.cursor/rules/code-standards.mdc
@@ -35,13 +35,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.gemini/commands/ds-ticket-triage.toml
+++ b/.gemini/commands/ds-ticket-triage.toml
@@ -230,13 +230,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.gemini/references/code-standards-detail.md
+++ b/.gemini/references/code-standards-detail.md
@@ -6,7 +6,6 @@ Purpose: Detailed code-standards reference blocks extracted from
          CLI usage for all browser verification tasks), the
          Discovery-Based Check Discipline block (mandated hard-fail forms
          for any check whose result depends on a discovered set of items),
-         the Context Window Management block (ctx_* MCP tool usage detail),
          and the Package Management block (dependency-versioning rules).
 
 Public API: Read-only reference document. Cross-referenced from:
@@ -19,8 +18,7 @@ Upstream deps: content/rules/code-standards.md (parent rules file; read
                rules).
 
 Downstream consumers: engineer agents (run per-language quality gates
-                      after every implementation; consult Context Window
-                      Management when ctx_* tools are present, and Package
+                      after every implementation; consult Package
                       Management when adding/upgrading a dependency);
                       content/sections/12-protocol-details.md (code
                       standards reference).
@@ -72,26 +70,6 @@ Every discovery-based check MUST hard-fail on zero discovered items, and MUST do
 A docstring reference to a guard's failure phrase (documenting what the guard does, or citing it as precedent for a sibling check) is the only sanctioned way to mention the phrase outside an actual guard - it is classified DOCUMENTATION, not a violation and not a guard, and does not count toward a check's live-guard total. A phrase mention anywhere else that is not a docstring (a `#` comment, a non-first-statement string, ordinary prose) reports as NON-CONFORMING; this is deliberate, not an oversight, so route future mentions of a guard phrase into a docstring or an actual guard.
 
 Reference implementations that conform: the `hooks-python-tests`, `bin-sh-tests`, `hooks-js-tests`, and `hooks-sh-tests` CI jobs, and `hooks/tests/test-hooks-pep604-guard.py`'s Form-B guards.
-
-## Context Window Management
-
-**See `content/rules/code-standards.md` §Context Window Management for the inline output-size threshold that triggers preferring `ctx_execute`/`ctx_batch_execute` over raw `Bash`.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.
-
-Key tools and their uses:
-- `ctx_execute(language, code)` - run a single script; only stdout enters context
-- `ctx_execute_file(path, language, code)` - analyze a file for inspection only; use `Read` instead when you intend to subsequently `Edit` the file
-
-> Never use `ctx_execute` or `ctx_execute_file` to create or modify files - these tools are for analysis, processing, and computation only. Use the native `Write`/`Edit` tools for all file writes.
-
-- `ctx_batch_execute(commands, queries)` - run multiple commands and search results in one call; replaces 10-30 Bash + search steps
-- `ctx_index(content, source)` / `ctx_search(queries)` - build and query a knowledge base from arbitrary content
-- `ctx_fetch_and_index(url, source)` - fetch a URL, index it, cache for 24 hours
-
-> When ctx tools are available, prefer `ctx_fetch_and_index` over `WebFetch` for URL fetches - `WebFetch` pulls full page content into context.
-
-**Raw Bash remains appropriate per the Tool Discipline rule in `content/rules/code-standards.md`** - `git`, builds, installs, process management, and any operation that needs direct filesystem side effects.
-
-**Platform support:** fully supported on Claude Code, Cursor, Codex CLI, OpenCode, Kimi, and oh-my-pi. The tools are available when `ctx_execute` is present as a callable tool in the session. When unavailable, fall back to the `Read`/`Glob`/`Grep` tool-discipline in `content/rules/code-standards.md`.
 
 ## Package Management
 

--- a/.gemini/skills/dinostack/SKILL.full.md
+++ b/.gemini/skills/dinostack/SKILL.full.md
@@ -672,13 +672,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.gemini/skills/dinostack/SKILL.md
+++ b/.gemini/skills/dinostack/SKILL.md
@@ -668,13 +668,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.github/prompts/ds-ticket-triage.prompt.md
+++ b/.github/prompts/ds-ticket-triage.prompt.md
@@ -227,13 +227,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.github/skills/dinostack/SKILL.md
+++ b/.github/skills/dinostack/SKILL.md
@@ -676,13 +676,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -687,13 +687,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 
@@ -1935,7 +1931,6 @@ Purpose: Detailed code-standards reference blocks extracted from
          CLI usage for all browser verification tasks), the
          Discovery-Based Check Discipline block (mandated hard-fail forms
          for any check whose result depends on a discovered set of items),
-         the Context Window Management block (ctx_* MCP tool usage detail),
          and the Package Management block (dependency-versioning rules).
 
 Public API: Read-only reference document. Cross-referenced from:
@@ -1948,8 +1943,7 @@ Upstream deps: content/rules/code-standards.md (parent rules file; read
                rules).
 
 Downstream consumers: engineer agents (run per-language quality gates
-                      after every implementation; consult Context Window
-                      Management when ctx_* tools are present, and Package
+                      after every implementation; consult Package
                       Management when adding/upgrading a dependency);
                       content/sections/12-protocol-details.md (code
                       standards reference).
@@ -2001,26 +1995,6 @@ Every discovery-based check MUST hard-fail on zero discovered items, and MUST do
 A docstring reference to a guard's failure phrase (documenting what the guard does, or citing it as precedent for a sibling check) is the only sanctioned way to mention the phrase outside an actual guard - it is classified DOCUMENTATION, not a violation and not a guard, and does not count toward a check's live-guard total. A phrase mention anywhere else that is not a docstring (a `#` comment, a non-first-statement string, ordinary prose) reports as NON-CONFORMING; this is deliberate, not an oversight, so route future mentions of a guard phrase into a docstring or an actual guard.
 
 Reference implementations that conform: the `hooks-python-tests`, `bin-sh-tests`, `hooks-js-tests`, and `hooks-sh-tests` CI jobs, and `hooks/tests/test-hooks-pep604-guard.py`'s Form-B guards.
-
-## Context Window Management
-
-**See `content/rules/code-standards.md` §Context Window Management for the inline output-size threshold that triggers preferring `ctx_execute`/`ctx_batch_execute` over raw `Bash`.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.
-
-Key tools and their uses:
-- `ctx_execute(language, code)` - run a single script; only stdout enters context
-- `ctx_execute_file(path, language, code)` - analyze a file for inspection only; use `Read` instead when you intend to subsequently `Edit` the file
-
-> Never use `ctx_execute` or `ctx_execute_file` to create or modify files - these tools are for analysis, processing, and computation only. Use the native `Write`/`Edit` tools for all file writes.
-
-- `ctx_batch_execute(commands, queries)` - run multiple commands and search results in one call; replaces 10-30 Bash + search steps
-- `ctx_index(content, source)` / `ctx_search(queries)` - build and query a knowledge base from arbitrary content
-- `ctx_fetch_and_index(url, source)` - fetch a URL, index it, cache for 24 hours
-
-> When ctx tools are available, prefer `ctx_fetch_and_index` over `WebFetch` for URL fetches - `WebFetch` pulls full page content into context.
-
-**Raw Bash remains appropriate per the Tool Discipline rule in `content/rules/code-standards.md`** - `git`, builds, installs, process management, and any operation that needs direct filesystem side effects.
-
-**Platform support:** fully supported on Claude Code, Cursor, Codex CLI, OpenCode, Kimi, and oh-my-pi. The tools are available when `ctx_execute` is present as a callable tool in the session. When unavailable, fall back to the `Read`/`Glob`/`Grep` tool-discipline in `content/rules/code-standards.md`.
 
 ## Package Management
 
@@ -23642,13 +23616,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.kimi/skills/dinostack/SKILL.md
+++ b/.kimi/skills/dinostack/SKILL.md
@@ -788,13 +788,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 

--- a/.openclaw/skills/ds-ticket-triage/SKILL.md
+++ b/.openclaw/skills/ds-ticket-triage/SKILL.md
@@ -229,13 +229,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/.opencode/commands/ds-ticket-triage.md
+++ b/.opencode/commands/ds-ticket-triage.md
@@ -228,13 +228,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/content/commands/ds-ticket-triage.md
+++ b/content/commands/ds-ticket-triage.md
@@ -224,13 +224,9 @@ The captured estimate (`story_points` / `timeestimate` / Linear `estimate`) popu
 > - **3-4 points:** no warning. `context_risk` is unset.
 > - **≤ 2 points or estimate absent:** no warning. Safe to run as-is.
 >
-> **Token-reduction reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
+> **Context-fill reminder** - if any ticket has `context_risk: high`, append this one-time callout at the end of the story-size preflight output:
 > ```
-> 💡 Token-reduction tools: if your harness supports ctx_* context-mode tools
->    (ctx_execute, ctx_batch_execute), prefer them over raw shell output for any
->    operation producing > 20 lines - they reduce context consumption by ~98%
->    (see content/rules/code-standards.md §Context Window Management).
->    If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
+> 💡 If context fills mid-session, /ds-wrap → /clear → re-invoke /ds-implement-ticket
 >    with the remaining ticket IDs to continue in a fresh window.
 > ```
 >

--- a/content/references/code-standards-detail.md
+++ b/content/references/code-standards-detail.md
@@ -6,7 +6,6 @@ Purpose: Detailed code-standards reference blocks extracted from
          CLI usage for all browser verification tasks), the
          Discovery-Based Check Discipline block (mandated hard-fail forms
          for any check whose result depends on a discovered set of items),
-         the Context Window Management block (ctx_* MCP tool usage detail),
          and the Package Management block (dependency-versioning rules).
 
 Public API: Read-only reference document. Cross-referenced from:
@@ -19,8 +18,7 @@ Upstream deps: content/rules/code-standards.md (parent rules file; read
                rules).
 
 Downstream consumers: engineer agents (run per-language quality gates
-                      after every implementation; consult Context Window
-                      Management when ctx_* tools are present, and Package
+                      after every implementation; consult Package
                       Management when adding/upgrading a dependency);
                       content/sections/12-protocol-details.md (code
                       standards reference).
@@ -72,26 +70,6 @@ Every discovery-based check MUST hard-fail on zero discovered items, and MUST do
 A docstring reference to a guard's failure phrase (documenting what the guard does, or citing it as precedent for a sibling check) is the only sanctioned way to mention the phrase outside an actual guard - it is classified DOCUMENTATION, not a violation and not a guard, and does not count toward a check's live-guard total. A phrase mention anywhere else that is not a docstring (a `#` comment, a non-first-statement string, ordinary prose) reports as NON-CONFORMING; this is deliberate, not an oversight, so route future mentions of a guard phrase into a docstring or an actual guard.
 
 Reference implementations that conform: the `hooks-python-tests`, `bin-sh-tests`, `hooks-js-tests`, and `hooks-sh-tests` CI jobs, and `hooks/tests/test-hooks-pep604-guard.py`'s Form-B guards.
-
-## Context Window Management
-
-**See `content/rules/code-standards.md` §Context Window Management for the inline output-size threshold that triggers preferring `ctx_execute`/`ctx_batch_execute` over raw `Bash`.** Raw Bash output enters the context window in full; context-mode tools sandbox execution into isolated subprocesses and only let stdout enter context - reducing context consumption by up to 98%.
-
-Key tools and their uses:
-- `ctx_execute(language, code)` - run a single script; only stdout enters context
-- `ctx_execute_file(path, language, code)` - analyze a file for inspection only; use `Read` instead when you intend to subsequently `Edit` the file
-
-> Never use `ctx_execute` or `ctx_execute_file` to create or modify files - these tools are for analysis, processing, and computation only. Use the native `Write`/`Edit` tools for all file writes.
-
-- `ctx_batch_execute(commands, queries)` - run multiple commands and search results in one call; replaces 10-30 Bash + search steps
-- `ctx_index(content, source)` / `ctx_search(queries)` - build and query a knowledge base from arbitrary content
-- `ctx_fetch_and_index(url, source)` - fetch a URL, index it, cache for 24 hours
-
-> When ctx tools are available, prefer `ctx_fetch_and_index` over `WebFetch` for URL fetches - `WebFetch` pulls full page content into context.
-
-**Raw Bash remains appropriate per the Tool Discipline rule in `content/rules/code-standards.md`** - `git`, builds, installs, process management, and any operation that needs direct filesystem side effects.
-
-**Platform support:** fully supported on Claude Code, Cursor, Codex CLI, OpenCode, Kimi, and oh-my-pi. The tools are available when `ctx_execute` is present as a callable tool in the session. When unavailable, fall back to the `Read`/`Glob`/`Grep` tool-discipline in `content/rules/code-standards.md`.
 
 ## Package Management
 

--- a/content/rules/code-standards.md
+++ b/content/rules/code-standards.md
@@ -29,13 +29,9 @@ When choosing between tool options for the same job, prefer the option that mini
 
 - **Prefer token-efficient output.** Text and tabular tool output is cheaper for models to consume than JSON dumps with identical semantic content. When a tool offers multiple output formats, pick the one that gives the model the signal it needs with the least surrounding structure.
 - **Prefer CLI over MCP server when the CLI is cheaper.** An MCP server adds a protocol layer that inflates token cost and latency with no functional gain when a CLI covers the same job. Concrete reference: the GitHub MCP server costs approximately 3x the tokens and 2x the latency of the `gh` CLI for the same GitHub operations. AE uses `gh` for all GitHub operations (see AGENTS.md) - this is the principle in action.
-- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative. The `ctx_*` context-mode tools earn their place because their token reduction is measured (~98% context savings versus raw Bash output) - not assumed.
+- **Measure before adopting.** Do not assume a new tool or MCP server is cost-neutral. Before integrating either, benchmark its token/latency profile against the alternative.
 
-These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash) and the Context Window Management rules below (`ctx_*` over raw Bash for large output). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
-
-## Context Window Management
-
-**When `ctx_execute` or `ctx_batch_execute` MCP tools are available, prefer them over raw `Bash` for any operation expected to produce more than ~20 lines of output.** For tool usage detail, the create/modify-files prohibition, the `ctx_fetch_and_index`-over-`WebFetch` preference, and platform support: read `content/references/code-standards-detail.md` §Context Window Management.
+These rules complement the existing tool hierarchy above (Read/Glob/Grep over Bash). Together they form AE's tool-selection standard: reach for the tool whose output-to-signal ratio is best for the model reading it.
 
 ## Module Manifests
 


### PR DESCRIPTION
Removes the recommendation to use the operator-local `context-mode` MCP plugin (`ctx_*` tools) from the methodology. Nothing replaces it.

## Why

`bin/ds-doctor`'s `foreign_agent_hook` check FAILs on this plugin: it registers a PreToolUse hook on the Agent/Task tools that can silently rewrite subagent spawn input (DS-198). Recommending a tool the repo's own health check flags as a spawn-integrity hazard is incoherent, and that incoherence is the defect here — not the token math, which was real and measured.

Secondary: recommending an operator-local plugin as the *preferred* tool cuts against the works-for-everyone pillar. `content/references/evidence-on-disk.md` already makes exactly this argument and declines to depend on the plugin; the rules corpus was contradicting it.

Deletion rather than a hedged "use it if you have it" rewrite, per the AGENTS.md rule preferring deletion over a narrowed rewrite.

## Changes

- `content/rules/code-standards.md` — deleted `## Context Window Management`; dropped the `ctx_*`-as-proof clause from "Measure before adopting", keeping the principle.
- `content/references/code-standards-detail.md` — deleted `## Context Window Management`; corrected the manifest's Purpose index and Downstream-consumers list.
- `content/commands/ds-ticket-triage.md` — retitled the callout "Context-fill reminder"; kept the `/ds-wrap → /clear` guidance and the `context_risk: high` trigger.
- 16 generated adapter files rebuilt via `scripts/build-all.sh`.
- `content/references/evidence-on-disk.md` deliberately untouched.

## Validation

`build-all.sh` clean across 11 adapters; zero adapter drift (17-path pathspec verbatim from `adapter-sync.yml`, all entries confirmed present on disk). `check-skill-embed-budget.sh`: 137,667 B, floor 100,000, ceiling 145,000. Hooks JS suite: 55/56 pass; `test-stdin-guard.js` fails on a missing `espree` dev dependency, reproduced identically on unmodified `main`. `check-methodology-drift.sh` fails locally with `manifest_names[@]: unbound variable` under bash 3.2, also reproduced on unmodified `main`; no `content/sections/**` change, so no baseline regen is owed. `test_ticket_triage_inflight.sh` 80/80, `test_ticket_rework_triage_badge.sh` 30/30.

Doc-sync: predicate triggered (`content/rules/`, `content/references/`, `content/commands/`). Grepped `docs/index.html`, `docs/slides/*.md`, `README.md`, `CONTRIBUTING.md`, `content/SKILL.md` by hand for `ctx_`, `context-mode`, and "Context Window" — zero matches; none documented this plugin, so no updates were needed. `content/sections/12-protocol-details.md` never listed the deleted section.

## Accepted debt

Skeptic Minor, not blocking: read-only agents (skeptic, investigator, architect) now have no large-output tool-selection guidance. §Tool Discipline carries no output-size axis, and `evidence-on-disk.md` is parked and scoped to write-capable workers. Narrow residual — the deleted rule was itself gated on `ctx_execute` being present, so nothing was lost for any session without the plugin.
