### PR TITLE
feat(skeptic): lead the sign-off block with the verdict

### DIFF
--- a/.claude/commands/ds-init-project.md
+++ b/.claude/commands/ds-init-project.md
@@ -350,7 +350,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.claude/commands/ds-skeptic.md
+++ b/.claude/commands/ds-skeptic.md
@@ -72,7 +72,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.claude/commands/ds-wrap.md
+++ b/.claude/commands/ds-wrap.md
@@ -441,7 +441,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -696,7 +696,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.codex/agents/skeptic.toml
+++ b/.codex/agents/skeptic.toml
@@ -123,17 +123,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -144,7 +146,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -154,7 +156,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/.codex/skill-compatibility.yml
+++ b/.codex/skill-compatibility.yml
@@ -22072,16 +22072,6 @@
       "source_token": "$CLAUDE_CODE_SESSION_ID"
     },
     {
-      "expected_target": "content/references/skeptic-protocol.md",
-      "generated_token": "$AE_REPO_DIR/content/references/skeptic-protocol.md",
-      "kind": "operational",
-      "occurrence_hash": "4f0cec8522ea2bad37b88792186f5ba80aff050dc1342d7a191c0d64bc9393bf",
-      "resolution_mode": "validated-repository",
-      "scope": "canonical-source",
-      "source": "content/commands/ds-wrap.md",
-      "source_token": "content/references/skeptic-protocol.md"
-    },
-    {
       "expected_target": "wrap",
       "generated_token": "$wrap",
       "kind": "operational",
@@ -23170,6 +23160,16 @@
       "scope": "dinostack-repository",
       "source": "content/commands/ds-wrap.md",
       "source_token": "/ds-wrap"
+    },
+    {
+      "expected_target": "content/references/skeptic-protocol.md",
+      "generated_token": "$AE_REPO_DIR/content/references/skeptic-protocol.md",
+      "kind": "operational",
+      "occurrence_hash": "8950345e890cda4e760737713396405c8badc36dd349e304f9ba3d0b9621df16",
+      "resolution_mode": "validated-repository",
+      "scope": "canonical-source",
+      "source": "content/commands/ds-wrap.md",
+      "source_token": "content/references/skeptic-protocol.md"
     },
     {
       "expected_target": "wrap",

--- a/.codex/skills/wrap/SKILL.md
+++ b/.codex/skills/wrap/SKILL.md
@@ -496,7 +496,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `$AE_REPO_DIR/content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `$AE_REPO_DIR/content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -751,7 +751,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `$AE_REPO_DIR/content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.copilot/references/skeptic-protocol.md
+++ b/.copilot/references/skeptic-protocol.md
@@ -659,18 +659,20 @@ Changes made:
 
 The structured sign-off format is required for every Skeptic response, whether findings exist or not:
 
+The verdict line comes FIRST (see `content/agents/skeptic.md` §Sign-off format, the canonical statement of this ordering and its rationale): it is the primary piece of information the block carries, and it is never placed behind the process attestations. The findings justifying it follow; `Reviewed:` and the four attestations form the audit tail.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 [Optional, only when applicable: Round value: low - <reason>]
 [Optional, only when applicable: Blocking-minor: <finding id/description> - <reason>]
 ```
@@ -725,7 +727,7 @@ Round 4 (most recent):
 
 ### Sign-off validation
 
-The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type:
+The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type. The `(a)`-`(l)` labels below are stable identifiers for cross-referencing, not an emission order - the emission order is the template above, verdict first:
 
 - (a) a line beginning "Reviewed:"
 - (b) a line beginning "Findings:"

--- a/.cursor/commands/ds-init-project.md
+++ b/.cursor/commands/ds-init-project.md
@@ -344,7 +344,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.cursor/commands/ds-skeptic.md
+++ b/.cursor/commands/ds-skeptic.md
@@ -66,7 +66,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.cursor/commands/ds-wrap.md
+++ b/.cursor/commands/ds-wrap.md
@@ -434,7 +434,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -689,7 +689,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.cursor/references/skeptic-protocol.md
+++ b/.cursor/references/skeptic-protocol.md
@@ -659,18 +659,20 @@ Changes made:
 
 The structured sign-off format is required for every Skeptic response, whether findings exist or not:
 
+The verdict line comes FIRST (see `content/agents/skeptic.md` §Sign-off format, the canonical statement of this ordering and its rationale): it is the primary piece of information the block carries, and it is never placed behind the process attestations. The findings justifying it follow; `Reviewed:` and the four attestations form the audit tail.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 [Optional, only when applicable: Round value: low - <reason>]
 [Optional, only when applicable: Blocking-minor: <finding id/description> - <reason>]
 ```
@@ -725,7 +727,7 @@ Round 4 (most recent):
 
 ### Sign-off validation
 
-The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type:
+The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type. The `(a)`-`(l)` labels below are stable identifiers for cross-referencing, not an emission order - the emission order is the template above, verdict first:
 
 - (a) a line beginning "Reviewed:"
 - (b) a line beginning "Findings:"

--- a/.gemini/agents/skeptic.md
+++ b/.gemini/agents/skeptic.md
@@ -124,17 +124,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -145,7 +147,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -155,7 +157,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/.gemini/commands/ds-init-project.toml
+++ b/.gemini/commands/ds-init-project.toml
@@ -350,7 +350,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.gemini/commands/ds-skeptic.toml
+++ b/.gemini/commands/ds-skeptic.toml
@@ -72,7 +72,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.gemini/commands/ds-wrap.toml
+++ b/.gemini/commands/ds-wrap.toml
@@ -440,7 +440,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -695,7 +695,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.gemini/references/skeptic-protocol.md
+++ b/.gemini/references/skeptic-protocol.md
@@ -659,18 +659,20 @@ Changes made:
 
 The structured sign-off format is required for every Skeptic response, whether findings exist or not:
 
+The verdict line comes FIRST (see `content/agents/skeptic.md` §Sign-off format, the canonical statement of this ordering and its rationale): it is the primary piece of information the block carries, and it is never placed behind the process attestations. The findings justifying it follow; `Reviewed:` and the four attestations form the audit tail.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 [Optional, only when applicable: Round value: low - <reason>]
 [Optional, only when applicable: Blocking-minor: <finding id/description> - <reason>]
 ```
@@ -725,7 +727,7 @@ Round 4 (most recent):
 
 ### Sign-off validation
 
-The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type:
+The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type. The `(a)`-`(l)` labels below are stable identifiers for cross-referencing, not an emission order - the emission order is the template above, verdict first:
 
 - (a) a line beginning "Reviewed:"
 - (b) a line beginning "Findings:"

--- a/.github/agents/skeptic.md
+++ b/.github/agents/skeptic.md
@@ -120,17 +120,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -141,7 +143,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -151,7 +153,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/.github/prompts/ds-init-project.prompt.md
+++ b/.github/prompts/ds-init-project.prompt.md
@@ -347,7 +347,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.github/prompts/ds-skeptic.prompt.md
+++ b/.github/prompts/ds-skeptic.prompt.md
@@ -69,7 +69,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.github/prompts/ds-wrap.prompt.md
+++ b/.github/prompts/ds-wrap.prompt.md
@@ -437,7 +437,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -692,7 +692,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.hermes/SKILL.md
+++ b/.hermes/SKILL.md
@@ -7220,18 +7220,20 @@ Changes made:
 
 The structured sign-off format is required for every Skeptic response, whether findings exist or not:
 
+The verdict line comes FIRST (see `content/agents/skeptic.md` §Sign-off format, the canonical statement of this ordering and its rationale): it is the primary piece of information the block carries, and it is never placed behind the process attestations. The findings justifying it follow; `Reviewed:` and the four attestations form the audit tail.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 [Optional, only when applicable: Round value: low - <reason>]
 [Optional, only when applicable: Blocking-minor: <finding id/description> - <reason>]
 ```
@@ -7286,7 +7288,7 @@ Round 4 (most recent):
 
 ### Sign-off validation
 
-The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type:
+The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type. The `(a)`-`(l)` labels below are stable identifiers for cross-referencing, not an emission order - the emission order is the template above, verdict first:
 
 - (a) a line beginning "Reviewed:"
 - (b) a line beginning "Findings:"
@@ -14376,17 +14378,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -14397,7 +14401,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -14407,7 +14411,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]
@@ -21108,7 +21112,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 
@@ -22699,7 +22703,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 
@@ -25150,7 +25154,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -25405,7 +25409,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.openclaw/skills/agent-skeptic/SKILL.md
+++ b/.openclaw/skills/agent-skeptic/SKILL.md
@@ -120,17 +120,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -141,7 +143,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -151,7 +153,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/.openclaw/skills/ds-init-project/SKILL.md
+++ b/.openclaw/skills/ds-init-project/SKILL.md
@@ -349,7 +349,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.openclaw/skills/ds-skeptic/SKILL.md
+++ b/.openclaw/skills/ds-skeptic/SKILL.md
@@ -71,7 +71,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.openclaw/skills/ds-wrap/SKILL.md
+++ b/.openclaw/skills/ds-wrap/SKILL.md
@@ -439,7 +439,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -694,7 +694,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/.opencode/agents/skeptic.md
+++ b/.opencode/agents/skeptic.md
@@ -125,17 +125,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -146,7 +148,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -156,7 +158,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/.opencode/commands/ds-init-project.md
+++ b/.opencode/commands/ds-init-project.md
@@ -348,7 +348,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/.opencode/commands/ds-skeptic.md
+++ b/.opencode/commands/ds-skeptic.md
@@ -70,7 +70,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/.opencode/commands/ds-wrap.md
+++ b/.opencode/commands/ds-wrap.md
@@ -438,7 +438,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -693,7 +693,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/content/agents/skeptic.md
+++ b/content/agents/skeptic.md
@@ -125,17 +125,19 @@ The bullet on amended-Section-4.5 diffs is a scoping note for both Step 0 checks
 
 The conductor validates this format exactly. Use it verbatim - do not paraphrase the structural lines.
 
+The verdict line comes FIRST - it is the one piece of information every reader of this block needs, and it must never be buried behind the process attestations. The findings that justify it follow, then the audit tail (`Reviewed:` and the four attestations). Every line below is mandatory; the ordering is what changed, not the content.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 ```
 
 **Prose-scoped re-check mode.** When the spawn prompt invokes the narrowed lever (see `content/references/skeptic-protocol.md` §Prose-scoped re-check), the sign-off requires one additional mandatory line, inserted directly after `Active search:`:
@@ -146,7 +148,7 @@ Scope: prose-scoped re-check (<sha1>..<sha2>; findings <ids> prose-only)
 
 In this mode, the `Active search:` line must not claim a full adversarial pass it did not run - state instead: `Active search: I have re-read the changed prose lines and the enclosing unit (manifest/section/header) end to end for <sha1>..<sha2>; I have not re-run the full adversarial brief.` If a code, test, or behavior finding surfaces during the narrowed read, escalate to a full pass immediately (see the rules governing the lever) rather than completing sign-off in scoped mode.
 
-If Critical or Major findings remain unresolved, replace the last line with:
+If Critical or Major findings remain unresolved, replace the first line (the granted verdict) with the withheld verdict and its resolution list, keeping both at the top of the block ahead of the findings list:
 
 ```
 Sign-off withheld. The following must be resolved:
@@ -156,7 +158,7 @@ Sign-off withheld. The following must be resolved:
 
 Every entry in the resolution list retains its `[CLASSIFICATION]:` prefix (colon form), including a finding referenced by name from Step 12's fabrication check - the "do not re-emit" instruction there bans a second `Critical -`/`Major -`/`Minor -`-prefixed (hyphen form) finding bullet duplicating the same fabrication earlier in the findings list, not the classification prefix on this resolution-list entry itself.
 
-**Two optional lines (round-cost signaling).** Add either or both, only when applicable, directly after the sign-off line (granted or withheld):
+**Two optional lines (round-cost signaling).** Add either or both, only when applicable, at the END of the block - after `Neutrality check:` - not adjacent to the verdict line. They are cost signals for the conductor, not part of the verdict the operator reads first:
 
 ```
 Round value: low - [one-line reason another round would buy little, e.g. "remaining findings are Minor-only style notes"]

--- a/content/commands/ds-init-project.md
+++ b/content/commands/ds-init-project.md
@@ -344,7 +344,7 @@ This step runs only when Step 2 detects an existing configured `AGENTS.md` (upda
 
    > "Does the split preserve every fact and instruction from the original CLAUDE.md? For each bucket: is any agentic content still sitting in the residual CLAUDE.md that should have moved to AGENTS.md? Is any project-specific Claude-only instruction incorrectly promoted to the tool-agnostic AGENTS.md where Codex/Cursor/Gemini will also read it? Are the MEMORY.md additions stable facts (rationale, dated observations) rather than temporary task state? Is the proposed AGENTS.md under 45 lines and does it have all required sections (H1, overview paragraph, Decisions, Tools, Docs, Conventions, Session start)? Did any implementation detail or rationale paragraph remain in AGENTS.md that belongs in MEMORY.md instead? Is the residual CLAUDE.md genuinely Claude-Code-specific, or is it agentic content that was dropped into the wrong bucket?"
 
-   Require the standard sign-off format: `Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted.`
+   Require the standard sign-off format: `No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:` (verdict first - see `content/agents/skeptic.md` §Sign-off format)
 
    **PRESENT the three-way split to the user BEFORE applying** (diff-style preview):
 

--- a/content/commands/ds-skeptic.md
+++ b/content/commands/ds-skeptic.md
@@ -66,7 +66,7 @@ The Skeptic is always a fresh spawn - never resumed, never continued from a prio
 
 ## Step 3 - Read findings
 
-A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines - Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
+A valid sign-off contains all mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first - the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements apply only when their triggering condition holds - see Section 11 for when).
 
 If any element is missing: spawn a new Skeptic with explicit format instructions ("Your previous response did not conform to the required sign-off format. Please restate your findings and sign-off using the required format."). This format re-invocation is not counted as a new adversarial round. Limit: 3 format re-invocations. If still noncompliant after 3, escalate to the human.
 

--- a/content/commands/ds-wrap.md
+++ b/content/commands/ds-wrap.md
@@ -434,7 +434,7 @@ Require this statement before sign-off: "Active search: I have applied the adver
 
 **Step 3 — Validate sign-off format.**
 
-A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines: Reviewed:, Findings:, Active search:, the sign-off phrase, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
+A valid sign-off requires the mandatory elements defined in `content/references/skeptic-protocol.md` Section 11 (the seven always-required lines, emitted verdict-first: the sign-off phrase, Findings:, Reviewed:, Active search:, Manifest check:, Test-CI-wiring check:, Neutrality check:; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply to this internal review). If any element is missing, spawn a new Skeptic with format instructions (not a new re-route round). Limit: 3 format re-invocations, then escalate to the user.
 
 If Critical or Major findings remain: spawn a new draft Worker with the original draft and findings, get a revised draft, then spawn a fresh Skeptic (Step 2). Repeat until sign-off. If the same finding is contested across 2+ re-routes without resolution, escalate to the user.
 
@@ -689,7 +689,7 @@ Otherwise skip that target silently.
    >
    > Require this statement before sign-off: "Active search: I walked the original section by section and verified every fact appears in the compressed output, independently re-ran every cited positive-match grep and falsity-proof check for deleted or merged entries, and for every SUPERSEDED_MERGE independently re-read the superseding prose and re-verified the fact-by-fact mapping."
    >
-   > Sign-off format: "Reviewed: ... Findings: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check: ... No unresolved Critical or Major findings. Sign-off granted."
+   > Sign-off format (verdict first): "No unresolved Critical or Major findings. Sign-off granted. ... Findings: ... Reviewed: ... Active search: ... Manifest check: ... Test-CI-wiring check: ... Neutrality check:"
 
 3. Validate sign-off format the same way Step 3 does (the mandatory elements per `content/references/skeptic-protocol.md` Section 11 - the seven always-required lines; the conditional spec-deviation, PR-SHA-range, and prose-scoped-re-check `Scope:` elements do not apply here). If any element is missing, spawn a new Skeptic with format instructions (not a re-route round). Limit: 3 format re-invocations, then escalate to the user.
 

--- a/content/references/skeptic-protocol.md
+++ b/content/references/skeptic-protocol.md
@@ -659,18 +659,20 @@ Changes made:
 
 The structured sign-off format is required for every Skeptic response, whether findings exist or not:
 
+The verdict line comes FIRST (see `content/agents/skeptic.md` §Sign-off format, the canonical statement of this ordering and its rationale): it is the primary piece of information the block carries, and it is never placed behind the process attestations. The findings justifying it follow; `Reviewed:` and the four attestations form the audit tail.
+
 ```
-Reviewed: [files/components examined]
-  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
+No unresolved Critical or Major findings. Sign-off granted.
 Findings: Critical: N, Major: N, Minor: N
 [Each finding on its own line: Critical - description (file:line or region)]
 If all counts are zero, write instead: Findings: No findings.
 [If any Minor finding is a spec-deviation downgrade, include the three-criterion "Spec deviation downgrade justification" block here - see format below]
+Reviewed: [files/components examined]
+  (For PR reviews: Reviewed: <base-sha>..<head-sha> - [files/components examined])
 Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.
 Manifest check: [pass | N stale (listed above) | N missing (listed above) | n/a - no non-trivial modules in diff]
 Test-CI-wiring check: [pass | N new test files not wired into CI (listed above) | n/a - no new test files in diff]
 Neutrality check: [pass | N steer(s) found (listed above)]
-No unresolved Critical or Major findings. Sign-off granted.
 [Optional, only when applicable: Round value: low - <reason>]
 [Optional, only when applicable: Blocking-minor: <finding id/description> - <reason>]
 ```
@@ -725,7 +727,7 @@ Round 4 (most recent):
 
 ### Sign-off validation
 
-The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type:
+The primary agent treats a Skeptic response as a valid sign-off only when it contains **the mandatory elements** as distinct lines. There are seven mandatory elements, always required on every Skeptic response regardless of review type. The `(a)`-`(l)` labels below are stable identifiers for cross-referencing, not an emission order - the emission order is the template above, verdict first:
 
 - (a) a line beginning "Reviewed:"
 - (b) a line beginning "Findings:"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1513,7 +1513,7 @@
     </div>
     <div class="note" style="border-left-color: var(--violet); margin-top: 10px;">
       <strong>Core thesis:</strong> "The value of an adversarial reviewer is independence. A reviewer who has already heard the implementer's justifications is no longer independent."
-      The brief must be passed verbatim - never softened. Sign-off requires 7 elements: Reviewed, Findings, Active search attestation, Manifest check, Test-CI-wiring check, Neutrality check, and explicit sign-off statement.
+      The brief must be passed verbatim - never softened. Sign-off requires the same 7 elements, emitted verdict-first: the explicit sign-off statement, Findings, Reviewed, Active search attestation, Manifest check, Test-CI-wiring check, Neutrality check.
     </div>
     <div class="note" style="border-left-color: var(--gold); margin-top: 10px;">
       <strong>Regression Test Obligation:</strong> Every Critical or Major finding that gets fixed without a regression test is a latent regression. The Worker adds a test that would have caught the failure; the Skeptic verifies it exists before sign-off. The test lives in the project's normal test suite, alongside existing tests for the affected module, so the same bug cannot silently reappear in a future change.

--- a/hooks/subagent-stop-spawn-emit.js
+++ b/hooks/subagent-stop-spawn-emit.js
@@ -674,9 +674,119 @@ const _FINDINGS_NONE_RE = /Findings:\s*(?:\*\*)?\s*No findings\.?/i;
 // format"): "No unresolved Critical or Major findings. Sign-off granted."
 // and "Sign-off withheld. The following must be resolved:". Matching the
 // short literal substring, not the full sentence, is deliberate - the
-// preceding clause is prose, not part of the format contract.
+// preceding clause is prose, not part of the format contract. Both the
+// line-anchored regexes below and the substring fallback honour this: each
+// side matches only the SHORT literal, symmetrically. An earlier revision
+// made the granted side require the full two-sentence form; that silently
+// made the "No unresolved ..." clause load-bearing, contradicting this
+// comment and leaving a bare `Sign-off granted.` verdict line unmatched.
 const _SIGNOFF_GRANTED_LITERAL = 'Sign-off granted.';
 const _SIGNOFF_WITHHELD_LITERAL = 'Sign-off withheld.';
+// Markers that may precede content on a line, in any combination:
+// indentation, blockquote carets, an ATX heading, and a bullet or numbered
+// list item. Shared by the verdict regexes AND the fence regex - a fence
+// opened inside a list item or blockquote must be tracked, or every line
+// after it is mis-bucketed.
+const _LINE_MARKER_PREFIX = '^[ \\t]*(?:>[ \\t]*)*(?:#{1,6}[ \\t]+)?(?:(?:[-*+]|\\d+[.)])[ \\t]+)?';
+// A verdict line may additionally be bold-wrapped, with or without a space
+// between the `**` and the literal.
+const _VERDICT_LINE_PREFIX = _LINE_MARKER_PREFIX + '(?:\\*\\*[ \\t]*)?';
+// The granted verdict's mandated line opens with a prose clause ("No
+// unresolved Critical or Major findings.") before the literal, where the
+// withheld line opens with its literal directly. That clause is therefore
+// OPTIONAL here, not required: the short literal stays the only token
+// either side matches on - honouring the comment above - while the
+// canonical two-sentence line and a bare `Sign-off granted.` line both
+// anchor. Requiring the clause instead would leave the bare form unmatched
+// and bias every ambiguous case toward withheld.
+const _SIGNOFF_GRANTED_CLAUSE = '(?:No unresolved Critical or Major findings\\.[ \\t]*(?:\\*\\*)?)?';
+const _SIGNOFF_GRANTED_LINE_RE = new RegExp(
+  _VERDICT_LINE_PREFIX + _SIGNOFF_GRANTED_CLAUSE + 'Sign-off granted\\.');
+const _SIGNOFF_WITHHELD_LINE_RE = new RegExp(_VERDICT_LINE_PREFIX + 'Sign-off withheld\\.');
+// Opening/closing marker of a fenced code block (``` or ~~~), carrying the
+// same marker prefixes a verdict line may carry. The marker must be the
+// LAST content on the line, optionally followed by a language tag (which
+// cannot itself contain a fence character). Without that end anchor an
+// inline code span that opens and closes on one line - "- ```inline```
+// code", "1. ```x``` y", "# ```z" - would toggle fence state, and an odd
+// number of such lines mis-buckets every line after it.
+const _CODE_FENCE_RE = new RegExp(
+  _LINE_MARKER_PREFIX + '(?:```|~~~)[ \\t]*[A-Za-z0-9_+.-]*[ \\t]*$');
+
+/**
+ * Resolve the verdict from a Skeptic's last assistant message.
+ *
+ * The rule is deliberately ORDER-FREE, because document order cannot tell
+ * a real verdict from a quoted one under both template shapes at once:
+ * the verdict-first template (current) puts the real verdict at the TOP of
+ * the block, the verdict-last template (superseded, but still emitted by
+ * any agent whose adapter/skill copy has not been re-installed yet - the
+ * same per-machine dormancy gap AGENTS.md documents for hook snapshots)
+ * puts it at the BOTTOM. A first-wins rule mis-scores the second shape and
+ * a last-wins rule mis-scores the first, so neither is usable during the
+ * rollout window when both shapes coexist.
+ *
+ * Instead: consider only literals that BEGIN their own line, and resolve
+ * in two tiers - UNFENCED lines first, then FENCED lines. Fencing does NOT
+ * discriminate a decoy from a real verdict, and must not be read that way:
+ * skeptic.md displays the sign-off template as a fenced block, so agents
+ * routinely emit their own real block fenced. Treating "fenced" as
+ * "quoted" therefore discards the dominant emission shape and silently
+ * falls through to the substring rule this function exists to replace.
+ * What the tiering actually buys is precedence: when a quoted template
+ * excerpt and a real verdict coexist, the excerpt is nearly always the
+ * fenced one, so an unfenced verdict outranks a fenced one - while a
+ * wholly-fenced block still resolves, from tier 2, rather than falling
+ * through.
+ *
+ * Within each tier, if BOTH verdicts appear, withheld wins: recording a
+ * blocking review as a pass is the failure furthest from Pillar 2, so the
+ * ambiguous case fails safe toward the blocking verdict.
+ *
+ * Two known, accepted mis-scores. Both need a line that OPENS with a
+ * verdict literal; a literal appearing anywhere later on a line is
+ * unaffected.
+ *
+ * (1) SAFE direction. Because a verdict line may be bulleted, a granted
+ * block whose findings list contains a bullet that itself starts with the
+ * withheld literal (e.g. "- Sign-off withheld. is still the wording in the
+ * stale copy (a.md:12)") resolves withheld. A real granted review recorded
+ * as blocking - noisy, but it over-reports blocking rather than
+ * under-reporting it, which is the trade this function is calibrated for.
+ *
+ * (2) UNSAFE direction, disclosed deliberately. Because tier 1 resolves
+ * before tier 2, a FENCED real withheld block loses to any UNFENCED line
+ * that starts with the granted literal - e.g. a closing recap after the
+ * fenced block: "Sign-off granted. would require the Major above to be
+ * resolved first." That records a blocking review as a pass. It is the
+ * price of tier-1 precedence, which is what makes the far more common
+ * quoted-excerpt case come out right; narrowing it would need to
+ * distinguish a recap from a verdict, which no line-shape rule can do.
+ * Prefer withheld-wins ACROSS tiers only if this shape is ever measured
+ * in the wild - it is not, today.
+ *
+ * Returns true (granted), false (withheld), or null (no line-anchored
+ * verdict in either tier - caller falls back to the substring rule).
+ */
+function _resolveVerdictLineAnchored(text) {
+  let inFence = false;
+  const unfenced = { granted: false, withheld: false };
+  const fenced = { granted: false, withheld: false };
+  for (const line of text.split('\n')) {
+    if (_CODE_FENCE_RE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    const tier = inFence ? fenced : unfenced;
+    if (_SIGNOFF_WITHHELD_LINE_RE.test(line)) tier.withheld = true;
+    else if (_SIGNOFF_GRANTED_LINE_RE.test(line)) tier.granted = true;
+  }
+  for (const tier of [unfenced, fenced]) {
+    if (tier.withheld) return false;
+    if (tier.granted) return true;
+  }
+  return null;
+}
 
 /**
  * Parse the LAST assistant message in a Skeptic transcript for the
@@ -693,6 +803,16 @@ const _SIGNOFF_WITHHELD_LITERAL = 'Sign-off withheld.';
  * true` is set alongside the parsed counts (measured frequency ~2-3%; a
  * separate boolean, never folded into `calibrationNote` - those two fields
  * are not mutually exclusive with each other).
+ *
+ * Verdict resolution is ORDER-FREE and tiered: among verdict literals that
+ * begin their own line, unfenced lines are consulted first and fenced
+ * lines second, withheld winning over granted within each tier. This
+ * scores the verdict-first and verdict-last template shapes identically,
+ * which matters while both are in the wild during adapter rollout, and
+ * resolves a wholly-fenced block (the shape agents copy from skeptic.md)
+ * rather than dropping it. See _resolveVerdictLineAnchored. Only when
+ * neither tier yields a verdict does the older substring "last literal
+ * wins" rule apply as a fallback.
  *
  * Both a `Findings:` line (either the `Critical: N, Major: N, Minor: N`
  * form or the `No findings.` form, mapping to three explicit zeros - never
@@ -763,25 +883,22 @@ function parseSkepticSignoff(transcriptPath) {
     return { calibrationNote: 'unavailable (no sign-off found in transcript)' };
   }
 
-  // Tie-break (round-2 fix, m5): use the LAST occurrence of either verdict
-  // literal, not "withheld always wins whenever both are present." A
-  // Skeptic transcript can legitimately contain both literals in the same
-  // last message - content/agents/skeptic.md's own sign-off-format section
-  // quotes both templates verbatim, and a Skeptic reviewing that file (or
-  // any file that reproduces the format contract) scored signed_off:false
-  // even on a real "granted" verdict under the prior first-match logic.
-  // The verdict is whichever literal actually appears LAST in the text,
-  // matching the same "last one wins" convention already used for the
-  // multi-`Findings:` tie-break above.
-  const lastWithheldIdx = lastAssistantText.lastIndexOf(_SIGNOFF_WITHHELD_LITERAL);
-  const lastGrantedIdx = lastAssistantText.lastIndexOf(_SIGNOFF_GRANTED_LITERAL);
-  let signedOff;
-  if (lastWithheldIdx === -1 && lastGrantedIdx === -1) {
-    return { calibrationNote: 'unavailable (no sign-off found in transcript)' };
-  } else if (lastGrantedIdx > lastWithheldIdx) {
-    signedOff = true;
-  } else {
-    signedOff = false;
+  // Verdict resolution: see _resolveVerdictLineAnchored for the rule and
+  // why it is deliberately order-free (it must score the verdict-first and
+  // verdict-last template shapes correctly at the same time).
+  let signedOff = _resolveVerdictLineAnchored(lastAssistantText);
+  if (signedOff === null) {
+    // Fallback: no line-anchored verdict in EITHER tier (e.g. a Skeptic
+    // that inlined its verdict into a sentence). Retain the
+    // pre-existing substring "last literal wins" behaviour rather than
+    // dropping to a calibrationNote, so this stays a strict superset of
+    // prior coverage.
+    const lastWithheldIdx = lastAssistantText.lastIndexOf(_SIGNOFF_WITHHELD_LITERAL);
+    const lastGrantedIdx = lastAssistantText.lastIndexOf(_SIGNOFF_GRANTED_LITERAL);
+    if (lastWithheldIdx === -1 && lastGrantedIdx === -1) {
+      return { calibrationNote: 'unavailable (no sign-off found in transcript)' };
+    }
+    signedOff = lastGrantedIdx > lastWithheldIdx;
   }
 
   const result = { findingsCount, signedOff };

--- a/hooks/tests/test-subagent-stop-spawn-emit-calibration.js
+++ b/hooks/tests/test-subagent-stop-spawn-emit-calibration.js
@@ -221,36 +221,36 @@ function hookSpawnStart(sessionId, spawnId, agent, toolUseId, tsOverride) {
 }
 
 const GRANTED_SIGNOFF = [
-  'Reviewed: hooks/subagent-stop-spawn-emit.js',
+  'No unresolved Critical or Major findings. Sign-off granted.',
   'Findings: Critical: 0, Major: 0, Minor: 1',
   '- Minor - a style nit (file.js:10)',
+  'Reviewed: hooks/subagent-stop-spawn-emit.js',
   'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
   'Manifest check: pass',
   'Test-CI-wiring check: n/a - no new test files in diff',
   'Neutrality check: pass',
-  'No unresolved Critical or Major findings. Sign-off granted.',
 ].join('\n');
 
 const WITHHELD_SIGNOFF = [
-  'Reviewed: hooks/subagent-stop-spawn-emit.js',
+  'Sign-off withheld. The following must be resolved:',
+  '- Critical: a real bug (file.js:20)',
   'Findings: Critical: 1, Major: 0, Minor: 0',
   '- Critical - a real bug (file.js:20)',
+  'Reviewed: hooks/subagent-stop-spawn-emit.js',
   'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
   'Manifest check: pass',
   'Test-CI-wiring check: n/a - no new test files in diff',
   'Neutrality check: pass',
-  'Sign-off withheld. The following must be resolved:',
-  '- Critical: a real bug (file.js:20)',
 ].join('\n');
 
 const NO_FINDINGS_SIGNOFF = [
-  'Reviewed: hooks/subagent-stop-spawn-emit.js',
+  'No unresolved Critical or Major findings. Sign-off granted.',
   'Findings: No findings.',
+  'Reviewed: hooks/subagent-stop-spawn-emit.js',
   'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
   'Manifest check: pass',
   'Test-CI-wiring check: n/a - no new test files in diff',
   'Neutrality check: pass',
-  'No unresolved Critical or Major findings. Sign-off granted.',
 ].join('\n');
 
 // ---------------------------------------------------------------------------
@@ -389,8 +389,8 @@ console.log('\nTest 7: no-verdict-yields-calibration-note');
     agentType: 'skeptic', toolUseId: 'toolu_cal_007', description: 'x', spawnDepth: 1,
   });
   const noVerdictText = [
-    'Reviewed: hooks/foo.js',
     'Findings: Critical: 0, Major: 0, Minor: 0',
+    'Reviewed: hooks/foo.js',
     'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
     // No "Sign-off granted." / "Sign-off withheld." literal anywhere.
   ].join('\n');
@@ -423,14 +423,14 @@ console.log('\nTest 8: multi-findings-tie-break');
     'Findings: Critical: N, Major: N, Minor: N',
     '(fill in the actual counts below)',
     '',
-    'Reviewed: hooks/foo.js',
+    'No unresolved Critical or Major findings. Sign-off granted.',
     'Findings: Critical: 0, Major: 1, Minor: 2',
     '- Major - a real finding (file.js:5)',
+    'Reviewed: hooks/foo.js',
     'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
     'Manifest check: pass',
     'Test-CI-wiring check: n/a - no new test files in diff',
     'Neutrality check: pass',
-    'No unresolved Critical or Major findings. Sign-off granted.',
   ].join('\n');
   writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(multiFindingsText)]);
   const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
@@ -967,13 +967,14 @@ console.log('\nTest 22: m1-no-agent-note-when-attribution-agrees');
   cleanup(cwd); cleanup(configDir);
 }
 
-console.log('\nTest 23: m5-signoff-tie-break-uses-last-literal-not-withheld-always-wins');
+console.log('\nTest 23: signoff-tie-break-ignores-non-line-anchored-decoy-literals');
 {
   // Both verdict literals appear in the last assistant message (e.g. the
   // Skeptic quoted skeptic.md's own sign-off-format section, which
-  // contains both templates), with "Sign-off granted." appearing AFTER
-  // "Sign-off withheld." - the real verdict is the LAST one, not
-  // "withheld always wins whenever both are present."
+  // contains both templates). Neither decoy is line-anchored at its own
+  // line start - one is introduced by narrative prose, the other is
+  // wrapped in quotes - so both are ignored and the verdict is the
+  // line-anchored "granted" line that opens the real sign-off block.
   const cwd = makeTmpDir('ae-calib-test-');
   const configDir = makeTmpDir('ae-calib-config-');
   const sessionId = 'sess-cal-023';
@@ -985,13 +986,13 @@ console.log('\nTest 23: m5-signoff-tie-break-uses-last-literal-not-withheld-alwa
     'Recall the sign-off format: "Sign-off withheld. The following must be resolved:" or',
     '"No unresolved Critical or Major findings. Sign-off granted."',
     '',
-    'Reviewed: hooks/foo.js',
+    'No unresolved Critical or Major findings. Sign-off granted.',
     'Findings: Critical: 0, Major: 0, Minor: 0',
+    'Reviewed: hooks/foo.js',
     'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
     'Manifest check: pass',
     'Test-CI-wiring check: n/a - no new test files in diff',
     'Neutrality check: pass',
-    'No unresolved Critical or Major findings. Sign-off granted.',
   ].join('\n');
   writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(bothLiteralsText)]);
   const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
@@ -1000,7 +1001,453 @@ console.log('\nTest 23: m5-signoff-tie-break-uses-last-literal-not-withheld-alwa
   assert(!!complete, 'spawn_complete emitted');
   if (complete) {
     assert((complete.data || {}).signed_off === true,
-      `signed_off === true - the LAST literal in the message is "granted" (got: ${(complete.data || {}).signed_off})`);
+      `signed_off === true - the only line-anchored literal is "granted" (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23b: verdict-first-granted-not-inverted-by-later-quoted-withheld');
+{
+  // Verdict-first regression guard. Under the verdict-first sign-off
+  // template the granted verdict opens the block, and a findings
+  // description further down may legitimately quote the withheld literal
+  // (exactly what a Skeptic reviewing skeptic.md itself would write).
+  // The superseded "last literal wins" rule scored this signed_off:false
+  // - it saw the quoted "Sign-off withheld." as the later, and therefore
+  // authoritative, verdict - inverting a real sign-off into a withhold.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023b';
+  const agentId = 'agentcal023b';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023b', description: 'x', spawnDepth: 1,
+  });
+  const verdictFirstText = [
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the doc still spells the withhold verdict "Sign-off withheld." here (skeptic.md:150)',
+    'Reviewed: content/agents/skeptic.md',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(verdictFirstText)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - the line-anchored granted verdict opens the block; the later "Sign-off withheld." is quoted mid-line inside a finding (got: ${(complete.data || {}).signed_off})`);
+    const fc = (complete.data || {}).findings_count || {};
+    assert(fc.critical === 0 && fc.major === 0 && fc.minor === 1,
+      `findings_count parsed from the verdict-first block (got: ${JSON.stringify(fc)})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23c: withheld-not-inverted-by-fenced-granted-template-above');
+{
+  // MAJOR-1 mirror of 23b. A Skeptic reviewing skeptic.md fences the
+  // granted template ABOVE its own withheld verdict. A first-line-anchored
+  // -literal-wins rule scored this signed_off:true - a BLOCKING review
+  // recorded as a pass. Two guards fire here: the fenced excerpt is
+  // skipped entirely, and withheld would win the ambiguous case anyway.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023c';
+  const agentId = 'agentcal023c';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023c', description: 'x', spawnDepth: 1,
+  });
+  const fencedGrantedAboveWithheld = [
+    'The template under review reads:',
+    '```',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: N, Major: N, Minor: N',
+    '```',
+    'That is wrong for the reason below.',
+    '',
+    'Sign-off withheld. The following must be resolved:',
+    '- Major: the ordering claim is false (skeptic.md:130)',
+    'Findings: Critical: 0, Major: 1, Minor: 0',
+    '- Major - the ordering claim is false (skeptic.md:130)',
+    'Reviewed: content/agents/skeptic.md',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(fencedGrantedAboveWithheld)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === false,
+      `signed_off === false - a blocking review must never record as a pass because a fenced granted template sits above it (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23d: verdict-last-rollout-shape-withheld-scored-correctly');
+{
+  // MAJOR-1, second reachable shape: a VERDICT-LAST block (the superseded
+  // template, still emitted by any agent whose adapter/skill copy has not
+  // been re-installed) that quotes the granted line UNFENCED above its own
+  // withheld verdict. This is the original m5 case; a first-wins rule
+  // inverted it to signed_off:true. Order-free + withheld-wins scores it
+  // correctly without knowing which template shape produced it.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023d';
+  const agentId = 'agentcal023d';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023d', description: 'x', spawnDepth: 1,
+  });
+  const verdictLastText = [
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    '',
+    'is the line I would have written, but:',
+    '',
+    'Reviewed: hooks/foo.js',
+    'Findings: Critical: 1, Major: 0, Minor: 0',
+    '- Critical - a real bug (foo.js:20)',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    'Sign-off withheld. The following must be resolved:',
+    '- Critical: a real bug (foo.js:20)',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(verdictLastText)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === false,
+      `signed_off === false - verdict-LAST output must still score correctly during the rollout window (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23e: bare-granted-verdict-line-matches-short-literal');
+{
+  // MAJOR-2: the granted regex once required the full two-sentence form
+  // ("No unresolved Critical or Major findings. Sign-off granted."), so a
+  // bare `Sign-off granted.` verdict line got NO line-anchored match and
+  // fell through to the substring fallback - where a line-anchored
+  // withheld literal below it scored the run withheld. Both sides now
+  // match the SHORT literal, symmetrically, as the module comment says.
+  // The blockquote prefix here also covers MINOR-4.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023e';
+  const agentId = 'agentcal023e';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023e', description: 'x', spawnDepth: 1,
+  });
+  const bareGrantedText = [
+    '> Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the withhold wording "Sign-off withheld." is quoted inline here (doc.md:9)',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(bareGrantedText)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - a bare, blockquoted "Sign-off granted." verdict line must match the short literal (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23f: fenced-real-granted-block-with-quoted-withheld-in-findings');
+{
+  // MAJOR (round 2). skeptic.md displays the sign-off template as a FENCED
+  // block, so agents routinely emit their own real block fenced. The
+  // round-2 parser treated "fenced" as "quoted" and skipped both verdict
+  // lines, returning null and falling through to the old lastIndexOf rule
+  // - which then scored this granted block withheld off the quoted
+  // literal in its findings. That is the round-1 bug, verbatim.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023f';
+  const agentId = 'agentcal023f';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023f', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    '```',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the stale doc still says "Sign-off withheld." there (a.md:12)',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    '```',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - a REAL sign-off block that happens to be fenced must resolve from tier 2, not fall through to the substring rule (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23g: fenced-real-withheld-block');
+{
+  // A fenced REAL withheld block must resolve withheld from tier 2.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023g';
+  const agentId = 'agentcal023g';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023g', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    '```',
+    'Sign-off withheld. The following must be resolved:',
+    '- Critical: a real bug (foo.js:20)',
+    'Findings: Critical: 1, Major: 0, Minor: 0',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    '```',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === false,
+      `signed_off === false - a fenced withheld block resolves from tier 2 (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23h: tilde-fence-tracked-same-as-backtick');
+{
+  // A ~~~ fence must toggle fence state exactly as ``` does.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023h';
+  const agentId = 'agentcal023h';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023h', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    '~~~',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the stale doc still says "Sign-off withheld." there (a.md:12)',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    '~~~',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - a ~~~-fenced real block resolves from tier 2 (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23i: language-tagged-fence-tracked');
+{
+  // A language tag after the fence marker must not defeat fence tracking.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023i';
+  const agentId = 'agentcal023i';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023i', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    '```text',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the stale doc still says "Sign-off withheld." there (a.md:12)',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    '```',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - a language-tagged fence still toggles fence state (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23j: unclosed-fence-at-eof-still-resolves');
+{
+  // An unclosed fence at EOF leaves every subsequent line bucketed as
+  // fenced. Tier 2 must still resolve it rather than returning null.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023j';
+  const agentId = 'agentcal023j';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023j', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    'Here is my sign-off:',
+    '```',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the stale doc still says "Sign-off withheld." there (a.md:12)',
+    'Reviewed: hooks/foo.js',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - an unclosed fence at EOF still resolves from tier 2 (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23k: fence-opener-inside-list-item-tracked');
+{
+  // The fence regex must admit the same list/number/heading prefixes the
+  // verdict regex does. The quoted excerpt here is WITHHELD and the
+  // agent's own verdict is GRANTED, which is what makes the fixture
+  // discriminating: if the bullet-prefixed fence opener is untracked, the
+  // quoted withheld literal lands in tier 1 alongside the real granted
+  // verdict, withheld-wins fires, and a clean review is recorded as
+  // blocking. Note the inverse arrangement (quoted granted + real
+  // withheld) canNOT discriminate - both literals land in the same tier
+  // either way and withheld-wins masks the difference.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023k';
+  const agentId = 'agentcal023k';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023k', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    'Notes:',
+    '- Example of the withheld form the doc still shows:',
+    '- ```',
+    '  Sign-off withheld. The following must be resolved:',
+    '- ```',
+    'That example is stale, but nothing blocks.',
+    '',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    'Findings: Critical: 0, Major: 0, Minor: 1',
+    '- Minor - the withheld example above is stale (a.md:3)',
+    'Reviewed: a.md',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === true,
+      `signed_off === true - a fence opened inside a list item is tracked, so the quoted withheld excerpt stays in tier 2 and the real granted verdict wins tier 1 (got: ${(complete.data || {}).signed_off})`);
+  }
+  cleanup(cwd); cleanup(configDir);
+}
+
+// ---------------------------------------------------------------------------
+console.log('\nTest 23l: inline-code-span-does-not-toggle-fence-state');
+{
+  // MINOR 2. The marker prefix admits bullets/numbers/headings, so without
+  // an end-of-line anchor a span that OPENS AND CLOSES on one line
+  // ("- ```inline``` code") toggles fence state, and an odd number of such
+  // lines mis-buckets everything after. Here the mis-bucketing is directly
+  // observable: if that line toggles the fence ON, the agent's own
+  // withheld verdict is bucketed as fenced and the later real fence
+  // toggles OFF, leaving the QUOTED granted line unfenced - so tier 1
+  // resolves granted and a blocking review is recorded as a pass.
+  const cwd = makeTmpDir('ae-calib-test-');
+  const configDir = makeTmpDir('ae-calib-config-');
+  const sessionId = 'sess-cal-023l';
+  const agentId = 'agentcal023l';
+  writeSidecar(configDir, cwd, sessionId, agentId, {
+    agentType: 'skeptic', toolUseId: 'toolu_cal_023l', description: 'x', spawnDepth: 1,
+  });
+  const text = [
+    'Notes:',
+    '- ```inline``` code appears in the diff (a.md:4)',
+    '',
+    'Sign-off withheld. The following must be resolved:',
+    '- Major: the inline span is mishandled (a.md:4)',
+    'Findings: Critical: 0, Major: 1, Minor: 0',
+    'Reviewed: a.md',
+    'Active search: I have applied the adversarial brief and actively searched for Critical and Major findings.',
+    'Manifest check: pass',
+    'Test-CI-wiring check: n/a - no new test files in diff',
+    'Neutrality check: pass',
+    '',
+    'For reference the granted form is:',
+    '```',
+    'No unresolved Critical or Major findings. Sign-off granted.',
+    '```',
+  ].join('\n');
+  writeTranscript(configDir, cwd, sessionId, agentId, [assistantRecord(text)]);
+  const { status } = runHook(stopPayload(cwd, sessionId, agentId), cwd, configDir);
+  assert(status === 0, 'hook exits 0');
+  const complete = readEvents(cwd).find((e) => e.event === 'spawn_complete');
+  assert(!!complete, 'spawn_complete emitted');
+  if (complete) {
+    assert((complete.data || {}).signed_off === false,
+      `signed_off === false - an inline code span must not toggle fence state (got: ${(complete.data || {}).signed_off})`);
   }
   cleanup(cwd); cleanup(configDir);
 }


### PR DESCRIPTION
## Summary
- Skeptic sign-off block now leads with the verdict. Order was `Reviewed / Findings / Active search / Manifest / Test-CI-wiring / Neutrality / verdict`; the verdict was last of seven lines. All seven survive; only the order changes. Optional round-cost lines move to the block's end.
- Both canonical copies (`content/agents/skeptic.md`, `content/references/skeptic-protocol.md` §11) reordered and kept in sync; four order-listing sites in `ds-init-project`, `ds-skeptic`, `ds-wrap` re-enumerated.
- `hooks/subagent-stop-spawn-emit.js` verdict resolution rewritten: the old `lastIndexOf` rule was correct only because the verdict sat last. New rule: line-anchored literals, unfenced tier before fenced tier, withheld-wins within a tier, `lastIndexOf` only as a final fallback. Handles both verdict-first and legacy verdict-last blocks during the rollout window.
- Regression tests 23b-23l added; each non-forward test verified failing on the pre-fix parser.

## North Star alignment
- Pillar(s) advanced (see docs/overview/vision.md): Pillar 1 - the operator finds the verdict at line 1 instead of behind five attestations.
- Trade-off or pillar this could regress, if any: Pillar 2 - a mis-scored `signed_off` corrupts the calibration signal. Two disclosed, accepted residuals remain (one safe-direction, one unsafe-direction, both requiring a line that opens with the opposite literal); documented in the parser doc-comment with revisit conditions.

## Review rigor
- Brief / Plan path: n/a - conductor-side design.
- Skeptic rounds (tier): 3 (opus). Round 1: 2 Major (verdict inversion during rollout; regex asymmetry), 3 Minor. Round 2: 1 Major (fenced real blocks bypassed the rule), 3 Minor. Round 3: 0 Major, 4 Minor; sign-off granted. Three Minors fixed post-sign-off.

## Test plan
- [x] Calibration suite 167/0; pytest 2196 passed
- [x] Adapter drift rc=0; Kimi embed delta 0 B
- [x] Doc-sync: `docs/index.html` enumeration reordered; 19 decks grepped, none render the block
