### PR TITLE
ci: consolidate the post-merge run into verify-merged-tree.yml; drop 15 duplicate push triggers

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,224 @@
+# .github/workflows
+
+Canonical site for this repo's **CI trigger policy**. Workflow files carry a
+short pointer here, never a copy of it.
+
+## The premise, stated accurately
+
+`main`'s ruleset (`14778332`) sets `strict_required_status_checks_policy: true`.
+Under `strict` alone, a PR must be up to date with its base before it can merge,
+so its squash reproduces its head tree byte-for-byte and the PR run **is** the
+evaluation of what landed.
+
+**But the same ruleset carries `bypass_actors: [{RepositoryRole admin,
+bypass_mode: always}]`, and `gh pr merge --admin --squash` is this repo's normal
+unattended-agent merge path** (root `AGENTS.md` documents it as such, because
+GitHub disallows self-approval and no human reviewer is present). Admin bypass
+defeats `strict`: a behind-base PR can merge without being brought up to date,
+and the resulting squash synthesizes a tree that no run ever evaluated.
+
+**This file is the ONLY site that carries the measurement.** The 15 consolidated
+workflows' `on:` comments state the qualitative claim and point here, and
+`verify-merged-tree.yml`'s header does the same, precisely so that re-measuring
+(see the retirement condition) touches one file rather than seventeen. Do not
+copy the figures below into a workflow comment.
+
+Measured over the 25 most recent first-parent merges (comparing each squash
+commit's tree object to its PR head commit's tree object) - **6 of the last 25
+merged trees had never been evaluated by any run**:
+
+| | count | meaning |
+|---|---|---|
+| merged tree **matches** PR head tree | 19 (76%) | PR run was the evaluation; a post-merge run is pure duplication |
+| merged tree **differs** | 6 (24%) | #850, #854, #855, #856, #857, #860 - the post-merge run was the *only* evaluation |
+
+`#850`'s merged tree differed from its head across 46 files.
+
+## Trigger policy
+
+- **PR-only by default.** A workflow triggers on `pull_request` (plus
+  `workflow_dispatch` where useful) and nothing else.
+- **`push: branches: [main]` only when the main tree is itself the subject.**
+  `codeql.yml` (SARIF upload is default-branch-scoped), `gitleaks.yml`
+  (full-history scan of `main`), and `scorecard.yml` (scores the default
+  branch). Nothing else.
+- **`verify-merged-tree.yml` is the single post-merge run**, on
+  `push: branches: [main]` + `workflow_dispatch`. Its `needs-full-run` gate job
+  (~10 s) compares the pushed commit's tree object against the tree of the
+  merged PR's head commit and sets `run_full`. When the trees match, the whole
+  suite skips - the PR already tested exactly this content. Both tree SHAs and
+  the verdict are printed to the log so the operator can read why it ran or
+  skipped.
+
+  **The gate fails open, always toward running, on two distinct axes:**
+  1. *Inside the script* - any inability to resolve the PR, fetch
+     `refs/pull/N/head`, or read either tree yields `run_full=true`.
+  2. *At the job boundary* - every suite job guards on
+     `if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}`.
+     The status-check function is load-bearing. A bare
+     `if: needs.needs-full-run.outputs.run_full == 'true'` carries none, so
+     GitHub applies the implicit `success()` and a **failed** gate job (step
+     timeout on a slow `git fetch`/`gh api`, lost runner, checkout failure)
+     would SKIP every suite job instead of running it - inverting the contract
+     precisely when the gate is least trustworthy. `!cancelled()` rather than
+     `always()`: the same run-on-gate-failure behavior, but an operator/API
+     cancel of the gate does not go on to start all 10 suite jobs. The
+     `${{ }}` wrapper is mandatory, not cosmetic - a bare leading `!` opens a
+     YAML tag and `if: !cancelled() && ...` is a scanner error.
+
+  The gate step also sets `shell: bash {0}`. GitHub's default is
+  `bash -e {0}` (errexit ON), which silently made two `emit true` branches -
+  parentless commit, unreadable merged SHA - dead code: the step aborted at the
+  first failing `git rev-parse` with no verdict line and nothing written to
+  `$GITHUB_OUTPUT`. The boundary guard still produced the right *outcome*, but
+  the operator lost the diagnostic. Relatedly, every `git rev-parse` in the
+  step uses `--verify`: without it git echoes the unresolvable argument back on
+  stdout, so an emptiness test never fires and the wrong branch reports.
+
+  A gate that cannot prove the tree was already tested must never assert that
+  it was, and a gate that never finished has proven nothing.
+
+- **The non-PR direct push.** `changelog-publish.yml` runs daily at 00:00 UTC,
+  regenerates `CHANGELOG.md` + `docs/changelog.html`, and pushes straight to
+  `main` with a PAT (`CHANGELOG_PUSH_TOKEN`) - and a PAT *does* trigger
+  workflows. Its commit subject (`chore(changelog): regenerate from merged
+  PRs`) has no `(#N)` and no PR, so it hits the gate's no-PR path. Left alone
+  that fires the entire suite - `merged-codex-skill-sync` alone is budgeted 45
+  minutes - every single day on a two-file bot commit, and makes the retirement
+  condition below unsatisfiable by construction.
+
+  The gate therefore has a **second `run_full=false` path**: when no PR
+  resolves, it diffs `<sha>^ <sha>` and skips only if the changed set is
+  non-empty and a subset of `UNTESTED_SAFE_PATHS` - exactly `CHANGELOG.md` and
+  `docs/changelog.html`. Verified by `grep -rn 'CHANGELOG\.md\|changelog\.html'
+  .github/workflows/ scripts/ bin/ hooks/`: no check reads the *content* of
+  either file. The only hits are `changelog-publish.yml`'s own `git add`,
+  `generate-changelog.js` (the producer), `update-needsrebuild.test.js` (paths
+  as literal test data), and `test_gate_provenance.sh` (asserts `CHANGELOG.md`
+  is DERIVED via D2, which reads the *workflow's* `git add` line, never the
+  file). The slide tooling is scoped to `docs/slides/*` and never sees
+  `docs/changelog.html`. Any other non-PR push stays `run_full=true`.
+  Keep this allowlist tiny. Catch: the daily 45-minute bot run. Retires when
+  `changelog-publish.yml` opens a PR instead of pushing to `main`.
+- **No `paths:` filters.** A path filter turns a required check into one that
+  never reports on a PR not touching its paths, which blocks the merge rather
+  than passing it. Scope by need (the gate), not by path.
+
+## What is in the full suite
+
+Every check the 15 consolidated workflows ran, because on a behind-base merged
+tree **any** of them can flip - including the ones whose verdict looks like a
+pure function of a single file. `check-skill-embed-budget`'s CEILING is measured
+over a `SKILL.md` generated from all of `content/**`: two PRs each adding
+content, the second merged behind, yield a merged embed larger than either PR
+run measured. Root `AGENTS.md` names this exact mode (KNW-20260818-001). The
+same applies to `check-command-file-budget` and to `hooks-js-tests`' sha256
+prose goldens.
+
+Jobs: `merged-adapter-sync` (incl. the DS-57 codex-hooks and DS-104
+symlinks-relative guards, which audit a landed SHA), `merged-methodology-drift`,
+`merged-agent-fragment-sync`, `merged-slides-sync` (incl. the advisory overflow
+check), `merged-codex-skill-sync`, `merged-budget-gates` (all 7),
+`merged-content-guards`, `merged-wrap-lock-tests`, `merged-hooks-js-tests`,
+`merged-hooks-sh-tests`.
+
+The three hook-test jobs are kept separate rather than folded into one, mirroring
+`hooks-tests.yml`: `bin/tests/test_discovery_zero_match_guard_spec.py` keys
+`LIVE_GUARD_SITES` on `(file, job)`, so two discovery loops sharing a job collapse
+to a single pin and either loop's zero-match guard can then be deleted with the
+spec still green. One loop per job means one pin per loop.
+
+`merged-slides-sync` runs the overflow checks *after* `build-slides.sh`, so it
+measures regenerated HTML where `slides-sync.yml` measures the committed HTML.
+Equivalent in practice: the drift step reddens first whenever the two differ.
+
+**Known gap - `bin-tests.yml`.** Its three jobs (`python-bin-tests`,
+`hooks-python-tests`, `bin-sh-tests`) are *not* in the suite. That file is owned
+by a separate change and **still carries its own `push: branches: [main]`
+trigger**, so its post-merge coverage is currently intact and nothing is lost.
+When that trigger is dropped, those three jobs must be added here in the same
+change - otherwise three required contexts lose behind-base coverage.
+
+## Pillar 8 record
+
+- **Named catch (a):** the 6 behind-base merges above. Without a post-merge run
+  those merged trees are evaluated by nothing at all.
+- **Retirement condition (b):** when the admin bypass is removed from ruleset
+  `14778332`, or every merge is reliably preceded by `gh pr update-branch
+  --rebase`, the gate stops finding differing trees. The condition is therefore
+  stated over *merge-triggered* runs only: **60 consecutive days in which no
+  `push`-triggered run whose commit resolves to a PR reports `run_full=true`.**
+  Runs that skip via the `UNTESTED_SAFE_PATHS` path are `run_full=false` and do
+  not reset the counter; a `workflow_dispatch` run is excluded because it always
+  forces `run_full=true` by design. (Phrasing this as "60 days of *every* run
+  reporting false" would be unsatisfiable while any PR-less push exists at all -
+  the earlier draft had that bug.) After that window, the full-suite jobs retire
+  and only the gate job remains as the standing measurement. The gate itself
+  retires when the bypass is gone.
+- **The cheap path that makes `run_full=false` the norm:** local `gh` is 2.100
+  and `gh pr update-branch --rebase` works, so the conductor can bring a BEHIND
+  PR up to date before an `--admin` merge. Prefer that over relying on this
+  workflow to catch the difference afterwards.
+
+## What the 0/600 measurement did and did not show
+
+Across 2026-08-26 -> 2026-09-03: 31 merges, 600+ push-to-`main` workflow runs
+(~19 per merge), 579 success, 20 cancelled, 1 failure - and that failure was the
+advisory `check-slide-overflow`. **Required-check catches on the post-merge run
+in that window: zero.**
+
+That is genuine evidence that **~19 duplicate runs per merge** is the wrong
+shape - it is not evidence that the post-merge run is unnecessary. A zero-catch
+window across 31 merges cannot distinguish "this run is redundant" from "this
+run is load-bearing on 24% of merges and those merges happened to be clean".
+The tree comparison above is what settles it, and it settles it the other way.
+The cost this policy removes is the ~19x duplication and the 20 cancel events;
+the coverage it keeps is the 24%.
+
+## Reinstatement condition
+
+A workflow's own `push: branches: [main]` trigger comes back if
+`verify-merged-tree.yml` proves inadequate - i.e. it skips (or cannot run) a
+tree that later turns out to have been broken. "Belt and braces", "it is cheap",
+and "for safety" are not reinstatement conditions.
+
+## Triage: a red `verify-merged-tree` run
+
+It has no PR, so there is nothing to push a fix to. Fixing main-tree drift means
+opening a normal PR that regenerates the artifact and commits it. Read the gate
+job's log first: it prints the merged tree SHA, the PR head tree SHA, and why it
+decided to run.
+
+Note that consolidation trades run count for failure granularity: sibling checks
+share a job and run as sequential steps with no `continue-on-error`, so a
+`Fail on slide drift` failure hides the overflow checks after it and a
+`check-resident-budget.sh` failure hides the other six budget gates - you get one
+finding per triage cycle rather than all of them at once. Accepted deliberately
+for a post-merge run (nobody is waiting on it), and the reason the hook-test
+loops are *not* consolidated (see `merged-hooks-js-tests`).
+
+## Related conventions
+
+- The 16-path adapter pathspec and the 18-entry existence loop are duplicated
+  verbatim between `adapter-sync.yml` and `verify-merged-tree.yml`. This is
+  **not** extracted into a composite action: `scripts/gate-provenance.sh`'s D1
+  rule only scans `.github/workflows/*.yml`, so moving the assertion out of a
+  workflow file would stop `.claude`/`.codex`/... classifying as DERIVED and
+  break `bin/tests/test_gate_provenance.sh`. Instead the duplication is
+  **mechanically guarded**: `merged-adapter-sync`'s first step fails the build
+  if the two pathspec lines are not byte-identical. Root `AGENTS.md`'s rule
+  ("copy it verbatim from `Fail on adapter drift` in `adapter-sync.yml`") now
+  has two in-repo consumers.
+- `verify-merged-tree.yml`'s "Verify public build is clean" step is scoped
+  `-- .codex`, unlike `codex-skill-sync.yml`'s bare `git diff --exit-code`.
+  `gate-provenance.sh`'s D4 rule takes the FIRST bare, no-pathspec assertion
+  across the sorted workflow files as its input, and both that script and
+  `test_gate_provenance.sh` treat `codex-skill-sync.yml` as the repo's only
+  one. A second bare assertion would make D4's input depend on filename order.
+- `verify-merged-tree.yml` is named to sort **after** `slides-sync.yml`.
+  D1 cites the first workflow whose pathspec covers the queried target, so an
+  earlier-sorting name would re-point `gate-provenance.sh docs/slides/<deck>.md`
+  at the post-merge suite instead of the canonical PR gate.
+- `bin-tests.yml`'s header holds the repo's TIMEOUT POLICY (job-level timeouts
+  are a backstop; network and execution steps carry their own).
+  `verify-merged-tree.yml` follows it.

--- a/.github/workflows/adapter-sync.yml
+++ b/.github/workflows/adapter-sync.yml
@@ -1,9 +1,11 @@
 name: adapter-sync
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/agent-fragment-sync.yml
+++ b/.github/workflows/agent-fragment-sync.yml
@@ -1,9 +1,11 @@
 name: agent-fragment-sync
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codex-skill-budget.yml
+++ b/.github/workflows/codex-skill-budget.yml
@@ -1,10 +1,12 @@
 name: codex-skill-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codex-skill-sync.yml
+++ b/.github/workflows/codex-skill-sync.yml
@@ -1,10 +1,12 @@
 name: codex-skill-sync
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/command-arg-substitution.yml
+++ b/.github/workflows/command-arg-substitution.yml
@@ -1,10 +1,12 @@
 name: command-arg-substitution
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/command-file-budget.yml
+++ b/.github/workflows/command-file-budget.yml
@@ -1,10 +1,12 @@
 name: command-file-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/copilot-skill-budget.yml
+++ b/.github/workflows/copilot-skill-budget.yml
@@ -1,10 +1,12 @@
 name: copilot-skill-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/gemini-skill-budget.yml
+++ b/.github/workflows/gemini-skill-budget.yml
@@ -1,10 +1,12 @@
 name: gemini-skill-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hooks-tests.yml
+++ b/.github/workflows/hooks-tests.yml
@@ -1,9 +1,11 @@
 name: hook-tests
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/kimi-skill-budget.yml
+++ b/.github/workflows/kimi-skill-budget.yml
@@ -1,10 +1,12 @@
 name: kimi-skill-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/methodology-drift.yml
+++ b/.github/workflows/methodology-drift.yml
@@ -1,10 +1,12 @@
 name: methodology-drift
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/no-false-umbrella-claims.yml
+++ b/.github/workflows/no-false-umbrella-claims.yml
@@ -1,9 +1,11 @@
 name: no-false-umbrella-claims
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/no-planning-docs.yml
+++ b/.github/workflows/no-planning-docs.yml
@@ -1,9 +1,11 @@
 name: no-planning-docs
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/resident-budget.yml
+++ b/.github/workflows/resident-budget.yml
@@ -1,10 +1,12 @@
 name: resident-budget
 
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/slides-sync.yml
+++ b/.github/workflows/slides-sync.yml
@@ -1,9 +1,11 @@
 name: slides-sync
 on:
+  # PR-only. The post-merge run is not deleted, it is consolidated into
+  # verify-merged-tree.yml, which re-runs this check on `main` only when an
+  # `--admin` merge bypassed the ruleset's up-to-date requirement and landed
+  # a tree no PR run tested. Measurement, policy and retirement (the only
+  # site carrying the figures): .github/workflows/AGENTS.md
   pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/verify-merged-tree.yml
+++ b/.github/workflows/verify-merged-tree.yml
@@ -1,0 +1,721 @@
+name: verify-merged-tree
+
+# The consolidated post-merge run, conditional on need.
+#
+# WHY THIS EXISTS. `main`'s ruleset (14778332) sets
+# `strict_required_status_checks_policy: true`, which would mean every PR was
+# up to date with its base at merge time and its run therefore evaluated the
+# exact tree that landed. But the same ruleset carries
+# `bypass_actors: [{RepositoryRole admin, bypass_mode: always}]`, and
+# `gh pr merge --admin --squash` is this repo's normal unattended-agent merge
+# path (root AGENTS.md documents it as such, because GitHub disallows
+# self-approval). Admin bypass defeats strict.
+#
+# A measured minority of recent merges landed a tree byte-different from the
+# one their PR run tested; for those, the post-merge run was the ONLY
+# evaluation the merged tree ever received. The figures, the PR numbers, and
+# the method are deliberately NOT restated here - .github/workflows/AGENTS.md
+# is the single site that carries them, so re-measuring (which the retirement
+# condition anticipates) touches one file rather than seventeen.
+#
+# So the post-merge run stays. What changes is that it is now ONE workflow
+# that asks first whether the merged tree differs from the tree already
+# tested on the PR, and skips the whole suite when it does not. On an
+# up-to-date merge that is a ~10-second gate job instead of ~19 duplicate
+# workflow runs; on a behind-base merge it is the full evaluation that
+# nothing else would perform.
+#
+# Policy, the measurement, the named catch, and the retirement condition:
+# .github/workflows/AGENTS.md
+#
+# FILENAME. Sorts after `slides-sync.yml` deliberately.
+# `scripts/gate-provenance.sh`'s D1 rule scans `.github/workflows/*.yml` in
+# sorted order and cites the FIRST workflow whose `git diff --exit-code`
+# pathspec covers the queried target, so a name sorting earlier than
+# `slides-sync.yml` would silently re-point `gate-provenance.sh
+# docs/slides/<deck>.md` at this file instead of at the canonical PR gate.
+# Same verdict, wrong citation. Do not rename this file to anything sorting
+# before `slides-sync.yml`.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+# Keyed on the pushed commit, NOT on the ref: each merge is its own subject
+# and must be evaluated on its own. `cancel-in-progress` is deliberately
+# false - cancelling a merge's verification because a later merge arrived is
+# precisely how a behind-base tree would go unevaluated.
+concurrency:
+  group: verify-merged-tree-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# TIMEOUT POLICY - see bin-tests.yml's header for the full rationale. A job's
+# `started_at` is stamped at runner assignment, so job-level `timeout-minutes`
+# is a BACKSTOP ONLY; every network install step and every build/check
+# execution step carries its own step-level bound. `actions/checkout`,
+# `actions/setup-python` and `actions/setup-node` are exempt, as they are
+# there: cache-backed GitHub-hosted actions, not custom network commands.
+jobs:
+  # --- The gate -------------------------------------------------------------
+  #
+  # Compares the tree object of the pushed commit against the tree object of
+  # the merged PR's head commit. Identical trees mean the PR run already
+  # evaluated exactly this content and the suite below is pure duplication.
+  #
+  # FAIL-OPEN, ALWAYS TOWARD RUNNING, on BOTH axes:
+  #   - inside the script: any inability to resolve the PR, fetch its head, or
+  #     read either tree yields run_full=true;
+  #   - at the job boundary: every suite job below guards on
+  #     `${{ !cancelled() && (needs.needs-full-run.result != 'success' || ...) }}`,
+  #     so a gate job that FAILS or times out runs the suite rather than
+  #     skipping it. Without a status-check function GitHub applies the
+  #     implicit `success()` and a failed gate would skip everything - the
+  #     exact inversion of this contract. `!cancelled()` rather than
+  #     `always()`: same run-on-gate-failure behavior, but an operator/API
+  #     cancel does not go on to start all 10 suite jobs.
+  # A gate that cannot prove the tree was already tested must not assert that
+  # it was, and a gate that never finished has proven nothing.
+  #
+  # There are exactly two run_full=false paths: an identical tree pair, and a
+  # non-PR direct push touching only UNTESTED_SAFE_PATHS (see that block).
+  needs-full-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      run_full: ${{ steps.compare.outputs.run_full }}
+    steps:
+      # fetch-depth: 2 is required, not incidental: the non-PR direct-push
+      # branch below diffs `<sha>^ <sha>`, and the default depth-1 checkout
+      # has no parent commit to diff against.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - name: Compare merged tree against the PR head tree
+        id: compare
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGED_SHA: ${{ github.sha }}
+          COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
+        # `shell: bash {0}` is REQUIRED, not stylistic. GitHub's default for a
+        # `run:` block is `bash -e {0}` - errexit ON - which silently defeats
+        # the "no set -e" contract below: a parentless commit or an unreadable
+        # merged SHA aborted the step at the first failing `git rev-parse`
+        # with NO verdict line and NOTHING written to $GITHUB_OUTPUT, making
+        # the `emit true` branches for both dead code. (Measured: exit 128 on
+        # both.) The job-boundary guard still produced the fail-open OUTCOME,
+        # so nothing was unsafe - but the operator lost the diagnostic line on
+        # exactly the paths where it explains the behavior. `{0}` with no `-e`
+        # is what actually gives this script the semantics it documents.
+        #
+        # No `set -e`: every failure path here must fall through to
+        # run_full=true rather than abort the step. `set -u` and the pipefail
+        # option are still on so a genuinely malformed script is loud.
+        shell: bash {0}
+        run: |
+          set -uo pipefail
+
+          emit() {
+            echo "run_full=$1" >> "$GITHUB_OUTPUT"
+            echo "verdict: run_full=$1 ($2)"
+            exit 0
+          }
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            emit true "manually dispatched - always runs the full suite"
+          fi
+
+          # `--verify` is load-bearing on every rev-parse here: WITHOUT it
+          # git echoes the unresolvable argument back on stdout and exits
+          # 128, so an emptiness test never fires and the operator sees a
+          # nonsense line like `merged tree: 0000...^{tree}`. Measured.
+          merged_tree="$(git rev-parse --verify "${MERGED_SHA}^{tree}" 2>/dev/null)"
+          if [ -z "${merged_tree:-}" ]; then
+            emit true "could not read the merged commit's tree object"
+          fi
+          echo "merged commit: ${MERGED_SHA}"
+          echo "merged tree:   ${merged_tree}"
+
+          # Primary resolution: ask the API which PR this commit closed.
+          #
+          # The numeric `case` guard is load-bearing, not defensive style. On
+          # an API error `gh api` writes the error JSON body to STDOUT, so a
+          # bare capture assigns that whole blob to `pr`; the variable is then
+          # non-empty, the subject fallback below never fires, and the fetch
+          # fails on a garbage ref. Verified locally against a 422. It also
+          # catches the literal `null` that `--jq '.[0].number'` emits for an
+          # empty array.
+          pr=""
+          if api_pr="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${MERGED_SHA}/pulls" \
+                         --jq '.[0].number' 2>/dev/null)"; then
+            case "${api_pr:-}" in
+              ''|*[!0-9]*) ;;
+              *) pr="$api_pr" ;;
+            esac
+          fi
+
+          # Fallback: parse the `(#N)` suffix GitHub appends to a squash
+          # commit's subject line. Used when the API returns nothing or errs -
+          # the commit/PR association is eventually consistent, and this
+          # workflow runs inside exactly that window.
+          if [ -z "${pr:-}" ]; then
+            pr="$(printf '%s' "${COMMIT_SUBJECT}" | head -1 \
+                    | sed -n 's/.*(#\([0-9]\{1,\}\))[[:space:]]*$/\1/p')"
+            [ -n "${pr:-}" ] && echo "resolved PR #${pr} from the commit subject (API gave no usable number)"
+          fi
+
+          # No PR resolved. Before falling open, classify the one PUSH shape
+          # that is legitimately PR-less: changelog-publish.yml's daily 00:00
+          # UTC bot commit. It checks out with a PAT (CHANGELOG_PUSH_TOKEN, so
+          # it DOES trigger this workflow), runs
+          # `git add CHANGELOG.md docs/changelog.html`, commits
+          # "chore(changelog): regenerate from merged PRs" with no `(#N)`
+          # suffix, and pushes straight to main. Without this branch that bot
+          # commit fires the entire suite - merged-codex-skill-sync alone is
+          # budgeted 45 minutes - every single day, and makes the Pillar 8
+          # retirement condition unsatisfiable by construction.
+          #
+          # The allowlist is deliberately two entries. Verified by
+          # `grep -rn 'CHANGELOG\.md\|changelog\.html' .github/workflows/
+          # scripts/ bin/ hooks/`: no check reads the CONTENT of either file.
+          # The only hits are changelog-publish.yml's own `git add`,
+          # generate-changelog.js (the producer), update-needsrebuild.test.js
+          # (uses the paths as literal test data), and test_gate_provenance.sh
+          # (asserts CHANGELOG.md classifies DERIVED via D2, which reads
+          # changelog-publish.yml's `git add` line, never the file). The slide
+          # tooling is scoped to `docs/slides/*` and never sees
+          # docs/changelog.html.
+          #
+          # Catch: the daily 45-minute bot run. Retires when
+          # changelog-publish.yml opens a PR instead of pushing to main.
+          # A bash ARRAY, not a space-separated string: a future entry
+          # containing a space would silently split into two, and a split
+          # fragment could coincidentally equal an unrelated changed path.
+          UNTESTED_SAFE_PATHS=(CHANGELOG.md docs/changelog.html)
+          if [ -z "${pr:-}" ]; then
+            parent="$(git rev-parse --verify "${MERGED_SHA}^" 2>/dev/null)"
+            if [ -z "${parent:-}" ]; then
+              emit true "no PR resolved and the parent commit is unavailable - cannot classify this push"
+            fi
+            changed="$(git diff --name-only "${parent}" "${MERGED_SHA}" 2>/dev/null)"
+            if [ -z "${changed:-}" ]; then
+              emit true "no PR resolved and no changed paths could be read"
+            fi
+            echo "no PR resolved; changed paths vs ${parent}:"
+            printf '%s\n' "${changed}" | sed 's/^/  /'
+            # UNTESTED_SAFE_PATHS is the SINGLE source of the match, not just
+            # of the message: an earlier revision matched against a hardcoded
+            # `case CHANGELOG.md|docs/changelog.html)` arm while reporting the
+            # variable, which is the same silent-divergence shape the adapter
+            # pathspec guard exists to prevent. Exact string equality only -
+            # no globbing, no prefix matching.
+            outside=0
+            while IFS= read -r changed_path; do
+              [ -z "${changed_path}" ] && continue
+              path_ok=0
+              for allowed in "${UNTESTED_SAFE_PATHS[@]}"; do
+                if [ "${changed_path}" = "${allowed}" ]; then
+                  path_ok=1
+                  break
+                fi
+              done
+              if [ "${path_ok}" -eq 0 ]; then
+                outside=1
+                break
+              fi
+            done <<< "${changed}"
+            if [ "${outside}" -eq 0 ]; then
+              emit false "non-PR push touching only files no check reads (${UNTESTED_SAFE_PATHS[*]})"
+            fi
+            emit true "could not resolve a PR for this commit - cannot prove the tree was already tested"
+          fi
+          echo "pull request:  #${pr}"
+
+          # refs/pull/N/head stays fetchable after the branch is deleted,
+          # unlike the raw head SHA.
+          if ! git fetch --depth=1 --quiet origin "refs/pull/${pr}/head" 2>/dev/null; then
+            emit true "could not fetch refs/pull/${pr}/head"
+          fi
+
+          head_tree="$(git rev-parse --verify 'FETCH_HEAD^{tree}' 2>/dev/null)"
+          if [ -z "${head_tree:-}" ]; then
+            emit true "could not read PR #${pr}'s head tree object"
+          fi
+          echo "PR head tree:  ${head_tree}"
+
+          if [ "${merged_tree}" = "${head_tree}" ]; then
+            emit false "merged tree is byte-identical to the tree PR #${pr} already tested"
+          fi
+          emit true "merged tree differs from PR #${pr}'s head tree - this content was never evaluated"
+
+  # --- The full suite -------------------------------------------------------
+  #
+  # Every check below is a verbatim reuse of the `run:` block from the
+  # PR-triggered workflow named in each job's comment. The duplication is
+  # deliberate and disclosed (see AGENTS.md); where it is mechanically
+  # guardable, it is guarded rather than trusted.
+
+  # Mirrors adapter-sync.yml's check-adapter-sync job.
+  merged-adapter-sync:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+        timeout-minutes: 5
+      # The 16-path pathspec below is duplicated from adapter-sync.yml, as
+      # root AGENTS.md requires of any adapter-drift check. It is NOT
+      # extracted into a composite action: gate-provenance.sh's D1 rule only
+      # scans .github/workflows/*.yml, so moving the assertion out of a
+      # workflow file would stop `.claude`/`.codex`/... classifying as
+      # DERIVED and would break bin/tests/test_gate_provenance.sh - and
+      # scripts/ is outside this change's ownership. This step makes the
+      # duplication fail loudly instead of silently diverging.
+      - name: Guard - adapter pathspec here is byte-identical to adapter-sync.yml's
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+          # The `[.]claude` character class is deliberate: it matches the two
+          # real assertion lines while ensuring this grep's own pattern text
+          # does not match itself (a literal `.claude` here would make the
+          # guard count its own line and fail on a correct tree - observed).
+          pat='git diff --exit-code -- [.]claude'
+          lines="$(grep -hE "$pat" \
+                     .github/workflows/adapter-sync.yml \
+                     .github/workflows/verify-merged-tree.yml \
+                   | sed 's/^[[:space:]]*//; s/^if ! //; s/; then$//')"
+          found="$(printf '%s\n' "$lines" | grep -c . || true)"
+          uniq_count="$(printf '%s\n' "$lines" | sort -u | grep -c . || true)"
+          if [ "$found" != "2" ]; then
+            echo "::error::expected exactly 2 adapter drift pathspec lines (one per workflow), found $found - the guard is no longer measuring what it claims." >&2
+            exit 1
+          fi
+          if [ "$uniq_count" != "1" ]; then
+            echo "::error::the adapter drift pathspec has diverged between adapter-sync.yml and verify-merged-tree.yml ($uniq_count distinct forms). Copy it verbatim from 'Fail on adapter drift' in adapter-sync.yml." >&2
+            exit 1
+          fi
+      - name: Rebuild all adapters
+        timeout-minutes: 10
+        run: |
+          bash .claude/build.sh
+          bash .cursor/build.sh
+          bash .codex/build.sh
+          bash .gemini/build.sh
+          bash .kimi/build.sh
+          bash .opencode/build.sh
+          bash .omp/build.sh
+          bash .pi/build.sh
+          bash .hermes/build.sh
+          bash .openclaw/build.sh
+          bash .copilot/build.sh
+      - name: Verify adapter-sync pathspec entries exist
+        timeout-minutes: 5
+        run: |
+          for p in .claude .codex .cursor .gemini .kimi .opencode .omp .pi .hermes .openclaw .copilot \
+                   .github/copilot-instructions.md .github/agents .github/prompts .github/instructions .github/hooks .github/skills; do
+            if [[ ! -e "$p" ]]; then
+              echo "::error::adapter-sync pathspec entry missing: $p (drift check would silently pass on this)" >&2
+              exit 1
+            fi
+          done
+      - name: Fail on adapter drift
+        timeout-minutes: 5
+        run: |
+          if ! git diff --exit-code -- .claude .codex .cursor .gemini .kimi .opencode .omp .pi .hermes .openclaw .copilot .github/copilot-instructions.md .github/agents .github/prompts .github/instructions .github/hooks .github/skills; then
+            echo "::error::Adapter output is out of sync with content/ on the merged tree. Open a PR that runs the build scripts and commits the regenerated adapter files." >&2
+            exit 1
+          fi
+      - name: Verify Codex hook commands resolve (DS-57 regression guard)
+        timeout-minutes: 5
+        run: bash bin/tests/test_codex_hooks_resolve.sh
+      - name: Verify dinostack skill symlinks are relative (DS-104 regression guard)
+        timeout-minutes: 5
+        run: bash scripts/check-symlinks-relative.sh "${{ github.sha }}"
+
+  # Mirrors methodology-drift.yml's check-drift job.
+  merged-methodology-drift:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run methodology drift check
+        timeout-minutes: 10
+        run: bash scripts/check-methodology-drift.sh
+      - name: Run corpus coverage check
+        timeout-minutes: 10
+        run: python3 scripts/check-corpus-coverage.py
+
+  # Mirrors agent-fragment-sync.yml's check-agent-fragment-sync job.
+  merged-agent-fragment-sync:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: Stamp shared agent-check fragments
+        timeout-minutes: 10
+        run: bash scripts/stamp-agent-fragments.sh
+      - name: Fail on agent-check fragment drift
+        timeout-minutes: 5
+        run: |
+          if ! git diff --exit-code -- content/agents/; then
+            echo "::error::one or more content/agents/*.md files are out of sync with content/fragments/pre-submit-check-kernels.md on the merged tree. Open a PR that runs 'bash scripts/stamp-agent-fragments.sh' and commits the result." >&2
+            exit 1
+          fi
+
+  # Mirrors both jobs of slides-sync.yml. check-slide-overflow is advisory on
+  # PRs (not on the ruleset's required list) but is included here on purpose:
+  # excluding a check because it "cannot matter" is the reasoning that left
+  # the behind-base merges unevaluated in the first place.
+  merged-slides-sync:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: scripts/package-lock.json
+      - run: npm ci --prefix scripts --no-audit --no-fund
+        timeout-minutes: 10
+      - run: bash scripts/build-slides.sh
+        timeout-minutes: 10
+      - name: Fail on slide drift
+        timeout-minutes: 5
+        run: |
+          if ! git diff --exit-code -- docs/slides; then
+            echo "::error::Slide HTML is out of sync on the merged tree. Open a PR that runs 'bash scripts/build-slides.sh' and commits docs/slides/*.html." >&2
+            exit 1
+          fi
+      # ORDERING DIFFERENCE, disclosed rather than "fixed". slides-sync.yml
+      # runs these in a separate job against the COMMITTED html; here they run
+      # after `build-slides.sh`, so they measure the REGENERATED html. The two
+      # are equivalent in practice because the drift step above reddens first
+      # whenever committed and regenerated differ - if that step passes, the
+      # two are byte-identical by construction. Reordering to measure the
+      # committed html instead would mean skipping the build, and a stale
+      # committed deck would then be measured as if current.
+      - run: bash scripts/check-slide-overflow.sh
+        timeout-minutes: 10
+      - run: bash scripts/check-slide-overflow-live-selftest.sh
+        timeout-minutes: 10
+
+  # Mirrors codex-skill-sync.yml's check-codex-skill-sync job.
+  merged-codex-skill-sync:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+        timeout-minutes: 2
+      - name: Bootstrap ignored prompt runtime
+        run: python3 .codex/lib/prompt-wrappers.py build --repo .
+        timeout-minutes: 2
+      - name: Check codex skill sync
+        run: bash scripts/check-codex-skill-sync.sh
+        timeout-minutes: 2
+      - name: Run full Codex skill test suite
+        run: python3 scripts/test/test_codex_skills.py
+        timeout-minutes: 25
+      - name: Run clean-clone mutation gate
+        run: python3 scripts/test/test_codex_skills.py --clean-clone
+        timeout-minutes: 5
+      - name: Run public Codex build
+        run: bash .codex/build.sh
+        timeout-minutes: 2
+      # Scoped to `-- .codex` rather than copied bare from
+      # codex-skill-sync.yml. gate-provenance.sh's D4 rule takes as its input
+      # the FIRST bare, no-pathspec `git diff --exit-code` across the sorted
+      # workflow files, and both that script's comments and
+      # bin/tests/test_gate_provenance.sh's D4 extraction test treat
+      # codex-skill-sync.yml as the repo's only such assertion. A second bare
+      # one here would make D4's input filename-ordering-dependent. `.codex`
+      # is the only tree these generator steps write, so the scoped form
+      # asserts the same thing this job can actually assert.
+      - name: Verify public build is clean
+        run: git diff --exit-code -- .codex
+        timeout-minutes: 1
+
+  # Mirrors resident-budget.yml (both jobs), command-file-budget.yml, and the
+  # four skill-budget workflows. `fetch-depth: 0` is required: every gate
+  # except check-resident-budget carries a git axis (budget_base_resolve /
+  # budget_delta / budget_burn_line) that silently degrades to its SKIPPED
+  # variant on a shallow checkout.
+  merged-budget-gates:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Run resident budget check
+        timeout-minutes: 2
+        run: bash scripts/check-resident-budget.sh
+      - name: Run skill embed budget check
+        timeout-minutes: 2
+        run: bash scripts/check-skill-embed-budget.sh
+      - name: Run command file budget check
+        timeout-minutes: 2
+        run: bash scripts/check-command-file-budget.sh
+      - name: Run Codex skill budget check
+        timeout-minutes: 2
+        run: bash scripts/check-codex-skill-budget.sh
+      - name: Run Copilot skill budget check
+        timeout-minutes: 2
+        run: bash scripts/check-copilot-skill-budget.sh
+      - name: Run Gemini skill budget check
+        timeout-minutes: 2
+        run: bash scripts/check-gemini-skill-budget.sh
+      - name: Run Kimi skill embed budget check
+        timeout-minutes: 2
+        run: bash scripts/check-kimi-skill-embed-budget.sh
+
+  # Mirrors no-planning-docs.yml, no-false-umbrella-claims.yml, and
+  # command-arg-substitution.yml.
+  merged-content-guards:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Guard - docs/planning must not be tracked
+        timeout-minutes: 2
+        run: |
+          tracked=$(git ls-files docs/planning/)
+          if [ -n "$tracked" ]; then
+            echo "::error::docs/planning/ files are tracked in git. Briefs, Plans, and working notes are gitignored by design." >&2
+            printf '%s\n' "$tracked" >&2
+            exit 1
+          fi
+      - name: Guard - no stale /ds-init-project Step 9 targeted-umbrella claims
+        timeout-minutes: 2
+        run: bash scripts/check-no-false-umbrella-claims.sh
+      - name: Run command arg-substitution gate
+        timeout-minutes: 2
+        run: python3 scripts/check-command-arg-substitution.py content/commands
+
+  # Mirrors hooks-tests.yml's wrap-lock-tests job.
+  merged-wrap-lock-tests:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+      - name: wrap-lock acquire test
+        timeout-minutes: 5
+        run: node hooks/tests/test-wrap-acquire-lock.js
+      - name: wrap-lock release test
+        timeout-minutes: 5
+        run: node hooks/tests/test-wrap-release-lock.js
+
+  # Mirrors hooks-tests.yml's hooks-js-tests job.
+  #
+  # This is a SEPARATE job from merged-hooks-sh-tests, not two steps of one
+  # job, and that is load-bearing: bin/tests/test_discovery_zero_match_guard_spec.py
+  # keys LIVE_GUARD_SITES on (file, job), so two discovery loops sharing one
+  # job collapse to a single pin and deleting either loop's zero-match guard
+  # would leave the spec green. One loop per job = one pin per loop.
+  merged-hooks-js-tests:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+      - name: Install locked hook-test parser dependencies
+        timeout-minutes: 5
+        run: npm ci
+      - name: run JS hook tests
+        timeout-minutes: 10
+        run: |
+          set -e
+          count=0
+          for f in hooks/tests/test-*.js; do
+            case "$f" in
+              hooks/tests/test-wrap-acquire-lock.js|hooks/tests/test-wrap-release-lock.js)
+                # Run by the merged-wrap-lock-tests job above, exactly as
+                # hooks-tests.yml runs them in its own separate wrap-lock-tests
+                # job. If that job is removed, DELETE these case arms so the
+                # files fall back into this loop.
+                continue
+                ;;
+            esac
+            echo "::group::$f"
+            node "$f"
+            echo "::endgroup::"
+            count=$((count+1))
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: glob hooks/tests/test-*.js matched zero runnable files - discovery is broken, not clean" >&2
+            exit 1
+          fi
+          echo "Ran $count JS hook test files (excludes the 2 covered by merged-wrap-lock-tests)"
+
+  # Mirrors hooks-tests.yml's hooks-sh-tests job. Separate job for the same
+  # per-loop pin reason given on merged-hooks-js-tests above.
+  merged-hooks-sh-tests:
+    needs: needs-full-run
+    # The `!cancelled() &&` prefix is load-bearing: without a status-check
+    # function GitHub applies the implicit `success()`, so a FAILED gate job
+    # (step timeout on a slow fetch, lost runner) would SKIP every suite job
+    # rather than run it - inverting the fail-open contract at the job
+    # boundary. A gate that did not finish has not proven the tree was tested.
+    # `!cancelled()` rather than `always()`: identical run-on-gate-failure
+    # behavior, but an operator/API cancel of the gate does not go on to start
+    # all 10 suite jobs.
+    # Wrapped in `${{ }}` because a bare `!` opens a YAML tag - `if: !cancelled()`
+    # is a YAML scanner error, not merely a style choice.
+    if: ${{ !cancelled() && (needs.needs-full-run.result != 'success' || needs.needs-full-run.outputs.run_full == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: run shell hook tests
+        timeout-minutes: 5
+        run: |
+          set -e
+          count=0
+          for f in hooks/tests/test-*.sh; do
+            case "$f" in
+              hooks/tests/test-version-check-core-repo-dir.sh)
+                # QUARANTINED (DS-89) - copied verbatim from hooks-tests.yml.
+                # Re-enable by deleting this arm once DS-89 lands, in the
+                # same commit that deletes it there.
+                continue
+                ;;
+            esac
+            echo "::group::$f"
+            bash "$f"
+            echo "::endgroup::"
+            count=$((count+1))
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: glob hooks/tests/test-*.sh matched zero runnable files - discovery is broken, not clean" >&2
+            exit 1
+          fi
+          echo "Ran $count shell hook test files (excludes 1 quarantined pending DS-89)"

--- a/bin/tests/test_discovery_zero_match_guard_spec.py
+++ b/bin/tests/test_discovery_zero_match_guard_spec.py
@@ -123,6 +123,15 @@ LIVE_GUARD_SITES = frozenset(
         (".github/workflows/bin-tests.yml", "bin-sh-tests"),
         (".github/workflows/hooks-tests.yml", "hooks-js-tests"),
         (".github/workflows/hooks-tests.yml", "hooks-sh-tests"),
+        # verify-merged-tree.yml re-runs the two hooks-tests.yml discovery
+        # loops above on the merged tree, carrying their zero-match guards
+        # verbatim. TWO entries, one per loop, because discovery keys on
+        # (file, job): an earlier revision put both loops in a single
+        # `merged-hook-tests` job, which collapsed them to one pin and left
+        # this spec green when the JS loop's guard was deleted. Keep them in
+        # separate jobs so each guard is individually pinned.
+        (".github/workflows/verify-merged-tree.yml", "merged-hooks-js-tests"),
+        (".github/workflows/verify-merged-tree.yml", "merged-hooks-sh-tests"),
         ("hooks/tests/test-hooks-pep604-guard.py", "hook_files"),
         ("hooks/tests/test-hooks-pep604-guard.py", "test_files"),
         (


### PR DESCRIPTION
## Summary
- 15 workflows drop `push: branches: [main]`; the post-merge run is consolidated into one workflow, `verify-merged-tree.yml`, not deleted. Rationale corrected in review: `strict_required_status_checks_policy` is bypassed by `gh pr merge --admin` (this repo's normal merge), and 6 of the last 25 merges landed trees no PR run ever evaluated. For those, the post-merge run was the only evaluation.
- A ~10 s gate compares the merged commit's tree to the PR head's tree and skips the full suite when they match (up-to-date merge: one gate job instead of ~19 runs); when they differ, or when the PR cannot be resolved, it runs every check the 15 workflows ran. Fail-open on both axes: inside the script, and at the job boundary via `if: ${{ !cancelled() && (needs.gate.result != 'success' || ...) }}`.
- `changelog-publish.yml`'s daily PAT push (no PR) is skipped only when the diff is confined to a two-entry allowlist of files no check reads.
- Canonical policy, measurement, Pillar 8 record and triage note: `.github/workflows/AGENTS.md`. Each workflow carries a two-sentence pointer; the figures live at one site.

## North Star alignment

- Pillar(s) advanced (see docs/overview/vision.md): Pillar 1 - ~19 duplicate post-merge runs and their red-main notifications become one gate job on the common path; Pillar 8 - measured (0 required-check catches in 600 runs) before removing anything.
- Trade-off or pillar this could regress, if any: Pillar 2 - the original premise ("strict means the PR tested the merged tree") was FALSE under admin bypass; the redesign keeps the floor by running the full suite whenever the merged tree was not the tested tree. Residual: a red post-merge run has no PR attached; triage is documented. `bin-tests.yml` keeps its own push trigger; when it is dropped, its three jobs must join the suite in the same change.

## Review rigor
- Brief / Plan path: n/a - architect plan delivered in-conversation.
- Skeptic rounds (tier): 4 (opus). R1: 2 Critical (false premise; false exclusion rationale), 2 Major. R2: 2 Major (job-boundary implicit success(); PR-less daily push). R3: 1 Major (`run:` default `bash -e` made fail-open branches dead). R4: no Major, 2 Minor; sign-off granted, Minors fixed post-sign-off.

## Test plan
- [x] Gate battery on real commits: 6/6 behind-base -> run; 4/4 up-to-date -> skip; unresolvable, parentless, unreadable-SHA -> run; changelog shape -> skip; +1 file -> run
- [x] All 46 invocations from the 15 workflows present in the suite (re-derived); 16 required contexts still on `pull_request`
- [x] pytest 2212/0; `test_gate_provenance.sh` 35/0; per-loop zero-match pins mutation-tested

Process rule this PR depends on: bring a `BEHIND` PR up to date with `gh pr update-branch --rebase` before an `--admin` merge; that keeps the gate on the skip path.
