### PR TITLE
docs(bin): ds-skill-load-rate figures expire - document the retention window

### DIFF
--- a/bin/ds-skill-load-rate
+++ b/bin/ds-skill-load-rate
@@ -144,23 +144,27 @@ Failure modes: collect()/classify_transcript() never raise and main() never
                JSONL lines inside an otherwise readable transcript are
                skipped individually.
 
-Reproducibility: The rate this tool prints is a snapshot, not a reproducible
-                 measurement. Claude Code prunes top-level session transcripts
-                 on a rolling window - observed directly against this repo's
-                 own project directory on 2026-09-12: oldest surviving
-                 transcript mtime 2026-08-12, newest 2026-09-03, a span of
-                 roughly 31 days back from today, consistent with (not proof
-                 of an exact) ~30-day rolling retention window. A later run
-                 therefore scans a DIFFERENT population of sessions than an
-                 earlier run did, because the older sessions have simply aged
-                 out - this is why the tool prints its scan window on every
-                 run, and any figure it produces must be recorded together
-                 with that printed window, at the moment of measurement, or
-                 the figure means nothing once the transcripts behind it are
-                 gone. Two runs taken at different times are NOT two points on
-                 a trend line: DS-227's 44.3% (27/61) recorded 2026-09-07 and
-                 53.7% (22/41) recorded 2026-09-11 are different populations
-                 four days apart, not a change in behavior.
+Reproducibility: The rate this tool prints is a snapshot that expires. Claude
+                 Code prunes top-level session transcripts on a rolling window
+                 - observed directly on 2026-09-12 against this repo's own
+                 project directory: oldest surviving transcript mtime
+                 2026-08-12, roughly 31 days back, consistent with (not proof
+                 of an exact) ~30-day retention. This is why the tool prints
+                 its scan window on every run: record any figure together with
+                 that window, at the moment of measurement, or the figure
+                 means nothing once the transcripts behind it are gone.
+                 Successive runs are NOT independent samples - each later
+                 window is a NESTED SUBSET of the earlier one (older sessions
+                 age past the retention cutoff and drop out; nothing about
+                 this makes them a fresh random draw). The same metric
+                 (unprompted load rate) at three points shows this sliding,
+                 not a trend: 44.3% (27/61) on 2026-09-07, 48.8% (20/41) on
+                 2026-09-11, 55.9% (19/34) on 2026-09-12. The corpus is also
+                 not independent of what it measures: this project directory's
+                 own sessions are dinostack methodology work by construction
+                 (this scan's 34 transcripts average ~164 "dinostack" mentions
+                 each), so a working session here is not a representative
+                 sample of a typical repo's activation rate.
 
 Performance: O(total transcript bytes), one streaming pass per file with an
              early-exit-per-signal (each of the three record shapes stops

--- a/bin/ds-skill-load-rate
+++ b/bin/ds-skill-load-rate
@@ -144,6 +144,24 @@ Failure modes: collect()/classify_transcript() never raise and main() never
                JSONL lines inside an otherwise readable transcript are
                skipped individually.
 
+Reproducibility: The rate this tool prints is a snapshot, not a reproducible
+                 measurement. Claude Code prunes top-level session transcripts
+                 on a rolling window - observed directly against this repo's
+                 own project directory on 2026-09-12: oldest surviving
+                 transcript mtime 2026-08-12, newest 2026-09-03, a span of
+                 roughly 31 days back from today, consistent with (not proof
+                 of an exact) ~30-day rolling retention window. A later run
+                 therefore scans a DIFFERENT population of sessions than an
+                 earlier run did, because the older sessions have simply aged
+                 out - this is why the tool prints its scan window on every
+                 run, and any figure it produces must be recorded together
+                 with that printed window, at the moment of measurement, or
+                 the figure means nothing once the transcripts behind it are
+                 gone. Two runs taken at different times are NOT two points on
+                 a trend line: DS-227's 44.3% (27/61) recorded 2026-09-07 and
+                 53.7% (22/41) recorded 2026-09-11 are different populations
+                 four days apart, not a change in behavior.
+
 Performance: O(total transcript bytes), one streaming pass per file with an
              early-exit-per-signal (each of the three record shapes stops
              being tracked for a file once its first occurrence is found;


### PR DESCRIPTION
Adds a `Reproducibility:` paragraph to `bin/ds-skill-load-rate`'s module manifest. Docstring text only - the executable AST is byte-identical to `origin/main` with docstrings stripped (verified by `ast.parse` comparison, reported in-branch and re-checked independently before opening this PR).

## Why

The tool reads Claude Code session transcripts, which are pruned on a rolling window of roughly 30 days. That makes its output non-reproducible after about a month, and nothing in the tool said so.

This was found by accident, not by design. DS-227 recorded 44.3% (27/61) on 2026-09-07, independently reproduced by three reviewers that day. A re-run on 2026-09-11 over the identical scope returned 41 sessions; on 2026-09-12, 34. Twenty-seven sessions aged out in five days. Confirmed directly: the oldest surviving transcript in this repo's project directory is dated 2026-08-12, about 31 days back.

Worth noting against DS-227's own history: eight engineer rounds and eight adversarial reviews did not surface this, because every round re-ran the tool inside the same retention window. A property that only appears after a month is structurally invisible to a same-week review loop, however rigorous.

## What the paragraph says

Three things a reader needs, and one confound:

- The printed figure expires. Record it together with the window the tool prints, at the moment of measurement, or it means nothing once the transcripts behind it are gone.
- Successive runs are **nested subsets**, not independent samples. Older sessions age past the cutoff and drop out; nothing about that makes a later run a fresh random draw.
- The same metric at three points shows that sliding rather than a trend: 44.3% (27/61) on 2026-09-07, 48.8% (20/41) on 2026-09-11, 55.9% (19/34) on 2026-09-12. All three are the unprompted load rate. An earlier draft of this paragraph compared 44.3% (unprompted) against 53.7% (any load) as though they were like-for-like; they are not, and that was corrected before this PR.
- The corpus is not independent of what it measures: this project directory's sessions are dinostack methodology work by construction, averaging about 164 literal "dinostack" mentions each across the 34 scanned transcripts. A working session here is not a representative sample of a typical repo's activation rate.

A stronger claim was considered and rejected on evidence: that the corpus contains the sessions which built the tool. A grep across all 34 transcripts for `ds-227`, `TARGET_SKILL_NAMES` and `unprompted_load_rate` returned zero hits, so the weaker verified claim is what ships.

## Verification

- Executable AST identical to `origin/main` with docstrings stripped.
- `python3 -m pytest bin/tests/test_ds_skill_load_rate.py -p no:cacheprovider -q` with `__pycache__` cleared: 45 passed.
- Retention figures in the paragraph were observed on disk, not taken from the brief. The brief asserted a "~30 day" window; the engineer wrote "consistent with (not proof of an exact) ~30-day retention" because a single snapshot's edge does not prove the exact figure.
- `Doc-sync: predicate not triggered.` `bin/AGENTS.md:38`'s row for this tool asserts nothing about reproducibility that this addition contradicts.

## North Star alignment

Advances **Pillar 2 (produce verifiable outcomes)**: a measurement whose expiry is undocumented invites being cited as a trend, which is the specific misreading this paragraph prevents - and which had already happened twice in the work that produced it.

Cuts against **Pillar 5 (guard agent context)**: 22 lines added to a manifest an agent loads when it reads this file. Accepted as proportionate, because the alternative is a figure that silently misleads whoever re-runs the tool, and the warning belongs at the point of use rather than only in a tracker comment.

Refs DS-227, DS-229.
